### PR TITLE
Reduce Gradle daemon memory and align Kotlin to 2.3.20

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
-org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
-org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Toolchain
-kotlin = "2.2.20"
+kotlin = "2.3.20"
 agp = "9.1.0"
 java = "17"
 


### PR DESCRIPTION
## Summary
- Drop Gradle daemon heap from `-Xmx4g` to `-Xmx2g`. Current build fits comfortably; aligns with the other local projects so a single idle daemon can be reused.
- Remove `org.gradle.parallel=true`. With configuration-cache enabled the incremental rebuild wins are small, and the worker JVMs it spawns add meaningful memory pressure when several projects are open.
- Bump Kotlin `2.2.20 → 2.3.20` so the Kotlin compiler daemon can be shared with the other multiplatform checkouts.

## Test plan
- [ ] `./gradlew assembleDebug` passes
- [ ] `./gradlew check` passes
- [ ] Compose previews still render (the Kotlin bump is the risky bit)
- [ ] Configuration-cache still clean — watch for new warnings under the 2.3.20 plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)