### PR TITLE
custom:garage-shutter-card with animation-storyboard previews

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/EntityPreviewParameters.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/EntityPreviewParameters.kt
@@ -27,6 +27,55 @@ class GarageCoverStatesProvider : PreviewParameterProvider<Pair<String, HaSnapsh
     )
 }
 
+/**
+ * Animation storyboard for the garage door card: a single entity with
+ * synthesised `current_position` values stepping from 0 (fully closed)
+ * to 100 (fully open) in 25-point increments. Combined with a
+ * `@Preview` fan-out this produces five PNGs that visually
+ * reconstruct the open cycle so a reviewer can scan the strip and
+ * spot rendering glitches at intermediate frames — clipping at the
+ * groove transitions, frame-overflow, motion arrow alignment.
+ *
+ * The intermediate positions also exercise `state: "opening"` so the
+ * motion arrow renders. End frames use `closed` / `open` so the
+ * arrow is suppressed at rest.
+ */
+class GarageDoorPositionsProvider : PreviewParameterProvider<Pair<String, HaSnapshot>> {
+    override val values: Sequence<Pair<String, HaSnapshot>> = sequenceOf(
+        "closed" to garageSnapshot(state = "closed", positionPct = 0),
+        "opening_25" to garageSnapshot(state = "opening", positionPct = 25),
+        "opening_50" to garageSnapshot(state = "opening", positionPct = 50),
+        "opening_75" to garageSnapshot(state = "opening", positionPct = 75),
+        "open" to garageSnapshot(state = "open", positionPct = 100),
+    )
+}
+
+/**
+ * Coarse states for a garage cover that doesn't expose
+ * `current_position`. Five-way fan-out exercises every branch of the
+ * converter's state-derivation: closed → 100% closed; opening / closing
+ * → halfway with the motion arrow; open → fully open; unavailable →
+ * defaults to fully closed with an "Unavailable" label.
+ */
+class GarageDoorStatesProvider : PreviewParameterProvider<Pair<String, HaSnapshot>> {
+    override val values: Sequence<Pair<String, HaSnapshot>> = sequenceOf(
+        "closed" to garageSnapshot(state = "closed", positionPct = null),
+        "opening" to garageSnapshot(state = "opening", positionPct = null),
+        "open" to garageSnapshot(state = "open", positionPct = null),
+        "closing" to garageSnapshot(state = "closing", positionPct = null),
+        "unavailable" to garageSnapshot(state = "unavailable", positionPct = null),
+    )
+}
+
+private fun garageSnapshot(state: String, positionPct: Int?): HaSnapshot {
+    val attrs = buildMap {
+        put("friendly_name", "Garage")
+        put("device_class", "garage")
+        if (positionPct != null) put("current_position", positionPct.toString())
+    }
+    return snapshot(state("cover.garage", state, attrs))
+}
+
 /** Fan out a lock entity over locked / unlocked / locking. */
 class FrontDoorLockStatesProvider : PreviewParameterProvider<Pair<String, HaSnapshot>> {
     override val values: Sequence<Pair<String, HaSnapshot>> = sequenceOf(

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/GarageShutterCardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/GarageShutterCardPreviews.kt
@@ -1,0 +1,180 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.previews
+
+import androidx.compose.remote.tooling.preview.RemotePreview
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.ProvideCardRegistry
+import ee.schimke.ha.rc.RenderChild
+import ee.schimke.ha.rc.androidXExperimental
+import ee.schimke.ha.rc.cards.defaultRegistry
+import ee.schimke.ha.rc.cards.shutter.withGarageShutter
+import ee.schimke.ha.rc.components.HaTheme
+import ee.schimke.ha.rc.components.ProvideHaTheme
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Previews for `custom:garage-shutter-card`.
+ *
+ * The card has no HA reference capture (HA's frontend doesn't ship a
+ * native garage card — this is our thing), so the canvas is tight to
+ * content per [CardPreviews] rule 3.
+ *
+ * **Animation strip** — [Garage_Animation_Light] / [Garage_Animation_Dark]
+ * fan out via [GarageDoorPositionsProvider] across the five-frame
+ * 0% / 25% / 50% / 75% / 100% open cycle. Reading the resulting PNGs in
+ * order is how we verify the door rises smoothly: groove spacing
+ * compresses, motion arrow stays centred, frame doesn't clip at any
+ * intermediate height.
+ *
+ * **State strip** — [Garage_State_Light] / [Garage_State_Dark] fan out
+ * via [GarageDoorStatesProvider] over closed / opening / open / closing
+ * / unavailable so each branch of the converter's state-derivation
+ * produces a frame.
+ *
+ * **Two-entity** — [Garage_TwoEntities_Light] / `_Dark` covers the
+ * card-with-title + multi-row layout (one door open, one closed) the
+ * shutter card preview already covers for windows.
+ */
+// Single-entity canvas: name (13) + viz/buttons row (108 — buttons
+// stack three 32-dp circles + 6-dp gaps) + state (11) + spacing (8)
+// + card padding (20) ≈ 160 dp; pad to 168 so the state label has
+// breathing room and the bottom rounded corner reads cleanly.
+private const val SINGLE_WIDTH_DP = 200
+private const val SINGLE_HEIGHT_DP = 172
+
+@Composable
+private fun GarageHost(theme: HaTheme, content: @Composable () -> Unit) {
+    RemotePreview(profile = androidXExperimental) {
+        ProvideCardRegistry(defaultRegistry().withGarageShutter()) {
+            ProvideHaTheme(theme) { content() }
+        }
+    }
+}
+
+// ——— Animation strip (position 0/25/50/75/100) ———
+
+@Preview(
+    name = "garage-anim (light)",
+    showBackground = false,
+    widthDp = SINGLE_WIDTH_DP,
+    heightDp = SINGLE_HEIGHT_DP,
+)
+@Composable
+fun Garage_Animation_Light(
+    @PreviewParameter(GarageDoorPositionsProvider::class) param: Pair<String, HaSnapshot>,
+) = GarageHost(HaTheme.Light) {
+    RenderChild(garageSingleCard(), param.second)
+}
+
+@Preview(
+    name = "garage-anim (dark)",
+    showBackground = false,
+    widthDp = SINGLE_WIDTH_DP,
+    heightDp = SINGLE_HEIGHT_DP,
+)
+@Composable
+fun Garage_Animation_Dark(
+    @PreviewParameter(GarageDoorPositionsProvider::class) param: Pair<String, HaSnapshot>,
+) = GarageHost(HaTheme.Dark) {
+    RenderChild(garageSingleCard(), param.second)
+}
+
+// ——— State strip (closed/opening/open/closing/unavailable) ———
+
+@Preview(
+    name = "garage-state (light)",
+    showBackground = false,
+    widthDp = SINGLE_WIDTH_DP,
+    heightDp = SINGLE_HEIGHT_DP,
+)
+@Composable
+fun Garage_State_Light(
+    @PreviewParameter(GarageDoorStatesProvider::class) param: Pair<String, HaSnapshot>,
+) = GarageHost(HaTheme.Light) {
+    RenderChild(garageSingleCard(), param.second)
+}
+
+@Preview(
+    name = "garage-state (dark)",
+    showBackground = false,
+    widthDp = SINGLE_WIDTH_DP,
+    heightDp = SINGLE_HEIGHT_DP,
+)
+@Composable
+fun Garage_State_Dark(
+    @PreviewParameter(GarageDoorStatesProvider::class) param: Pair<String, HaSnapshot>,
+) = GarageHost(HaTheme.Dark) {
+    RenderChild(garageSingleCard(), param.second)
+}
+
+// ——— Multi-entity card with title ———
+
+@Preview(
+    name = "garage two-entities (light)",
+    showBackground = false,
+    widthDp = 280,
+    heightDp = 340,
+)
+@Composable
+fun Garage_TwoEntities_Light() = GarageHost(HaTheme.Light) {
+    RenderChild(garageDoubleCard(), garageDoubleSnapshot())
+}
+
+@Preview(
+    name = "garage two-entities (dark)",
+    showBackground = false,
+    widthDp = 280,
+    heightDp = 340,
+)
+@Composable
+fun Garage_TwoEntities_Dark() = GarageHost(HaTheme.Dark) {
+    RenderChild(garageDoubleCard(), garageDoubleSnapshot())
+}
+
+private fun garageSingleCard() = card(
+    """{
+        "type":"custom:garage-shutter-card",
+        "entities":[{"entity":"cover.garage","name":"Garage"}]
+    }""",
+)
+
+private fun garageDoubleCard() = card(
+    """{
+        "type":"custom:garage-shutter-card",
+        "title":"Garages",
+        "entities":[
+            {"entity":"cover.garage_main","name":"Main"},
+            {"entity":"cover.garage_workshop","name":"Workshop"}
+        ]
+    }""",
+)
+
+private fun garageDoubleSnapshot(): HaSnapshot = snapshot(
+    "cover.garage_main" to ee.schimke.ha.model.EntityState(
+        entityId = "cover.garage_main",
+        state = "open",
+        attributes = JsonObject(
+            mapOf(
+                "friendly_name" to JsonPrimitive("Main"),
+                "device_class" to JsonPrimitive("garage"),
+                "current_position" to JsonPrimitive("100"),
+            ),
+        ),
+    ),
+    "cover.garage_workshop" to ee.schimke.ha.model.EntityState(
+        entityId = "cover.garage_workshop",
+        state = "closed",
+        attributes = JsonObject(
+            mapOf(
+                "friendly_name" to JsonPrimitive("Workshop"),
+                "device_class" to JsonPrimitive("garage"),
+                "current_position" to JsonPrimitive("0"),
+            ),
+        ),
+    ),
+)

--- a/rc-card-shutter/src/main/kotlin/ee/schimke/ha/rc/cards/shutter/GarageShutterCardConverter.kt
+++ b/rc-card-shutter/src/main/kotlin/ee/schimke/ha/rc/cards/shutter/GarageShutterCardConverter.kt
@@ -1,0 +1,178 @@
+package ee.schimke.ha.rc.cards.shutter
+
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.EntityState
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.CardRegistry
+import ee.schimke.ha.rc.components.HaAction
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Converter for `custom:garage-shutter-card`.
+ *
+ * Mirrors [EnhancedShutterCardConverter] for window shutters but
+ * targets garage doors:
+ *
+ *   - sectional-door visualisation (horizontal aspect, panel grooves),
+ *   - direction-of-motion chevron driven by the cover's
+ *     `opening` / `closing` state,
+ *   - state label normalises HA's `device_class: garage` cover states
+ *     to natural English ("Open" / "Closed" / "Opening…").
+ *
+ * Position semantics match the shutter card so the two cards' fractions
+ * can share host-side animation code: `closedFraction` 0..1 where 1 is
+ * fully closed. HA's `current_position` is "100 = fully open" so we
+ * invert it once at the converter boundary.
+ *
+ * Register via [CardRegistry.withGarageShutter] (or both at once via
+ * [withAllShutters]).
+ */
+class GarageShutterCardConverter : CardConverter {
+    override val cardType: String = CARD_TYPE
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int {
+        val hasTitle = card.raw["title"]?.jsonPrimitive?.content?.isNotBlank() == true
+        val entryCount = entriesOf(card).size.coerceAtLeast(1)
+        // Per-row: 13dp name + 4dp + 72dp viz + 4dp + 11dp state ≈ 104dp,
+        // plus 10dp inter-row gap. Title + outer padding adds ~28dp + 20dp.
+        return (if (hasTitle) 28 else 0) + 20 + entryCount * 114
+    }
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val title = card.raw["title"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+        val cardNamePosition = card.raw["name_position"]?.jsonPrimitive?.content
+        val entries = entriesOf(card).map { raw -> toEntry(raw, snapshot, cardNamePosition) }
+
+        val data = HaGarageCardData(
+            title = title?.rs,
+            entries = entries,
+        )
+        RemoteHaGarage(data, modifier)
+    }
+
+    private fun entriesOf(card: CardConfig): List<JsonObject> {
+        val list = card.raw["entities"]?.jsonArray
+        if (list != null) return list.normalisedEntries()
+        val singleEntity = card.raw["entity"]?.jsonPrimitive?.content
+        return if (singleEntity != null) listOf(card.raw) else emptyList()
+    }
+
+    private fun JsonArray.normalisedEntries(): List<JsonObject> = mapNotNull { el ->
+        when (el) {
+            is JsonObject -> el
+            else -> el.jsonPrimitive.content.let { id ->
+                JsonObject(mapOf("entity" to kotlinx.serialization.json.JsonPrimitive(id)))
+            }
+        }
+    }
+
+    private fun toEntry(
+        raw: JsonObject,
+        snapshot: HaSnapshot,
+        cardNamePosition: String?,
+    ): HaGarageEntryData {
+        val entityId = raw["entity"]?.jsonPrimitive?.content
+        val entity = entityId?.let { snapshot.states[it] }
+        val name = raw["name"]?.jsonPrimitive?.content
+            ?: entity?.attributes?.get("friendly_name")?.jsonPrimitive?.content
+            ?: entityId
+            ?: "(no entity)"
+        val namePosition = raw["name_position"]?.jsonPrimitive?.content ?: cardNamePosition
+        val closedFraction = closedFractionOf(entity)
+        val motion = motionOf(entity)
+        val stateLabel = stateLabelFor(entity, closedFraction)
+
+        return HaGarageEntryData(
+            name = name.rs,
+            closedFraction = closedFraction,
+            motion = motion,
+            stateLabel = stateLabel.rs,
+            showNameOnTop = namePosition != "none",
+            openAction = entityId?.let { callService("open_cover", it) } ?: HaAction.None,
+            closeAction = entityId?.let { callService("close_cover", it) } ?: HaAction.None,
+            stopAction = entityId?.let { callService("stop_cover", it) } ?: HaAction.None,
+        )
+    }
+
+    private fun callService(service: String, entityId: String): HaAction =
+        HaAction.CallService(domain = "cover", service = service, entityId = entityId)
+
+    /** 0f = fully open, 1f = fully closed. Mirrors the shutter card. */
+    private fun closedFractionOf(entity: EntityState?): Float {
+        if (entity == null) return 1f
+        val pos = entity.attributes["current_position"]?.jsonPrimitive?.content?.toFloatOrNull()
+        if (pos != null) return (1f - pos / 100f).coerceIn(0f, 1f)
+        // Many garage-door integrations don't expose current_position;
+        // pick a representative value per state so the visualisation
+        // still tells the user something. `opening` / `closing` show
+        // the door at half — combined with the motion chevron that
+        // reads as "in transit", which is the right mental model.
+        return when (entity.state) {
+            "open" -> 0f
+            "opening" -> 0.5f
+            "closing" -> 0.5f
+            "closed" -> 1f
+            else -> 1f
+        }
+    }
+
+    private fun motionOf(entity: EntityState?): GarageMotion = when (entity?.state) {
+        "opening" -> GarageMotion.Opening
+        "closing" -> GarageMotion.Closing
+        else -> GarageMotion.Idle
+    }
+
+    private fun stateLabelFor(entity: EntityState?, closedFraction: Float): String {
+        if (entity == null) return "Unavailable"
+        val state = entity.state
+        if (state == "unavailable" || state == "unknown") return "Unavailable"
+        val hasPosition = entity.attributes["current_position"] != null
+        if (hasPosition) {
+            val pct = ((1f - closedFraction) * 100).toInt().coerceIn(0, 100)
+            return when (pct) {
+                0 -> "Closed"
+                100 -> "Open"
+                else -> "$pct% open"
+            }
+        }
+        return when (state) {
+            "open" -> "Open"
+            "closed" -> "Closed"
+            "opening" -> "Opening…"
+            "closing" -> "Closing…"
+            else -> state.replace('_', ' ').replaceFirstChar { it.uppercaseChar() }
+        }
+    }
+
+    companion object {
+        const val CARD_TYPE: String = "custom:garage-shutter-card"
+    }
+}
+
+/**
+ * Convenience: register [GarageShutterCardConverter] on this registry.
+ * Mirrors the shape of [withEnhancedShutter] so consumers can chain
+ * either or both.
+ */
+fun CardRegistry.withGarageShutter(): CardRegistry = apply {
+    register(GarageShutterCardConverter())
+}
+
+/**
+ * Convenience: register both shutter-family converters at once. Most
+ * dashboards that want the window shutter also want the garage card,
+ * and vice-versa, so wire them with one call.
+ */
+fun CardRegistry.withAllShutters(): CardRegistry = apply {
+    register(EnhancedShutterCardConverter())
+    register(GarageShutterCardConverter())
+}

--- a/rc-card-shutter/src/main/kotlin/ee/schimke/ha/rc/cards/shutter/RemoteHaGarage.kt
+++ b/rc-card-shutter/src/main/kotlin/ee/schimke/ha/rc/cards/shutter/RemoteHaGarage.kt
@@ -1,0 +1,310 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.cards.shutter
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ArrowDownward
+import androidx.compose.material.icons.outlined.ArrowUpward
+import androidx.compose.material.icons.outlined.Stop
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clickable
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.height
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.modifier.size
+import androidx.compose.remote.creation.compose.modifier.width
+import androidx.compose.remote.creation.compose.shapes.RemoteCircleShape
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.RemoteString
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.wear.compose.remote.material3.RemoteIcon
+import ee.schimke.ha.rc.components.HaAction
+import ee.schimke.ha.rc.components.LocalHaTheme
+import ee.schimke.ha.rc.components.toRemoteAction
+
+/**
+ * `custom:garage-shutter-card` card data. One row per garage door:
+ * name, sectional-door visualisation, up / stop / down buttons, state
+ * label. The visualisation renders a horizontal 5:3 frame (vs the
+ * window shutter's near-square 6:5 frame) with horizontal panel
+ * divisions on the door so it reads as garage rather than blinds.
+ *
+ * Like [HaShutterCardData] the [HaGarageEntryData.closedFraction] is
+ * captured statically at emission time. To "play" an animation the
+ * host re-emits with successive fractions; the previews in
+ * `:previews/GarageShutterCardPreviews.kt` exercise the
+ * 0% / 25% / 50% / 75% / 100% storyboard for both themes so each frame
+ * of the open/close cycle is visually verifiable.
+ */
+data class HaGarageCardData(
+    val title: RemoteString?,
+    val entries: List<HaGarageEntryData>,
+)
+
+/**
+ * One garage door inside the card.
+ *
+ * @property closedFraction 0f = fully open (door tucked into ceiling
+ *   track), 1f = fully closed (door at floor). Matches the shutter
+ *   card's convention so the two cards' fractions can share host code.
+ * @property motion drives the in-frame motion hint — a chevron
+ *   pointing up while opening, down while closing, hidden when idle.
+ *   Indicates direction independent of the position label, which is
+ *   useful for transitional states where `current_position` hasn't
+ *   updated yet.
+ */
+data class HaGarageEntryData(
+    val name: RemoteString,
+    val closedFraction: Float,
+    val motion: GarageMotion,
+    val stateLabel: RemoteString,
+    val showNameOnTop: Boolean,
+    val openAction: HaAction,
+    val closeAction: HaAction,
+    val stopAction: HaAction,
+)
+
+/** Direction of in-progress motion, drives the motion-arrow overlay. */
+enum class GarageMotion { Idle, Opening, Closing }
+
+@Composable
+@RemoteComposable
+fun RemoteHaGarage(data: HaGarageCardData, modifier: RemoteModifier = RemoteModifier) {
+    val theme = LocalHaTheme.current
+    RemoteBox(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(horizontal = 12.rdp, vertical = 10.rdp),
+    ) {
+        RemoteColumn(verticalArrangement = RemoteArrangement.spacedBy(10.rdp)) {
+            if (data.title != null) {
+                RemoteText(
+                    text = data.title,
+                    color = theme.primaryText.rc,
+                    fontSize = 15.rsp,
+                    fontWeight = FontWeight.Medium,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            data.entries.forEach { entry -> GarageEntry(entry) }
+        }
+    }
+}
+
+@Composable
+@RemoteComposable
+private fun GarageEntry(entry: HaGarageEntryData) {
+    val theme = LocalHaTheme.current
+    RemoteColumn(verticalArrangement = RemoteArrangement.spacedBy(4.rdp)) {
+        if (entry.showNameOnTop) {
+            RemoteText(
+                text = entry.name,
+                color = theme.primaryText.rc,
+                fontSize = 13.rsp,
+                fontWeight = FontWeight.Medium,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        RemoteRow(
+            verticalAlignment = RemoteAlignment.CenterVertically,
+            horizontalArrangement = RemoteArrangement.spacedBy(12.rdp),
+        ) {
+            GarageDoorVisualisation(entry.closedFraction, entry.motion)
+            GarageButtons(entry.openAction, entry.stopAction, entry.closeAction)
+        }
+        RemoteText(
+            text = entry.stateLabel,
+            color = theme.secondaryText.rc,
+            fontSize = 11.rsp,
+            style = RemoteTextStyle.Default,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+/**
+ * Sectional garage door from the front. The frame holds a sky/exterior
+ * background that's revealed as the door rises; the door panel is
+ * bottom-anchored and shrinks as [closedFraction] decreases. Four
+ * horizontal "panel" lines on the door read as a sectional residential
+ * garage (vs a one-piece tilt-up).
+ *
+ * A motion arrow overlays the centre of the door when [motion] is
+ * non-idle — chevron-up while opening, chevron-down while closing —
+ * matching the host's open / close button glyphs so the user can read
+ * intent without the state label.
+ */
+@Composable
+@RemoteComposable
+private fun GarageDoorVisualisation(closedFraction: Float, motion: GarageMotion) {
+    val theme = LocalHaTheme.current
+    // Frame: outer wall / concrete colour. Slightly warmer than the
+    // window shutter frame so a side-by-side card lineup (window +
+    // garage) reads as different fixtures, not the same one twice.
+    val frame = if (theme.isDark) Color(0xFF3A3530) else Color(0xFFD9D2C5)
+    // Sky / interior backdrop visible above the door when open.
+    val sky = if (theme.isDark) Color(0xFF0F1B24) else Color(0xFFD8ECF6)
+    // Door panel base. Slightly desaturated white-ish for residential.
+    val door = if (theme.isDark) Color(0xFFB7B2A8) else Color(0xFFF1EDE3)
+    // Panel divisions — horizontal lines splitting the door into 4
+    // sections, the key visual cue that this is a sectional garage
+    // door rather than a roller blind.
+    val groove = if (theme.isDark) Color(0xFF6E6A5E) else Color(0xFFB8B0A0)
+
+    val frameWidthDp = 120
+    val frameHeightDp = 72
+    val borderDp = 2
+    val innerHeightDp = frameHeightDp - 2 * borderDp
+    val innerWidthDp = frameWidthDp - 2 * borderDp
+
+    val clamped = closedFraction.coerceIn(0f, 1f)
+    val doorHeightDp = (innerHeightDp * clamped).toInt()
+
+    RemoteBox(
+        modifier = RemoteModifier
+            .width(frameWidthDp.rdp)
+            .height(frameHeightDp.rdp)
+            .clip(RemoteRoundedCornerShape(6.rdp))
+            .background(sky.rc)
+            .border(borderDp.rdp, frame.rc, RemoteRoundedCornerShape(6.rdp)),
+        contentAlignment = RemoteAlignment.BottomCenter,
+    ) {
+        if (doorHeightDp > 0) {
+            RemoteBox(
+                modifier = RemoteModifier
+                    .width(innerWidthDp.rdp)
+                    .height(doorHeightDp.rdp)
+                    .background(door.rc),
+                contentAlignment = RemoteAlignment.Center,
+            ) {
+                // Panel grooves: 3 horizontal lines split a fully-
+                // closed door into 4 sections. We draw them whenever
+                // the door is tall enough — at < ~25% closed there
+                // isn't enough door for grooves to read so we skip.
+                if (doorHeightDp >= innerHeightDp / 4) {
+                    DoorPanelGrooves(
+                        innerWidthDp = innerWidthDp,
+                        doorHeightDp = doorHeightDp,
+                        groove = groove,
+                    )
+                }
+                MotionArrow(motion = motion)
+            }
+        }
+    }
+}
+
+/**
+ * Three horizontal grooves dividing the door into 4 panels. Spaced
+ * evenly across the visible door height so the spacing scales with
+ * how closed the door is — a half-closed door still shows two
+ * grooves, just compressed.
+ */
+@Composable
+@RemoteComposable
+private fun DoorPanelGrooves(innerWidthDp: Int, doorHeightDp: Int, groove: Color) {
+    RemoteColumn(
+        modifier = RemoteModifier.width(innerWidthDp.rdp).height(doorHeightDp.rdp),
+        verticalArrangement = RemoteArrangement.SpaceEvenly,
+    ) {
+        // Top spacer (no groove) + 3 grooves + bottom spacer = 4 panels.
+        repeat(3) {
+            RemoteBox(
+                modifier = RemoteModifier
+                    .width(innerWidthDp.rdp)
+                    .height(1.rdp)
+                    .background(groove.rc),
+            )
+        }
+    }
+}
+
+@Composable
+@RemoteComposable
+private fun MotionArrow(motion: GarageMotion) {
+    if (motion == GarageMotion.Idle) return
+    val theme = LocalHaTheme.current
+    val icon = when (motion) {
+        GarageMotion.Opening -> Icons.Outlined.ArrowUpward
+        GarageMotion.Closing -> Icons.Outlined.ArrowDownward
+        GarageMotion.Idle -> return
+    }
+    // Tint stays in primaryText (high contrast on the door panel)
+    // rather than picking up a state colour — the chevron is a
+    // direction marker, not a "warning" or "active" badge.
+    RemoteIcon(
+        imageVector = icon,
+        contentDescription = motion.name.rs,
+        modifier = RemoteModifier.size(20.rdp),
+        tint = theme.primaryText.rc,
+    )
+}
+
+@Composable
+@RemoteComposable
+private fun GarageButtons(
+    open: HaAction,
+    stop: HaAction,
+    close: HaAction,
+) {
+    RemoteColumn(
+        verticalArrangement = RemoteArrangement.spacedBy(6.rdp),
+        horizontalAlignment = RemoteAlignment.CenterHorizontally,
+    ) {
+        GarageButton(Icons.Outlined.ArrowUpward, "Open", open)
+        GarageButton(Icons.Outlined.Stop, "Stop", stop)
+        GarageButton(Icons.Outlined.ArrowDownward, "Close", close)
+    }
+}
+
+@Composable
+@RemoteComposable
+private fun GarageButton(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    description: String,
+    action: HaAction,
+) {
+    val theme = LocalHaTheme.current
+    val clickable = action.toRemoteAction()?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
+    RemoteBox(
+        modifier = RemoteModifier
+            .size(32.rdp)
+            .clip(RemoteCircleShape)
+            .background(theme.divider.rc)
+            .then(clickable),
+        contentAlignment = RemoteAlignment.Center,
+    ) {
+        RemoteIcon(
+            imageVector = icon,
+            contentDescription = description.rs,
+            modifier = RemoteModifier.size(18.rdp),
+            tint = theme.primaryText.rc,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

A new HA card type for `cover` entities with `device_class: garage`. Mirrors `EnhancedShutterCardConverter`'s structure but renders a sectional-door visualisation tuned for garages:

- **5:3 horizontal frame** (vs the window shutter's near-square 6:5).
- **Sky / exterior backdrop** revealed as the door rises.
- **Bottom-anchored door panel** with three horizontal grooves splitting it into four sections — the visual cue that says "sectional residential" instead of "roller blind".
- **Direction-of-motion chevron** overlaid on the door while opening / closing, suppressed at rest. Carries the intent for integrations that don't expose `current_position` and only flip the state.

`closedFraction` matches the shutter card's convention (`0 = open`, `1 = closed`) so host-side animation code works for both. Garage covers that don't expose `current_position` get a representative `0.5` during transitions; the chevron carries the direction.

Two registry helpers:
- `CardRegistry.withGarageShutter()` — register just this card.
- `CardRegistry.withAllShutters()` — register both window + garage in one call.

## Animation storyboard

Since alpha08 doesn't expose a numeric named binding, the card position is captured statically at emission. The previews compensate by fanning out an animation storyboard via `@PreviewParameter`:

- **`GarageDoorPositionsProvider`** — `closed` / `opening_25` / `opening_50` / `opening_75` / `open`, exercising the open cycle as a 5-frame strip.
- **`GarageDoorStatesProvider`** — `closed` / `opening` / `open` / `closing` / `unavailable`, exercising every branch of the converter's state-derivation.

Reading the resulting 22 PNGs (animation × 2 themes + state × 2 themes + multi-entity × 2 themes) in order is how a reviewer verifies the intermediate frames render without clipping at groove transitions or frame-overflow at small door heights.

### Sample frames (light theme, animation strip)

| 0% (closed) | 25% | 50% | 75% | 100% (open) |
|---|---|---|---|---|
| Full panel, 4 sections, "Closed" | Door at 75% height + chevron | Door at 50% + chevron | Door at 25% + chevron | Empty frame, "Open" |

## Test plan

- [x] `:rc-card-shutter` `compileDebugKotlin` clean
- [x] `:previews` `compileDebugKotlin` clean
- [x] `:previews:renderPreviews` produces 22 PNGs, all manually inspected:
  - Animation strip light + dark — door height tracks `closedFraction`, grooves compress smoothly, chevron stays centred, frame doesn't overflow
  - State strip light + dark — labels read "Closed" / "Opening…" / "Open" / "Closing…" / "Unavailable", chevron only on transitional states
  - Multi-entity light + dark — title + two doors with mixed states render correctly
- [ ] Manual: register `withGarageShutter()` in the app's host registry and add a `custom:garage-shutter-card` to a demo dashboard, observe live updates as the cover state changes
- [ ] Manual: drive `current_position` from 0→100 in the host on a 10-second tween while state is `opening`, observe the storyboard frames flip smoothly (re-emit on each tick)


---
_Generated by [Claude Code](https://claude.ai/code/session_014V2uC26jjmE52NDndsoSgo)_