### PR TITLE
Honour dashboard structure: section titles + side-by-side columns on wide

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardLayout.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardLayout.kt
@@ -1,0 +1,60 @@
+package ee.schimke.terrazzo.dashboard
+
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.Dashboard
+
+/**
+ * Structured projection of a Lovelace [Dashboard] that preserves the
+ * pieces the renderer needs to lay out faithfully:
+ *
+ *   - **views** keep their order and titles so multi-view dashboards
+ *     can render boundaries (most dashboards have one view; HA tabs
+ *     map to views, which we don't expose as tabs yet).
+ *   - **sections** keep their titles. HA's modern dashboard model uses
+ *     sections as the column unit on wide screens; we mirror that on
+ *     Expanded widths and stack-with-headings on Compact.
+ *   - **orphan cards** are the legacy `view.cards` array used before
+ *     sections existed. They render as a single column above any
+ *     sections in the same view.
+ *
+ * The previous renderer concatenated all cards from all views and
+ * sections into one flat list ([flattenCards] in `DashboardViewScreen`),
+ * which threw away every grouping signal HA exposes. This type keeps
+ * those signals so the layout layer can reflow them per width class.
+ */
+data class DashboardLayout(val views: List<ViewLayout>) {
+    val sectionCount: Int get() = views.sumOf { it.sections.size }
+    val isEmpty: Boolean get() = views.all { it.orphanCards.isEmpty() && it.sections.isEmpty() }
+}
+
+data class ViewLayout(
+    val title: String?,
+    val orphanCards: List<CardConfig>,
+    val sections: List<SectionLayout>,
+)
+
+data class SectionLayout(
+    val title: String?,
+    val cards: List<CardConfig>,
+)
+
+/**
+ * Project a Lovelace dashboard payload onto [DashboardLayout]. View /
+ * section / card order is preserved. Empty views (no orphans, no
+ * sections) survive the projection — the renderer drops them with
+ * [DashboardLayout.isEmpty] handling rather than us pruning here, so
+ * a dashboard that legitimately has zero cards still surfaces a "no
+ * cards" empty state instead of the loading spinner.
+ */
+fun buildDashboardLayout(dashboard: Dashboard): DashboardLayout =
+    DashboardLayout(
+        views = dashboard.views.map { view ->
+            ViewLayout(
+                title = view.title,
+                orphanCards = view.cards,
+                sections = view.sections.map { section ->
+                    SectionLayout(title = section.title, cards = section.cards)
+                },
+            )
+        },
+    )

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -4,6 +4,7 @@ package ee.schimke.terrazzo.dashboard
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,7 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -42,6 +43,7 @@ import ee.schimke.ha.rc.cardWidthClass
 import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.components.ProvideHaTheme
 import ee.schimke.ha.rc.components.haThemeFor
+import ee.schimke.terrazzo.ui.LayoutConfig
 import ee.schimke.terrazzo.ui.LocalIsDarkTheme
 import ee.schimke.terrazzo.ui.LocalThemeStyle
 import ee.schimke.terrazzo.ui.rememberLayoutConfig
@@ -53,16 +55,24 @@ import kotlinx.coroutines.delay
  * widget-per-card model — a dashboard here is a stack of players, not
  * one giant document.
  *
- * Layout is single-column on every form factor; the only thing that
- * scales with width is how many [CardWidthClass.Compact] cards (tile,
- * button, entity) we pack into a row. On phones a "lights cluster" of
- * four buttons fits 2-up; on tablets / unfolded foldables 4-up. Full
- * cards (entities, glance, markdown, shutter) stay one-per-row at any
- * width — they'd be unreadable side-by-side on a wall display anyway.
+ * Layout follows the dashboard's own structure as faithfully as the
+ * window allows:
  *
