### PR TITLE
Dashboard-first shell: TopAppBar with quick-switcher dropdown (re-open)

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -2,12 +2,10 @@ package ee.schimke.terrazzo
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -15,17 +13,18 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Dashboard
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.Widgets
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -47,26 +46,31 @@ import ee.schimke.terrazzo.core.prefs.ThemePref
 import ee.schimke.terrazzo.core.session.DemoData
 import ee.schimke.terrazzo.core.session.DemoHaSession
 import ee.schimke.terrazzo.core.session.HaSession
-import ee.schimke.terrazzo.widget.WidgetRefreshScheduler
+import ee.schimke.terrazzo.dashboard.DashboardListState
 import ee.schimke.terrazzo.dashboard.DashboardPickerScreen
+import ee.schimke.terrazzo.dashboard.DashboardSwitcher
 import ee.schimke.terrazzo.dashboard.DashboardViewScreen
+import ee.schimke.terrazzo.dashboard.TopBarOverflowMenu
+import ee.schimke.terrazzo.dashboard.rememberDashboardListState
 import ee.schimke.terrazzo.discovery.DiscoveryScreen
 import ee.schimke.terrazzo.monitor.MonitoringService
 import ee.schimke.terrazzo.widget.WidgetInstallSheet
+import ee.schimke.terrazzo.widget.WidgetRefreshScheduler
 import ee.schimke.terrazzo.widget.WidgetsScreen
 import kotlinx.coroutines.launch
 
 /**
  * Root composable. Two phases:
  *
- * 1. **Unauthenticated**: discovery + login flow (one screen, not in
- *    the nav suite). Completing login — or enabling demo mode —
- *    promotes to phase 2.
- * 2. **Authenticated**: `NavigationSuiteScaffold` with three top-level
- *    destinations — Dashboards, Widgets, Settings. The suite picks
- *    bottom bar / nav rail / nav drawer based on window size class
- *    (phone / foldable-closed / unfolded / tablet). Within
- *    Dashboards, a lightweight back-stack walks picker → view.
+ * 1. **Unauthenticated**: discovery + login flow (one screen, no chrome).
+ *    Completing login — or enabling demo mode — promotes to phase 2.
+ * 2. **Authenticated**: a dashboard-first shell. The dashboard fills the
+ *    screen; a small `TopAppBar` carries a [DashboardSwitcher] (current
+ *    dashboard name + chevron + 1-tap-switch dropdown) and an overflow
+ *    menu hosting Settings / Manage widgets / Sign out. No more
+ *    `NavigationSuiteScaffold` — there's nothing to navigate to other
+ *    than dashboards, and Settings / widgets are rare visits hidden
+ *    behind one tap of the overflow.
  *
  * Demo mode (toggled from Settings, or from the Discovery "try demo"
  * button) swaps the live [HaSession] for a deterministic fake so the
@@ -113,7 +117,7 @@ fun TerrazzoApp(initialDashboard: String? = null) {
             },
             error = lastError,
         )
-        else -> AuthenticatedScaffold(
+        else -> AuthenticatedShell(
             session = s,
             initialDashboard = initialDashboard,
             onToggleDemo = { enabled ->
@@ -168,125 +172,135 @@ private fun UnauthenticatedScreen(
     }
 }
 
-private enum class Destination(val label: String) {
-    Dashboards("Dashboards"),
-    Widgets("Widgets"),
-    Settings("Settings"),
-}
+private enum class AppScreen { Dashboards, Settings, Widgets }
 
 @Composable
-private fun AuthenticatedScaffold(
+private fun AuthenticatedShell(
     session: HaSession,
     initialDashboard: String?,
     onToggleDemo: (Boolean) -> Unit,
     onSignOut: () -> Unit,
 ) {
-    var current by rememberSaveable { mutableStateOf(Destination.Dashboards) }
+    var screen by rememberSaveable { mutableStateOf(AppScreen.Dashboards) }
 
-    NavigationSuiteScaffold(
-        navigationSuiteItems = {
-            item(
-                selected = current == Destination.Dashboards,
-                onClick = { current = Destination.Dashboards },
-                icon = { Icon(Icons.Filled.Dashboard, contentDescription = null) },
-                label = { Text("Dashboards") },
-            )
-            item(
-                selected = current == Destination.Widgets,
-                onClick = { current = Destination.Widgets },
-                icon = { Icon(Icons.Filled.Widgets, contentDescription = null) },
-                label = { Text("Widgets") },
-            )
-            item(
-                selected = current == Destination.Settings,
-                onClick = { current = Destination.Settings },
-                icon = { Icon(Icons.Filled.Settings, contentDescription = null) },
-                label = { Text("Settings") },
-            )
-        },
-    ) {
-        // Edge-to-edge: the outer Box fills the entire window (background
-        // paints behind the status bar / nav bar), and each destination
-        // gets the safe-drawing insets as `contentPadding`. Scrollable
-        // tabs apply it to their LazyColumn so list items scroll under
-        // the bars; static tabs pad their root container so chrome
-        // doesn't get clipped.
-        val safeInsets = WindowInsets.safeDrawing.asPaddingValues()
-        Box(Modifier.fillMaxSize()) {
-            when (current) {
-                Destination.Dashboards -> DashboardsTab(
-                    session = session,
-                    initialDashboard = initialDashboard,
-                    contentPadding = safeInsets,
-                )
-                Destination.Widgets -> WidgetsScreen(safeInsets)
-                Destination.Settings -> SettingsScreen(
-                    session = session,
-                    onToggleDemo = onToggleDemo,
-                    onSignOut = onSignOut,
-                    contentPadding = safeInsets,
-                )
-            }
-        }
+    // System-back from Settings / Widgets returns to the dashboards
+    // root. Inside DashboardsRoot another BackHandler routes view →
+    // picker; the platform handles back at the picker (exits app).
+    BackHandler(enabled = screen != AppScreen.Dashboards) {
+        screen = AppScreen.Dashboards
+    }
+
+    when (screen) {
+        AppScreen.Dashboards -> DashboardsRoot(
+            session = session,
+            initialDashboard = initialDashboard,
+            onOpenSettings = { screen = AppScreen.Settings },
+            onOpenWidgets = { screen = AppScreen.Widgets },
+            onSignOut = onSignOut,
+        )
+        AppScreen.Settings -> SettingsScreen(
+            session = session,
+            onToggleDemo = onToggleDemo,
+            onSignOut = onSignOut,
+            onBack = { screen = AppScreen.Dashboards },
+        )
+        AppScreen.Widgets -> WidgetsScreen(
+            onBack = { screen = AppScreen.Dashboards },
+        )
     }
 }
 
 /**
- * Two-step stack inside the Dashboards tab: picker → view. Kept local
- * here rather than wiring in Nav3's NavDisplay for this shallow flow —
- * when the app gets deeper navigation (per-card detail, widget
- * configure) we promote to a real `NavDisplay`.
+ * The dashboard-first shell. Loads the dashboards list once for the
+ * session, hosts the picker → view local nav, and renders the
+ * [TopAppBar] with the [DashboardSwitcher] + [TopBarOverflowMenu].
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun DashboardsTab(
+private fun DashboardsRoot(
     session: HaSession,
     initialDashboard: String?,
-    contentPadding: PaddingValues,
+    onOpenSettings: () -> Unit,
+    onOpenWidgets: () -> Unit,
+    onSignOut: () -> Unit,
 ) {
     val graph = LocalTerrazzoGraph.current
     val scope = rememberCoroutineScope()
+    val dashboards by rememberDashboardListState(session)
+
     var opened by rememberSaveable {
         mutableStateOf(initialDashboardToOpened(initialDashboard))
     }
     var installPending by remember { mutableStateOf<Pair<CardConfig, HaSnapshot>?>(null) }
     val openedValue = opened
 
-    // System-back navigates from view → picker. On the picker itself
-    // back is disabled, so the platform handles it (exits the app or
-    // pops the activity). Without this, the only way back to the
-    // picker is sign-out — and on cold launch we now auto-jump into
-    // the persisted last-viewed, so users would otherwise be stuck.
+    // System-back: view → picker; on the picker the platform handles it.
     BackHandler(enabled = openedValue != DASHBOARD_UNSET) {
         opened = DASHBOARD_UNSET
     }
 
-    if (openedValue == DASHBOARD_UNSET) {
-        DashboardPickerScreen(
-            session = session,
-            onDashboardPicked = { urlPath ->
-                opened = urlPath
-                // Persist for the next cold start. The picker is the
-                // only entry point that changes which dashboard we
-                // consider "current", so this is the only write site.
-                scope.launch { graph.preferencesStore.setLastViewedDashboard(urlPath) }
-            },
-            contentPadding = contentPadding,
-        )
-    } else {
-        DashboardViewScreen(
-            session = session,
-            urlPath = openedValue,
-            onCardLongPress = { card ->
-                // In demo mode the preview — and the installed widget —
-                // render against the current fake snapshot so values
-                // aren't empty. Live mode uses an empty snapshot; the
-                // pinned widget will refresh from HA on first tick.
-                val previewSnapshot =
-                    if (session is DemoHaSession) DemoData.snapshot() else HaSnapshot()
-                installPending = card to previewSnapshot
-            },
-            contentPadding = contentPadding,
-        )
+    val readyDashboards = (dashboards as? DashboardListState.Ready)?.dashboards.orEmpty()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    if (openedValue == DASHBOARD_UNSET) {
+                        Text("Pick a dashboard")
+                    } else {
+                        DashboardSwitcher(
+                            dashboards = readyDashboards,
+                            currentUrlPath = openedValue,
+                            onSwitch = { newPath ->
+                                opened = newPath
+                                scope.launch {
+                                    graph.preferencesStore.setLastViewedDashboard(newPath)
+                                }
+                            },
+                        )
+                    }
+                },
+                actions = {
+                    TopBarOverflowMenu(
+                        onOpenSettings = onOpenSettings,
+                        onOpenWidgets = onOpenWidgets,
+                        onSignOut = onSignOut,
+                    )
+                },
+            )
+        },
+        // Scaffold consumes the top inset for the bar; we hand the
+        // bottom + sides to the content as the inner contentPadding.
+        contentWindowInsets = WindowInsets.safeDrawing,
+    ) { padding ->
+        if (openedValue == DASHBOARD_UNSET) {
+            DashboardPickerScreen(
+                state = dashboards,
+                onDashboardPicked = { urlPath ->
+                    opened = urlPath
+                    // Persist for the next cold start. The picker
+                    // and the switcher are the only entry points
+                    // that change which dashboard is "current".
+                    scope.launch { graph.preferencesStore.setLastViewedDashboard(urlPath) }
+                },
+                contentPadding = padding,
+            )
+        } else {
+            DashboardViewScreen(
+                session = session,
+                urlPath = openedValue,
+                onCardLongPress = { card ->
+                    // In demo mode the preview — and the installed widget —
+                    // render against the current fake snapshot so values
+                    // aren't empty. Live mode uses an empty snapshot; the
+                    // pinned widget will refresh from HA on first tick.
+                    val previewSnapshot =
+                        if (session is DemoHaSession) DemoData.snapshot() else HaSnapshot()
+                    installPending = card to previewSnapshot
+                },
+                contentPadding = padding,
+            )
+        }
     }
 
     val monitorContext = LocalContext.current
@@ -311,7 +325,7 @@ private const val DASHBOARD_UNSET = "__none__"
 
 /**
  * Translate the persisted last-viewed-dashboard pref into the local
- * `opened` sentinel/urlPath encoding `DashboardsTab` uses:
+ * `opened` sentinel/urlPath encoding `DashboardsRoot` uses:
  *
  *   - `null` (pref absent) → [DASHBOARD_UNSET] (show picker).
  *   - [PreferencesStore.DEFAULT_DASHBOARD_SENTINEL] → `null`
@@ -324,12 +338,13 @@ private fun initialDashboardToOpened(stored: String?): String? = when (stored) {
     else -> stored
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SettingsScreen(
     session: HaSession,
     onToggleDemo: (Boolean) -> Unit,
     onSignOut: () -> Unit,
-    contentPadding: PaddingValues = PaddingValues(0.dp),
+    onBack: () -> Unit,
 ) {
     val isDemo = session is DemoHaSession
     val graph = LocalTerrazzoGraph.current
@@ -339,62 +354,74 @@ private fun SettingsScreen(
     val themePref by graph.preferencesStore.themeStyle.collectAsState(initial = ThemePref.TerrazzoHome)
     val darkPref by graph.preferencesStore.darkMode.collectAsState(initial = DarkModePref.Follow)
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(contentPadding)
-            .padding(24.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        Text("Settings", style = MaterialTheme.typography.headlineMedium)
-
-        Text("Connected to", style = MaterialTheme.typography.labelMedium)
-        Text(
-            if (isDemo) "Demo mode — offline fake data" else session.baseUrl,
-            style = MaterialTheme.typography.bodyMedium,
-        )
-
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Settings") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        contentWindowInsets = WindowInsets.safeDrawing,
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(padding)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            Column {
-                Text("Demo mode", style = MaterialTheme.typography.titleMedium)
-                Text(
-                    "Populate the app with an interesting set of fake widgets that animate.",
-                    style = MaterialTheme.typography.bodySmall,
+            Text("Connected to", style = MaterialTheme.typography.labelMedium)
+            Text(
+                if (isDemo) "Demo mode — offline fake data" else session.baseUrl,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+            ) {
+                Column {
+                    Text("Demo mode", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        "Populate the app with an interesting set of fake widgets that animate.",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                Switch(
+                    checked = isDemo,
+                    onCheckedChange = onToggleDemo,
                 )
             }
-            Switch(
-                checked = isDemo,
-                onCheckedChange = onToggleDemo,
+
+            ThemeSection(
+                selected = themePref,
+                darkMode = darkPref,
+                onSelectTheme = { pref ->
+                    scope.launch {
+                        graph.preferencesStore.setThemeStyle(pref)
+                        // Each pinned widget has a baked .rc doc using the
+                        // old palette; broadcast a refresh so the provider
+                        // re-captures under the new one.
+                        widgetRefresh.refreshAllNow()
+                    }
+                },
+                onSelectDark = { pref ->
+                    scope.launch {
+                        graph.preferencesStore.setDarkMode(pref)
+                        widgetRefresh.refreshAllNow()
+                    }
+                },
             )
-        }
 
-        ThemeSection(
-            selected = themePref,
-            darkMode = darkPref,
-            onSelectTheme = { pref ->
-                scope.launch {
-                    graph.preferencesStore.setThemeStyle(pref)
-                    // Each pinned widget has a baked .rc doc using the
-                    // old palette; broadcast a refresh so the provider
-                    // re-captures under the new one.
-                    widgetRefresh.refreshAllNow()
-                }
-            },
-            onSelectDark = { pref ->
-                scope.launch {
-                    graph.preferencesStore.setDarkMode(pref)
-                    widgetRefresh.refreshAllNow()
-                }
-            },
-        )
-
-        OutlinedButton(onClick = onSignOut) {
-            Text(if (isDemo) "Exit demo" else "Sign out")
+            OutlinedButton(onClick = onSignOut) {
+                Text(if (isDemo) "Exit demo" else "Sign out")
+            }
         }
     }
 }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardListState.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardListState.kt
@@ -1,0 +1,59 @@
+package ee.schimke.terrazzo.dashboard
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import ee.schimke.ha.client.DashboardSummary
+import ee.schimke.terrazzo.core.session.HaSession
+
+/**
+ * Cached dashboards-list state shared between [DashboardPickerScreen]
+ * (the first-launch experience) and the top-bar
+ * `DashboardSwitcher` (the in-flight quick-switcher). Both surfaces
+ * want the same list — without hoisting we'd re-fetch from HA each
+ * time the user opens the dropdown vs. visits the picker, which on a
+ * cold network is visible.
+ */
+sealed interface DashboardListState {
+    data object Loading : DashboardListState
+    data class Error(val message: String) : DashboardListState
+
+    /**
+     * Dashboards as returned by HA, with one synthetic exception: HA
+     * returns an *empty* list when the only dashboard is the default
+     * one, so we materialise a `(urlPath = null, title = "Home")` entry
+     * in that case so the picker / switcher always have something to
+     * render.
+     */
+    data class Ready(val dashboards: List<DashboardSummary>) : DashboardListState
+}
+
+/**
+ * Load + cache the dashboards list for the lifetime of [session]. A
+ * new [HaSession] (sign-in / demo toggle / sign-out → sign-in) keys a
+ * fresh load. Within one session this is one HTTP-equivalent call,
+ * and dashboards are stable enough on the HA side that we don't poll.
+ */
+@Composable
+fun rememberDashboardListState(session: HaSession): State<DashboardListState> {
+    val state = remember(session) { mutableStateOf<DashboardListState>(DashboardListState.Loading) }
+    LaunchedEffect(session) {
+        runCatching {
+            session.connect()
+            session.listDashboards()
+        }.onSuccess { list ->
+            state.value = DashboardListState.Ready(
+                dashboards = list.ifEmpty {
+                    listOf(DashboardSummary(urlPath = null, title = "Home"))
+                },
+            )
+        }.onFailure {
+            state.value = DashboardListState.Error(it.message ?: it::class.simpleName ?: "error")
+        }
+    }
+    return state
+}

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardPickerScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardPickerScreen.kt
@@ -14,61 +14,46 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import ee.schimke.ha.client.DashboardSummary
-import ee.schimke.terrazzo.core.session.HaSession
 
