### PR TITLE
Single-column responsive dashboard + edge-to-edge insets

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -3,11 +3,16 @@ package ee.schimke.terrazzo
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Dashboard
 import androidx.compose.material.icons.filled.Settings
@@ -189,16 +194,22 @@ private fun AuthenticatedScaffold(
             )
         },
     ) {
-        // `safeDrawingPadding` pads status bar (top) + IME; the
-        // navigation suite already handles its own bottom-bar insets.
-        Box(Modifier.fillMaxSize().safeDrawingPadding()) {
+        // Edge-to-edge: the outer Box fills the entire window (background
+        // paints behind the status bar / nav bar), and each destination
+        // gets the safe-drawing insets as `contentPadding`. Scrollable
+        // tabs apply it to their LazyColumn so list items scroll under
+        // the bars; static tabs pad their root container so chrome
+        // doesn't get clipped.
+        val safeInsets = WindowInsets.safeDrawing.asPaddingValues()
+        Box(Modifier.fillMaxSize()) {
             when (current) {
-                Destination.Dashboards -> DashboardsTab(session)
-                Destination.Widgets -> WidgetsScreen()
+                Destination.Dashboards -> DashboardsTab(session, safeInsets)
+                Destination.Widgets -> WidgetsScreen(safeInsets)
                 Destination.Settings -> SettingsScreen(
                     session = session,
                     onToggleDemo = onToggleDemo,
                     onSignOut = onSignOut,
+                    contentPadding = safeInsets,
                 )
             }
         }
@@ -212,7 +223,7 @@ private fun AuthenticatedScaffold(
  * configure) we promote to a real `NavDisplay`.
  */
 @Composable
-private fun DashboardsTab(session: HaSession) {
+private fun DashboardsTab(session: HaSession, contentPadding: PaddingValues) {
     var opened by rememberSaveable { mutableStateOf<String?>(DASHBOARD_UNSET) }
     var installPending by remember { mutableStateOf<Pair<CardConfig, HaSnapshot>?>(null) }
     val openedValue = opened
@@ -221,6 +232,7 @@ private fun DashboardsTab(session: HaSession) {
         DashboardPickerScreen(
             session = session,
             onDashboardPicked = { urlPath -> opened = urlPath },
+            contentPadding = contentPadding,
         )
     } else {
         DashboardViewScreen(
@@ -235,6 +247,7 @@ private fun DashboardsTab(session: HaSession) {
                     if (session is DemoHaSession) DemoData.snapshot() else HaSnapshot()
                 installPending = card to previewSnapshot
             },
+            contentPadding = contentPadding,
         )
     }
 
@@ -263,6 +276,7 @@ private fun SettingsScreen(
     session: HaSession,
     onToggleDemo: (Boolean) -> Unit,
     onSignOut: () -> Unit,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
 ) {
     val isDemo = session is DemoHaSession
     val graph = LocalTerrazzoGraph.current
@@ -272,7 +286,14 @@ private fun SettingsScreen(
     val themePref by graph.preferencesStore.themeStyle.collectAsState(initial = ThemePref.TerrazzoHome)
     val darkPref by graph.preferencesStore.darkMode.collectAsState(initial = DarkModePref.Follow)
 
-    Column(Modifier.fillMaxSize().padding(24.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(contentPadding)
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
         Text("Settings", style = MaterialTheme.typography.headlineMedium)
 
         Text("Connected to", style = MaterialTheme.typography.labelMedium)

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -5,12 +5,14 @@ package ee.schimke.terrazzo.dashboard
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -20,7 +22,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
@@ -29,26 +33,36 @@ import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.Dashboard
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.terrazzo.core.session.HaSession
+import ee.schimke.ha.rc.CardWidthClass
 import ee.schimke.ha.rc.ProvideCardRegistry
 import ee.schimke.ha.rc.RenderChild
 import ee.schimke.ha.rc.androidXExperimental
 import ee.schimke.ha.rc.cardHeightDp
+import ee.schimke.ha.rc.cardWidthClass
 import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.components.ProvideHaTheme
 import ee.schimke.ha.rc.components.haThemeFor
 import ee.schimke.terrazzo.ui.LocalIsDarkTheme
 import ee.schimke.terrazzo.ui.LocalThemeStyle
+import ee.schimke.terrazzo.ui.rememberLayoutConfig
 import kotlinx.coroutines.delay
 
 /**
  * Renders every top-level card in a dashboard as an independent `.rc`
  * document hosted in its own `RemotePreview`. This matches the
- * widget-per-card model — a dashboard here is a responsive grid of
- * players, not one giant document.
+ * widget-per-card model — a dashboard here is a stack of players, not
+ * one giant document.
  *
- * `LazyVerticalGrid(GridCells.Adaptive(minSize = 320.dp))` collapses
- * to 1 column on folded / compact widths and grows to 2–3 on tablets /
- * unfolded, honoring the nav-3 responsive-ui brief.
+ * Layout is single-column on every form factor; the only thing that
+ * scales with width is how many [CardWidthClass.Compact] cards (tile,
+ * button, entity) we pack into a row. On phones a "lights cluster" of
+ * four buttons fits 2-up; on tablets / unfolded foldables 4-up. Full
+ * cards (entities, glance, markdown, shutter) stay one-per-row at any
+ * width — they'd be unreadable side-by-side on a wall display anyway.
+ *
+ * The dashboard column is centred and capped to ~840 dp on Expanded
+ * widths so an `entities` list doesn't render 1280 dp wide and become
+ * a horizontal eyeline-skipping disaster.
  */
 @Composable
 fun DashboardViewScreen(
@@ -85,7 +99,7 @@ fun DashboardViewScreen(
         is DashboardState.Error -> Box(Modifier.fillMaxSize().padding(contentPadding).padding(24.dp)) {
             Text("Failed: ${s.message}", style = MaterialTheme.typography.bodyMedium)
         }
-        is DashboardState.Ready -> DashboardGrid(s.dashboard, s.snapshot, onCardLongPress, contentPadding)
+        is DashboardState.Ready -> DashboardList(s.dashboard, s.snapshot, onCardLongPress, contentPadding)
     }
 }
 
@@ -96,32 +110,85 @@ private sealed interface DashboardState {
 }
 
 @Composable
-private fun DashboardGrid(
+private fun DashboardList(
     dashboard: Dashboard,
     snapshot: HaSnapshot,
     onCardLongPress: (CardConfig) -> Unit,
     contentPadding: PaddingValues,
 ) {
     val registry = remember { defaultRegistry() }
-    val cards = remember(dashboard) { flattenCards(dashboard) }
-    LazyVerticalGrid(
-        columns = GridCells.Adaptive(minSize = 320.dp),
-        contentPadding = contentPadding,
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-        modifier = Modifier.fillMaxSize().padding(horizontal = 12.dp),
+    val layout = rememberLayoutConfig()
+    val rows = remember(dashboard, snapshot, layout.compactCardsPerRow) {
+        packRows(flattenCards(dashboard), snapshot) { card ->
+            registry.cardWidthClass(card, snapshot)
+        }.let { groups -> chunkCompactGroups(groups, layout.compactCardsPerRow) }
+    }
+
+    // The inner column carries the contentPadding so the LazyColumn
+    // itself fills the window edge-to-edge (background paints behind
+    // status bar / nav bar). centring + maxContentWidth comes via
+    // `widthIn` on the LazyColumn modifier, applied inside an outer
+    // Box that consumes the leftover horizontal space.
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.TopCenter,
     ) {
-        items(cards) { card ->
-            CardSlot(card, snapshot, registry, onCardLongPress)
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .columnMaxWidth(layout.maxContentWidth)
+                .padding(horizontal = layout.horizontalGutter),
+            contentPadding = contentPadding,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            items(rows, key = { it.key }) { row ->
+                CardRow(row, snapshot, registry, onCardLongPress)
+            }
+        }
+    }
+}
+
+private fun Modifier.columnMaxWidth(maxContentWidth: Dp): Modifier =
+    if (maxContentWidth == Dp.Unspecified) this else widthIn(max = maxContentWidth)
+
+/**
+ * One LazyColumn item — either a single full-width card or a row of
+ * 2..N compact cards sharing the row equally. Height pins to the
+ * tallest card in the row so [RemotePreview] (which sizes to its
+ * container) gets bounded constraints.
+ */
+@Composable
+private fun CardRow(
+    row: DashboardRow,
+    snapshot: HaSnapshot,
+    registry: ee.schimke.ha.rc.CardRegistry,
+    onLongPress: (CardConfig) -> Unit,
+) {
+    val rowHeightDp = remember(row, snapshot) {
+        row.cards.maxOf { registry.cardHeightDp(it, snapshot) }
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(rowHeightDp.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        row.cards.forEach { card ->
+            CardSlot(
+                card = card,
+                snapshot = snapshot,
+                registry = registry,
+                onLongPress = onLongPress,
+                modifier = Modifier.weight(1f).fillMaxWidth(),
+            )
         }
     }
 }
 
 /**
- * Hosts one card's own `.rc` document. Height is pinned so
- * `RemoteDocPreview` (which sizes to its container) has bounded
- * constraints. The value comes from the converter itself
- * (`CardRegistry.cardHeightDp`) — app doesn't know per-card sizing.
+ * Hosts one card's own `.rc` document. Sized by the parent Row (via
+ * `weight(1f)`) so packing logic decides the slot width, not the
+ * RemoteCompose document.
  */
 @Composable
 private fun CardSlot(
@@ -129,8 +196,8 @@ private fun CardSlot(
     snapshot: HaSnapshot,
     registry: ee.schimke.ha.rc.CardRegistry,
     onLongPress: (CardConfig) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
-    val heightDp = remember(card, snapshot) { registry.cardHeightDp(card, snapshot) }
     val style = LocalThemeStyle.current
     val dark = LocalIsDarkTheme.current
     // Re-capture the `.rc` document when the user switches theme — the
@@ -138,9 +205,7 @@ private fun CardSlot(
     // `RemotePreview` on the style+dark pair.
     val haTheme = remember(style, dark) { haThemeFor(style, dark) }
     Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .height(heightDp.dp)
+        modifier = modifier
             .combinedClickLongPress(onLongPress = { onLongPress(card) }),
     ) {
         RemotePreview(profile = androidXExperimental) {
@@ -159,3 +224,65 @@ private fun flattenCards(dashboard: Dashboard): List<CardConfig> =
         val fromSections = view.sections.flatMap { it.cards }
         fromCards + fromSections
     }
+
+/**
+ * One emitted dashboard row. Either a single full-width card or a
+ * cluster of compact cards that have been deemed "shareable".
+ */
+private data class DashboardRow(val key: String, val cards: List<CardConfig>)
+
+/**
+ * Group consecutive cards by [CardWidthClass]. The dashboard's authored
+ * order is preserved — a Full card between two Compact runs splits
+ * them into two clusters, never reorders.
+ */
+private fun packRows(
+    cards: List<CardConfig>,
+    snapshot: HaSnapshot,
+    widthClassOf: (CardConfig) -> CardWidthClass,
+): List<List<CardConfig>> {
+    val groups = mutableListOf<List<CardConfig>>()
+    val pending = mutableListOf<CardConfig>()
+    var pendingClass: CardWidthClass? = null
+    for (card in cards) {
+        val cls = widthClassOf(card)
+        if (cls == CardWidthClass.Full) {
+            if (pending.isNotEmpty()) {
+                groups += pending.toList(); pending.clear(); pendingClass = null
+            }
+            groups += listOf(card)
+        } else {
+            if (pendingClass != null && pendingClass != cls) {
+                groups += pending.toList(); pending.clear()
+            }
+            pending += card
+            pendingClass = cls
+        }
+    }
+    if (pending.isNotEmpty()) groups += pending.toList()
+    return groups
+}
+
+/**
+ * Chunk Compact groups into rows of [perRow] siblings while keeping
+ * Full groups as standalone single-card rows. Stable keys are
+ * synthesised from the position so LazyColumn can recycle correctly
+ * across recompositions.
+ */
+private fun chunkCompactGroups(
+    groups: List<List<CardConfig>>,
+    perRow: Int,
+): List<DashboardRow> {
+    var index = 0
+    return buildList {
+        groups.forEach { group ->
+            if (group.size <= 1) {
+                add(DashboardRow(key = "row-${index++}", cards = group))
+            } else {
+                group.chunked(perRow).forEach { chunk ->
+                    add(DashboardRow(key = "row-${index++}", cards = chunk))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/ee/schimke/terrazzo/ui/WindowSize.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/ui/WindowSize.kt
@@ -1,0 +1,85 @@
+package ee.schimke.terrazzo.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Coarse window-width buckets used by the dashboard layout to decide
+ * how aggressively to pack [ee.schimke.ha.rc.CardWidthClass.Compact]
+ * cards into a single row. Thresholds match the Material 3 window
+ * size class breakpoints (`Compact <600dp`, `Medium 600..839dp`,
+ * `Expanded ≥840dp`) — same numbers as `WindowSizeClass`, without the
+ * extra dependency surface.
+ */
+enum class WindowSize {
+    /** Phone portrait, foldable closed. */
+    Compact,
+
+    /** Phone landscape, small tablets, foldable inner-display in portrait. */
+    Medium,
+
+    /** Tablets, foldable unfolded in landscape, desktops. */
+    Expanded,
+    ;
+
+    companion object {
+        fun fromWidthDp(widthDp: Int): WindowSize = when {
+            widthDp < 600 -> Compact
+            widthDp < 840 -> Medium
+            else -> Expanded
+        }
+    }
+}
+
+/**
+ * Per-bucket layout parameters consumed by `DashboardViewScreen`.
+ *
+ * @property compactCardsPerRow how many [CardWidthClass.Compact] cards
+ *   fit in one row at this width. Two on a phone is enough to make a
+ *   typical "lights / cover / scene" cluster usable; tablets and
+ *   foldables get more so a dashboard authored for the wall display
+ *   doesn't waste the extra real estate.
+ * @property maxContentWidth caps the dashboard column on very wide
+ *   screens so a 1280-dp tablet doesn't render a 1280-dp-wide
+ *   `entities` list — beyond ~720 dp the list becomes unscannable.
+ *   `Dp.Unspecified` means "no cap".
+ * @property horizontalGutter outer padding either side of the dashboard
+ *   column. Bigger on tablets purely for breathing room.
+ */
+data class LayoutConfig(
+    val windowSize: WindowSize,
+    val compactCardsPerRow: Int,
+    val maxContentWidth: Dp,
+    val horizontalGutter: Dp,
+)
+
+private val ExpandedMaxWidth = 840.dp
+
+@Composable
+@ReadOnlyComposable
+fun rememberLayoutConfig(): LayoutConfig {
+    val widthDp = LocalConfiguration.current.screenWidthDp
+    return when (WindowSize.fromWidthDp(widthDp)) {
+        WindowSize.Compact -> LayoutConfig(
+            windowSize = WindowSize.Compact,
+            compactCardsPerRow = 2,
+            maxContentWidth = Dp.Unspecified,
+            horizontalGutter = 12.dp,
+        )
+        WindowSize.Medium -> LayoutConfig(
+            windowSize = WindowSize.Medium,
+            compactCardsPerRow = 3,
+            maxContentWidth = Dp.Unspecified,
+            horizontalGutter = 16.dp,
+        )
+        WindowSize.Expanded -> LayoutConfig(
+            windowSize = WindowSize.Expanded,
+            compactCardsPerRow = 4,
+            maxContentWidth = ExpandedMaxWidth,
+            horizontalGutter = 24.dp,
+        )
+    }
+}

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetsScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetsScreen.kt
@@ -1,8 +1,11 @@
 package ee.schimke.terrazzo.widget
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -16,9 +19,13 @@ import androidx.compose.ui.unit.dp
  *   - up-to-5 cap enforced here.
  */
 @Composable
-fun WidgetsScreen() {
+fun WidgetsScreen(contentPadding: PaddingValues = PaddingValues(0.dp)) {
     Column(
-        modifier = Modifier.fillMaxSize().padding(24.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(contentPadding)
+            .padding(24.dp),
     ) {
         Text("Widgets", style = MaterialTheme.typography.headlineMedium)
         Text(

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardConverter.kt
@@ -51,6 +51,33 @@ interface CardConverter {
      * override to compute from [card] / [snapshot].
      */
     fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 160
+
+    /**
+     * Whether this card prefers to share its row with siblings
+     * ([CardWidthClass.Compact] — small button-shaped tiles like `tile`,
+     * `button`, `entity`) or wants the full content width
+     * ([CardWidthClass.Full] — list-shaped, hero, or chrome cards).
+     *
+     * The dashboard layout reads this to pack consecutive Compact
+     * cards into a single row on tablets / unfolded foldables, while
+     * keeping Full cards stacked one-per-row regardless of width.
+     * Default is [CardWidthClass.Full]: the conservative choice that
+     * preserves how the card was authored.
+     */
+    fun naturalWidthClass(card: CardConfig, snapshot: HaSnapshot): CardWidthClass =
+        CardWidthClass.Full
+}
+
+/**
+ * Layout hint emitted by a [CardConverter]. The dashboard renderer uses
+ * it to decide whether the card stays on its own row or pairs up with
+ * neighbouring small cards.
+ */
+enum class CardWidthClass {
+    /** Small button-shaped card (tile, button, entity). Pairs into rows. */
+    Compact,
+    /** Wants the full content width — list / hero / chrome. */
+    Full,
 }
 
 /**

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/LocalCardRegistry.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/LocalCardRegistry.kt
@@ -54,4 +54,14 @@ fun CardRegistry.cardHeightDp(card: CardConfig, snapshot: HaSnapshot): Int {
     return converter?.naturalHeightDp(card, snapshot) ?: 160
 }
 
+/**
+ * Host-side lookup of a card's [CardWidthClass]. Unknown / unsupported
+ * cards fall back to [CardWidthClass.Full] so a placeholder slot
+ * spans the row rather than visually pairing with a real card.
+ */
+fun CardRegistry.cardWidthClass(card: CardConfig, snapshot: HaSnapshot): CardWidthClass {
+    val converter = get(card.type) ?: get(UNSUPPORTED_CARD_TYPE)
+    return converter?.naturalWidthClass(card, snapshot) ?: CardWidthClass.Full
+}
+
 internal const val UNSUPPORTED_CARD_TYPE = "__unsupported__"

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ButtonCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ButtonCardConverter.kt
@@ -9,6 +9,7 @@ import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.model.toTyped
 import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.CardWidthClass
 import ee.schimke.ha.rc.HaStateColor
 import ee.schimke.ha.rc.LiveBindings
 import ee.schimke.ha.rc.components.HaButtonData
@@ -32,6 +33,9 @@ class ButtonCardConverter : CardConverter {
     override val cardType: String = CardTypes.BUTTON
 
     override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 91
+
+    override fun naturalWidthClass(card: CardConfig, snapshot: HaSnapshot): CardWidthClass =
+        CardWidthClass.Compact
 
     @Composable
     override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/EntityCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/EntityCardConverter.kt
@@ -10,6 +10,7 @@ import ee.schimke.ha.model.EntityState
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.model.toTyped
 import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.CardWidthClass
 import ee.schimke.ha.rc.HaStateColor
 import ee.schimke.ha.rc.LiveBindings
 import ee.schimke.ha.rc.components.HaEntityRowData
@@ -27,6 +28,9 @@ class EntityCardConverter : CardConverter {
     override val cardType: String = CardTypes.ENTITY
 
     override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 48
+
+    override fun naturalWidthClass(card: CardConfig, snapshot: HaSnapshot): CardWidthClass =
+        CardWidthClass.Compact
 
     @Composable
     override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/TileCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/TileCardConverter.kt
@@ -8,6 +8,7 @@ import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.CardWidthClass
 import ee.schimke.ha.rc.HaStateColor
 import ee.schimke.ha.rc.LiveBindings
 import ee.schimke.ha.rc.components.HaTileData
@@ -25,6 +26,9 @@ class TileCardConverter : CardConverter {
     override val cardType: String = CardTypes.TILE
 
     override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 43
+
+    override fun naturalWidthClass(card: CardConfig, snapshot: HaSnapshot): CardWidthClass =
+        CardWidthClass.Compact
 
     @Composable
     override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {


### PR DESCRIPTION
## Summary

This commit was originally pushed to the PR #6 branch but landed *after* PR #6 was squash-merged, so it's currently sitting on a closed branch and never made it into `main`. Re-opening on a fresh branch off `main`.

### Single-column responsive dashboard
- Replaces `LazyVerticalGrid(GridCells.Adaptive(320dp))` with a single-column `LazyColumn` that packs consecutive small cards into rows.
- Adds `CardWidthClass` (`Compact` / `Full`) to the `CardConverter` API. `Tile` (43 dp), `Button` (91 dp), `Entity` (48 dp) declare `Compact`; everything else (entities, glance, markdown, stacks, headings, shutter) stays `Full` (the default).
- New `WindowSize` helper maps `LocalConfiguration.screenWidthDp` to `Compact` (<600 dp) / `Medium` (600–839 dp) / `Expanded` (≥840 dp) — same thresholds as M3 `WindowSizeClass` without pulling the dep. Compact cards per row: 2 / 3 / 4. Expanded widths cap the column at 840 dp and centre it so a 1280-dp tablet doesn't render an entities list 1280-dp wide.

### Edge-to-edge & insets
- Drops `safeDrawingPadding()` from the outer `Box` in `AuthenticatedScaffold`. The theme background now paints behind the status / nav bar.
- `WindowInsets.safeDrawing.asPaddingValues()` is computed once in `AuthenticatedScaffold` and passed as `contentPadding` to each tab. `DashboardViewScreen` / `DashboardPickerScreen` apply it to their `LazyColumn.contentPadding` so list items scroll under the bars without clipping.
- `SettingsScreen` and `WidgetsScreen` are now `verticalScroll`able and apply the inset padding to their root `Column` so short screens / large fonts don't overflow.

## Test plan

- [x] `:rc-converter`, `:rc-components`, `:app`, `:previews`, `:demo-app` all `compileDebugKotlin` clean
- [x] `:rc-converter`, `:rc-components`, `:app` unit tests pass
- [x] `:app:assembleDebug` succeeds
- [ ] Manual: phone portrait — dashboard renders single-column with small Compact clusters paired 2-up
- [ ] Manual: rotate to landscape / open a foldable — Compact clusters re-pack to 3- / 4-up; Full cards stay one-per-row at every width
- [ ] Manual: scroll the dashboard — list scrolls behind status bar without clipping
- [ ] Manual: Settings on a short screen — column scrolls instead of overflowing


---
_Generated by [Claude Code](https://claude.ai/code/session_014V2uC26jjmE52NDndsoSgo)_