- * The dashboard column is centred and capped to ~840 dp on Expanded
- * widths so an `entities` list doesn't render 1280 dp wide and become
- * a horizontal eyeline-skipping disaster.
+ *   - **Wide (Expanded width, ≥2 sections)** — sections render
+ *     side-by-side as columns, mirroring HA's modern dashboard. Up
+ *     to 2 columns at 840 dp / 3 at 1200 dp. Section titles sit at
+ *     the top of each column.
+ *   - **Single-column (Compact / Medium, or no sections)** — sections
+ *     stack vertically with their titles preserved as inline
+ *     headings. Cards inside a section pack consecutive
+ *     [CardWidthClass.Compact] entries (tile / button / entity) into
+ *     a single row so a four-button cluster doesn't take four full
+ *     screen heights on a phone.
+ *
+ * View titles are not rendered: each top-level dashboard has one
+ * "view" in the typical case, and the user already saw the view name
+ * in the picker. Multi-view dashboards are an HA tab construct; we'd
+ * surface them as tabs, not stacked, when we get to that.
  */
 @Composable
 fun DashboardViewScreen(
@@ -117,18 +127,17 @@ private fun DashboardList(
     contentPadding: PaddingValues,
 ) {
     val registry = remember { defaultRegistry() }
-    val layout = rememberLayoutConfig()
-    val rows = remember(dashboard, snapshot, layout.compactCardsPerRow) {
-        packRows(flattenCards(dashboard), snapshot) { card ->
-            registry.cardWidthClass(card, snapshot)
-        }.let { groups -> chunkCompactGroups(groups, layout.compactCardsPerRow) }
-    }
+    val layout = remember(dashboard) { buildDashboardLayout(dashboard) }
+    val cfg = rememberLayoutConfig()
 
-    // The inner column carries the contentPadding so the LazyColumn
-    // itself fills the window edge-to-edge (background paints behind
-    // status bar / nav bar). centring + maxContentWidth comes via
-    // `widthIn` on the LazyColumn modifier, applied inside an outer
-    // Box that consumes the leftover horizontal space.
+    val sectionColumns = (cfg.maxSectionColumns).coerceAtMost(layout.sectionCount).coerceAtLeast(1)
+    val sideBySide = sectionColumns >= 2
+
+    // Centre + cap the column on Expanded ONLY when the dashboard has
+    // no sections — sections drive their own grid width and shouldn't
+    // be capped to a single-column max.
+    val constrainColumn = !sideBySide && cfg.maxContentWidth != Dp.Unspecified
+
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.TopCenter,
@@ -136,20 +145,193 @@ private fun DashboardList(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .columnMaxWidth(layout.maxContentWidth)
-                .padding(horizontal = layout.horizontalGutter),
+                .let { if (constrainColumn) it.widthIn(max = cfg.maxContentWidth) else it }
+                .padding(horizontal = cfg.horizontalGutter),
             contentPadding = contentPadding,
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            items(rows, key = { it.key }) { row ->
-                CardRow(row, snapshot, registry, onCardLongPress)
+            layout.views.forEachIndexed { viewIndex, view ->
+                renderView(
+                    viewIndex = viewIndex,
+                    view = view,
+                    snapshot = snapshot,
+                    registry = registry,
+                    cfg = cfg,
+                    sideBySide = sideBySide,
+                    sectionColumns = sectionColumns,
+                    onLongPress = onCardLongPress,
+                )
             }
         }
     }
 }
 
-private fun Modifier.columnMaxWidth(maxContentWidth: Dp): Modifier =
-    if (maxContentWidth == Dp.Unspecified) this else widthIn(max = maxContentWidth)
+/**
+ * Emit one view's blocks into the parent [LazyListScope]. Orphan
+ * cards (legacy `view.cards`) come first as a single column;
+ * sections follow, either stacked (single-column mode) or
+ * chunked into rows of [sectionColumns] section-columns
+ * (wide mode).
+ */
+private fun LazyListScope.renderView(
+    viewIndex: Int,
+    view: ViewLayout,
+    snapshot: HaSnapshot,
+    registry: ee.schimke.ha.rc.CardRegistry,
+    cfg: LayoutConfig,
+    sideBySide: Boolean,
+    sectionColumns: Int,
+    onLongPress: (CardConfig) -> Unit,
+) {
+    val viewKey = "v$viewIndex"
+
+    if (view.orphanCards.isNotEmpty()) {
+        cardRows(
+            keyPrefix = "$viewKey-orphan",
+            cards = view.orphanCards,
+            snapshot = snapshot,
+            registry = registry,
+            compactPerRow = cfg.compactCardsPerRow,
+            onLongPress = onLongPress,
+        )
+    }
+
+    if (view.sections.isEmpty()) return
+
+    if (!sideBySide) {
+        view.sections.forEachIndexed { sectionIndex, section ->
+            val sectionKey = "$viewKey-s$sectionIndex"
+            section.title?.let { title ->
+                item(key = "$sectionKey-title") { SectionHeading(title) }
+            }
+            cardRows(
+                keyPrefix = "$sectionKey",
+                cards = section.cards,
+                snapshot = snapshot,
+                registry = registry,
+                // Within a single-column section, keep the same
+                // packing rule the orphan path uses — small buttons
+                // pair up so a "lights" cluster stays usable on
+                // narrow screens.
+                compactPerRow = cfg.compactCardsPerRow,
+                onLongPress = onLongPress,
+            )
+        }
+    } else {
+        view.sections.chunked(sectionColumns).forEachIndexed { rowIndex, sectionRow ->
+            item(key = "$viewKey-srow$rowIndex") {
+                SectionRow(
+                    sections = sectionRow,
+                    columns = sectionColumns,
+                    snapshot = snapshot,
+                    registry = registry,
+                    onLongPress = onLongPress,
+                )
+            }
+        }
+    }
+}
+
+/** Heading for a section title. Shared between single-column and wide layouts. */
+@Composable
+private fun SectionHeading(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.onSurface,
+        modifier = Modifier.fillMaxWidth().padding(top = 8.dp, bottom = 4.dp),
+    )
+}
+
+/**
+ * One row of [columns] section-columns laid out side-by-side. Cards
+ * within each section stack vertically — wide mode treats sections
+ * as the primary layout unit so we don't compact-pack inside them
+ * (a 400-dp section column can show a tile at full width without
+ * eyeline pain). If [sections] is shorter than [columns] we pad with
+ * empty `weight(1f)` Spacer-equivalents via empty columns so the
+ * remaining sections in the next row still align with this one.
+ */
+@Composable
+private fun SectionRow(
+    sections: List<SectionLayout>,
+    columns: Int,
+    snapshot: HaSnapshot,
+    registry: ee.schimke.ha.rc.CardRegistry,
+    onLongPress: (CardConfig) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        sections.forEach { section ->
+            SectionColumn(
+                section = section,
+                snapshot = snapshot,
+                registry = registry,
+                onLongPress = onLongPress,
+                modifier = Modifier.weight(1f),
+            )
+        }
+        // Reserve weight for missing columns so the row geometry
+        // matches its sibling rows when sections.size % columns != 0.
+        repeat(columns - sections.size) {
+            Box(modifier = Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
+private fun SectionColumn(
+    section: SectionLayout,
+    snapshot: HaSnapshot,
+    registry: ee.schimke.ha.rc.CardRegistry,
+    onLongPress: (CardConfig) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        section.title?.let { SectionHeading(it) }
+        section.cards.forEach { card ->
+            val heightDp = remember(card, snapshot) { registry.cardHeightDp(card, snapshot) }
+            CardSlot(
+                card = card,
+                snapshot = snapshot,
+                registry = registry,
+                onLongPress = onLongPress,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(heightDp.dp),
+            )
+        }
+    }
+}
+
+/**
+ * Emit packed rows for [cards] into the parent [LazyListScope].
+ * Consecutive [CardWidthClass.Compact] cards group into rows of
+ * [compactPerRow]; full-width cards stand alone.
+ */
+private fun LazyListScope.cardRows(
+    keyPrefix: String,
+    cards: List<CardConfig>,
+    snapshot: HaSnapshot,
+    registry: ee.schimke.ha.rc.CardRegistry,
+    compactPerRow: Int,
+    onLongPress: (CardConfig) -> Unit,
+) {
+    val rows = packAndChunk(cards, compactPerRow) { c ->
+        registry.cardWidthClass(c, snapshot)
+    }
+    rows.forEachIndexed { rowIndex, row ->
+        item(key = "$keyPrefix-r$rowIndex") {
+            CardRow(row, snapshot, registry, onLongPress)
+        }
+    }
+}
 
 /**
  * One LazyColumn item — either a single full-width card or a row of
@@ -186,9 +368,9 @@ private fun CardRow(
 }
 
 /**
- * Hosts one card's own `.rc` document. Sized by the parent Row (via
- * `weight(1f)`) so packing logic decides the slot width, not the
- * RemoteCompose document.
+ * Hosts one card's own `.rc` document. Sized by the parent (via
+ * `weight(1f)` in compact rows, or `height(...)` in section columns)
+ * so the layout decides the slot size, not the RemoteCompose document.
  */
 @Composable
 private fun CardSlot(
@@ -218,71 +400,35 @@ private fun CardSlot(
     }
 }
 
-private fun flattenCards(dashboard: Dashboard): List<CardConfig> =
-    dashboard.views.flatMap { view ->
-        val fromCards = view.cards
-        val fromSections = view.sections.flatMap { it.cards }
-        fromCards + fromSections
-    }
+/**
+ * One emitted dashboard row in the LazyColumn. Either a single
+ * full-width card or a cluster of compact cards sharing the row.
+ */
+private data class DashboardRow(val cards: List<CardConfig>)
 
 /**
- * One emitted dashboard row. Either a single full-width card or a
- * cluster of compact cards that have been deemed "shareable".
+ * Group consecutive cards by [CardWidthClass], then chunk Compact
+ * groups into rows of [perRow]. Authored order is preserved — a Full
+ * card between two Compact runs splits them into two clusters.
  */
-private data class DashboardRow(val key: String, val cards: List<CardConfig>)
-
-/**
- * Group consecutive cards by [CardWidthClass]. The dashboard's authored
- * order is preserved — a Full card between two Compact runs splits
- * them into two clusters, never reorders.
- */
-private fun packRows(
+private fun packAndChunk(
     cards: List<CardConfig>,
-    snapshot: HaSnapshot,
-    widthClassOf: (CardConfig) -> CardWidthClass,
-): List<List<CardConfig>> {
-    val groups = mutableListOf<List<CardConfig>>()
-    val pending = mutableListOf<CardConfig>()
-    var pendingClass: CardWidthClass? = null
-    for (card in cards) {
-        val cls = widthClassOf(card)
-        if (cls == CardWidthClass.Full) {
-            if (pending.isNotEmpty()) {
-                groups += pending.toList(); pending.clear(); pendingClass = null
-            }
-            groups += listOf(card)
-        } else {
-            if (pendingClass != null && pendingClass != cls) {
-                groups += pending.toList(); pending.clear()
-            }
-            pending += card
-            pendingClass = cls
-        }
-    }
-    if (pending.isNotEmpty()) groups += pending.toList()
-    return groups
-}
-
-/**
- * Chunk Compact groups into rows of [perRow] siblings while keeping
- * Full groups as standalone single-card rows. Stable keys are
- * synthesised from the position so LazyColumn can recycle correctly
- * across recompositions.
- */
-private fun chunkCompactGroups(
-    groups: List<List<CardConfig>>,
     perRow: Int,
-): List<DashboardRow> {
-    var index = 0
-    return buildList {
-        groups.forEach { group ->
-            if (group.size <= 1) {
-                add(DashboardRow(key = "row-${index++}", cards = group))
-            } else {
-                group.chunked(perRow).forEach { chunk ->
-                    add(DashboardRow(key = "row-${index++}", cards = chunk))
-                }
-            }
+    widthClassOf: (CardConfig) -> CardWidthClass,
+): List<DashboardRow> = buildList {
+    val pending = mutableListOf<CardConfig>()
+    fun flushPending() {
+        if (pending.isEmpty()) return
+        pending.chunked(perRow).forEach { add(DashboardRow(it.toList())) }
+        pending.clear()
+    }
+    for (card in cards) {
+        if (widthClassOf(card) == CardWidthClass.Full) {
+            flushPending()
+            add(DashboardRow(listOf(card)))
+        } else {
+            pending += card
         }
     }
+    flushPending()
 }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/ui/WindowSize.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/ui/WindowSize.kt
@@ -45,15 +45,23 @@ enum class WindowSize {
  * @property maxContentWidth caps the dashboard column on very wide
  *   screens so a 1280-dp tablet doesn't render a 1280-dp-wide
  *   `entities` list — beyond ~720 dp the list becomes unscannable.
- *   `Dp.Unspecified` means "no cap".
+ *   `Dp.Unspecified` means "no cap". Only applied when the dashboard
+ *   has no sections (legacy `view.cards`); section columns enforce
+ *   their own width via [maxSectionColumns].
  * @property horizontalGutter outer padding either side of the dashboard
  *   column. Bigger on tablets purely for breathing room.
+ * @property maxSectionColumns ceiling on how many HA sections render
+ *   side-by-side in wide mode. The actual column count is
+ *   `min(maxSectionColumns, sectionCount)`. `1` means "always
+ *   single-column" — sections still render with their titles, just
+ *   stacked vertically.
  */
 data class LayoutConfig(
     val windowSize: WindowSize,
     val compactCardsPerRow: Int,
     val maxContentWidth: Dp,
     val horizontalGutter: Dp,
+    val maxSectionColumns: Int,
 )
 
 private val ExpandedMaxWidth = 840.dp
@@ -68,18 +76,32 @@ fun rememberLayoutConfig(): LayoutConfig {
             compactCardsPerRow = 2,
             maxContentWidth = Dp.Unspecified,
             horizontalGutter = 12.dp,
+            maxSectionColumns = 1,
         )
         WindowSize.Medium -> LayoutConfig(
             windowSize = WindowSize.Medium,
             compactCardsPerRow = 3,
             maxContentWidth = Dp.Unspecified,
             horizontalGutter = 16.dp,
+            // Medium is 600..839 dp — splitting 3 sections across that
+            // would give ~260 dp / col which is below the ~320 dp
+            // floor most HA cards read well at. Keep single-column;
+            // section titles still preserve structure.
+            maxSectionColumns = 1,
         )
         WindowSize.Expanded -> LayoutConfig(
             windowSize = WindowSize.Expanded,
             compactCardsPerRow = 4,
+            // No per-content cap when sections drive the layout — the
+            // section grid handles width. The cap kicks in for legacy
+            // sectionless dashboards via `widthIn(max = …)`.
             maxContentWidth = ExpandedMaxWidth,
             horizontalGutter = 24.dp,
+            // 2 columns at 840 dp (≈400 dp / col), 3 columns at
+            // 1280 dp (≈400 dp / col). Beyond 3 the diminishing
+            // returns aren't worth the eyeline-skip cost; the
+            // renderer caps further with `min(this, sectionCount)`.
+            maxSectionColumns = if (widthDp >= 1200) 3 else 2,
         )
     }
 }


### PR DESCRIPTION
## Summary

> Stacked on top of #7 — base will auto-retarget to `main` once #7 merges.

`flattenCards()` concatenated every view + section into one stream, throwing away the grouping signals HA exposes. This PR replaces it with a structured `DashboardLayout` projection and a renderer that respects it per width class:

### Wide mode (Expanded width, ≥2 sections)
Sections render side-by-side as columns, mirroring HA's modern dashboard. Up to **2 columns at 840 dp**, **3 columns at 1200 dp+**. Section titles head each column. Cards inside a section column stack at full column width — at this width, the section is the layout unit, so no compact-card packing inside (a 400-dp section column shows a tile at full width without eyeline pain).

### Single-column mode (Compact / Medium, or sectionless dashboards)
Sections stack vertically with their titles preserved as inline headings. Inside each section, the existing `CardWidthClass` row-packing still kicks in — consecutive Compact tiles (tile / button / entity) pair into 2-up / 3-up rows so a four-button cluster doesn't take four screen heights on a phone.

### What's preserved
- **View order & boundaries** (view titles aren't rendered yet — most dashboards have one view, and HA's tab construct deserves real tabs, not stacking).
- **Section titles** as `titleMedium` headings.
- **Orphan `view.cards`** (legacy, pre-sections layout) render as a single column above any sections in the same view, with the same compact-pack rules.
- **Authored card order** within sections.

### Internal changes
- New `DashboardLayout` / `ViewLayout` / `SectionLayout` data classes + `buildDashboardLayout(dashboard)` projector.
- `LayoutConfig` grows `maxSectionColumns` (1 / 1 / 2-or-3 by width). Actual count is `min(maxSectionColumns, sectionCount)`, so a single-section dashboard always renders single-column.
- The 840-dp content cap now only applies to legacy sectionless dashboards; section grids drive their own width via `weight(1f)` on each section column.

## Test plan

- [x] `:app` `compileDebugKotlin` clean
- [x] `:app:testDebugUnitTest` passes
- [x] `:app:assembleDebug` succeeds
- [ ] Manual: phone portrait against a sectioned dashboard — section titles render, cards stack under them, compact clusters pair 2-up
- [ ] Manual: tablet landscape (≥1200 dp) against same dashboard — sections render 3-up side-by-side, titles head each column
- [ ] Manual: foldable open in landscape (840-1199 dp range) — sections render 2-up
- [ ] Manual: legacy dashboard (only `view.cards`, no sections) on tablet — single centred column at 840-dp cap, same as before
- [ ] Manual: empty section title — heading is skipped, cards render directly


---
_Generated by [Claude Code](https://claude.ai/code/session_014V2uC26jjmE52NDndsoSgo)_