+/**
+ * Dashboard picker. **Presentational** — the dashboards list is loaded
+ * by the caller (`DashboardsRoot`) so the same data drives both this
+ * screen and the top-bar quick-switcher dropdown without re-querying.
+ *
+ * The picker is the first-launch experience (when no `lastViewedDashboard`
+ * pref is set) and the destination of the system-back gesture from a
+ * dashboard view. With the new top-bar dropdown most users won't visit
+ * this screen often once they've picked a dashboard.
+ */
 @Composable
 fun DashboardPickerScreen(
-    session: HaSession,
+    state: DashboardListState,
     onDashboardPicked: (urlPath: String?) -> Unit,
     contentPadding: PaddingValues = PaddingValues(0.dp),
 ) {
-    var dashboards by remember { mutableStateOf<List<DashboardSummary>?>(null) }
-    var error by remember { mutableStateOf<String?>(null) }
-
-    LaunchedEffect(session) {
-        runCatching {
-            session.connect()
-            session.listDashboards()
-        }.onSuccess {
-            // HA returns an empty list if there are no *extra* dashboards; the
-            // default dashboard always lives at url_path = null.
-            dashboards = it.ifEmpty { listOf(DashboardSummary(urlPath = null, title = "Home")) }
-        }.onFailure { error = it.message ?: it::class.simpleName }
-    }
-
-    when {
-        error != null -> Column(Modifier.fillMaxSize().padding(contentPadding).padding(24.dp)) {
-            Text("Couldn't load dashboards", style = MaterialTheme.typography.titleMedium)
-            Text(error!!)
-        }
-        dashboards == null -> Column(
+    when (state) {
+        DashboardListState.Loading -> Column(
             Modifier.fillMaxSize().padding(contentPadding).padding(24.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             CircularProgressIndicator()
             Text("Fetching dashboards…")
         }
-        else -> LazyColumn(
+        is DashboardListState.Error -> Column(
+            Modifier.fillMaxSize().padding(contentPadding).padding(24.dp),
+        ) {
+            Text("Couldn't load dashboards", style = MaterialTheme.typography.titleMedium)
+            Text(state.message)
+        }
+        is DashboardListState.Ready -> LazyColumn(
             modifier = Modifier.fillMaxSize(),
             contentPadding = contentPadding,
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            item {
-                Text(
-                    "Dashboards",
-                    style = MaterialTheme.typography.headlineMedium,
-                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
-                )
-            }
-            items(dashboards!!) { d ->
+            items(state.dashboards, key = { it.urlPath ?: "__default__" }) { d ->
                 Card(
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardSwitcher.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardSwitcher.kt
@@ -1,0 +1,99 @@
+package ee.schimke.terrazzo.dashboard
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import ee.schimke.ha.client.DashboardSummary
+
+/**
+ * Top-app-bar title slot for the dashboard view. Renders the active
+ * dashboard's name and, when there are 2+ dashboards, a chevron that
+ * opens a [DropdownMenu] with the other dashboards as 1-tap switch
+ * targets.
+ *
+ * This is the chrome the persona-2 (2–3 favourites) user pays per
+ * switch: 2 taps total — chevron + favourite. Persona 1 (single
+ * dashboard) sees plain text, no chevron, no dropdown — chrome scales
+ * with what's available.
+ *
+ * Settings / widgets / sign-out live behind a separate overflow menu
+ * in the top-bar's actions slot ([TopBarOverflowMenu]) so the
+ * dashboards dropdown stays focused on dashboard switching.
+ */
+@Composable
+fun DashboardSwitcher(
+    dashboards: List<DashboardSummary>,
+    currentUrlPath: String?,
+    onSwitch: (urlPath: String?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val current = dashboards.firstOrNull { it.urlPath == currentUrlPath }
+    val title = current?.title ?: "Dashboard"
+    val canSwitch = dashboards.size >= 2
+
+    if (!canSwitch) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = modifier,
+        )
+        return
+    }
+
+    var expanded by remember { mutableStateOf(false) }
+    Box(modifier = modifier) {
+        TextButton(onClick = { expanded = true }) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Icon(
+                imageVector = Icons.Filled.ArrowDropDown,
+                contentDescription = "Switch dashboard",
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            dashboards.forEach { d ->
+                DropdownMenuItem(
+                    text = { Text(d.title) },
+                    leadingIcon = {
+                        if (d.urlPath == currentUrlPath) {
+                            Icon(Icons.Filled.Check, contentDescription = "Currently open")
+                        } else {
+                            // 24 dp keeps the labels left-aligned to a
+                            // consistent column whether or not the row
+                            // has a leading checkmark.
+                            Spacer(Modifier.size(24.dp))
+                        }
+                    },
+                    onClick = {
+                        expanded = false
+                        if (d.urlPath != currentUrlPath) onSwitch(d.urlPath)
+                    },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/TopBarOverflowMenu.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/TopBarOverflowMenu.kt
@@ -1,0 +1,51 @@
+package ee.schimke.terrazzo.dashboard
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+/**
+ * Trailing overflow menu in the dashboard top-bar. Carries the
+ * destinations the [DashboardSwitcher] dropdown deliberately doesn't:
+ * Settings, installed widgets, sign-out. Dashboard quick-switching
+ * stays in the title-side dropdown so users don't have to scroll past
+ * "Manage widgets" / "Settings" entries to reach the dashboards
+ * they actually want to switch between.
+ */
+@Composable
+fun TopBarOverflowMenu(
+    onOpenSettings: () -> Unit,
+    onOpenWidgets: () -> Unit,
+    onSignOut: () -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    IconButton(onClick = { expanded = true }) {
+        Icon(Icons.Filled.MoreVert, contentDescription = "More options")
+    }
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = { expanded = false },
+    ) {
+        DropdownMenuItem(
+            text = { Text("Settings") },
+            onClick = { expanded = false; onOpenSettings() },
+        )
+        DropdownMenuItem(
+            text = { Text("Manage widgets") },
+            onClick = { expanded = false; onOpenWidgets() },
+        )
+        DropdownMenuItem(
+            text = { Text("Sign out") },
+            onClick = { expanded = false; onSignOut() },
+        )
+    }
+}

--- a/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
@@ -7,9 +7,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import ee.schimke.ha.client.DashboardSummary
 import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.terrazzo.core.prefs.DarkModePref
 import ee.schimke.terrazzo.core.session.DemoHaSession
+import ee.schimke.terrazzo.dashboard.DashboardListState
 import ee.schimke.terrazzo.dashboard.DashboardPickerScreen
 import ee.schimke.terrazzo.dashboard.DashboardViewScreen
 import ee.schimke.terrazzo.discovery.DiscoveryScreen
@@ -53,13 +55,22 @@ fun Screen_Discovery() = PhoneHost {
 @Preview(name = "widgets", showBackground = false, widthDp = PHONE_WIDTH_DP, heightDp = PHONE_HEIGHT_DP)
 @Composable
 fun Screen_Widgets() = PhoneHost {
-    WidgetsScreen()
+    WidgetsScreen(onBack = {})
 }
 
 @Preview(name = "dashboard picker", showBackground = false, widthDp = PHONE_WIDTH_DP, heightDp = PHONE_HEIGHT_DP)
 @Composable
 fun Screen_DashboardPicker() = PhoneHost {
-    DashboardPickerScreen(session = DemoHaSession(), onDashboardPicked = {})
+    DashboardPickerScreen(
+        state = DashboardListState.Ready(
+            dashboards = listOf(
+                DashboardSummary(urlPath = null, title = "Home"),
+                DashboardSummary(urlPath = "lovelace-mobile", title = "Living room"),
+                DashboardSummary(urlPath = "lovelace-garage", title = "Garage"),
+            ),
+        ),
+        onDashboardPicked = {},
+    )
 }
 
 @Preview(name = "dashboard view", showBackground = false, widthDp = PHONE_WIDTH_DP, heightDp = PHONE_HEIGHT_DP)

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetsScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetsScreen.kt
@@ -1,36 +1,59 @@
 package ee.schimke.terrazzo.widget
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 /**
- * Installed-widgets tab. Placeholder — wired in the next pass with:
+ * Installed-widgets screen, reached via the dashboard top-bar's
+ * overflow menu. Placeholder — wired in the next pass with:
  *   - list of installed `AppWidgetId`s + their card configs (from DataStore),
  *   - an "install new" entry that walks the user to a dashboard to long-press,
  *   - up-to-5 cap enforced here.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun WidgetsScreen(contentPadding: PaddingValues = PaddingValues(0.dp)) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(contentPadding)
-            .padding(24.dp),
-    ) {
-        Text("Widgets", style = MaterialTheme.typography.headlineMedium)
-        Text(
-            "Long-press a card on a dashboard to install it here. Up to 5.",
-            style = MaterialTheme.typography.bodyMedium,
-        )
+fun WidgetsScreen(onBack: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Installed widgets") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        contentWindowInsets = WindowInsets.safeDrawing,
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(padding)
+                .padding(24.dp),
+        ) {
+            Text(
+                "Long-press a card on a dashboard to install it here. Up to 5.",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary

Re-opens the dashboard-shell rework. Original PR #15 was stacked on `claude/launch-into-last-dashboard` (the #13 branch). When #13 squash-merged, GitHub closed #15's base branch, and the subsequent #15 merge wrote into the now-deleted intermediate branch rather than `main` — same merge-order trap as the earlier #7/#8 incident.

This PR is the same single commit, rebased cleanly onto current `main`.

PR 2 of the dashboard-shell rework. Drops `NavigationSuiteScaffold(Dashboards|Widgets|Settings)` — there's nothing to navigate to other than dashboards, and the bottom nav spent permanent screen real estate on destinations most users visit rarely. Replaces with a dashboard-first shell:

### What's new

**`TopAppBar` carries the switcher.** Title slot holds a `DashboardSwitcher` — tap the dashboard name + chevron to open a `DropdownMenu` listing the other dashboards with a checkmark on the current one. 1-tap switch, persists via `lastViewedDashboard` so the next cold launch lands on whichever favourite the user picked last. **The chevron hides when there's only one dashboard** — a single-dashboard user never sees switcher chrome they don't need.

**Trailing overflow menu** — the `⋮` in the actions slot opens a small `DropdownMenu` with **Settings**, **Manage widgets**, **Sign out**. Rare destinations, one tap deep from anywhere on the dashboard.

**Settings and Widgets** each get their own back-arrow-topped `Scaffold`. System-back from either routes to Dashboards (handled by a `BackHandler` in `AuthenticatedShell`); `BackHandler` inside `DashboardsRoot` still routes view → picker.

### Internal changes

- **`DashboardListState` + `rememberDashboardListState`** hoist `session.listDashboards()` out of `DashboardPickerScreen` up to `DashboardsRoot`. The picker AND the switcher now consume one cached list — no double fetch when the user opens the dropdown after visiting the picker (and vice versa).
- **`DashboardPickerScreen`** becomes presentational: it takes a `DashboardListState` instead of a session, and no longer renders its own "Dashboards" headline (the `TopAppBar` carries the title now).
- **`DashboardSwitcher`** + **`TopBarOverflowMenu`** are new files in `dashboard/`. Two separate dropdowns deliberately — title-side for switching, trailing for rare actions.
- `ScreenPreviews` updated for the new signatures.

## Test plan

- [x] Rebased cleanly onto current `main`
- [x] `:app:compileDebugKotlin` clean
- [x] `:app:testDebugUnitTest` passes
- [ ] Manual: 1-dashboard demo → top-bar shows plain title, no chevron
- [ ] Manual: 2+ dashboard live → tap title → dropdown lists all dashboards with ✓ on current
- [ ] Manual: pick a different dashboard from dropdown → main pane swaps + pref updated
- [ ] Manual: `⋮` → Settings → back arrow → returns to dashboard, dashboard state preserved
- [ ] Manual: `⋮` → Sign out → returns to discovery


---
_Generated by [Claude Code](https://claude.ai/code/session_014V2uC26jjmE52NDndsoSgo)_