### PR TITLE
addon-server: HA add-on serving RemoteCompose dashboards

### DIFF
--- a/addon-server/INSTALL.md
+++ b/addon-server/INSTALL.md
@@ -1,0 +1,304 @@
+# `addon-server` — installation, testing, connectivity
+
+How to develop on the add-on, how to verify changes, and how the wires
+actually go between the add-on, Home Assistant, and your clients.
+
+For the design rationale see [`PLAN.md`](PLAN.md). For a quick orientation
+see [`README.md`](README.md).
+
+> Assumes the PR has landed and you're on `main`.
+
+---
+
+## 1. Local development
+
+### Prereqs
+
+| Tool | Version | Why |
+|---|---|---|
+| JDK 17 | exact | Kotlin toolchain target — every JVM module is compiled to bytecode 17 |
+| JDK 21 | exact | Gradle daemon. The Metro KSP plugin (used by `:app` and friends) needs runtime 21+ |
+| `./gradlew` | shipped | Pins Gradle 9.3.x |
+| Docker + Compose v2 | recent | Add-on packaging + e2e test |
+| `jq`, `curl` | any | Smoke checks |
+
+Install both JDKs, then either set `JAVA_HOME` to JDK 21 (daemon) and pass
+`-Dorg.gradle.java.installations.paths=…/jdk-17,…/jdk-21` once, or use the
+`.github/actions/setup` recipe locally — it sets `JAVA_HOME_17_X64` and
+`JAVA_HOME_21_X64` so Gradle's auto-detection finds both.
+
+If you only have JDK 21 installed, the build fails at:
+
+```
+Cannot find a Java installation … matching: {languageVersion=17, …}.
+Toolchain download repositories have not been configured.
+```
+
+The repo doesn't include a foojay toolchain resolver on purpose — CI
+pre-installs both JDKs and we'd rather not auto-download a toolchain
+during a developer build.
+
+### Build
+
+```sh
+./gradlew :addon-server:installDist
+```
+
+Produces a runnable distribution at
+`addon-server/build/install/addon-server/`:
+
+```
+addon-server/build/install/addon-server/
+├── bin/addon-server          # POSIX launcher (used by Dockerfile ENTRYPOINT)
+├── bin/addon-server.bat
+└── lib/                      # all dependency jars
+```
+
+### Run against your real Home Assistant
+
+Outside the supervisor we use a long-lived access token (the same one the
+existing `integration/` flow uses).
+
+```sh
+export HA_BASE_URL=http://homeassistant.local:8123
+export HA_TOKEN=<long-lived access token from HA Profile → Security>
+export PORT=8099                      # default; pick another if 8099 is taken
+
+./gradlew :addon-server:run            # iterative, with the Gradle daemon
+# or
+./addon-server/build/install/addon-server/bin/addon-server   # the same thing the docker image runs
+```
+
+You should see:
+
+```
+INFO  ee.schimke.ha.addon.Main - starting addon-server on :8099, ha=http://homeassistant.local:8123
+INFO  ee.schimke.ha.addon.HaSupervisorBridge - HA bridge authenticated
+INFO  ee.schimke.ha.addon.HaSupervisorBridge - hydrated <N> entities
+INFO  io.ktor.server.Application - Responding at http://0.0.0.0:8099
+```
+
+If `/readyz` stays at `503`, check the bridge log line — most likely your
+token is wrong or HA is unreachable from the JVM (firewall / wrong host).
+
+### Iterating
+
+- `./gradlew :addon-server:compileKotlin` is the fastest "did it compile"
+  loop.
+- For interactive runs, `./gradlew :addon-server:run` keeps the Gradle
+  daemon warm; restart-after-edit is ~1 s once the daemon is hot.
+- The `Main.kt` shutdown hook drains the WS bridge cleanly on `Ctrl-C`,
+  so HA doesn't see an abandoned connection between iterations.
+
+### Code layout cheat-sheet
+
+```
+addon-server/src/main/kotlin/ee/schimke/ha/addon/
+├── Main.kt                       # Ktor server + DI
+├── Config.kt                     # env → AddonConfig
+├── bridge/
+│   ├── HaSupervisorBridge.kt     # one persistent WS to HA Core
+│   └── StateCache.kt             # entity_id → EntityState (StateFlow)
+└── routes/
+    ├── HealthRoutes.kt           # /healthz, /readyz
+    ├── DashboardRoutes.kt        # REST /v1/...
+    └── StreamRoute.kt            # WS /v1/stream
+```
+
+The `.rc` byte encoder lives outside this module — see PLAN.md "M3" for
+the rc-converter-jvm port. Today the `.rc` endpoint returns a typed 501.
+
+---
+
+## 2. Testing
+
+There are three test layers, in order of cost.
+
+### a. Compile + unit tests
+
+```sh
+./gradlew :addon-server:test
+```
+
+No external services required. This is the only layer that runs in CI on
+every PR. Use it for any code that doesn't need a real HA on the other end.
+
+### b. Local smoke (no docker)
+
+With `HA_BASE_URL` + `HA_TOKEN` exported as in §1:
+
+```sh
+./gradlew :addon-server:run &
+PID=$!
+sleep 5
+
+curl -s http://localhost:8099/healthz                         # → ok
+curl -s http://localhost:8099/readyz                          # → ready
+curl -s http://localhost:8099/v1/snapshot | jq '.states | length'
+curl -s http://localhost:8099/v1/dashboards | jq
+
+# WS smoke (needs websocat or similar):
+echo '{"id":1,"type":"subscribe","entities":["sun.sun"]}' | \
+  websocat ws://localhost:8099/v1/stream
+
+kill $PID
+```
+
+Good for "did my routing change break anything obvious" — but it doesn't
+exercise the Dockerfile path.
+
+### c. Docker end-to-end
+
+The full thing: Dockerfile build, real HA in a sibling container, all
+public endpoints. Lives at [`test-docker/`](test-docker/).
+
+```sh
+addon-server/test-docker/run.sh
+```
+
+What it asserts:
+
+- `addon/Dockerfile` builds against the current tree
+- `/healthz` = `200 ok`
+- `/readyz` flips to `200` once the bridge has authenticated **and**
+  hydrated the state cache
+- `/v1/snapshot.states` is non-empty
+- `/v1/dashboards` is a JSON array
+- `/v1/cards/*.rc` is the typed `501` placeholder (until M3 lands)
+
+On failure, addon-server logs are dumped to
+`/tmp/ha-rc-addon-test-server.log` before teardown.
+
+Prereq: `integration/.env.local` must have `HA_TOKEN=<…>`. If you've
+already run the reference-capture pipeline once, you have it. If not:
+
+```sh
+cd integration
+docker compose up -d homeassistant
+# → open http://localhost:${HA_HOST_PORT:-8124}, complete onboarding
+# → Profile → Security → create a long-lived access token
+echo "HA_TOKEN=<token>" >> .env.local
+docker compose down
+```
+
+### d. Real-add-on install
+
+Ultimate end-to-end: install into a real HA Supervisor, exercise from a
+real client. See §3.4 below.
+
+---
+
+## 3. Connectivity
+
+Three connections matter. From bottom up:
+
+```
+                      ┌─────────────────────────────────────┐
+                      │  HA Supervisor host                 │
+                      │                                     │
+   client ─── [3]───▶ │   addon-server  ◀──[1]──▶ HA Core   │
+                      │                                     │
+                      └─────────────────────────────────────┘
+                                  ▲
+                                  └──[2]── ingress proxy
+```
+
+### 3.1 [1] add-on → Home Assistant Core
+
+One persistent WebSocket from `HaSupervisorBridge` to HA, used for both
+request/response commands (`lovelace/config`, `get_states`,
+`call_service`) and long-running event subscriptions (`state_changed`,
+`lovelace_updated`).
+
+Two modes, picked at startup by `Config.fromEnv`:
+
+| Mode | When | Base URL | Auth |
+|---|---|---|---|
+| **supervisor** | running as an installed add-on | `http://supervisor/core` (injected) | `SUPERVISOR_TOKEN` env var (injected by the supervisor — needs `homeassistant_api: true` in `addon/config.yaml`, which we have) |
+| **external** | local dev, the docker e2e test, or any side-car deployment | `HA_BASE_URL` env var (e.g. `http://homeassistant.local:8123`) | `HA_TOKEN` env var (long-lived access token) |
+
+Both append the path `/api/websocket` — HA's actual WS handler. The
+supervisor proxy is path-transparent, so `http://supervisor/core/api/websocket`
+hits the same handler as `http://homeassistant.local:8123/api/websocket`.
+
+Reconnect is 1→2→4→8→16→30 s exponential backoff, capped at 30 s. After
+each reconnect the bridge re-runs:
+
+1. auth handshake
+2. `get_states` → repopulates `StateCache`
+3. `subscribe_events` for `state_changed`
+4. `subscribe_events` for `lovelace_updated`
+
+Clients see a brief gap in `/v1/stream` events but their connection isn't
+dropped; the bridge logs `HA bridge disconnected: …` and `HA bridge
+authenticated` on either side of the gap.
+
+### 3.2 [2] HA browser frontend → add-on (ingress)
+
+`addon/config.yaml` declares `ingress: true`, `ingress_port: 8099`. The
+supervisor reverse-proxies HA's browser session at
+`/api/hassio_ingress/<token>/...` straight into our Ktor server. No
+authentication code on our side — the supervisor only forwards requests
+from already-authenticated HA users.
+
+This path is "free": every existing HA web user can hit our REST + WS
+endpoints under their existing login. Nothing else needs to be wired up
+for a panel UI later.
+
+### 3.3 [3] LAN client → add-on (Glance widget, Wear, ESP32, …)
+
+For native clients that aren't going through the HA frontend, the add-on
+also publishes its port on the LAN. `addon/config.yaml` exposes
+`8099/tcp` (default mapping is `null` — the user picks the host port in
+the add-on UI). Clients then talk to `http://<ha-host>:<port>/v1/...`.
+
+This path needs explicit auth. The current prototype trusts whoever
+reaches the port; the production behaviour described in PLAN.md
+"§Auth → External" is `Authorization: Bearer <ha-token>`, validated by
+proxying a `GET /api/` to HA Core with the supplied token. **Not yet
+implemented** — landing it is M4 in the plan.
+
+### 3.4 Installing the add-on into a real HA Supervisor
+
+Once a published image lives at `ghcr.io/yschimke/ha-remotecompose-{arch}`
+(see CI follow-up), users add the repo to their Supervisor and install
+in two clicks:
+
+1. **Settings → Add-ons → Add-on Store → ⋮ → Repositories →**
+   `https://github.com/yschimke/homeassistant-remotecompose`
+2. The store reloads and lists "RemoteCompose Dashboards". Click it,
+   "Install", "Start".
+3. **Logs** tab shows the standard JVM/Ktor startup. After ~3 s you
+   should see the `HA bridge authenticated` line.
+4. Open the in-frontend URL via "Open Web UI" (ingress) — for now this
+   serves only the JSON endpoints; a panel UI lands later.
+
+For local-on-your-own-machine development of the *real* add-on flow
+(supervisor + ingress) without publishing an image:
+
+1. Clone this repo onto the HA host.
+2. Symlink `addon-server/addon/` into your local add-on repo dir
+   (`/addons/remotecompose`), then add a `repository.yaml` next to it.
+3. **Settings → Add-ons → ⋮ → Check for updates** and the supervisor
+   builds the Dockerfile locally.
+
+The Dockerfile is repo-context aware (it copies `gradle/`, `ha-model/`,
+`ha-client/`, `addon-server/` together), so the supervisor needs the
+whole repo on disk, not just `addon-server/addon/`. We can split a
+self-contained add-on subtree later if that becomes painful.
+
+### 3.5 Wire format reference
+
+REST + WS shapes are documented in
+[`PLAN.md` §"Wire protocol"](PLAN.md#wire-protocol). The short version:
+
+- REST: `/v1/dashboards`, `/v1/dashboards/{path}`, `/v1/snapshot`,
+  `/v1/cards/{id}.rc`, `/healthz`, `/readyz`.
+- WS `/v1/stream`: client `subscribe`/`unsubscribe`/`call_service`;
+  server `ready` / `state` (with `LiveBindings`-style names like
+  `light.kitchen.is_on`) / `lovelace_updated` / `error`.
+
+The named bindings in `state` messages match exactly what the existing
+`rc-converter` `LiveBindings` bakes into `.rc` documents, so a client can
+hand the bindings map straight to its `RemoteDocumentPlayer` named-state
+setter without any name translation.

--- a/addon-server/PLAN.md
+++ b/addon-server/PLAN.md
@@ -1,0 +1,364 @@
+# `addon-server` — Home Assistant add-on serving RemoteCompose dashboards
+
+Status: **plan**. Prototype scaffold lives alongside this document.
+
+## Goal
+
+Run a Home Assistant add-on that speaks to HA over its existing WebSocket
+API and exposes, to native clients (Android phone, Glance widget, Wear, TV,
+ESP32, e-paper, …), a RemoteCompose-native view of the user's Lovelace
+dashboards:
+
+1. A REST surface returns a `.rc` byte stream per card, pre-rendered by
+   our converters on the JVM.
+2. A WebSocket fan-out streams HA state changes to clients as named-state
+   updates that the RemoteCompose player applies **without re-fetching** the
+   document.
+3. The server picks layout/variant per client profile (phone, wear, tv,
+   glance, mono) so the same Lovelace card can adapt across surfaces.
+
+This moves the "fetch config + render" loop off every device and puts a
+single, cache-friendly encoder inside the HA host.
+
+## Why an add-on, not a custom component
+
+- Add-ons run as their own container with their own runtime (JVM today,
+  GraalVM native-image later) — no Python interop, no need to ship our
+  converter into `homeassistant/components/`.
+- The HA supervisor gives us:
+  - `SUPERVISOR_TOKEN` env var → auth against the HA Core API at
+    `http://supervisor/core/api/` and `ws://supervisor/core/websocket`.
+  - `ingress: true` → HA reverse-proxies us under the user's existing
+    session, so we don't have to do auth for in-frontend usage.
+  - One-click install, versioned updates, log surface in the Supervisor UI.
+- Users who want to call us from a native app outside the HA frontend can
+  still do so by forwarding a port; the same endpoints work with an HA
+  long-lived access token.
+
+## High-level architecture
+
+```
+            ┌──────────────────────────────────────────────────┐
+            │                 HA supervisor host               │
+            │                                                  │
+  HA Core ──┼──▶ ws://supervisor/core/websocket ──┐            │
+            │                                      │            │
+            │   ┌──────────────────────────────────▼─────────┐ │
+            │   │              addon-server (JVM)            │ │
+            │   │                                            │ │
+            │   │  HaSupervisorBridge  (1 persistent WS)     │ │
+            │   │     ├─ subscribe state_changed             │ │
+            │   │     ├─ subscribe lovelace_updated          │ │
+            │   │     └─ StateCache  (entity_id → snapshot)  │ │
+            │   │                                            │ │
+            │   │  DashboardCache                            │ │
+            │   │     ├─ lovelace/config → Dashboard         │ │
+            │   │     └─ (cardId, profile) → CardDocument    │ │
+            │   │                                            │ │
+            │   │  RcRenderService (rc-converter-jvm)        │ │
+            │   │                                            │ │
+            │   │  Ktor HTTP + WS server                     │ │
+            │   │     ├─ /v1/... REST                        │ │
+            │   │     └─ /v1/stream  (per-client fan-out)    │ │
+            │   └─────────────────────┬──────────────────────┘ │
+            └─────────────────────────┼────────────────────────┘
+                                      │
+                                      ▼ (ingress or forwarded port)
+                ┌──────────────────────────────────────────────┐
+                │  Clients                                     │
+                │    phone app, Glance widget, Wear tile, …    │
+                │    fetch .rc once, subscribe stream forever  │
+                └──────────────────────────────────────────────┘
+```
+
+The invariant we're optimising for: **the document bytes are stable across
+a state change**. The existing `LiveBindings` in `rc-converter/` encode
+every entity-dependent text/boolean as a named `RemoteString` /
+`RemoteBoolean` in the `User` domain, keyed `"<entity_id>.<suffix>"`. The
+add-on's job is to keep that stream alive: subscribe to HA state, forward
+updates with matching names, and only re-encode the document when the card
+config itself changes.
+
+## Module layout
+
+```
+addon-server/
+├── PLAN.md                  (this file)
+├── build.gradle.kts         Kotlin/JVM, Ktor server, depends on ha-model
+│                            + ha-client + (future) rc-converter-jvm
+├── addon/                   HA add-on packaging
+│   ├── config.yaml          add-on manifest (slug, image, ports, ingress)
+│   ├── Dockerfile           multi-stage: gradle build → distroless JRE
+│   └── run.sh               entrypoint (reads SUPERVISOR_TOKEN, starts JVM)
+└── src/main/kotlin/ee/schimke/ha/addon/
+    ├── Main.kt                       entry point; wires Ktor + services
+    ├── Config.kt                     env/options parsing
+    ├── bridge/
+    │   ├── HaSupervisorBridge.kt     one persistent WS to HA
+    │   ├── StateCache.kt             entity_id → EntityState (MutableStateFlow)
+    │   └── LovelaceCache.kt          cached Dashboards + invalidation
+    ├── render/
+    │   ├── RcRenderService.kt        calls CardConverter, caches bytes
+    │   └── ClientProfile.kt          phone / wear / tv / glance / mono
+    ├── client/
+    │   └── ClientSession.kt          per-WS subscription + entity filter
+    ├── routes/
+    │   ├── DashboardRoutes.kt        REST endpoints
+    │   ├── StreamRoute.kt            /v1/stream WebSocket
+    │   └── HealthRoutes.kt           /healthz, /readyz for supervisor
+    └── auth/
+        ├── IngressAuth.kt            trust X-Remote-User from ingress
+        └── TokenAuth.kt              validate HA access token
+```
+
+Tests go under `src/test/kotlin/...`. An `integration` sub-target can wrap
+the existing `integration/` module's ephemeral HA container to give us
+end-to-end coverage.
+
+## Wire protocol
+
+### REST
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/v1/dashboards` | List Lovelace dashboards (wraps `lovelace/dashboards/list`). |
+| `GET` | `/v1/dashboards/{urlPath}` | The resolved dashboard config (views, cards). |
+| `GET` | `/v1/dashboards/{urlPath}/views/{viewIdx}/cards/{cardId}.rc` | Encoded `.rc` bytes for one card, adapted to the querying client. |
+| `GET` | `/v1/snapshot` | Current state cache as JSON (debug / fall-back clients). |
+| `GET` | `/healthz`, `/readyz` | Liveness + readiness. |
+
+Card fetch query params:
+
+- `w`, `h`, `density` — natural pixel size; defaults come from the card
+  converter's `naturalHeightDp` + profile.
+- `profile` — client kind (`phone`, `wear`, `tv`, `glance`, `mono`). If
+  absent, inferred from `X-RC-Client` header.
+- `rc` — RemoteCompose wire version the client speaks. Server picks the
+  highest encoder it has that `rc ≥ version` accepts.
+
+Response headers include:
+
+- `Content-Type: application/x-remote-compose`
+- `ETag: "<sha256 of bytes>"` — lets clients skip re-downloads across
+  reconnects when the document didn't change.
+- `X-RC-Entity-IDs: light.kitchen,sensor.outside_temp` — comma list of
+  entity IDs whose `.is_on` / `.state` named bindings this document reads,
+  so a narrowing client can pre-subscribe.
+
+### WebSocket `/v1/stream`
+
+Newline-delimited JSON frames, symmetric with HA's own style.
+
+Client → server:
+
+```json
+{ "id": 1, "type": "auth",       "token": "<long-lived-token>" }
+{ "id": 2, "type": "subscribe",  "entities": ["light.kitchen", "sensor.x"] }
+{ "id": 3, "type": "unsubscribe","entities": ["sensor.x"] }
+{ "id": 4, "type": "call_service","domain":"light","service":"toggle",
+  "target":{"entity_id":"light.kitchen"} }
+```
+
+Server → client:
+
+```json
+{ "type": "ready" }
+{ "type": "state",
+  "bindings": {
+    "light.kitchen.is_on": true,
+    "light.kitchen.state": "on",
+    "sensor.outside_temp.state": "21.4 °C"
+  }
+}
+{ "type": "lovelace_updated", "url_path": "lovelace" }
+{ "type": "error", "id": 2, "message": "..." }
+```
+
+The `bindings` shape matches `LiveBindings` exactly, so a client can hand
+the map straight to its `RemoteDocumentPlayer` without mapping.
+
+### Adaptive behaviour
+
+`ClientProfile` is the single knob.
+
+- **phone** — full Material3 card, touch targets, colour, shadow.
+- **wear** — compact layout, safe for AOD, no shadows; override
+  `naturalHeightDp`; converters may swap to the Wear M3 RC primitives
+  where available.
+- **tv** — larger typography, focusable affordances, 10-ft safe margins.
+- **glance** — single-card documents sized for launcher widgets; no
+  horizontal scroll, no nested players.
+- **mono** — dithered 1-bit colour substitution for e-paper / ESP32;
+  collapses backgrounds, drops icons missing mono masks.
+
+Per profile we can (a) choose a different converter per `type` (via a
+profile-indexed `CardRegistry`), or (b) pass the profile as a render
+parameter to a single converter. We'll start with (b) and promote (a) if
+wear/tv diverge enough.
+
+## Live-update lifecycle
+
+1. Client opens `/v1/stream`, authenticates.
+2. Client fetches one card's `.rc`. Response includes
+   `X-RC-Entity-IDs: <list>`.
+3. Client sends `{type:"subscribe", entities:[<list>]}`.
+4. Server joins the union of all active subscriptions. If the requested
+   entity isn't in the server's supervisor-wide `state_changed`
+   subscription, the server adds it (or, simpler, keeps a wildcard
+   subscription and just gates the per-client fan-out).
+5. Each HA `state_changed` event → server computes the `bindings` diff for
+   subscribed entities (using the same formatters as the converters, via
+   `HaStateFormat`) → pushes `{type:"state", bindings:{...}}` to clients
+   whose subscription intersects.
+6. `lovelace_updated` event → server invalidates `DashboardCache` +
+   matching `CardDocument` entries → pushes `lovelace_updated` so clients
+   re-fetch.
+
+Formatter invariant: whatever string the client sees for
+`entity.state` at subscribe time (server's initial "hydrate" push) must be
+byte-identical to what the converter baked into the initial document. Both
+must call the same `HaStateFormat` code path.
+
+## Auth
+
+Two mutually-exclusive modes, selected at startup:
+
+- **Ingress** (default). `ingress: true` in `config.yaml`. HA proxies us;
+  we trust `X-Remote-User-Name` / `X-Remote-User-Id` headers, which HA
+  signs before passing through. No token needed.
+- **External**. Client presents `Authorization: Bearer <ha-token>`.
+  `TokenAuth` validates by calling HA Core `GET /api/` with the token; a
+  200 means valid. Cache the (token, userId) for 5 min to avoid a lookup
+  per request.
+
+Service calls (`call_service`) always go through the supervisor bridge, so
+the HA-side audit log sees the supervisor as the actor. If that's not
+acceptable, we require per-user tokens and open a short-lived HA WS per
+call — defer.
+
+## Rendering path on the JVM
+
+The existing `rc-converter/` is Android-targeted. To run encoders on the
+server we have two options.
+
+**Option A — port the converters to `remote-creation-jvm`** (the JVM-only
+sibling already in `libs.versions.toml` at line 36). This is the pure
+`RemoteCreationCore` writer API — no Compose runtime, no Android
+`Context`, no `VirtualDisplay`. Trade-off: the converters lose the
+`@Composable` DSL and become imperative "emit-to-writer" code.
+
+**Option B — run the current Compose-based converters on the JVM**. The
+Compose compiler plugin and runtime work on JVM today. `captureSingle
+RemoteDocumentV2` expects an Android `Context`, so we'd need a JVM
+equivalent of that capture entry point.
+
+Starting plan: **A, phased**. A new `rc-converter-jvm` module that starts
+by porting `tile`, `entities`, `glance`, `button` (in that order — the
+bulk of real dashboards per the README). Each port is gated by the same
+pixel-parity harness (`integration/`) used for Android. The existing
+`rc-converter` module stays intact for the Android client, sharing
+`HaStateFormat`, `HaStateColor`, `HaIconMap`, `LiveBindings`, and
+`HaActionParser` via a common source set we extract during the port.
+
+This also keeps **native-image** on the table: no Compose runtime, no
+reflection beyond kotlinx-serialization's (which has first-class
+native-image metadata).
+
+## Native-image (phase 2)
+
+- GraalVM 21, `native-image --no-fallback --enable-url-protocols=http,https`.
+- Netty is painful; use Ktor CIO server + OkHttp client (or Ktor CIO
+  client). Both have working native-image configs.
+- kotlinx.serialization: register `@Serializable` types via
+  `@ReflectiveAccess` + `META-INF/native-image/.../reflect-config.json`
+  generated by the `serialization-agent` plugin, or hand-written.
+- `remote-creation-jvm` inspection: flag any AWT / ImageIO usage before
+  committing to native; if present, either substitute or stay on HotSpot.
+- Image budget target: <30 MB binary, <60 MB RSS, <200 ms cold start. Only
+  if we hit those does native-image pay for itself; otherwise stay on a
+  distroless JRE.
+
+## Packaging as an HA add-on
+
+`addon/config.yaml` (sketch):
+
+```yaml
+slug: remotecompose
+name: RemoteCompose Dashboards
+version: 0.1.0
+arch: [amd64, aarch64]
+startup: application
+boot: auto
+hassio_api: true
+homeassistant_api: true
+auth_api: true
+ingress: true
+ingress_port: 8099
+panel_icon: mdi:remote
+ports:
+  8099/tcp: 8099          # optional: expose to LAN for native apps
+options:
+  log_level: info
+schema:
+  log_level: list(trace|debug|info|warning|error|fatal)
+image: ghcr.io/yschimke/ha-remotecompose-{arch}
+```
+
+Dockerfile strategy:
+
+1. `gradle/gradle:8-jdk21` builder → `./gradlew :addon-server:installDist`.
+2. Final: `gcr.io/distroless/java21-debian12:nonroot`. Copy the install
+   dir, `ENTRYPOINT ["/app/bin/addon-server"]`.
+3. For native-image phase 2: builder is a GraalVM image, final is
+   `gcr.io/distroless/static-debian12:nonroot` with just the binary.
+
+## Milestones
+
+- **M0 — scaffold (this PR).** Module exists, `./gradlew :addon-server:run`
+  starts an empty Ktor server answering `/healthz`, Dockerfile + config.yaml
+  checked in. No actual HA plumbing.
+- **M1 — supervisor bridge.** `HaSupervisorBridge` connects, authenticates,
+  subscribes to `state_changed`, holds a `StateCache`. `/v1/snapshot` dumps
+  the cache as JSON. Verify end-to-end against the `integration/`
+  compose file.
+- **M2 — dashboards + passthrough.** `/v1/dashboards`, `/v1/dashboards/{p}`
+  — wraps `HaClient` calls. No `.rc` bytes yet.
+- **M3 — first card on JVM.** Extract a `rc-converter-common` (pure Kotlin)
+  source set from `rc-converter`; add `rc-converter-jvm` with a JVM port of
+  `tile`. Wire `RcRenderService` and expose `GET …/cards/{id}.rc`.
+  Pixel-parity test replays the existing `references/` fixtures.
+- **M4 — live stream.** `/v1/stream` WS, `state_changed` → `bindings`
+  fan-out, per-client entity filter, formatter parity with converter.
+- **M5 — adaptive profiles.** `ClientProfile` threaded through
+  `RcRenderService`; split per-profile tests. Start with `phone` +
+  `glance`; wear/tv gated behind their own converter ports.
+- **M6 — native image.** `:addon-server:nativeCompile` producing a static
+  binary; CI matrix builds arm64 + amd64; image size and cold-start budgets
+  in `README.md`.
+
+## Risks / unknowns
+
+- **`remote-creation-jvm` surface.** We've never built against it. M3 may
+  surface missing primitives (text measurement, icons). Mitigation: spike
+  `tile` first; if blocked, fall back to Compose-on-JVM for M3 and revisit
+  native in M6.
+- **Strategy dashboards.** HA resolves strategies client-side today.
+  Either we port the resolution logic (tractable — it's JS that reads
+  registries) or we require `type:` dashboards. Defer to M2.
+- **Service-call audit log identity.** See "Auth" above. Worst case:
+  per-call HA WS with user token. Defer to M4.
+- **WebSocket load.** A single supervisor WS fanning out to many clients
+  is our bottleneck. HA doesn't have per-entity filtering on the server —
+  we get every `state_changed`. At ~50 events/sec, filtering + JSON
+  encoding per client is fine up to O(100) clients on a Pi; benchmark at M4.
+- **Custom cards.** Out of scope for the initial set, same as `rc-converter`.
+  The server should return a typed 404 (`X-RC-Unsupported: custom:foo`) so
+  clients can render a placeholder.
+
+## Out of scope (initial)
+
+- Map, picture-elements, history-graph, energy cards (same list as the
+  Android converter).
+- Writing to HA from profiles other than `phone` (wear/tv/glance still only
+  display — no `call_service` from tiles yet).
+- Multi-tenant add-on hosting — one HA instance per add-on install.

--- a/addon-server/README.md
+++ b/addon-server/README.md
@@ -41,3 +41,9 @@ The add-on runs against the supervisor-injected `SUPERVISOR_TOKEN`; no
 extra config required. Once published to a repo and installed, the
 endpoints are reachable via ingress (in-frontend) or via the LAN port
 exposed in `addon/config.yaml`.
+
+## End-to-end test
+
+`test-docker/run.sh` builds the add-on image, runs it next to a real
+HA container, and smoke-checks the public endpoints. See
+[`test-docker/README.md`](test-docker/README.md).

--- a/addon-server/README.md
+++ b/addon-server/README.md
@@ -1,7 +1,9 @@
 # addon-server
 
 Home Assistant add-on that serves RemoteCompose dashboards from the HA
-host. See [`PLAN.md`](PLAN.md) for the full design.
+host. See [`PLAN.md`](PLAN.md) for the full design and
+[`INSTALL.md`](INSTALL.md) for dev setup, testing, and connectivity
+details.
 
 ## Status
 

--- a/addon-server/README.md
+++ b/addon-server/README.md
@@ -1,0 +1,43 @@
+# addon-server
+
+Home Assistant add-on that serves RemoteCompose dashboards from the HA
+host. See [`PLAN.md`](PLAN.md) for the full design.
+
+## Status
+
+Prototype scaffold:
+
+- Ktor/CIO server on `:8099`
+- `HaSupervisorBridge` — long-lived WS to HA Core, hydrates a per-entity
+  state cache, fans out `state_changed` and `lovelace_updated` events
+- REST: `/v1/dashboards`, `/v1/dashboards/{path}`, `/v1/snapshot`,
+  `/healthz`, `/readyz`
+- WS: `/v1/stream` — per-client subscribe + named-binding state push,
+  service calls round-tripped to HA via the bridge
+- Add-on packaging in `addon/` (`config.yaml`, `Dockerfile`, `run.sh`)
+
+The `.rc` byte endpoint is a typed 501 placeholder — see PLAN.md "M3" for
+the converter port plan.
+
+## Running locally (no add-on supervisor)
+
+```sh
+HA_BASE_URL=http://homeassistant.local:8123 \
+HA_TOKEN=<long-lived access token> \
+./gradlew :addon-server:run
+```
+
+Then:
+
+```sh
+curl http://localhost:8099/healthz
+curl http://localhost:8099/v1/dashboards
+curl http://localhost:8099/v1/snapshot | jq '.states | length'
+```
+
+## Running as an HA add-on
+
+The add-on runs against the supervisor-injected `SUPERVISOR_TOKEN`; no
+extra config required. Once published to a repo and installed, the
+endpoints are reachable via ingress (in-frontend) or via the LAN port
+exposed in `addon/config.yaml`.

--- a/addon-server/addon/Dockerfile
+++ b/addon-server/addon/Dockerfile
@@ -1,24 +1,30 @@
 # Multi-stage build:
-#   1) gradle builder produces a `installDist` tarball
-#   2) distroless JRE serves it with the smallest reasonable runtime surface
+#   1) builder: gradle wrapper + JDK 17 (project's toolchain target;
+#      the wrapper downloads its own Gradle, so the daemon is whatever
+#      `./gradlew` pins). None of `:ha-model` / `:ha-client` /
+#      `:addon-server` apply the Metro plugin, so we don't need JDK 21+.
+#   2) runtime: distroless JRE 21 — smallest reasonable surface.
 #
 # We don't use HA's `homeassistant/<arch>-base` image because we want a
 # vanilla JRE — the supervisor doesn't require the bashio base for plain
 # `application` startup. If we ever need bashio (for `/data/options.json`
 # parsing) we can switch and run `run.sh` instead.
-ARG BUILD_FROM=gradle:8-jdk21
+ARG BUILD_FROM=eclipse-temurin:17-jdk-jammy
 ARG RUN_FROM=gcr.io/distroless/java21-debian12:nonroot
 
 FROM ${BUILD_FROM} AS build
 WORKDIR /src
-# Copy only what we need to resolve the build cache before copying sources,
-# so dependency resolution can be cached across edits.
-COPY settings.gradle.kts build.gradle.kts gradle.properties /src/
+# Copy the wrapper + minimal gradle config first, so dependency resolution
+# can be cached across source-only edits.
+COPY gradlew /src/gradlew
 COPY gradle /src/gradle
+COPY settings.gradle.kts build.gradle.kts gradle.properties /src/
 COPY ha-model /src/ha-model
 COPY ha-client /src/ha-client
 COPY addon-server /src/addon-server
-RUN gradle --no-daemon :addon-server:installDist
+RUN chmod +x /src/gradlew && \
+    /src/gradlew --no-daemon :addon-server:installDist \
+      -x :addon-server:test
 
 FROM ${RUN_FROM}
 WORKDIR /app

--- a/addon-server/addon/Dockerfile
+++ b/addon-server/addon/Dockerfile
@@ -1,0 +1,28 @@
+# Multi-stage build:
+#   1) gradle builder produces a `installDist` tarball
+#   2) distroless JRE serves it with the smallest reasonable runtime surface
+#
+# We don't use HA's `homeassistant/<arch>-base` image because we want a
+# vanilla JRE — the supervisor doesn't require the bashio base for plain
+# `application` startup. If we ever need bashio (for `/data/options.json`
+# parsing) we can switch and run `run.sh` instead.
+ARG BUILD_FROM=gradle:8-jdk21
+ARG RUN_FROM=gcr.io/distroless/java21-debian12:nonroot
+
+FROM ${BUILD_FROM} AS build
+WORKDIR /src
+# Copy only what we need to resolve the build cache before copying sources,
+# so dependency resolution can be cached across edits.
+COPY settings.gradle.kts build.gradle.kts gradle.properties /src/
+COPY gradle /src/gradle
+COPY ha-model /src/ha-model
+COPY ha-client /src/ha-client
+COPY addon-server /src/addon-server
+RUN gradle --no-daemon :addon-server:installDist
+
+FROM ${RUN_FROM}
+WORKDIR /app
+COPY --from=build /src/addon-server/build/install/addon-server /app
+EXPOSE 8099
+ENV LOG_LEVEL=info
+ENTRYPOINT ["/app/bin/addon-server"]

--- a/addon-server/addon/config.yaml
+++ b/addon-server/addon/config.yaml
@@ -1,0 +1,48 @@
+# Home Assistant add-on manifest. Lives in the directory the user adds as a
+# local add-on repo, or that we publish via the GitHub Pages add-on store.
+#
+# Reference: https://developers.home-assistant.io/docs/add-ons/configuration/
+
+slug: remotecompose
+name: RemoteCompose Dashboards
+version: "0.1.0"
+description: >-
+  Serves Home Assistant Lovelace dashboards as RemoteCompose documents over
+  HTTP/WebSocket, with live state updates pushed to native clients (phone,
+  Wear, TV, Glance widgets, ESP32).
+url: https://github.com/yschimke/homeassistant-remotecompose
+arch:
+  - amd64
+  - aarch64
+startup: application
+boot: auto
+init: false
+
+# Required so the supervisor injects SUPERVISOR_TOKEN with rights against
+# Home Assistant Core's WebSocket + REST API.
+homeassistant_api: true
+hassio_api: true
+auth_api: true
+
+# Ingress lets users open the add-on through HA's authenticated proxy. We
+# don't ship a UI; ingress is here so future debug/admin pages live under
+# the user's HA session.
+ingress: true
+ingress_port: 8099
+panel_icon: mdi:remote
+panel_title: RemoteCompose
+
+# Optional LAN exposure for native apps that aren't going through the HA
+# frontend (Glance widgets, Wear tiles, ESP32). Off by default.
+ports:
+  8099/tcp: null
+ports_description:
+  8099/tcp: RemoteCompose API (HTTP + WebSocket)
+
+options:
+  log_level: info
+schema:
+  log_level: list(trace|debug|info|warning|error|fatal)
+
+# Multi-arch image lives in GHCR. The supervisor substitutes {arch}.
+image: ghcr.io/yschimke/ha-remotecompose-{arch}

--- a/addon-server/addon/run.sh
+++ b/addon-server/addon/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env sh
+# Optional entrypoint for builds that pull in HA's bashio base instead of
+# distroless. Reads /data/options.json (the resolved add-on options) and
+# exports them as env vars before exec'ing the JVM.
+#
+# Distroless build (the default) bypasses this and goes straight to the
+# JVM through the Dockerfile's ENTRYPOINT.
+set -eu
+
+if [ -f /data/options.json ]; then
+  LOG_LEVEL=$(jq -r '.log_level // "info"' /data/options.json)
+  export LOG_LEVEL
+fi
+
+exec /app/bin/addon-server

--- a/addon-server/build.gradle.kts
+++ b/addon-server/build.gradle.kts
@@ -1,0 +1,46 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+    application
+}
+
+kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
+
+application {
+    mainClass.set("ee.schimke.ha.addon.MainKt")
+}
+
+dependencies {
+    implementation(project(":ha-model"))
+    implementation(project(":ha-client"))
+
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.cio)
+    implementation(libs.ktor.server.websockets)
+    implementation(libs.ktor.server.content.negotiation)
+    implementation(libs.ktor.server.status.pages)
+    implementation(libs.ktor.server.call.logging)
+    implementation(libs.ktor.server.default.headers)
+    implementation(libs.ktor.server.auth)
+    implementation(libs.ktor.serialization.kotlinx.json)
+
+    // Client used by the supervisor bridge. CIO keeps things native-image
+    // friendly; OkHttp would pull in Android artifacts we don't want.
+    implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.cio)
+    implementation(libs.ktor.client.websockets)
+    implementation(libs.ktor.client.content.negotiation)
+
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.serialization.json)
+
+    runtimeOnly(libs.logback.classic)
+
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(platform("org.junit:junit-bom:5.11.4"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test { useJUnitPlatform() }

--- a/addon-server/src/main/kotlin/ee/schimke/ha/addon/Config.kt
+++ b/addon-server/src/main/kotlin/ee/schimke/ha/addon/Config.kt
@@ -1,0 +1,41 @@
+package ee.schimke.ha.addon
+
+/**
+ * Runtime configuration, assembled from env + add-on options.
+ *
+ * HA supervisor contract for add-ons: `SUPERVISOR_TOKEN` is injected by
+ * the supervisor when `hassio_api` / `homeassistant_api` is requested in
+ * `config.yaml`. When that's present we address Core at
+ * `http://supervisor/core` (REST) and `ws://supervisor/core/websocket`
+ * (WS). For local development outside the supervisor we fall through to
+ * `HA_BASE_URL` + `HA_TOKEN` — same shape `HaClient` already uses.
+ */
+data class AddonConfig(
+    val port: Int,
+    val haBaseUrl: String,
+    val haAccessToken: String,
+    val logLevel: String,
+) {
+    companion object {
+        private const val SUPERVISOR_URL = "http://supervisor/core"
+
+        fun fromEnv(env: Map<String, String> = System.getenv()): AddonConfig {
+            val supervisor = env["SUPERVISOR_TOKEN"]
+            val baseUrl = env["HA_BASE_URL"]
+                ?: if (supervisor != null) SUPERVISOR_URL else error(
+                    "no HA endpoint: set SUPERVISOR_TOKEN (add-on) or HA_BASE_URL+HA_TOKEN (local)",
+                )
+            val token = supervisor
+                ?: env["HA_TOKEN"]
+                ?: error("no HA auth: set SUPERVISOR_TOKEN or HA_TOKEN")
+            val port = env["PORT"]?.toIntOrNull() ?: 8099
+            val logLevel = env["LOG_LEVEL"] ?: "info"
+            return AddonConfig(
+                port = port,
+                haBaseUrl = baseUrl,
+                haAccessToken = token,
+                logLevel = logLevel,
+            )
+        }
+    }
+}

--- a/addon-server/src/main/kotlin/ee/schimke/ha/addon/Main.kt
+++ b/addon-server/src/main/kotlin/ee/schimke/ha/addon/Main.kt
@@ -1,0 +1,71 @@
+package ee.schimke.ha.addon
+
+import ee.schimke.ha.addon.bridge.HaSupervisorBridge
+import ee.schimke.ha.addon.routes.dashboardRoutes
+import ee.schimke.ha.addon.routes.healthRoutes
+import ee.schimke.ha.addon.routes.streamRoute
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.plugins.calllogging.CallLogging
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.defaultheaders.DefaultHeaders
+import io.ktor.server.plugins.statuspages.StatusPages
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.routing
+import io.ktor.server.websocket.WebSockets
+import io.ktor.http.HttpStatusCode
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+import java.util.concurrent.TimeUnit
+
+private val log = LoggerFactory.getLogger("ee.schimke.ha.addon.Main")
+
+fun main() {
+    val cfg = AddonConfig.fromEnv()
+    log.info("starting addon-server on :{}, ha={}", cfg.port, cfg.haBaseUrl)
+
+    val bridge = HaSupervisorBridge(cfg.haBaseUrl, cfg.haAccessToken)
+    bridge.start()
+
+    val server = embeddedServer(CIO, port = cfg.port, host = "0.0.0.0") {
+        configure(bridge)
+    }
+    Runtime.getRuntime().addShutdownHook(
+        Thread {
+            log.info("shutdown: stopping server + bridge")
+            server.stop(1, 5, TimeUnit.SECONDS)
+            kotlinx.coroutines.runBlocking { bridge.close() }
+        },
+    )
+    server.start(wait = true)
+}
+
+internal fun Application.configure(bridge: HaSupervisorBridge) {
+    install(DefaultHeaders) {
+        header("X-Powered-By", "ha-remotecompose")
+    }
+    install(CallLogging)
+    install(WebSockets)
+    install(ContentNegotiation) {
+        json(Json { ignoreUnknownKeys = true; isLenient = true })
+    }
+    install(StatusPages) {
+        exception<Throwable> { call, cause ->
+            log.error("unhandled error", cause)
+            call.respondText(
+                text = """{"error":"${cause.message?.replace("\"", "\\\"")}"}""",
+                contentType = io.ktor.http.ContentType.Application.Json,
+                status = HttpStatusCode.InternalServerError,
+            )
+        }
+    }
+
+    routing {
+        healthRoutes(bridge)
+        dashboardRoutes(bridge)
+        streamRoute(bridge)
+    }
+}

--- a/addon-server/src/main/kotlin/ee/schimke/ha/addon/bridge/HaSupervisorBridge.kt
+++ b/addon-server/src/main/kotlin/ee/schimke/ha/addon/bridge/HaSupervisorBridge.kt
@@ -1,0 +1,334 @@
+package ee.schimke.ha.addon.bridge
+
+import ee.schimke.ha.model.Dashboard
+import ee.schimke.ha.model.EntityState
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocketSession
+import io.ktor.client.request.url
+import io.ktor.websocket.CloseReason
+import io.ktor.websocket.DefaultWebSocketSession
+import io.ktor.websocket.Frame
+import io.ktor.websocket.close
+import io.ktor.websocket.readText
+import io.ktor.websocket.send
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.slf4j.LoggerFactory
+
+/**
+ * One long-lived WebSocket session to the Home Assistant Core API. Owns:
+ *
+ * - auth handshake (`SUPERVISOR_TOKEN` when running as an HA add-on, or a
+ *   long-lived access token for local dev)
+ * - request/response commands multiplexed by monotonic `id`
+ * - `state_changed` / `lovelace_updated` event subscriptions, materialised
+ *   as a [StateCache] (latest per entity) and a [SharedFlow] of raw events
+ *
+ * This is intentionally a superset of `ha-client`'s [HaClient]: that class
+ * is shared with the Android client and only needs request/response; the
+ * server also needs long-running event subscriptions, so we open a second
+ * kind of connection here rather than widen the shared API.
+ *
+ * Reconnect policy is exponential-backoff with a cap; on reconnect we
+ * re-subscribe and refresh the state snapshot so downstream clients just
+ * see a brief gap, not an incoherent cache.
+ */
+class HaSupervisorBridge(
+    private val baseUrl: String,
+    private val accessToken: String,
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default + CoroutineName("ha-bridge")),
+) {
+    private val log = LoggerFactory.getLogger(HaSupervisorBridge::class.java)
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val http = HttpClient(CIO) { install(WebSockets) }
+
+    private val idMutex = Mutex()
+    private var nextId = 1
+    private val pending = mutableMapOf<Int, CompletableDeferred<JsonObject>>()
+    private val pendingMutex = Mutex()
+
+    @Volatile private var session: DefaultWebSocketSession? = null
+    private var receiveJob: Job? = null
+    private var connectJob: Job? = null
+
+    private val _state = MutableStateFlow(ConnectionState.Disconnected)
+    val state: StateFlow<ConnectionState> = _state.asStateFlow()
+
+    val cache = StateCache()
+
+    private val _events = MutableSharedFlow<HaEvent>(
+        replay = 0, extraBufferCapacity = 256,
+    )
+    val events: SharedFlow<HaEvent> = _events.asSharedFlow()
+
+    enum class ConnectionState { Disconnected, Connecting, Authenticating, Ready, Error }
+
+    fun start() {
+        if (connectJob != null) return
+        connectJob = scope.launch { runWithReconnect() }
+    }
+
+    suspend fun close() {
+        connectJob?.cancel()
+        receiveJob?.cancel()
+        runCatching { session?.close(CloseReason(CloseReason.Codes.NORMAL, "bye")) }
+        session = null
+        http.close()
+        scope.cancel()
+        _state.value = ConnectionState.Disconnected
+    }
+
+    /** Snapshot of dashboards registered in the Lovelace storage layer. */
+    suspend fun listDashboards(): JsonArray = runCommandArray("lovelace/dashboards/list")
+
+    /**
+     * Resolved Lovelace dashboard. `urlPath=null` asks HA for the default
+     * dashboard (i.e. the one mounted at `/lovelace`).
+     */
+    suspend fun fetchDashboard(urlPath: String?): Dashboard {
+        val obj = runCommand("lovelace/config") {
+            if (urlPath != null) put("url_path", urlPath)
+        }
+        return json.decodeFromJsonElement(Dashboard.serializer(), obj)
+    }
+
+    /** Passthrough `call_service` — runs under the supervisor identity. */
+    suspend fun callService(domain: String, service: String, entityId: String?, data: JsonObject?): JsonObject =
+        runCommand("call_service") {
+            put("domain", domain)
+            put("service", service)
+            if (entityId != null) {
+                put("target", buildJsonObject { put("entity_id", entityId) })
+            }
+            if (data != null) put("service_data", data)
+        }
+
+    private suspend fun runWithReconnect() {
+        var backoffMs = 1_000L
+        while (true) {
+            try {
+                connectOnce()
+                backoffMs = 1_000L
+                receiveJob?.join()
+            } catch (t: Throwable) {
+                log.warn("HA bridge disconnected: {}", t.message)
+                _state.value = ConnectionState.Error
+            }
+            _state.value = ConnectionState.Disconnected
+            delay(backoffMs)
+            backoffMs = (backoffMs * 2).coerceAtMost(30_000L)
+        }
+    }
+
+    private suspend fun connectOnce() {
+        _state.value = ConnectionState.Connecting
+        // Same path whether we hit HA directly (http://ha:8123) or via the
+        // supervisor proxy (http://supervisor/core) — the proxy is path-
+        // transparent, so `/api/websocket` lands at HA's WS handler in both.
+        val wsUrl = baseUrl.toWsUrl() + "/api/websocket"
+        val s = http.webSocketSession { url(wsUrl) }
+        session = s
+
+        val authRequired = readMessage(s)
+        require(authRequired["type"]?.jsonPrimitive?.content == "auth_required") {
+            "expected auth_required, got $authRequired"
+        }
+        _state.value = ConnectionState.Authenticating
+        s.send(
+            json.encodeToString(
+                JsonObject.serializer(),
+                buildJsonObject {
+                    put("type", "auth")
+                    put("access_token", accessToken)
+                },
+            ),
+        )
+        val authResult = readMessage(s)
+        if (authResult["type"]?.jsonPrimitive?.content != "auth_ok") {
+            error("HA auth rejected: $authResult")
+        }
+        _state.value = ConnectionState.Ready
+        log.info("HA bridge authenticated")
+
+        // Start receive loop before sending subscriptions so their results
+        // aren't dropped.
+        receiveJob = scope.launch { receiveLoop(s) }
+
+        hydrateStates()
+        subscribe("state_changed")
+        subscribe("lovelace_updated")
+    }
+
+    private suspend fun hydrateStates() {
+        val arr = runCommandArray("get_states")
+        val map = LinkedHashMap<String, EntityState>(arr.size)
+        for (el in arr) {
+            val obj = el.jsonObject
+            val id = obj["entity_id"]?.jsonPrimitive?.content ?: continue
+            map[id] = json.decodeFromJsonElement(EntityState.serializer(), camelizeState(obj))
+        }
+        cache.replaceAll(map)
+        log.info("hydrated {} entities", map.size)
+    }
+
+    private suspend fun subscribe(eventType: String): Int {
+        val id = idMutex.withLock { nextId++ }
+        val deferred = CompletableDeferred<JsonObject>()
+        pendingMutex.withLock { pending[id] = deferred }
+        val frame = json.encodeToString(
+            JsonObject.serializer(),
+            buildJsonObject {
+                put("id", id)
+                put("type", "subscribe_events")
+                put("event_type", eventType)
+            },
+        )
+        session!!.send(frame)
+        withTimeout(10_000) {
+            val resp = deferred.await()
+            require(resp["success"]?.jsonPrimitive?.content != "false") { "subscribe $eventType failed: $resp" }
+        }
+        return id
+    }
+
+    private suspend fun runCommand(
+        type: String,
+        extra: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit = {},
+    ): JsonObject {
+        val response = awaitCommand(type, extra)
+        return response["result"]?.jsonObject ?: JsonObject(emptyMap())
+    }
+
+    private suspend fun runCommandArray(
+        type: String,
+        extra: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit = {},
+    ): JsonArray {
+        val response = awaitCommand(type, extra)
+        return response["result"]?.jsonArray ?: JsonArray(emptyList())
+    }
+
+    private suspend fun awaitCommand(
+        type: String,
+        extra: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit,
+    ): JsonObject {
+        val s = session ?: error("HA bridge not connected")
+        val id = idMutex.withLock { nextId++ }
+        val deferred = CompletableDeferred<JsonObject>()
+        pendingMutex.withLock { pending[id] = deferred }
+        val msg = buildJsonObject {
+            put("id", id)
+            put("type", type)
+            extra()
+        }
+        s.send(json.encodeToString(JsonObject.serializer(), msg))
+        return withTimeout(30_000) {
+            val resp = deferred.await()
+            val success = resp["success"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: true
+            if (!success) {
+                val err = resp["error"]?.jsonObject?.get("message")?.jsonPrimitive?.content ?: "unknown"
+                error("HA command $type failed: $err")
+            }
+            resp
+        }
+    }
+
+    private suspend fun receiveLoop(s: DefaultWebSocketSession) {
+        try {
+            for (frame in s.incoming) {
+                val text = (frame as? Frame.Text)?.readText() ?: continue
+                val obj = json.parseToJsonElement(text).jsonObject
+                when (obj["type"]?.jsonPrimitive?.content) {
+                    "event" -> handleEvent(obj["event"]?.jsonObject ?: continue)
+                    else -> {
+                        val id = obj["id"]?.jsonPrimitive?.content?.toIntOrNull() ?: continue
+                        pendingMutex.withLock { pending.remove(id) }?.complete(obj)
+                    }
+                }
+            }
+        } catch (t: Throwable) {
+            pendingMutex.withLock {
+                pending.values.forEach { it.completeExceptionally(t) }
+                pending.clear()
+            }
+            _state.value = ConnectionState.Error
+        }
+    }
+
+    private suspend fun handleEvent(event: JsonObject) {
+        val eventType = event["event_type"]?.jsonPrimitive?.content ?: return
+        val data = event["data"]?.jsonObject ?: JsonObject(emptyMap())
+        when (eventType) {
+            "state_changed" -> {
+                val entityId = data["entity_id"]?.jsonPrimitive?.content ?: return
+                val newState = data["new_state"]?.jsonObject
+                if (newState == null) {
+                    cache.remove(entityId)
+                } else {
+                    val typed = json.decodeFromJsonElement(EntityState.serializer(), camelizeState(newState))
+                    cache.put(entityId, typed)
+                }
+                _events.tryEmit(HaEvent.StateChanged(entityId))
+            }
+            "lovelace_updated" -> {
+                val urlPath = data["url_path"]?.jsonPrimitive?.content
+                _events.tryEmit(HaEvent.LovelaceUpdated(urlPath))
+            }
+            else -> Unit
+        }
+    }
+
+    private suspend fun readMessage(s: DefaultWebSocketSession): JsonObject {
+        val frame = s.incoming.receive() as? Frame.Text ?: error("expected text frame")
+        return json.parseToJsonElement(frame.readText()).jsonObject
+    }
+
+    /** HA returns snake_case; our `EntityState` is camelCase. */
+    private fun camelizeState(obj: JsonObject): JsonObject = buildJsonObject {
+        for ((k, v) in obj) {
+            when (k) {
+                "entity_id" -> put("entityId", v)
+                "last_changed" -> put("lastChanged", v)
+                "last_updated" -> put("lastUpdated", v)
+                else -> put(k, v)
+            }
+        }
+    }
+
+    private fun String.toWsUrl(): String = when {
+        startsWith("https://") -> "wss://" + removePrefix("https://").removeSuffix("/")
+        startsWith("http://") -> "ws://" + removePrefix("http://").removeSuffix("/")
+        startsWith("wss://") || startsWith("ws://") -> removeSuffix("/")
+        else -> "ws://" + removeSuffix("/")
+    }
+}
+
+sealed interface HaEvent {
+    data class StateChanged(val entityId: String) : HaEvent
+    data class LovelaceUpdated(val urlPath: String?) : HaEvent
+}

--- a/addon-server/src/main/kotlin/ee/schimke/ha/addon/bridge/StateCache.kt
+++ b/addon-server/src/main/kotlin/ee/schimke/ha/addon/bridge/StateCache.kt
@@ -1,0 +1,36 @@
+package ee.schimke.ha.addon.bridge
+
+import ee.schimke.ha.model.EntityState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Latest [EntityState] per `entity_id`, mirroring what HA's frontend
+ * holds in `hass.states`. The whole map is wrapped in a [StateFlow] so
+ * routes can publish read-only views; updates from the bridge mutate the
+ * underlying map under a structural-equality check that keeps the flow
+ * from emitting on no-op writes.
+ */
+class StateCache {
+    private val _states = MutableStateFlow<Map<String, EntityState>>(emptyMap())
+    val states: StateFlow<Map<String, EntityState>> = _states.asStateFlow()
+
+    fun get(entityId: String): EntityState? = _states.value[entityId]
+
+    fun replaceAll(map: Map<String, EntityState>) {
+        _states.value = map.toMap()
+    }
+
+    fun put(entityId: String, value: EntityState) {
+        val current = _states.value
+        if (current[entityId] == value) return
+        _states.value = current + (entityId to value)
+    }
+
+    fun remove(entityId: String) {
+        val current = _states.value
+        if (entityId !in current) return
+        _states.value = current - entityId
+    }
+}

--- a/addon-server/src/main/kotlin/ee/schimke/ha/addon/routes/DashboardRoutes.kt
+++ b/addon-server/src/main/kotlin/ee/schimke/ha/addon/routes/DashboardRoutes.kt
@@ -1,0 +1,53 @@
+package ee.schimke.ha.addon.routes
+
+import ee.schimke.ha.addon.bridge.HaSupervisorBridge
+import ee.schimke.ha.model.Dashboard
+import ee.schimke.ha.model.EntityState
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Routing
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
+
+/**
+ * Public REST surface, version-pinned at /v1.
+ *
+ * - `/v1/dashboards` — list registered Lovelace dashboards
+ * - `/v1/dashboards/{path}` — resolved dashboard config
+ * - `/v1/snapshot` — current state cache (debug + fallback for clients
+ *   that don't speak the WS stream yet)
+ *
+ * The `.rc`-byte endpoint is intentionally omitted at this milestone —
+ * see PLAN.md (M3). Card rendering on the JVM lands once the
+ * `rc-converter-jvm` port exists.
+ */
+fun Routing.dashboardRoutes(bridge: HaSupervisorBridge) {
+    route("/v1") {
+        get("/dashboards") {
+            val arr: JsonArray = bridge.listDashboards()
+            call.respond(arr)
+        }
+        get("/dashboards/{path}") {
+            val path = call.parameters["path"]
+            val dashboard: Dashboard = bridge.fetchDashboard(path)
+            call.respond(dashboard)
+        }
+        get("/snapshot") {
+            call.respond(SnapshotResponse(bridge.cache.states.value))
+        }
+        get("/cards/{cardId}.rc") {
+            // M3 — encoder lives in `rc-converter-jvm`, not yet wired.
+            // Returning a typed 501 lets clients surface an "unsupported
+            // server build" rather than a generic transport error.
+            call.respond(
+                HttpStatusCode.NotImplemented,
+                mapOf("error" to "rc encoder not yet available in this build"),
+            )
+        }
+    }
+}
+
+@Serializable
+private data class SnapshotResponse(val states: Map<String, EntityState>)

--- a/addon-server/src/main/kotlin/ee/schimke/ha/addon/routes/HealthRoutes.kt
+++ b/addon-server/src/main/kotlin/ee/schimke/ha/addon/routes/HealthRoutes.kt
@@ -1,0 +1,31 @@
+package ee.schimke.ha.addon.routes
+
+import ee.schimke.ha.addon.bridge.HaSupervisorBridge
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Routing
+import io.ktor.server.routing.get
+
+/**
+ * Liveness + readiness for the HA supervisor's healthcheck. Liveness is
+ * always 200 once the JVM is up; readiness only flips green when the HA
+ * bridge has authenticated and hydrated its state cache.
+ */
+fun Routing.healthRoutes(bridge: HaSupervisorBridge) {
+    get("/healthz") {
+        call.respondText("ok", ContentType.Text.Plain)
+    }
+    get("/readyz") {
+        val ready = bridge.state.value == HaSupervisorBridge.ConnectionState.Ready
+        if (ready) {
+            call.respondText("ready", ContentType.Text.Plain)
+        } else {
+            call.respondText(
+                bridge.state.value.name,
+                ContentType.Text.Plain,
+                HttpStatusCode.ServiceUnavailable,
+            )
+        }
+    }
+}

--- a/addon-server/src/main/kotlin/ee/schimke/ha/addon/routes/StreamRoute.kt
+++ b/addon-server/src/main/kotlin/ee/schimke/ha/addon/routes/StreamRoute.kt
@@ -1,0 +1,172 @@
+package ee.schimke.ha.addon.routes
+
+import ee.schimke.ha.addon.bridge.HaEvent
+import ee.schimke.ha.addon.bridge.HaSupervisorBridge
+import io.ktor.server.routing.Routing
+import io.ktor.server.websocket.webSocket
+import io.ktor.websocket.Frame
+import io.ktor.websocket.readText
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.slf4j.LoggerFactory
+
+/**
+ * Per-client WebSocket. Wire format mirrors PLAN.md §"WebSocket /v1/stream".
+ *
+ * Client subscribes to a set of `entity_id`s; server pushes state updates
+ * keyed by the same names that `LiveBindings` bakes into the `.rc`
+ * document, so the client can hand the map straight to its
+ * `RemoteDocumentPlayer` named-state setter.
+ *
+ * Per-client filtering is done in-process — the bridge holds a global
+ * `state_changed` subscription against HA, so the cost of a new client is
+ * a Set membership check per event.
+ */
+fun Routing.streamRoute(bridge: HaSupervisorBridge) {
+    val log = LoggerFactory.getLogger("ee.schimke.ha.addon.StreamRoute")
+    val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    webSocket("/v1/stream") {
+        val subscribed = mutableSetOf<String>()
+        val mutex = kotlinx.coroutines.sync.Mutex()
+
+        send(Frame.Text("""{"type":"ready"}"""))
+
+        // Fan-out coroutine: every HA event we care about → filtered push.
+        val pump = launch {
+            bridge.events.collect { event ->
+                when (event) {
+                    is HaEvent.StateChanged -> {
+                        val match = mutex.withLockReturn { event.entityId in subscribed }
+                        if (!match) return@collect
+                        val state = bridge.cache.get(event.entityId) ?: return@collect
+                        val msg = buildJsonObject {
+                            put("type", "state")
+                            put(
+                                "bindings",
+                                buildJsonObject {
+                                    put("${state.entityId}.state", JsonPrimitive(state.state))
+                                    // `is_on` is the only typed binding the
+                                    // client knows by default; emitting it
+                                    // for everything is harmless — clients
+                                    // ignore unknown names.
+                                    put(
+                                        "${state.entityId}.is_on",
+                                        JsonPrimitive(state.state == "on"),
+                                    )
+                                },
+                            )
+                        }
+                        send(Frame.Text(msg.toString()))
+                    }
+                    is HaEvent.LovelaceUpdated -> {
+                        send(
+                            Frame.Text(
+                                buildJsonObject {
+                                    put("type", "lovelace_updated")
+                                    if (event.urlPath != null) put("url_path", event.urlPath)
+                                }.toString(),
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+
+        try {
+            for (frame in incoming) {
+                if (frame !is Frame.Text) continue
+                val text = frame.readText()
+                val obj = runCatching { json.parseToJsonElement(text).jsonObject }.getOrNull() ?: continue
+                handleClientFrame(obj, subscribed, mutex, bridge)?.let { reply ->
+                    send(Frame.Text(reply.toString()))
+                }
+            }
+        } catch (t: Throwable) {
+            log.warn("stream client error: {}", t.message)
+        } finally {
+            pump.cancel()
+        }
+    }
+}
+
+private suspend fun handleClientFrame(
+    obj: JsonObject,
+    subscribed: MutableSet<String>,
+    mutex: kotlinx.coroutines.sync.Mutex,
+    bridge: HaSupervisorBridge,
+): JsonObject? {
+    val id = obj["id"]?.jsonPrimitive?.intOrNull
+    val type = obj["type"]?.jsonPrimitive?.content ?: return errorReply(id, "missing type")
+    return when (type) {
+        "subscribe" -> {
+            val entities = obj["entities"]?.jsonArray
+                ?.mapNotNull { it.jsonPrimitive.contentOrNull }
+                ?: return errorReply(id, "missing entities")
+            mutex.withLockReturn { subscribed.addAll(entities) }
+            // Hydrate: send current state for newly-subscribed entities so
+            // the client doesn't have to wait for the next `state_changed`
+            // before its document looks right.
+            val bindings = entities.mapNotNull { entityId ->
+                val s = bridge.cache.get(entityId) ?: return@mapNotNull null
+                entityId to s
+            }
+            buildJsonObject {
+                put("type", "state")
+                put(
+                    "bindings",
+                    buildJsonObject {
+                        for ((entityId, state) in bindings) {
+                            put("$entityId.state", JsonPrimitive(state.state))
+                            put("$entityId.is_on", JsonPrimitive(state.state == "on"))
+                        }
+                    },
+                )
+            }
+        }
+        "unsubscribe" -> {
+            val entities = obj["entities"]?.jsonArray
+                ?.mapNotNull { it.jsonPrimitive.contentOrNull }
+                ?: return errorReply(id, "missing entities")
+            mutex.withLockReturn { subscribed.removeAll(entities.toSet()) }
+            null
+        }
+        "call_service" -> {
+            val domain = obj["domain"]?.jsonPrimitive?.content ?: return errorReply(id, "missing domain")
+            val service = obj["service"]?.jsonPrimitive?.content ?: return errorReply(id, "missing service")
+            val target = obj["target"]?.jsonObject
+            val entityId = target?.get("entity_id")?.jsonPrimitive?.content
+            val data = obj["service_data"]?.jsonObject
+            val result = bridge.callService(domain, service, entityId, data)
+            buildJsonObject {
+                if (id != null) put("id", JsonPrimitive(id))
+                put("type", "result")
+                put("result", result)
+            }
+        }
+        else -> errorReply(id, "unknown type=$type")
+    }
+}
+
+private fun errorReply(id: Int?, message: String): JsonObject = buildJsonObject {
+    if (id != null) put("id", JsonPrimitive(id))
+    put("type", "error")
+    put("message", message)
+}
+
+// Minimal lock helper that returns the block's result. The stdlib has
+// `withLock` already; this just keeps the call-sites a little tidier.
+private suspend fun <T> kotlinx.coroutines.sync.Mutex.withLockReturn(block: () -> T): T {
+    lock()
+    return try { block() } finally { unlock() }
+}

--- a/addon-server/src/main/resources/logback.xml
+++ b/addon-server/src/main/resources/logback.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="${LOG_LEVEL:-INFO}">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="io.ktor" level="INFO"/>
+</configuration>

--- a/addon-server/test-docker/README.md
+++ b/addon-server/test-docker/README.md
@@ -1,0 +1,52 @@
+# `test-docker/` — end-to-end add-on smoke test
+
+Builds the add-on Docker image (using `addon-server/addon/Dockerfile`),
+runs it next to a real Home Assistant Core container, hits the public
+endpoints, and tears down. Useful for catching breakage between the
+JVM code, the Dockerfile, and the HA WebSocket contract before publishing
+the add-on image.
+
+## What it checks
+
+- `addon-server/addon/Dockerfile` builds cleanly against this repo
+- `/healthz` returns `200 ok`
+- `/readyz` flips to `200` once the supervisor bridge has authenticated
+  and hydrated its state cache
+- `/v1/snapshot` returns a non-empty `states` map
+- `/v1/dashboards` returns a JSON array
+- `/v1/cards/*.rc` returns the typed `501` placeholder (until M3 lands)
+
+## Prereqs
+
+- Docker + Docker Compose v2
+- `jq`
+- `integration/.env.local` containing `HA_TOKEN=<long-lived access token>`.
+  Create the token via the existing onboarding flow once:
+
+  ```sh
+  cd integration
+  docker compose up -d homeassistant   # HA on :${HA_HOST_PORT:-8124}
+  # → open the URL, complete onboarding, Profile → Security → create token
+  echo "HA_TOKEN=<token>" >> .env.local
+  docker compose down
+  ```
+
+## Running
+
+```sh
+addon-server/test-docker/run.sh
+```
+
+On failure the runner dumps `addon-server` logs to
+`/tmp/ha-rc-addon-test-server.log` before tearing down.
+
+## Notes
+
+- This runs the add-on outside the supervisor, so there's no
+  `SUPERVISOR_TOKEN`. We fall through to the `HA_BASE_URL` + `HA_TOKEN`
+  path in [`Config.kt`](../src/main/kotlin/ee/schimke/ha/addon/Config.kt).
+- HA is on the compose-internal network as `ha:8123`; the add-on
+  publishes `127.0.0.1:18099` so the host smoke checks can hit it without
+  clashing with any HA install on `:8124` or another local add-on.
+- The compose stack uses project name `ha-rc-addon-test` so it doesn't
+  collide with `integration/compose.yaml`.

--- a/addon-server/test-docker/compose.yaml
+++ b/addon-server/test-docker/compose.yaml
@@ -1,0 +1,53 @@
+# End-to-end smoke test:
+#   - real Home Assistant Core container, reusing the onboarded config
+#     from `integration/config/`
+#   - the add-on built from `addon-server/addon/Dockerfile`, talking to
+#     HA over the compose-internal network at `http://ha:8123`
+#
+# Usage: `addon-server/test-docker/run.sh`. The runner brings this up,
+# waits for `/readyz`, hits a handful of endpoints, tears down.
+#
+# This is *not* the supervisor flow — there's no `SUPERVISOR_TOKEN`
+# injected, so we authenticate via the HA long-lived token the user
+# already created for the existing reference-capture pipeline.
+
+services:
+  ha:
+    image: ghcr.io/home-assistant/home-assistant:stable
+    container_name: ha-remotecompose-addon-test-ha
+    restart: "no"
+    # Reuse the same pre-onboarded config the integration/ pipeline uses.
+    # No host port published — the add-on reaches HA via the compose
+    # network at `ha:8123`.
+    volumes:
+      - ../../integration/config:/config
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:8123 || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 20s
+
+  addon-server:
+    container_name: ha-remotecompose-addon-test-server
+    build:
+      # Build context = repo root, so we can COPY `gradle/`, `ha-model/`,
+      # `ha-client/`, `addon-server/` in one layer.
+      context: ../..
+      dockerfile: addon-server/addon/Dockerfile
+    environment:
+      HA_BASE_URL: "http://ha:8123"
+      # HA_TOKEN comes from integration/.env.local via env_file below.
+      PORT: "8099"
+      LOG_LEVEL: "info"
+    ports:
+      - "127.0.0.1:18099:8099"
+    depends_on:
+      ha:
+        condition: service_healthy
+    env_file:
+      # Same token the rest of integration/ uses. Optional so a CI run
+      # can override HA_TOKEN via plain env without committing a file.
+      - path: ../../integration/.env.local
+        required: false
+    restart: "no"

--- a/addon-server/test-docker/run.sh
+++ b/addon-server/test-docker/run.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# End-to-end smoke test: build the add-on Docker image, run it next to a
+# real Home Assistant container, hit the public endpoints, tear down.
+#
+# Prereqs:
+#   - docker + docker compose v2
+#   - integration/.env.local with HA_TOKEN=<long-lived access token>
+#     (created via the existing reference-capture onboarding flow — see
+#     integration/scripts/capture-references.sh)
+#   - jq
+#
+# Exit codes: 0 success, non-zero on any failed check.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# --- preflight ---------------------------------------------------------
+
+ENV_FILE="../../integration/.env.local"
+if [[ ! -f "$ENV_FILE" ]]; then
+  cat >&2 <<'EOF'
+Missing integration/.env.local — first-time setup needed.
+
+The add-on container needs a Home Assistant access token. Create one
+once via the existing onboarding flow:
+
+  1) cd integration
+  2) docker compose up -d homeassistant
+  3) Open http://localhost:${HA_HOST_PORT:-8124} and complete onboarding
+  4) Profile → Security → create a long-lived access token
+  5) Put it in integration/.env.local as HA_TOKEN=<...>
+  6) docker compose down
+
+Then re-run this script.
+EOF
+  exit 2
+fi
+
+# Load the token so the smoke checks below can also read it (the compose
+# `env_file` only injects it into the addon-server container).
+# shellcheck disable=SC1090
+set -a; source "$ENV_FILE"; set +a
+
+if [[ -z "${HA_TOKEN:-}" ]]; then
+  echo "HA_TOKEN missing in $ENV_FILE" >&2
+  exit 2
+fi
+
+for cmd in docker jq curl; do
+  command -v "$cmd" >/dev/null || { echo "missing: $cmd" >&2; exit 2; }
+done
+
+# --- lifecycle ---------------------------------------------------------
+
+# Project name keeps containers separate from any other docker-compose
+# stack running on the host (e.g. integration/compose.yaml on the same
+# user's box).
+COMPOSE=(docker compose -p ha-rc-addon-test -f compose.yaml)
+
+cleanup() {
+  echo "==> tearing down"
+  "${COMPOSE[@]}" logs addon-server > /tmp/ha-rc-addon-test-server.log 2>&1 || true
+  "${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+echo "==> building + starting (HA + addon-server)"
+"${COMPOSE[@]}" up -d --build
+
+# --- wait for /readyz --------------------------------------------------
+
+ADDON_URL="http://127.0.0.1:18099"
+echo "==> waiting for ${ADDON_URL}/readyz (HA hydrate may take ~30s)"
+ready=""
+for _ in $(seq 1 90); do
+  status=$(curl -s -o /dev/null -w "%{http_code}" "${ADDON_URL}/readyz" || echo "000")
+  if [[ "$status" == "200" ]]; then
+    ready=1
+    break
+  fi
+  sleep 1
+done
+if [[ -z "$ready" ]]; then
+  echo "FAIL: /readyz never returned 200" >&2
+  echo "---- addon-server logs ----" >&2
+  "${COMPOSE[@]}" logs addon-server >&2 || true
+  exit 1
+fi
+echo "==> ready"
+
+# --- endpoint checks ---------------------------------------------------
+
+echo "==> /healthz"
+curl -fsS "${ADDON_URL}/healthz" | grep -qx "ok"
+
+echo "==> /v1/snapshot has entities"
+snapshot=$(curl -fsS "${ADDON_URL}/v1/snapshot")
+count=$(jq '.states | length' <<<"$snapshot")
+if (( count <= 0 )); then
+  echo "FAIL: /v1/snapshot returned 0 entities" >&2
+  echo "$snapshot" | head -c 500 >&2
+  exit 1
+fi
+echo "    $count entities"
+
+echo "==> /v1/dashboards is a JSON array"
+curl -fsS "${ADDON_URL}/v1/dashboards" | jq -e 'type == "array"' >/dev/null
+
+echo "==> /v1/cards/x.rc returns the typed 501 placeholder"
+status=$(curl -s -o /dev/null -w "%{http_code}" "${ADDON_URL}/v1/cards/whatever.rc")
+if [[ "$status" != "501" ]]; then
+  echo "FAIL: expected 501 for unimplemented .rc endpoint, got $status" >&2
+  exit 1
+fi
+
+echo "==> all checks passed"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ ktor = "3.0.3"
 kotlinx-serialization = "1.7.3"
 kotlinx-coroutines = "1.10.1"
 kotlinx-datetime = "0.6.1"
+logback = "1.5.12"
 
 # Preview tooling
 compose-preview-plugin = "0.7.11"
@@ -84,6 +85,17 @@ ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negoti
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+
+# Ktor server (addon-server)
+ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
+ktor-server-websockets = { module = "io.ktor:ktor-server-websockets", version.ref = "ktor" }
+ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
+ktor-server-status-pages = { module = "io.ktor:ktor-server-status-pages", version.ref = "ktor" }
+ktor-server-call-logging = { module = "io.ktor:ktor-server-call-logging", version.ref = "ktor" }
+ktor-server-default-headers = { module = "io.ktor:ktor-server-default-headers", version.ref = "ktor" }
+ktor-server-auth = { module = "io.ktor:ktor-server-auth", version.ref = "ktor" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 
 # Kotlinx
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,4 +35,5 @@ include(
     ":wear",
     ":tv",
     ":integration",
+    ":addon-server",
 )


### PR DESCRIPTION
New :addon-server module with the plan in PLAN.md and a working Ktor/CIO
prototype focused on the add-on + HA integration story (card .rc encoding
deferred to M3, see plan).

What works:
- HaSupervisorBridge: long-lived WS to HA Core with auth, reconnect/
  backoff, request/response multiplexing, and event subscriptions for
  state_changed + lovelace_updated. Maintains a StateCache keyed by
  entity_id, exposed as a StateFlow.
- REST /v1/dashboards, /v1/dashboards/{path}, /v1/snapshot, /healthz,
  /readyz. /v1/cards/{id}.rc returns a typed 501 placeholder until the
  JVM converter port lands.
- WS /v1/stream: per-client subscribe/unsubscribe, hydrate-on-subscribe,
  state-change fan-out using LiveBindings naming (entity.state /
  entity.is_on), and call_service round-trip via the bridge.
- HA add-on packaging in addon/: config.yaml (ingress + LAN port,
  homeassistant_api), multi-stage Dockerfile (gradle build → distroless
  java21), bashio-friendly run.sh fallback.

Smoke-tested locally: server starts on :PORT, /healthz=200,
/readyz=503 while bridge can't reach HA, bridge attempts exponential-
backoff reconnect, shutdown hook drains cleanly.

https://claude.ai/code/session_01M9eRBGwonyv1vdc2jSpWmu