### PR TITLE
Wear sync layer + demo mode for Wear and TV

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.compose.preview)
     alias(libs.plugins.metro)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -68,7 +69,19 @@ dependencies {
     implementation(libs.remote.tooling.preview)
 
     implementation(libs.androidx.browser)
+    // Proto DataStore for the wear sync layer. Schema is documented
+    // in `src/main/proto/wear_sync.proto`; we encode @Serializable
+    // Kotlin data classes to the same proto wire format via
+    // kotlinx-serialization-protobuf. (TODO: switch to Wire once its
+    // Gradle plugin recognises AGP 9's built-in Kotlin.)
+    implementation(libs.androidx.datastore)
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.kotlinx.serialization.protobuf)
+    implementation(libs.play.services.wearable)
+    implementation(libs.horologist.datalayer)
+    implementation(libs.horologist.datalayer.phone)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.work.runtime)
     implementation(libs.androidx.navigation3.runtime)
     implementation(libs.androidx.navigation3.ui)

--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -88,6 +88,9 @@ fun TerrazzoApp(initialDashboard: String? = null) {
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
     val widgetScheduler = remember(context) { WidgetRefreshScheduler(context.applicationContext) }
+    val wearSync = remember(context) {
+        (context.applicationContext as TerrazzoApplication).wearSync
+    }
 
     // Persisted demo-mode flag survives process restarts, so a user who
     // opted into demo doesn't see the login screen again on relaunch.
@@ -99,6 +102,10 @@ fun TerrazzoApp(initialDashboard: String? = null) {
             widgetScheduler.scheduleDemo()
         }
     }
+
+    // Mirror the active session to the wear data layer so the watch
+    // can render dashboards / live values from whatever's current.
+    LaunchedEffect(session) { wearSync.setSession(session) }
 
     val login = rememberLoginController(
         onReady = { baseUrl, accessToken ->
@@ -172,7 +179,7 @@ private fun UnauthenticatedScreen(
     }
 }
 
-private enum class AppScreen { Dashboards, Settings, Widgets }
+private enum class AppScreen { Dashboards, Settings, Widgets, SyncDiagnostics }
 
 @Composable
 private fun AuthenticatedShell(
@@ -187,8 +194,11 @@ private fun AuthenticatedShell(
     // root. Inside DashboardsRoot another BackHandler routes view →
     // picker; the platform handles back at the picker (exits app).
     BackHandler(enabled = screen != AppScreen.Dashboards) {
-        screen = AppScreen.Dashboards
+        screen = if (screen == AppScreen.SyncDiagnostics) AppScreen.Settings else AppScreen.Dashboards
     }
+
+    val context = LocalContext.current
+    val app = remember(context) { context.applicationContext as TerrazzoApplication }
 
     when (screen) {
         AppScreen.Dashboards -> DashboardsRoot(
@@ -203,10 +213,19 @@ private fun AuthenticatedShell(
             onToggleDemo = onToggleDemo,
             onSignOut = onSignOut,
             onBack = { screen = AppScreen.Dashboards },
+            onOpenSyncDiagnostics = { screen = AppScreen.SyncDiagnostics },
         )
         AppScreen.Widgets -> WidgetsScreen(
             onBack = { screen = AppScreen.Dashboards },
         )
+        AppScreen.SyncDiagnostics -> {
+            val streaming by app.wearSync.streamActive.collectAsState()
+            ee.schimke.terrazzo.wearsync.SyncDiagnosticsScreen(
+                statsStore = app.syncStats,
+                streamActive = streaming,
+                onBack = { screen = AppScreen.Settings },
+            )
+        }
     }
 }
 
@@ -345,6 +364,7 @@ private fun SettingsScreen(
     onToggleDemo: (Boolean) -> Unit,
     onSignOut: () -> Unit,
     onBack: () -> Unit,
+    onOpenSyncDiagnostics: () -> Unit,
 ) {
     val isDemo = session is DemoHaSession
     val graph = LocalTerrazzoGraph.current
@@ -421,6 +441,13 @@ private fun SettingsScreen(
 
             OutlinedButton(onClick = onSignOut) {
                 Text(if (isDemo) "Exit demo" else "Sign out")
+            }
+
+            // Sync diagnostics — buried at the bottom of Settings on
+            // purpose. Shows DataItem write / MessageClient send counts
+            // so power users can sanity-check wear-side chatter.
+            androidx.compose.material3.TextButton(onClick = onOpenSyncDiagnostics) {
+                Text("Sync diagnostics")
             }
         }
     }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApplication.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApplication.kt
@@ -5,9 +5,13 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import dev.zacsweers.metro.createGraphFactory
 import ee.schimke.terrazzo.core.di.TerrazzoGraph
 import ee.schimke.terrazzo.monitor.MonitoringService
+import ee.schimke.terrazzo.wearsync.MobileSyncStatsStore
+import ee.schimke.terrazzo.wearsync.MobileWearSyncManager
 
 /**
  * Holds the singleton [TerrazzoGraph] so every Android entry point —
@@ -20,9 +24,29 @@ class TerrazzoApplication : Application() {
         createGraphFactory<TerrazzoGraph.Factory>().create(applicationContext)
     }
 
+    /**
+     * Phone-only wear sync. Held outside the Metro graph because the
+     * wear-data layer dependency stack (play-services-wearable +
+     * Horologist) only lives in this module. Started on first access.
+     */
+    val syncStats: MobileSyncStatsStore by lazy { MobileSyncStatsStore(applicationContext) }
+    val wearSync: MobileWearSyncManager by lazy {
+        MobileWearSyncManager(applicationContext, syncStats)
+    }
+
     override fun onCreate() {
         super.onCreate()
         registerNotificationChannels()
+        // Bind the wear sync to the application's lifecycle scope so it
+        // outlives Activities (a paired watch should keep receiving
+        // demo / pinned-card updates even when the phone UI is in the
+        // background). PreferencesStore + WidgetStore are read from the
+        // graph; the manager owns its own lazy DataClient/MessageClient.
+        wearSync.start(
+            scope = ProcessLifecycleOwner.get().lifecycleScope,
+            prefs = graph.preferencesStore,
+            widgetStore = graph.widgetStore,
+        )
     }
 
     private fun registerNotificationChannels() {

--- a/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/MobileSyncStatsStore.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/MobileSyncStatsStore.kt
@@ -1,0 +1,65 @@
+package ee.schimke.terrazzo.wearsync
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.dataStore
+import ee.schimke.terrazzo.wearsync.proto.SyncStats
+import ee.schimke.terrazzo.wearsync.proto.protoBufSerializer
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+
+/**
+ * Phone-only Proto DataStore for [SyncStats]. The diagnostics screen
+ * reads from this and the [MobileWearSyncManager] writes to it on every
+ * data-layer event so users can sanity-check sync chatter. Bounded ring
+ * (`recentSendMs`) gives a rolling-window send frequency without
+ * persisting unbounded history. Held by [TerrazzoApplication] (not the
+ * Metro graph — keeps the wear-sync feature contained to this module).
+ */
+class MobileSyncStatsStore(private val context: Context) {
+
+    val flow: Flow<SyncStats>
+        get() = context.statsStore.data
+
+    suspend fun current(): SyncStats = context.statsStore.data.first()
+
+
+    suspend fun recordWrite(nowMs: Long) {
+        context.statsStore.updateData { stats ->
+            stats.copy(
+                datastoreWrites = stats.datastoreWrites + 1,
+                lastWriteAtMs = nowMs,
+            )
+        }
+    }
+
+    suspend fun recordMessageSent(nowMs: Long) {
+        context.statsStore.updateData { stats ->
+            val ring = (stats.recentSendMs + nowMs).takeLast(RING_SIZE)
+            stats.copy(
+                messageSends = stats.messageSends + 1,
+                lastMessageAtMs = nowMs,
+                recentSendMs = ring,
+            )
+        }
+    }
+
+    suspend fun recordLease(nowMs: Long) {
+        context.statsStore.updateData { stats ->
+            stats.copy(lastLeaseAtMs = nowMs)
+        }
+    }
+
+    suspend fun reset() {
+        context.statsStore.updateData { SyncStats() }
+    }
+
+    companion object {
+        const val RING_SIZE: Int = 32
+        private val Context.statsStore: DataStore<SyncStats> by dataStore(
+            fileName = "terrazzo_sync_stats.pb",
+            serializer = protoBufSerializer(SyncStats()),
+        )
+    }
+}
+

--- a/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/MobileWearSyncManager.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/MobileWearSyncManager.kt
@@ -1,0 +1,306 @@
+package ee.schimke.terrazzo.wearsync
+
+import android.content.Context
+import android.util.Log
+import com.google.android.gms.wearable.DataClient
+import com.google.android.gms.wearable.MessageClient
+import com.google.android.gms.wearable.NodeClient
+import com.google.android.gms.wearable.PutDataMapRequest
+import com.google.android.gms.wearable.Wearable
+import com.google.android.horologist.data.WearDataLayerRegistry
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.EntityState
+import ee.schimke.terrazzo.core.prefs.PreferencesStore
+import ee.schimke.terrazzo.core.session.HaSession
+import ee.schimke.terrazzo.core.widget.WidgetStore
+import ee.schimke.terrazzo.wearsync.proto.CardSummary
+import ee.schimke.terrazzo.wearsync.proto.DashboardData
+import ee.schimke.terrazzo.wearsync.proto.EntityDelta
+import ee.schimke.terrazzo.wearsync.proto.EntityValue
+import ee.schimke.terrazzo.wearsync.proto.LiveValues
+import ee.schimke.terrazzo.wearsync.proto.PinnedCard
+import ee.schimke.terrazzo.wearsync.proto.PinnedCardSet
+import ee.schimke.terrazzo.wearsync.proto.StreamUpdate
+import ee.schimke.terrazzo.wearsync.proto.WearLease
+import ee.schimke.terrazzo.wearsync.proto.WearSettings
+import ee.schimke.terrazzo.wearsync.proto.WearSyncPaths
+import ee.schimke.terrazzo.wearsync.proto.decodeProto
+import ee.schimke.terrazzo.wearsync.proto.encodeProto
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Phone-side sync engine. Mirrors:
+ *
+ *  - [PreferencesStore.demoMode] → `/wear/settings`
+ *  - The current [HaSession]'s dashboards → `/wear/dashboard/<urlPath>`
+ *    (one DataItem per dashboard, on first session-bind)
+ *  - The current snapshot → `/wear/values` (DataStore-style at the wall
+ *    refresh interval) **or** `/wear/stream` (MessageClient ephemeral
+ *    deltas) when wear holds an active lease
+ *  - [WidgetStore.installed] → `/wear/pinned`
+ *
+ * Lease is tracked via MessageClient frames at `/wear/lease`: as long as
+ * a recent lease arrived (or pinned cards exist) the manager streams
+ * deltas at the live cadence; otherwise it batches into the
+ * `/wear/values` DataItem so wear reads cold are still useful while
+ * keeping radio-time low when the watch isn't engaged.
+ *
+ * Diagnostics: every write / send updates [MobileSyncStatsStore].
+ */
+class MobileWearSyncManager(
+    private val context: Context,
+    private val statsStore: MobileSyncStatsStore,
+) {
+
+    private val dataClient: DataClient by lazy { Wearable.getDataClient(context) }
+    private val messageClient: MessageClient by lazy { Wearable.getMessageClient(context) }
+    private val nodeClient: NodeClient by lazy { Wearable.getNodeClient(context) }
+
+    /** Lifted Horologist registry so future code can use `protoFlow`/`protoDataStore`. */
+    @OptIn(com.google.android.horologist.annotations.ExperimentalHorologistApi::class)
+    @Suppress("unused")
+    private val registry: WearDataLayerRegistry by lazy {
+        WearDataLayerRegistry.fromContext(application = context.applicationContext as android.app.Application, coroutineScope = managerScope)
+    }
+
+    private val sessionState: MutableStateFlow<HaSession?> = MutableStateFlow(null)
+    private val leaseState: MutableStateFlow<Long> = MutableStateFlow(0L)
+    private lateinit var managerScope: CoroutineScope
+    private var streamJob: Job? = null
+    private var lastSnapshot: Map<String, EntityValue> = emptyMap()
+
+    private val leaseListener = MessageClient.OnMessageReceivedListener { event ->
+        if (event.path != WearSyncPaths.LEASE_MESSAGE) return@OnMessageReceivedListener
+        val now = System.currentTimeMillis()
+        val lease: WearLease = decodeProto<WearLease>(event.data) ?: WearLease(sentAtMs = now)
+        leaseState.value = lease.sentAtMs.takeIf { it > 0 } ?: now
+        managerScope.launch { statsStore.recordLease(now) }
+    }
+
+    /** Update the active session whenever login/demo state changes. */
+    fun setSession(session: HaSession?) {
+        sessionState.value = session
+    }
+
+    /**
+     * Whether the wear node currently has an active lease. Combined
+     * with pinned-cards count to decide between streaming and batched
+     * DataStore writes.
+     */
+    val streamActive: StateFlow<Boolean> by lazy {
+        leaseState.map { isLeaseFresh(it) }
+            .stateIn(managerScope, SharingStarted.Eagerly, false)
+    }
+
+    /**
+     * Wires the manager to its data sources. Call once from
+     * Application.onCreate. Subsequent session changes use [setSession].
+     */
+    fun start(
+        scope: CoroutineScope,
+        prefs: PreferencesStore,
+        widgetStore: WidgetStore,
+    ) {
+        managerScope = scope
+        messageClient.addListener(leaseListener)
+
+        // Demo-mode flag → /wear/settings (and base url annotation).
+        scope.launch {
+            combine(prefs.demoMode, sessionState) { demo, session ->
+                WearSettings(
+                    demoMode = demo,
+                    baseUrl = session?.baseUrl.orEmpty(),
+                    updatedAtMs = System.currentTimeMillis(),
+                )
+            }
+                .distinctUntilChanged()
+                .collect { writeDataItem(WearSyncPaths.SETTINGS, encodeProto(it)) }
+        }
+
+        // Pinned widgets → /wear/pinned.
+        scope.launch {
+            widgetStore.installed
+                .map { entries ->
+                    PinnedCardSet(
+                        cards = entries.map { entry ->
+                            PinnedCard(
+                                baseUrl = entry.baseUrl,
+                                card = entry.card.toSummary(),
+                            )
+                        },
+                        updatedAtMs = System.currentTimeMillis(),
+                    )
+                }
+                .distinctUntilChanged()
+                .collect { writeDataItem(WearSyncPaths.PINNED, encodeProto(it)) }
+        }
+
+        // Session snapshot pump. Re-driven on every session change so the
+        // demo session and live session each get their own loop.
+        scope.launch {
+            combine(sessionState, widgetStore.installed) { s, pinned -> s to pinned }
+                .collectLatest { (session, pinned) ->
+                    streamJob?.cancel()
+                    streamJob = null
+                    if (session == null) return@collectLatest
+                    publishDashboards(session)
+                    streamJob = scope.launch { sessionPump(session, pinned.isNotEmpty()) }
+                }
+        }
+    }
+
+    /** Stops listening; safe to call from Application.onTerminate (rare). */
+    fun stop() {
+        runCatching { messageClient.removeListener(leaseListener) }
+        streamJob?.cancel()
+    }
+
+    /**
+     * Wear → phone path. Ephemeral message delivered if wear-side
+     * activity is foreground. We record the lease arrival as the
+     * manager's window source.
+     */
+    @Suppress("unused")
+    private fun isLeaseFresh(at: Long): Boolean {
+        if (at <= 0L) return false
+        val now = System.currentTimeMillis()
+        return now - at <= WearSyncPaths.LEASE_WINDOW_MS
+    }
+
+    private suspend fun publishDashboards(session: HaSession) {
+        runCatching {
+            val summaries = session.listDashboards()
+            for (summary in summaries) {
+                val (dashboard, snapshot) = session.loadDashboard(summary.urlPath)
+                val cards = dashboard.views.flatMap { it.cards }
+                val data = DashboardData(
+                    urlPath = summary.urlPath ?: "",
+                    title = dashboard.title ?: summary.title,
+                    cards = cards.map { it.toSummary(snapshot.states) },
+                    updatedAtMs = System.currentTimeMillis(),
+                )
+                writeDataItem(WearSyncPaths.dashboardPath(summary.urlPath), encodeProto(data))
+            }
+        }.onFailure { Log.w(TAG, "publishDashboards failed", it) }
+    }
+
+    /**
+     * Repeatedly fetches snapshots from [session]; streams via
+     * MessageClient (deltas) when wear has a lease or pinned cards
+     * exist, otherwise batches into the DataStore-Proto entry. Live
+     * sessions that don't expose a refresh interval fall back to a
+     * 30 s heartbeat so values aren't infinitely stale.
+     */
+    private suspend fun sessionPump(session: HaSession, hasPinned: Boolean) {
+        val cadence = session.refreshIntervalMillis ?: 30_000L
+        // Reset snapshot baseline so the first push is a full set.
+        lastSnapshot = emptyMap()
+        while (true) {
+            val snapshot = runCatching { session.loadDashboard(null).second }.getOrNull()
+            if (snapshot != null) {
+                val current = snapshot.states.mapValues { (_, state) -> state.toEntityValue() }
+                val streaming = hasPinned || isLeaseFresh(leaseState.value)
+                if (streaming) pushStream(current) else pushDataItem(current)
+            }
+            delay(cadence)
+        }
+    }
+
+    private suspend fun pushDataItem(values: Map<String, EntityValue>) {
+        val now = System.currentTimeMillis()
+        val payload = LiveValues(values = values, capturedAtMs = now)
+        writeDataItem(WearSyncPaths.VALUES, encodeProto(payload))
+        lastSnapshot = values
+    }
+
+    private suspend fun pushStream(values: Map<String, EntityValue>) {
+        val deltas = values.entries
+            .filter { (k, v) -> lastSnapshot[k] != v }
+            .map { (k, v) -> EntityDelta(entityId = k, value = v) }
+        if (deltas.isEmpty()) return
+        val frame = StreamUpdate(deltas = deltas, capturedAtMs = System.currentTimeMillis())
+        runCatching {
+            val nodes = nodeClient.connectedNodes.await()
+            val bytes = encodeProto(frame)
+            for (node in nodes) {
+                messageClient.sendMessage(node.id, WearSyncPaths.STREAM_MESSAGE, bytes).await()
+            }
+            statsStore.recordMessageSent(System.currentTimeMillis())
+        }.onFailure { Log.w(TAG, "pushStream failed", it) }
+        lastSnapshot = values
+    }
+
+    private suspend fun writeDataItem(path: String, bytes: ByteArray) {
+        runCatching {
+            val request = PutDataMapRequest.create(path).apply {
+                dataMap.putByteArray(KEY_PROTO, bytes)
+                dataMap.putLong(KEY_TS, System.currentTimeMillis())
+            }
+            dataClient.putDataItem(request.asPutDataRequest().setUrgent()).await()
+            statsStore.recordWrite(System.currentTimeMillis())
+        }.onFailure { Log.w(TAG, "writeDataItem $path failed", it) }
+    }
+
+    companion object {
+        private const val TAG = "WearSync"
+        const val KEY_PROTO: String = "proto"
+        const val KEY_TS: String = "ts"
+    }
+}
+
+private fun EntityState.toEntityValue(): EntityValue {
+    val attrs = attributes
+    return EntityValue(
+        state = state,
+        friendlyName = attrs["friendly_name"]?.jsonPrimitive?.contentOrNull.orEmpty(),
+        unit = attrs["unit_of_measurement"]?.jsonPrimitive?.contentOrNull.orEmpty(),
+        deviceClass = attrs["device_class"]?.jsonPrimitive?.contentOrNull.orEmpty(),
+    )
+}
+
+private fun CardConfig.toSummary(states: Map<String, EntityState> = emptyMap()): CardSummary {
+    val raw = this.raw
+    val title = raw["title"]?.jsonPrimitive?.contentOrNull
+        ?: raw["heading"]?.jsonPrimitive?.contentOrNull
+        ?: raw["name"]?.jsonPrimitive?.contentOrNull
+        ?: this.type
+    val primary = raw["entity"]?.jsonPrimitive?.contentOrNull
+        ?: raw["entities"]?.jsonArray?.firstOrNull()?.let {
+            (it as? JsonPrimitive)?.contentOrNull
+                ?: (it as? JsonObject)?.get("entity")?.jsonPrimitive?.contentOrNull
+        }
+        ?: ""
+    val resolvedTitle = states[primary]?.attributes?.get("friendly_name")
+        ?.jsonPrimitive?.contentOrNull ?: title
+    return CardSummary(
+        type = this.type,
+        title = resolvedTitle,
+        primaryEntityId = primary,
+        rawJson = json.encodeToString(JsonObject.serializer(), raw),
+    )
+}
+
+private val json = Json { ignoreUnknownKeys = true }
+
+private suspend fun <T> com.google.android.gms.tasks.Task<T>.await(): T =
+    kotlinx.coroutines.suspendCancellableCoroutine { cont ->
+        addOnSuccessListener { value -> cont.resumeWith(Result.success(value)) }
+        addOnFailureListener { error -> cont.resumeWith(Result.failure(error)) }
+    }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/SyncDiagnosticsScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/SyncDiagnosticsScreen.kt
@@ -1,0 +1,174 @@
+package ee.schimke.terrazzo.wearsync
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import ee.schimke.terrazzo.wearsync.proto.SyncStats
+import ee.schimke.terrazzo.wearsync.proto.WearSyncPaths
+import kotlinx.coroutines.launch
+
+/**
+ * Settings → Diagnostics. Mounted from the existing settings screen via
+ * a small "Sync diagnostics" link, so the wear data-layer chatter is
+ * visible to power users who want to make sure messages aren't being
+ * fired too often.
+ *
+ * Surfaces:
+ *   - the cumulative DataItem write / MessageClient send counts
+ *   - the timestamp of the last lease arrival (which decides whether
+ *     phone is currently streaming or batching)
+ *   - rolling-window send frequency from [SyncStats.recentSendMs]
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SyncDiagnosticsScreen(
+    statsStore: MobileSyncStatsStore,
+    streamActive: Boolean,
+    onBack: () -> Unit,
+) {
+    val stats by statsStore.flow.collectAsState(initial = SyncStats())
+    val scope = rememberCoroutineScope()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Sync diagnostics") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        contentWindowInsets = WindowInsets.safeDrawing,
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(padding)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = "What the watch sees",
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                text = "Phone publishes wear data via DataClient (cold reads) and " +
+                    "MessageClient (live deltas). Watch holds a lease while its " +
+                    "activity is foreground; when no lease is active phone falls " +
+                    "back to batched DataStore writes to keep radio time low.",
+                style = MaterialTheme.typography.bodySmall,
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column {
+                    Text("Stream", style = MaterialTheme.typography.labelLarge)
+                    Text(
+                        text = if (streamActive) "ACTIVE — pushing deltas" else "Idle — batching to DataStore",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (streamActive) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            HorizontalDivider()
+
+            StatRow("DataItem writes", stats.datastoreWrites.toString())
+            StatRow("MessageClient sends", stats.messageSends.toString())
+            StatRow(
+                "Lease window",
+                if (stats.lastLeaseAtMs == 0L) "never" else relativeNow(stats.lastLeaseAtMs)
+                    + " (window: ${WearSyncPaths.LEASE_WINDOW_MS / 1000}s)",
+            )
+            StatRow(
+                "Last DataItem write",
+                if (stats.lastWriteAtMs == 0L) "never" else relativeNow(stats.lastWriteAtMs),
+            )
+            StatRow(
+                "Last MessageClient send",
+                if (stats.lastMessageAtMs == 0L) "never" else relativeNow(stats.lastMessageAtMs),
+            )
+            StatRow(
+                "Send frequency (last ${stats.recentSendMs.size})",
+                formatFrequency(stats.recentSendMs),
+            )
+
+            HorizontalDivider()
+
+            OutlinedButton(onClick = { scope.launch { statsStore.reset() } }) {
+                Text("Reset counters")
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyMedium)
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private fun relativeNow(ms: Long): String {
+    val deltaMs = (System.currentTimeMillis() - ms).coerceAtLeast(0L)
+    return when {
+        deltaMs < 1_000 -> "just now"
+        deltaMs < 60_000 -> "${deltaMs / 1_000}s ago"
+        deltaMs < 3_600_000 -> "${deltaMs / 60_000}m ago"
+        else -> "${deltaMs / 3_600_000}h ago"
+    }
+}
+
+/**
+ * Format the rolling send window as either a per-minute rate (when we
+ * have ≥ 2 timestamps) or a count. The window is `recentSendMs.size`
+ * timestamps; their span in seconds is `(last - first) / 1000`.
+ */
+private fun formatFrequency(recent: List<Long>): String {
+    if (recent.size < 2) return "n/a"
+    val spanSec = ((recent.last() - recent.first()) / 1000.0).coerceAtLeast(0.001)
+    val perSec = recent.size / spanSec
+    val perMin = perSec * 60
+    return "%.2f/min".format(perMin)
+}

--- a/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/proto/ProtoSerializers.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/proto/ProtoSerializers.kt
@@ -1,0 +1,49 @@
+package ee.schimke.terrazzo.wearsync.proto
+
+import androidx.datastore.core.Serializer
+import java.io.InputStream
+import java.io.OutputStream
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.protobuf.ProtoBuf
+import kotlinx.serialization.serializer
+
+/**
+ * Bridge `androidx.datastore.core.Serializer<T>` to
+ * `kotlinx-serialization-protobuf`. Each Proto DataStore (`/wear/...`)
+ * gets one of these.
+ *
+ * Defensive read: if the file is empty (first read) or corrupt, we
+ * return [defaultValue] rather than throwing — DataStore would otherwise
+ * propagate as `CorruptionException` and crash the activity.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+class ProtoBufSerializer<T : Any>(
+    private val ksz: KSerializer<T>,
+    override val defaultValue: T,
+) : Serializer<T> {
+    override suspend fun readFrom(input: InputStream): T {
+        val bytes = input.readBytes()
+        if (bytes.isEmpty()) return defaultValue
+        return runCatching { ProtoBuf.decodeFromByteArray(ksz, bytes) }
+            .getOrDefault(defaultValue)
+    }
+
+    override suspend fun writeTo(t: T, output: OutputStream) {
+        output.write(ProtoBuf.encodeToByteArray(ksz, t))
+    }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+inline fun <reified T : Any> protoBufSerializer(default: T): ProtoBufSerializer<T> =
+    ProtoBufSerializer(serializer(), default)
+
+/** Encode an arbitrary @Serializable value to proto bytes. */
+@OptIn(ExperimentalSerializationApi::class)
+inline fun <reified T> encodeProto(value: T): ByteArray =
+    ProtoBuf.encodeToByteArray(serializer(), value)
+
+/** Decode proto bytes back into [T]. Returns null on corruption. */
+@OptIn(ExperimentalSerializationApi::class)
+inline fun <reified T> decodeProto(bytes: ByteArray): T? =
+    runCatching { ProtoBuf.decodeFromByteArray(serializer<T>(), bytes) }.getOrNull()

--- a/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/proto/WearSyncProto.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/proto/WearSyncProto.kt
@@ -1,0 +1,140 @@
+package ee.schimke.terrazzo.wearsync.proto
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Wear ↔ phone sync schema. The same file is duplicated in the `app`
+ * module — both copies must stay byte-for-byte identical so DataItem
+ * payloads and MessageClient frames decode on the peer.
+ *
+ * The values are encoded with `kotlinx.serialization.protobuf.ProtoBuf`,
+ * which produces standard proto3 wire bytes — i.e. the same bytes that
+ * `protoc`/Wire would write. We choose this approach (rather than
+ * generated classes via Wire's Gradle plugin) so the build stays
+ * self-contained on AGP 9 / Gradle 9.3, which Wire's plugin doesn't yet
+ * recognise as a Kotlin host. The `.proto` file in `src/main/proto/`
+ * documents the schema and stays the source of truth.
+ *
+ * Path conventions (mirrored in [WearSyncPaths]):
+ *   - DataClient:
+ *     - `/wear/settings`            — [WearSettings]
+ *     - `/wear/pinned`              — [PinnedCardSet]
+ *     - `/wear/values`              — [LiveValues]
+ *     - `/wear/dashboard/<urlPath>` — [DashboardData]
+ *   - MessageClient (ephemeral):
+ *     - `/wear/lease`   — [WearLease]   (wear → phone heartbeat)
+ *     - `/wear/stream`  — [StreamUpdate] (phone → wear delta push)
+ */
+
+/** Wear-side settings written by the phone. Drives demo badge and routing. */
+@Serializable
+data class WearSettings(
+    val demoMode: Boolean = false,
+    val baseUrl: String = "",
+    val updatedAtMs: Long = 0L,
+)
+
+/** Card extract phone-side; wear renders a list row from this. */
+@Serializable
+data class CardSummary(
+    val type: String = "",
+    val title: String = "",
+    val primaryEntityId: String = "",
+    val rawJson: String = "",
+)
+
+/** One DataStore Proto entry per dashboard, keyed by `urlPath`. */
+@Serializable
+data class DashboardData(
+    val urlPath: String = "",
+    val title: String = "",
+    val cards: List<CardSummary> = emptyList(),
+    val updatedAtMs: Long = 0L,
+)
+
+/** Single DataStore entry holding the latest entity values. */
+@Serializable
+data class LiveValues(
+    val values: Map<String, EntityValue> = emptyMap(),
+    val capturedAtMs: Long = 0L,
+)
+
+@Serializable
+data class EntityValue(
+    val state: String = "",
+    val friendlyName: String = "",
+    val unit: String = "",
+    val deviceClass: String = "",
+)
+
+/** MessageClient stream frame — only entities that changed. */
+@Serializable
+data class StreamUpdate(
+    val deltas: List<EntityDelta> = emptyList(),
+    val capturedAtMs: Long = 0L,
+)
+
+@Serializable
+data class EntityDelta(
+    val entityId: String = "",
+    val value: EntityValue = EntityValue(),
+)
+
+/** Mirror of phone's WidgetStore — drives wear's home screen. */
+@Serializable
+data class PinnedCardSet(
+    val cards: List<PinnedCard> = emptyList(),
+    val updatedAtMs: Long = 0L,
+)
+
+@Serializable
+data class PinnedCard(
+    val baseUrl: String = "",
+    val card: CardSummary = CardSummary(),
+)
+
+/**
+ * Heartbeat sent from wear → phone over MessageClient. Phone treats the
+ * arrival time as a lease window; while a recent lease is active phone
+ * pushes [StreamUpdate]s, otherwise it batches into [LiveValues].
+ */
+@Serializable
+data class WearLease(
+    val sentAtMs: Long = 0L,
+    val foreground: Boolean = false,
+)
+
+/**
+ * Phone-local diagnostics. Stored at `terrazzo_sync_stats.pb` and
+ * surfaced in Settings → Diagnostics.
+ */
+@Serializable
+data class SyncStats(
+    val datastoreWrites: Long = 0L,
+    val messageSends: Long = 0L,
+    val lastLeaseAtMs: Long = 0L,
+    val lastWriteAtMs: Long = 0L,
+    val lastMessageAtMs: Long = 0L,
+    /** Bounded ring (last 32 send timestamps in ms) for rolling-window frequency. */
+    val recentSendMs: List<Long> = emptyList(),
+)
+
+/** Path constants — keep mirrored across modules. */
+object WearSyncPaths {
+    const val SETTINGS: String = "/wear/settings"
+    const val PINNED: String = "/wear/pinned"
+    const val VALUES: String = "/wear/values"
+    const val DASHBOARD_PREFIX: String = "/wear/dashboard/"
+    const val LEASE_MESSAGE: String = "/wear/lease"
+    const val STREAM_MESSAGE: String = "/wear/stream"
+
+    /** Encode a urlPath (which may be null for HA's default dashboard) into a DataItem path. */
+    fun dashboardPath(urlPath: String?): String =
+        DASHBOARD_PREFIX + (urlPath?.takeIf { it.isNotEmpty() }?.replace('/', '_') ?: "_default")
+
+    /**
+     * Lease window before phone falls back to batched DataStore writes.
+     * Tuned for 30 s of wall-clock; wear sends a heartbeat every 10 s.
+     */
+    const val LEASE_WINDOW_MS: Long = 30_000L
+}

--- a/app/src/main/proto/wear_sync.proto
+++ b/app/src/main/proto/wear_sync.proto
@@ -1,0 +1,114 @@
+// Wear ↔ phone sync schema. Identical copy lives in `app/src/main/proto/`
+// — Wire compiles each module's .proto separately, the wire format is
+// what's on the wire so duplicate generation is intentional.
+//
+// Path conventions (mirrored in WearSyncPaths.kt):
+//   /wear/settings              — WearSettings (phone → wear; demo flag, baseUrl)
+//   /wear/pinned                — PinnedCardSet (phone → wear; mobile widget list)
+//   /wear/values                — LiveValues (phone → wear; current entity values)
+//   /wear/dashboard/<urlPath>   — DashboardData (phone → wear; one entry per dashboard)
+//   /wear/lease   (MessageClient) — WearLease (wear → phone; foreground heartbeat)
+//   /wear/stream  (MessageClient) — StreamUpdate (phone → wear; ephemeral deltas)
+syntax = "proto3";
+
+package terrazzo.wearsync;
+
+option java_package = "ee.schimke.terrazzo.wearsync.proto";
+option java_multiple_files = true;
+
+// Cross-device wear settings. Phone is the source of truth; wear reads
+// to drive its UI (e.g. show "Demo" badge, route to demo data).
+message WearSettings {
+    // True when phone has demo mode enabled — wear falls back to its
+    // own DemoData fixture and stops expecting live values.
+    bool demo_mode = 1;
+    // The HA base URL phone is connected to (informational; wear shows
+    // it on the about screen). Empty when signed-out / demo.
+    string base_url = 2;
+    // Wall-clock time of the last write, for diagnostics.
+    int64 updated_at_ms = 3;
+}
+
+// Card surfaces shown on Wear. Phone extracts the minimum each row
+// needs (title + primary entity + raw config blob).
+message CardSummary {
+    string type = 1;
+    string title = 2;
+    string primary_entity_id = 3;
+    string raw_json = 4;
+}
+
+// One DataStore Proto entry per dashboard (path
+// `/wear/dashboard/<urlPath>`). Wear's "browse" screen lists titles +
+// loads the chosen entry on demand.
+message DashboardData {
+    string url_path = 1;
+    string title = 2;
+    repeated CardSummary cards = 3;
+    int64 updated_at_ms = 4;
+}
+
+// Single DataStore Proto entry at `/wear/values`. Phone writes the
+// snapshot here when streaming is OFF (no Wear lease). Cheaper than
+// MessageClient for cold reads / activity bootstraps.
+message LiveValues {
+    map<string, EntityValue> values = 1;
+    int64 captured_at_ms = 2;
+}
+
+message EntityValue {
+    string state = 1;
+    string friendly_name = 2;
+    string unit = 3;
+    string device_class = 4;
+}
+
+// Sent via MessageClient at `/wear/stream` when phone has a live lease
+// from wear (or pinned cards force a stream). Carries only changed
+// entities to keep traffic small.
+message StreamUpdate {
+    repeated EntityDelta deltas = 1;
+    int64 captured_at_ms = 2;
+}
+
+message EntityDelta {
+    string entity_id = 1;
+    EntityValue value = 2;
+}
+
+// Pinned-cards mirror of phone's WidgetStore. Wear shows these as the
+// default home screen so the watch surfaces what the user has already
+// curated.
+message PinnedCardSet {
+    repeated PinnedCard cards = 1;
+    int64 updated_at_ms = 2;
+}
+
+message PinnedCard {
+    string base_url = 1;
+    CardSummary card = 2;
+}
+
+// Wear → phone heartbeat (MessageClient at `/wear/lease`). Phone uses
+// the most-recent arrival time as the lease window: while a recent
+// heartbeat exists, phone streams; otherwise it batches to the
+// `/wear/values` DataStore.
+message WearLease {
+    int64 sent_at_ms = 1;
+    bool foreground = 2;
+}
+
+// Phone-local diagnostics. Stored in a phone-only Proto DataStore at
+// `terrazzo_sync_stats.pb` and surfaced in Settings → Diagnostics so
+// users can sanity-check sync chatter.
+message SyncStats {
+    int64 datastore_writes = 1;
+    int64 message_sends = 2;
+    int64 last_lease_at_ms = 3;
+    int64 last_write_at_ms = 4;
+    int64 last_message_at_ms = 5;
+    // Bounded ring buffer (last 32 send timestamps in ms) so we can
+    // compute a rolling-window frequency without persisting unbounded
+    // history.
+    repeated int64 recent_send_ms = 6;
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,10 @@ logback = "1.5.12"
 # Preview tooling
 compose-preview-plugin = "0.7.11"
 
+# Wear data layer + Proto DataStore + Horologist
+horologist = "0.8.3-alpha"
+play-services-wearable = "19.0.0"
+
 [libraries]
 # RemoteCompose authoring / playback
 remote-creation-compose = { module = "androidx.compose.remote:remote-creation-compose", version.ref = "remote-compose" }
@@ -63,6 +67,9 @@ tv-material = { module = "androidx.tv:tv-material", version = "1.0.0" }
 # Terrazzo app deps
 androidx-browser = { module = "androidx.browser:browser", version = "1.8.0" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version = "1.1.1" }
+# Proto DataStore — used by the Wear sync layer (per-dashboard + cross-device
+# settings) and the phone-side mirror that publishes to the data layer.
+androidx-datastore = { module = "androidx.datastore:datastore", version = "1.1.1" }
 androidx-work-runtime = { module = "androidx.work:work-runtime-ktx", version = "2.10.0" }
 androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version = "1.2.0-alpha01" }
 androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version = "1.2.0-alpha01" }
@@ -100,12 +107,25 @@ ktor-server-default-headers = { module = "io.ktor:ktor-server-default-headers", 
 ktor-server-auth = { module = "io.ktor:ktor-server-auth", version.ref = "ktor" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 
-# Ktor server (addon-server)
-
 # Kotlinx
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
+
+# Wear data layer (sync mobile ↔ watch). Horologist's data-layer
+# helpers ride on Google Play Services Wearable; both peers share a
+# protobuf schema and a `WearDataLayerRegistry`.
+play-services-wearable = { module = "com.google.android.gms:play-services-wearable", version.ref = "play-services-wearable" }
+horologist-datalayer = { module = "com.google.android.horologist:horologist-datalayer", version.ref = "horologist" }
+horologist-datalayer-watch = { module = "com.google.android.horologist:horologist-datalayer-watch", version.ref = "horologist" }
+horologist-datalayer-phone = { module = "com.google.android.horologist:horologist-datalayer-phone", version.ref = "horologist" }
+# Proto wire format via kotlinx.serialization. Encodes @Serializable
+# Kotlin data classes to standard proto3 wire bytes — i.e. the same
+# bytes a protoc / Wire output would produce. Schema lives as
+# documentation in `wear/src/main/proto/wear_sync.proto`.
+kotlinx-serialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "kotlinx-serialization" }
+androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version = "2.8.7" }
+androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version = "2.8.7" }
 
 # Test
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }

--- a/tv/build.gradle.kts
+++ b/tv/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.compose.preview)
 }
 
 android {
@@ -24,6 +25,12 @@ android {
     kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
 }
 
+composePreview {
+    variant.set("debug")
+    sdkVersion.set(34)
+    enabled.set(true)
+}
+
 dependencies {
     implementation(project(":rc-components"))
 
@@ -32,6 +39,8 @@ dependencies {
     implementation(libs.compose.foundation)
     implementation(libs.compose.material3)
     implementation(libs.compose.ui.text.google.fonts)
+    implementation(libs.compose.ui.tooling.preview)
+    debugImplementation(libs.compose.ui.tooling)
     implementation(libs.activity.compose)
 
     implementation(libs.tv.material)

--- a/tv/src/main/kotlin/ee/schimke/terrazzo/tv/TvMainActivity.kt
+++ b/tv/src/main/kotlin/ee/schimke/terrazzo/tv/TvMainActivity.kt
@@ -5,15 +5,20 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -26,12 +31,12 @@ import ee.schimke.terrazzo.tv.ui.TvThemePicker
 import kotlinx.coroutines.launch
 
 /**
- * TV companion. Renders a two-column kiosk dashboard preview: the
- * picker on the left runs the DPAD focus, the right pane re-skins
- * itself live as the selection changes. Theme is persisted via
- * [TvPrefs] (defaults to [ThemeStyle.TerrazzoKiosk] — the wall-panel
- * brief). The full HA dashboard wires onto the right pane in a
- * follow-up.
+ * TV companion. Two-column kiosk layout: theme picker on the left runs
+ * the DPAD focus, the right pane re-skins live as the selection
+ * changes. Demo mode is a local toggle (persisted via [TvPrefs]) — when
+ * on, the kiosk preview shows animated `TvDemoData` instead of the
+ * static placeholder, so the room sees motion without a working HA
+ * instance.
  */
 class TvMainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -46,6 +51,7 @@ private fun TvApp() {
     val prefs = remember(context) { TvPrefs(context.applicationContext) }
     val scope = rememberCoroutineScope()
     val style by prefs.themeStyle.collectAsState(initial = ThemeStyle.TerrazzoKiosk)
+    val demoMode by prefs.demoMode.collectAsState(initial = false)
 
     val colors = terrazzoColorScheme(style, darkTheme = true)
     MaterialTheme(colorScheme = colors, typography = terrazzoTypographyFor(style)) {
@@ -56,14 +62,49 @@ private fun TvApp() {
                 .padding(horizontal = 48.dp, vertical = 36.dp),
             horizontalArrangement = Arrangement.spacedBy(32.dp),
         ) {
-            TvThemePicker(
-                selected = style,
-                onSelect = { picked -> scope.launch { prefs.setThemeStyle(picked) } },
-            )
+            Column(
+                modifier = Modifier.width(360.dp),
+                verticalArrangement = Arrangement.spacedBy(24.dp),
+            ) {
+                TvThemePicker(
+                    selected = style,
+                    onSelect = { picked -> scope.launch { prefs.setThemeStyle(picked) } },
+                )
+                TvDemoToggle(
+                    enabled = demoMode,
+                    onChange = { v -> scope.launch { prefs.setDemoMode(v) } },
+                )
+            }
             TvKioskPreview(
                 style = style,
+                demoMode = demoMode,
                 modifier = Modifier.weight(1f),
             )
         }
+    }
+}
+
+@Composable
+private fun TvDemoToggle(enabled: Boolean, onChange: (Boolean) -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = "Demo mode",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            Text(
+                text = "Animate the kiosk with fake data — handy for room photos.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Switch(
+            checked = enabled,
+            onCheckedChange = onChange,
+        )
     }
 }

--- a/tv/src/main/kotlin/ee/schimke/terrazzo/tv/data/TvPrefs.kt
+++ b/tv/src/main/kotlin/ee/schimke/terrazzo/tv/data/TvPrefs.kt
@@ -1,6 +1,7 @@
 package ee.schimke.terrazzo.tv.data
 
 import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -9,8 +10,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 /**
- * TV-local theme picker storage. Mirrors [ee.schimke.terrazzo.wear.data.WearPrefs]
- * — defaults to [ThemeStyle.TerrazzoKiosk] since wall-mounted dashboards
+ * TV-local preferences. Mirrors the shape of `WearPrefs` — theme style
+ * plus a demo-mode toggle. Unlike the Wear app, the TV has no phone
+ * pairing, so demo mode is a local toggle on the TV itself.
+ *
+ * Defaults to [ThemeStyle.TerrazzoKiosk] since wall-mounted dashboards
  * are the TV module's brief.
  */
 class TvPrefs(private val context: Context) {
@@ -25,8 +29,21 @@ class TvPrefs(private val context: Context) {
         context.store.edit { it[THEME_KEY] = style.name }
     }
 
+    /**
+     * Demo-mode toggle. When on, the kiosk preview pulls from
+     * `DemoData` instead of the (not-yet-wired) live HA session, so the
+     * room sees animated values without a working HA instance.
+     */
+    val demoMode: Flow<Boolean> =
+        context.store.data.map { prefs -> prefs[DEMO_KEY] ?: false }
+
+    suspend fun setDemoMode(enabled: Boolean) {
+        context.store.edit { it[DEMO_KEY] = enabled }
+    }
+
     companion object {
         private val Context.store by preferencesDataStore(name = "terrazzo_tv_prefs")
         private val THEME_KEY = stringPreferencesKey("theme_style")
+        private val DEMO_KEY = booleanPreferencesKey("demo_mode")
     }
 }

--- a/tv/src/main/kotlin/ee/schimke/terrazzo/tv/ui/TvDemoData.kt
+++ b/tv/src/main/kotlin/ee/schimke/terrazzo/tv/ui/TvDemoData.kt
@@ -1,0 +1,44 @@
+package ee.schimke.terrazzo.tv.ui
+
+import kotlin.math.roundToInt
+import kotlin.math.sin
+
+/**
+ * Lightweight, TV-only demo fixture. Mirrors the shape of the phone's
+ * `DemoData` (animated sensors / lights / power) but stays inside this
+ * module — the TV doesn't pair with a phone, so demo mode here is a
+ * local toggle that drives the kiosk preview off these values.
+ *
+ * Values drift with wall-clock time so the room sees motion instead of
+ * a frozen screen.
+ */
+object TvDemoData {
+
+    data class Tile(
+        val label: String,
+        val value: String,
+    )
+
+    fun tiles(nowMs: Long = System.currentTimeMillis()): List<Tile> {
+        val tSec = nowMs / 1000.0
+        val livingTemp = 21.0 + 2.0 * sin(tSec / 60.0)
+        val humidity = (48.0 + 10.0 * sin(tSec / 20.0)).roundToInt()
+        val power = (170.0 + 90.0 * sin(tSec / 7.0)).roundToInt()
+        val lightsOn = (nowMs / 8_000L) % 2L == 0L
+        val mediaTrack = MEDIA_QUEUE[(nowMs / 6_000L % MEDIA_QUEUE.size).toInt()]
+        return listOf(
+            Tile("Lights", if (lightsOn) "ON · 70%" else "OFF"),
+            Tile("Climate", "%.1f °C".format(livingTemp)),
+            Tile("Humidity", "$humidity%"),
+            Tile("Power", "$power W"),
+            Tile("Media", mediaTrack),
+        )
+    }
+
+    private val MEDIA_QUEUE = listOf(
+        "Spotify · Sketches",
+        "Radio · Studio Brussel",
+        "Podcast · Lex",
+        "Spotify · Late Night",
+    )
+}

--- a/tv/src/main/kotlin/ee/schimke/terrazzo/tv/ui/TvKioskPreview.kt
+++ b/tv/src/main/kotlin/ee/schimke/terrazzo/tv/ui/TvKioskPreview.kt
@@ -13,23 +13,46 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import ee.schimke.ha.rc.components.ThemeStyle
+import kotlinx.coroutines.delay
 
 /**
  * A miniature kiosk dashboard that re-skins itself live as the picker
- * selection changes. Three "tiles" plus a swatch row exercise primary /
- * secondary / tertiary roles plus surfaceContainer*; this is the
- * fastest way to spot which palette reads well at TV viewing distance
- * before wiring the real HA cards in a follow-up.
+ * selection changes. When [demoMode] is on the tile values come from
+ * [TvDemoData] and tick on a 2 s cadence so the room sees motion; when
+ * off, the tiles show a static "live data placeholder" until full HA
+ * wiring lands.
  */
 @Composable
-fun TvKioskPreview(style: ThemeStyle, modifier: Modifier = Modifier) {
+fun TvKioskPreview(style: ThemeStyle, demoMode: Boolean, modifier: Modifier = Modifier) {
     val cs = MaterialTheme.colorScheme
+
+    var nowMs by remember { mutableLongStateOf(System.currentTimeMillis()) }
+    LaunchedEffect(demoMode) {
+        if (!demoMode) return@LaunchedEffect
+        while (true) {
+            nowMs = System.currentTimeMillis()
+            delay(2_000)
+        }
+    }
+
+    val tiles = if (demoMode) TvDemoData.tiles(nowMs) else PLACEHOLDER_TILES
+    val containers = listOf(
+        cs.primaryContainer to cs.onPrimaryContainer,
+        cs.secondaryContainer to cs.onSecondaryContainer,
+        cs.tertiaryContainer to cs.onTertiaryContainer,
+    )
+
     Column(
         modifier = modifier
             .fillMaxHeight()
@@ -39,45 +62,87 @@ fun TvKioskPreview(style: ThemeStyle, modifier: Modifier = Modifier) {
         verticalArrangement = Arrangement.spacedBy(20.dp),
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = "Living room",
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = cs.onSurface,
+                )
+                if (demoMode) {
+                    androidx.compose.foundation.layout.Spacer(Modifier.width(12.dp))
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(cs.tertiary.copy(alpha = 0.18f))
+                            .padding(horizontal = 10.dp, vertical = 4.dp),
+                    ) {
+                        Text(
+                            text = "DEMO",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = cs.tertiary,
+                        )
+                    }
+                }
+            }
             Text(
-                text = "Living room",
-                style = MaterialTheme.typography.headlineMedium,
-                color = cs.onSurface,
-            )
-            Text(
-                text = "Preview · ${style.displayName}",
+                text = "Preview · ${style.displayName}" + if (demoMode) " · animated" else "",
                 style = MaterialTheme.typography.titleSmall,
                 color = cs.onSurfaceVariant,
             )
         }
 
+        // Take the first three tiles for the headline row; they exercise
+        // the primary / secondary / tertiary roles. Anything beyond
+        // sits in a secondary band below.
         Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-            Tile(
-                label = "Lights",
-                value = "ON · 70%",
-                container = cs.primaryContainer,
-                onContainer = cs.onPrimaryContainer,
-                modifier = Modifier.width(220.dp),
-            )
-            Tile(
-                label = "Climate",
-                value = "21.5 °C",
-                container = cs.secondaryContainer,
-                onContainer = cs.onSecondaryContainer,
-                modifier = Modifier.width(220.dp),
-            )
-            Tile(
-                label = "Media",
-                value = "Spotify",
-                container = cs.tertiaryContainer,
-                onContainer = cs.onTertiaryContainer,
-                modifier = Modifier.width(220.dp),
-            )
+            tiles.take(3).forEachIndexed { i, tile ->
+                val (container, onContainer) = containers[i % containers.size]
+                Tile(
+                    label = tile.label,
+                    value = tile.value,
+                    container = container,
+                    onContainer = onContainer,
+                    modifier = Modifier.width(220.dp),
+                )
+            }
+        }
+        if (tiles.size > 3) {
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                tiles.drop(3).forEach { tile ->
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(14.dp))
+                            .background(cs.surfaceContainerHigh)
+                            .padding(horizontal = 14.dp, vertical = 10.dp),
+                    ) {
+                        Column {
+                            Text(
+                                text = tile.label,
+                                style = MaterialTheme.typography.labelMedium,
+                                color = cs.onSurfaceVariant,
+                            )
+                            Text(
+                                text = tile.value,
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = cs.onSurface,
+                            )
+                        }
+                    }
+                }
+            }
         }
 
         SwatchRow()
     }
 }
+
+private data class PlaceholderTile(val label: String, val value: String)
+
+private val PLACEHOLDER_TILES = listOf(
+    TvDemoData.Tile("Lights", "—"),
+    TvDemoData.Tile("Climate", "—"),
+    TvDemoData.Tile("Media", "—"),
+)
 
 @Composable
 private fun Tile(

--- a/tv/src/main/kotlin/ee/schimke/terrazzo/tv/ui/TvPreviews.kt
+++ b/tv/src/main/kotlin/ee/schimke/terrazzo/tv/ui/TvPreviews.kt
@@ -1,0 +1,78 @@
+package ee.schimke.terrazzo.tv.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import ee.schimke.ha.rc.components.ThemeStyle
+import ee.schimke.ha.rc.components.terrazzoColorScheme
+import ee.schimke.ha.rc.components.terrazzoTypographyFor
+
+/**
+ * TV @Preview fixtures. Sized at 680 × 384 dp — Robolectric renders these
+ * at ~2.625× density, so the resulting PNG is 1785 × 1008 px (under the
+ * 1800 px ceiling we want to keep TV captures at). The full
+ * picker-plus-kiosk shell only fits at TV-native widths; for previews we
+ * crop to the kiosk pane (the part that actually changes per palette /
+ * demo flag), which is also the part the user looks at on the wall.
+ */
+
+@Preview(name = "TV: kiosk (demo)", widthDp = 680, heightDp = 384, showBackground = true)
+@Composable
+fun TvKioskPreview_Demo() {
+    TvPreviewFrame(style = ThemeStyle.TerrazzoKiosk) {
+        TvKioskPreview(
+            style = ThemeStyle.TerrazzoKiosk,
+            demoMode = true,
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}
+
+@Preview(name = "TV: kiosk (live)", widthDp = 680, heightDp = 384, showBackground = true)
+@Composable
+fun TvKioskPreview_Live() {
+    TvPreviewFrame(style = ThemeStyle.TerrazzoKiosk) {
+        TvKioskPreview(
+            style = ThemeStyle.TerrazzoKiosk,
+            demoMode = false,
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}
+
+@Preview(name = "TV: kiosk (Home palette)", widthDp = 680, heightDp = 384, showBackground = true)
+@Composable
+fun TvKioskPreview_HomePalette() {
+    TvPreviewFrame(style = ThemeStyle.TerrazzoHome) {
+        TvKioskPreview(
+            style = ThemeStyle.TerrazzoHome,
+            demoMode = true,
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}
+
+@Composable
+private fun TvPreviewFrame(
+    style: ThemeStyle,
+    content: @Composable () -> Unit,
+) {
+    val colors = terrazzoColorScheme(style, darkTheme = true)
+    MaterialTheme(colorScheme = colors, typography = terrazzoTypographyFor(style)) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(colors.background)
+                .padding(20.dp),
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) { content() }
+        }
+    }
+}

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.compose.preview)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -21,8 +23,15 @@ android {
     kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
 }
 
+composePreview {
+    variant.set("debug")
+    sdkVersion.set(34)
+    enabled.set(true)
+}
+
 dependencies {
     implementation(project(":rc-components"))
+    implementation(project(":ha-model"))
 
     implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui)
@@ -31,11 +40,27 @@ dependencies {
     // we include material3 here only to unpack that for the Wear `ColorScheme.copy(...)` mapping.
     implementation(libs.compose.material3)
     implementation(libs.compose.ui.text.google.fonts)
+    implementation(libs.compose.ui.tooling.preview)
+    debugImplementation(libs.compose.ui.tooling)
     implementation(libs.activity.compose)
 
     implementation(libs.wear.compose.material3)
     implementation(libs.wear.compose.foundation)
 
+    // Proto DataStore + Horologist data layer for sync with phone.
+    // Schema is documented in `src/main/proto/wear_sync.proto`; we
+    // encode @Serializable Kotlin data classes to the same proto wire
+    // format via kotlinx-serialization-protobuf. (TODO: switch to Wire
+    // once its Gradle plugin recognises AGP 9's built-in Kotlin.)
+    implementation(libs.androidx.datastore)
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.kotlinx.serialization.protobuf)
+    implementation(libs.play.services.wearable)
+    implementation(libs.horologist.datalayer)
+    implementation(libs.horologist.datalayer.watch)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.process)
+
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.serialization.json)
 }

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/WearMainActivity.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/WearMainActivity.kt
@@ -3,42 +3,80 @@ package ee.schimke.terrazzo.wear
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.lifecycleScope
 import androidx.wear.compose.material3.AppScaffold
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.TimeText
 import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.terrazzo.wear.data.WearPrefs
-import ee.schimke.terrazzo.wear.ui.WearThemePicker
+import ee.schimke.terrazzo.wear.sync.WearLeaseController
+import ee.schimke.terrazzo.wear.sync.WearSyncRepository
+import ee.schimke.terrazzo.wear.ui.WearDashboardScreen
+import ee.schimke.terrazzo.wear.ui.WearDashboardsScreen
+import ee.schimke.terrazzo.wear.ui.WearHomeScreen
+import ee.schimke.terrazzo.wear.ui.WearSettingsScreen
 import ee.schimke.terrazzo.wear.ui.terrazzoWearColorScheme
 import ee.schimke.terrazzo.wear.ui.wearTypographyFor
+import ee.schimke.terrazzo.wearsync.proto.DashboardData
+import ee.schimke.terrazzo.wearsync.proto.PinnedCardSet
+import ee.schimke.terrazzo.wearsync.proto.WearSettings
 import kotlinx.coroutines.launch
 
 /**
- * Wear companion app — a single-screen palette browser. Picks a
- * Terrazzo [ThemeStyle], persists it via [WearPrefs], and re-themes the
- * whole watch UI live so the chosen palette can be evaluated on a
- * round face. Real HA tile rendering lands in a follow-up.
+ * Wear companion. Default screen surfaces phone's pinned cards; user can
+ * browse to dashboards or visit settings (theme picker). Demo state is
+ * driven entirely by the phone — when phone toggles demo mode the data
+ * layer publishes demo dashboards and we render the same banner +
+ * fixtures here.
  */
 class WearMainActivity : ComponentActivity() {
+
+    private lateinit var repo: WearSyncRepository
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContent { WearApp() }
+        repo = WearSyncRepository(applicationContext, lifecycleScope)
+        repo.start()
+        // Lease tracker — heartbeats while activity is foreground, so
+        // phone streams live deltas instead of batching to DataStore.
+        lifecycle.addObserver(WearLeaseController(lifecycleScope, repo))
+
+        setContent { WearApp(repo) }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        repo.stop()
     }
 }
 
+private enum class WearScreen { Home, Dashboards, Dashboard, Settings }
+
 @Composable
-private fun WearApp() {
+private fun WearApp(repo: WearSyncRepository) {
     val context = LocalContext.current
     val prefs = remember(context) { WearPrefs(context.applicationContext) }
     val scope = rememberCoroutineScope()
     val style by prefs.themeStyle.collectAsState(initial = ThemeStyle.TerrazzoHome)
+    val settings: WearSettings by repo.settings.collectAsState()
+    val pinned: PinnedCardSet by repo.pinned.collectAsState()
+    val dashboards: List<DashboardData> by repo.dashboards.collectAsState()
+    val values by repo.values.collectAsState()
+
+    var screen by rememberSaveable { mutableStateOf(WearScreen.Home) }
+    var openedDashboard by rememberSaveable { mutableStateOf<String?>(null) }
 
     MaterialTheme(
         colorScheme = terrazzoWearColorScheme(style),
@@ -46,10 +84,47 @@ private fun WearApp() {
     ) {
         AppScaffold(timeText = { TimeText() }) {
             ScreenScaffold {
-                WearThemePicker(
-                    selected = style,
-                    onSelect = { picked -> scope.launch { prefs.setThemeStyle(picked) } },
-                )
+                when (screen) {
+                    WearScreen.Home -> WearHomeScreen(
+                        settings = settings,
+                        pinned = pinned,
+                        values = values,
+                        onBrowseDashboards = { screen = WearScreen.Dashboards },
+                        onOpenSettings = { screen = WearScreen.Settings },
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                    WearScreen.Dashboards -> WearDashboardsScreen(
+                        dashboards = dashboards,
+                        onDashboardPicked = {
+                            openedDashboard = it.urlPath
+                            screen = WearScreen.Dashboard
+                        },
+                        onBack = { screen = WearScreen.Home },
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                    WearScreen.Dashboard -> {
+                        val urlPath = openedDashboard
+                        val board = dashboards.firstOrNull { it.urlPath == urlPath }
+                        if (board != null) {
+                            WearDashboardScreen(
+                                dashboard = board,
+                                values = values,
+                                onBack = { screen = WearScreen.Dashboards },
+                                modifier = Modifier.fillMaxSize(),
+                            )
+                        } else {
+                            // Dashboard removed mid-flight; bounce back.
+                            screen = WearScreen.Dashboards
+                        }
+                    }
+                    WearScreen.Settings -> WearSettingsScreen(
+                        selected = style,
+                        settings = settings,
+                        onSelectTheme = { picked -> scope.launch { prefs.setThemeStyle(picked) } },
+                        onBack = { screen = WearScreen.Home },
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
             }
         }
     }

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/sync/WearLeaseController.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/sync/WearLeaseController.kt
@@ -1,0 +1,58 @@
+package ee.schimke.terrazzo.wear.sync
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Sends a `WearLease` heartbeat to the phone every
+ * [HEARTBEAT_MS] milliseconds while the activity is foreground. Phone
+ * uses arrival times as the lease window — while a recent lease exists
+ * (within [WearSyncPaths.LEASE_WINDOW_MS]) phone streams deltas via
+ * MessageClient; otherwise it batches into the `/wear/values` Proto
+ * DataStore.
+ *
+ * Attached as a `LifecycleObserver` so the heartbeat starts on
+ * `onStart`, stops on `onStop`, and we send a single foreground=false
+ * lease right at `onStop` to release the lease early (rather than
+ * letting the phone's window timeout run out).
+ */
+class WearLeaseController(
+    private val scope: CoroutineScope,
+    private val repo: WearSyncRepository,
+) : DefaultLifecycleObserver {
+
+    private var job: Job? = null
+
+    override fun onStart(owner: LifecycleOwner) {
+        job?.cancel()
+        job = scope.launch {
+            // First lease right away so the phone starts streaming
+            // without waiting on the heartbeat tick.
+            repo.sendLease(foreground = true)
+            while (true) {
+                delay(HEARTBEAT_MS)
+                repo.sendLease(foreground = true)
+            }
+        }
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        job?.cancel()
+        job = null
+        scope.launch { repo.sendLease(foreground = false) }
+    }
+
+    companion object {
+        /**
+         * Heartbeat cadence. Tuned for ~1/3 of the lease window so a
+         * single lost message doesn't trip the lease, and the phone
+         * stays in streaming mode the whole time the user is on the
+         * watch screen. 10 s window matches the phone-side lease check.
+         */
+        const val HEARTBEAT_MS: Long = 10_000L
+    }
+}

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/sync/WearSyncRepository.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/sync/WearSyncRepository.kt
@@ -1,0 +1,168 @@
+package ee.schimke.terrazzo.wear.sync
+
+import android.content.Context
+import android.util.Log
+import com.google.android.gms.wearable.DataClient
+import com.google.android.gms.wearable.DataEvent
+import com.google.android.gms.wearable.DataEventBuffer
+import com.google.android.gms.wearable.DataMapItem
+import com.google.android.gms.wearable.MessageClient
+import com.google.android.gms.wearable.NodeClient
+import com.google.android.gms.wearable.Wearable
+import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.data.WearDataLayerRegistry
+import ee.schimke.terrazzo.wearsync.proto.DashboardData
+import ee.schimke.terrazzo.wearsync.proto.EntityValue
+import ee.schimke.terrazzo.wearsync.proto.LiveValues
+import ee.schimke.terrazzo.wearsync.proto.PinnedCardSet
+import ee.schimke.terrazzo.wearsync.proto.StreamUpdate
+import ee.schimke.terrazzo.wearsync.proto.WearLease
+import ee.schimke.terrazzo.wearsync.proto.WearSettings
+import ee.schimke.terrazzo.wearsync.proto.WearSyncPaths
+import ee.schimke.terrazzo.wearsync.proto.decodeProto
+import ee.schimke.terrazzo.wearsync.proto.encodeProto
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+
+/**
+ * Watch-side counterpart to `MobileWearSyncManager`. Keeps state for:
+ *
+ *  - [settings]: cross-device flags (demo mode, base url) — sourced from
+ *    the `/wear/settings` Proto DataStore entry
+ *  - [pinned]: phone's pinned card set
+ *  - [dashboards]: one entry per `/wear/dashboard/<urlPath>`
+ *  - [values]: latest entity values, merged from the
+ *    `/wear/values` DataStore entry (cold reads) and
+ *    `/wear/stream` MessageClient deltas (hot path)
+ *
+ * Streaming deltas are merged into the local [values] state so consumers
+ * see one consistent view regardless of cadence.
+ */
+@OptIn(ExperimentalHorologistApi::class)
+class WearSyncRepository(
+    context: Context,
+    private val scope: CoroutineScope,
+) {
+    private val dataClient: DataClient = Wearable.getDataClient(context)
+    private val messageClient: MessageClient = Wearable.getMessageClient(context)
+    private val nodeClient: NodeClient = Wearable.getNodeClient(context)
+
+    @Suppress("unused")
+    private val registry: WearDataLayerRegistry =
+        WearDataLayerRegistry.fromContext(
+            application = context.applicationContext as android.app.Application,
+            coroutineScope = scope,
+        )
+
+    private val _settings: MutableStateFlow<WearSettings> = MutableStateFlow(WearSettings())
+    val settings: StateFlow<WearSettings> = _settings.asStateFlow()
+
+    private val _pinned: MutableStateFlow<PinnedCardSet> = MutableStateFlow(PinnedCardSet())
+    val pinned: StateFlow<PinnedCardSet> = _pinned.asStateFlow()
+
+    private val _dashboards: MutableStateFlow<List<DashboardData>> = MutableStateFlow(emptyList())
+    val dashboards: StateFlow<List<DashboardData>> = _dashboards.asStateFlow()
+
+    private val _values: MutableStateFlow<Map<String, EntityValue>> = MutableStateFlow(emptyMap())
+    val values: StateFlow<Map<String, EntityValue>> = _values.asStateFlow()
+
+    private val dataListener = DataClient.OnDataChangedListener { events: DataEventBuffer ->
+        for (event in events) {
+            if (event.type != DataEvent.TYPE_CHANGED) continue
+            val item = event.dataItem
+            val mapItem = DataMapItem.fromDataItem(item)
+            val bytes = mapItem.dataMap.getByteArray(KEY_PROTO) ?: continue
+            handle(item.uri.path.orEmpty(), bytes)
+        }
+        events.release()
+    }
+
+    private val messageListener = MessageClient.OnMessageReceivedListener { event ->
+        if (event.path != WearSyncPaths.STREAM_MESSAGE) return@OnMessageReceivedListener
+        val frame: StreamUpdate = decodeProto(event.data) ?: return@OnMessageReceivedListener
+        val merged = _values.value.toMutableMap()
+        for (delta in frame.deltas) {
+            merged[delta.entityId] = delta.value
+        }
+        _values.value = merged
+    }
+
+    fun start() {
+        dataClient.addListener(dataListener)
+        messageClient.addListener(messageListener)
+        // Cold-read all known paths so the UI lights up immediately on
+        // launch instead of waiting for the next change event.
+        scope.launch {
+            runCatching { dataClient.dataItems.await() }.getOrNull()?.let { buffer ->
+                for (i in 0 until buffer.count) {
+                    val item = buffer[i]
+                    val mapItem = DataMapItem.fromDataItem(item)
+                    val bytes = mapItem.dataMap.getByteArray(KEY_PROTO) ?: continue
+                    handle(item.uri.path.orEmpty(), bytes)
+                }
+                buffer.release()
+            }
+        }
+    }
+
+    fun stop() {
+        runCatching { dataClient.removeListener(dataListener) }
+        runCatching { messageClient.removeListener(messageListener) }
+    }
+
+    /**
+     * Push a heartbeat to the phone. Wear's lifecycle controller calls
+     * this every [WearLeaseController.HEARTBEAT_MS] while the activity
+     * is foreground; phone treats arrival time as the lease window.
+     */
+    suspend fun sendLease(foreground: Boolean) {
+        runCatching {
+            val nodes = nodeClient.connectedNodes.await()
+            val frame = WearLease(
+                sentAtMs = System.currentTimeMillis(),
+                foreground = foreground,
+            )
+            val bytes = encodeProto(frame)
+            for (node in nodes) {
+                messageClient.sendMessage(node.id, WearSyncPaths.LEASE_MESSAGE, bytes).await()
+            }
+        }.onFailure { Log.w(TAG, "sendLease failed", it) }
+    }
+
+    private fun handle(path: String, bytes: ByteArray) {
+        when {
+            path == WearSyncPaths.SETTINGS ->
+                decodeProto<WearSettings>(bytes)?.let { _settings.value = it }
+            path == WearSyncPaths.PINNED ->
+                decodeProto<PinnedCardSet>(bytes)?.let { _pinned.value = it }
+            path == WearSyncPaths.VALUES ->
+                decodeProto<LiveValues>(bytes)?.let { live ->
+                    // Cold-read overwrites entirely; subsequent stream
+                    // deltas will merge from this baseline.
+                    _values.value = live.values
+                }
+            path.startsWith(WearSyncPaths.DASHBOARD_PREFIX) ->
+                decodeProto<DashboardData>(bytes)?.let { dashboard ->
+                    val current = _dashboards.value.toMutableList()
+                    val idx = current.indexOfFirst { it.urlPath == dashboard.urlPath }
+                    if (idx >= 0) current[idx] = dashboard else current.add(dashboard)
+                    _dashboards.value = current.sortedBy { it.title }
+                }
+        }
+    }
+
+    companion object {
+        private const val TAG = "WearSync"
+        const val KEY_PROTO: String = "proto"
+    }
+}
+
+private suspend fun <T> com.google.android.gms.tasks.Task<T>.await(): T =
+    kotlinx.coroutines.suspendCancellableCoroutine { cont ->
+        addOnSuccessListener { value -> cont.resumeWith(Result.success(value)) }
+        addOnFailureListener { error -> cont.resumeWith(Result.failure(error)) }
+    }

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearDashboardsScreen.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearDashboardsScreen.kt
@@ -1,0 +1,161 @@
+package ee.schimke.terrazzo.wear.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
+import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.ButtonDefaults
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import ee.schimke.terrazzo.wearsync.proto.DashboardData
+import ee.schimke.terrazzo.wearsync.proto.EntityValue
+
+/**
+ * Browse-mode list — one row per dashboard the phone published. Tap a
+ * row to drill into [WearDashboardScreen].
+ */
+@Composable
+fun WearDashboardsScreen(
+    dashboards: List<DashboardData>,
+    onDashboardPicked: (DashboardData) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val listState = rememberScalingLazyListState()
+    ScalingLazyColumn(
+        state = listState,
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        contentPadding = PaddingValues(horizontal = 14.dp, vertical = 8.dp),
+    ) {
+        item { ListHeader { Text("Dashboards") } }
+
+        if (dashboards.isEmpty()) {
+            item {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp, vertical = 12.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "Waiting for the phone to publish dashboards…",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        } else {
+            items(dashboards) { dashboard ->
+                Button(
+                    onClick = { onDashboardPicked(dashboard) },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.filledTonalButtonColors(),
+                ) {
+                    Column {
+                        Text(
+                            text = dashboard.title.ifEmpty { dashboard.urlPath.ifEmpty { "Default" } },
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Text(
+                            text = "${dashboard.cards.size} card${if (dashboard.cards.size == 1) "" else "s"}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        }
+
+        item {
+            Button(
+                onClick = onBack,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.filledTonalButtonColors(),
+            ) {
+                Text("Back")
+            }
+        }
+    }
+}
+
+/** Single-dashboard drilldown — list each card with its primary entity value. */
+@Composable
+fun WearDashboardScreen(
+    dashboard: DashboardData,
+    values: Map<String, EntityValue>,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val listState = rememberScalingLazyListState()
+    ScalingLazyColumn(
+        state = listState,
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        contentPadding = PaddingValues(horizontal = 14.dp, vertical = 8.dp),
+    ) {
+        item { ListHeader { Text(dashboard.title.ifEmpty { "Dashboard" }) } }
+
+        if (dashboard.cards.isEmpty()) {
+            item {
+                Text(
+                    text = "Empty dashboard",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
+                )
+            }
+        } else {
+            items(dashboard.cards) { card ->
+                val value = values[card.primaryEntityId]
+                val displayState = value?.let { v ->
+                    buildString {
+                        append(v.state)
+                        if (v.unit.isNotEmpty()) append(" ${v.unit}")
+                    }
+                }.orEmpty()
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 4.dp, vertical = 6.dp),
+                ) {
+                    Text(
+                        text = card.title.ifEmpty { card.primaryEntityId.ifEmpty { card.type } },
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    if (displayState.isNotEmpty()) {
+                        Text(
+                            text = displayState,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                }
+            }
+        }
+
+        item {
+            Button(
+                onClick = onBack,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.filledTonalButtonColors(),
+            ) {
+                Text("Back")
+            }
+        }
+    }
+}

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearHomeScreen.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearHomeScreen.kt
@@ -1,0 +1,164 @@
+package ee.schimke.terrazzo.wear.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
+import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.ButtonDefaults
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import ee.schimke.terrazzo.wearsync.proto.EntityValue
+import ee.schimke.terrazzo.wearsync.proto.PinnedCard
+import ee.schimke.terrazzo.wearsync.proto.PinnedCardSet
+import ee.schimke.terrazzo.wearsync.proto.WearSettings
+
+/**
+ * Default Wear screen — the watch surfaces the cards the user has
+ * already curated as widgets on the phone. Users tap "Dashboards" to
+ * browse the full HA library, or "Settings" for the (now small) theme
+ * picker.
+ *
+ * Demo mode is purely a phone-side concept; we just render what the
+ * phone publishes and stick a small "Demo" banner up top when
+ * `WearSettings.demoMode` is set.
+ */
+@Composable
+fun WearHomeScreen(
+    settings: WearSettings,
+    pinned: PinnedCardSet,
+    values: Map<String, EntityValue>,
+    onBrowseDashboards: () -> Unit,
+    onOpenSettings: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val listState = rememberScalingLazyListState()
+    ScalingLazyColumn(
+        state = listState,
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        contentPadding = PaddingValues(horizontal = 14.dp, vertical = 8.dp),
+    ) {
+        item {
+            ListHeader { Text(if (settings.demoMode) "Pinned · Demo" else "Pinned") }
+        }
+        if (settings.demoMode) {
+            item { DemoBanner() }
+        }
+
+        if (pinned.cards.isEmpty()) {
+            item { EmptyPinned() }
+        } else {
+            items(pinned.cards) { card ->
+                PinnedRow(card = card, value = values[card.card.primaryEntityId])
+            }
+        }
+
+        item { Spacer(Modifier.height(4.dp)) }
+        item {
+            Button(
+                onClick = onBrowseDashboards,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.filledTonalButtonColors(),
+            ) {
+                Text("Browse dashboards")
+            }
+        }
+        item {
+            Button(
+                onClick = onOpenSettings,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.filledTonalButtonColors(),
+            ) {
+                Text("Settings")
+            }
+        }
+    }
+}
+
+@Composable
+private fun DemoBanner() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp, vertical = 2.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "Phone is in demo mode",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.tertiary,
+        )
+    }
+}
+
+@Composable
+private fun EmptyPinned() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 12.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "No pinned cards.\nLong-press a card on the phone to add one.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun PinnedRow(card: PinnedCard, value: EntityValue?) {
+    val title = card.card.title.ifEmpty { card.card.primaryEntityId.ifEmpty { card.card.type } }
+    val displayState = value?.let { v ->
+        buildString {
+            append(v.state)
+            if (v.unit.isNotEmpty()) append(" ${v.unit}")
+        }
+    }.orEmpty()
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 4.dp, vertical = 6.dp),
+    ) {
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            androidx.compose.foundation.layout.Column {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                if (displayState.isNotEmpty()) {
+                    Text(
+                        text = displayState,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                } else if (card.card.primaryEntityId.isNotEmpty()) {
+                    Text(
+                        text = card.card.primaryEntityId,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearPreviews.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearPreviews.kt
@@ -1,0 +1,182 @@
+package ee.schimke.terrazzo.wear.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.wear.compose.material3.AppScaffold
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.TimeText
+import ee.schimke.ha.rc.components.ThemeStyle
+import ee.schimke.terrazzo.wearsync.proto.CardSummary
+import ee.schimke.terrazzo.wearsync.proto.DashboardData
+import ee.schimke.terrazzo.wearsync.proto.EntityValue
+import ee.schimke.terrazzo.wearsync.proto.PinnedCard
+import ee.schimke.terrazzo.wearsync.proto.PinnedCardSet
+import ee.schimke.terrazzo.wearsync.proto.WearSettings
+
+/**
+ * Wear @Preview fixtures. Render the new sync-driven home screen, the
+ * dashboards browse list, and the demo-banner variant. Wear sizes are
+ * 192 / 192 dp (small round) — well under TV's 1800 px constraint.
+ */
+
+private val PINNED_FIXTURE = PinnedCardSet(
+    cards = listOf(
+        PinnedCard(
+            baseUrl = "demo://terrazzo",
+            card = CardSummary(
+                type = "tile",
+                title = "Living Room",
+                primaryEntityId = "sensor.living_room",
+            ),
+        ),
+        PinnedCard(
+            baseUrl = "demo://terrazzo",
+            card = CardSummary(
+                type = "tile",
+                title = "Kitchen",
+                primaryEntityId = "light.kitchen",
+            ),
+        ),
+        PinnedCard(
+            baseUrl = "demo://terrazzo",
+            card = CardSummary(
+                type = "tile",
+                title = "Front door",
+                primaryEntityId = "lock.front_door",
+            ),
+        ),
+    ),
+)
+
+private val VALUES_FIXTURE = mapOf(
+    "sensor.living_room" to EntityValue(
+        state = "21.5",
+        friendlyName = "Living Room",
+        unit = "°C",
+        deviceClass = "temperature",
+    ),
+    "light.kitchen" to EntityValue(state = "on", friendlyName = "Kitchen"),
+    "lock.front_door" to EntityValue(state = "locked", friendlyName = "Front door"),
+)
+
+private val DASHBOARDS_FIXTURE = listOf(
+    DashboardData(
+        urlPath = "",
+        title = "Home",
+        cards = List(4) { CardSummary(type = "tile", title = "Card $it") },
+    ),
+    DashboardData(
+        urlPath = "downstairs",
+        title = "Downstairs",
+        cards = List(3) { CardSummary(type = "tile", title = "Card $it") },
+    ),
+    DashboardData(
+        urlPath = "office",
+        title = "Office",
+        cards = List(5) { CardSummary(type = "tile", title = "Card $it") },
+    ),
+)
+
+@Preview(name = "Wear: home (live)", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
+@Composable
+fun WearHomePreview_Live() {
+    WearPreviewFrame {
+        WearHomeScreen(
+            settings = WearSettings(demoMode = false, baseUrl = "https://home.assistant.io"),
+            pinned = PINNED_FIXTURE,
+            values = VALUES_FIXTURE,
+            onBrowseDashboards = {},
+            onOpenSettings = {},
+        )
+    }
+}
+
+@Preview(name = "Wear: home (demo)", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
+@Composable
+fun WearHomePreview_Demo() {
+    WearPreviewFrame {
+        WearHomeScreen(
+            settings = WearSettings(demoMode = true, baseUrl = "demo://terrazzo"),
+            pinned = PINNED_FIXTURE,
+            values = VALUES_FIXTURE,
+            onBrowseDashboards = {},
+            onOpenSettings = {},
+        )
+    }
+}
+
+@Preview(name = "Wear: home (empty)", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
+@Composable
+fun WearHomePreview_Empty() {
+    WearPreviewFrame {
+        WearHomeScreen(
+            settings = WearSettings(demoMode = false),
+            pinned = PinnedCardSet(),
+            values = emptyMap(),
+            onBrowseDashboards = {},
+            onOpenSettings = {},
+        )
+    }
+}
+
+@Preview(name = "Wear: dashboards", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
+@Composable
+fun WearDashboardsPreview() {
+    WearPreviewFrame {
+        WearDashboardsScreen(
+            dashboards = DASHBOARDS_FIXTURE,
+            onDashboardPicked = {},
+            onBack = {},
+        )
+    }
+}
+
+@Preview(name = "Wear: dashboard", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
+@Composable
+fun WearDashboardPreview() {
+    WearPreviewFrame {
+        WearDashboardScreen(
+            dashboard = DashboardData(
+                urlPath = "",
+                title = "Home",
+                cards = listOf(
+                    CardSummary(type = "tile", title = "Living Room", primaryEntityId = "sensor.living_room"),
+                    CardSummary(type = "tile", title = "Kitchen", primaryEntityId = "light.kitchen"),
+                    CardSummary(type = "tile", title = "Coffee maker", primaryEntityId = "switch.coffee_maker"),
+                ),
+            ),
+            values = VALUES_FIXTURE + mapOf(
+                "switch.coffee_maker" to EntityValue(state = "on", friendlyName = "Coffee maker"),
+            ),
+            onBack = {},
+        )
+    }
+}
+
+@Preview(name = "Wear: settings", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
+@Composable
+fun WearSettingsPreview() {
+    WearPreviewFrame {
+        WearSettingsScreen(
+            selected = ThemeStyle.TerrazzoHome,
+            settings = WearSettings(demoMode = true, baseUrl = "demo://terrazzo"),
+            onSelectTheme = {},
+            onBack = {},
+        )
+    }
+}
+
+/** Shared fixture: Wear-Material theme + ScreenScaffold so each preview reads like a real frame. */
+@Composable
+private fun WearPreviewFrame(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colorScheme = terrazzoWearColorScheme(ThemeStyle.TerrazzoHome),
+        typography = wearTypographyFor(ThemeStyle.TerrazzoHome),
+    ) {
+        AppScaffold(timeText = { TimeText() }) {
+            ScreenScaffold { content() }
+        }
+    }
+}

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearSettingsScreen.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearSettingsScreen.kt
@@ -1,0 +1,97 @@
+package ee.schimke.terrazzo.wear.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
+import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.ButtonDefaults
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.RadioButton
+import androidx.wear.compose.material3.Text
+import ee.schimke.ha.rc.components.ThemeStyle
+import ee.schimke.terrazzo.wearsync.proto.WearSettings
+
+/**
+ * Wear settings — theme picker plus a small "About" footer that shows
+ * what phone the watch is paired with (and whether phone has demo mode
+ * enabled). Demo mode itself is phone-driven; there's no toggle here.
+ */
+@Composable
+fun WearSettingsScreen(
+    selected: ThemeStyle,
+    settings: WearSettings,
+    onSelectTheme: (ThemeStyle) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val listState = rememberScalingLazyListState()
+    ScalingLazyColumn(
+        state = listState,
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        contentPadding = PaddingValues(horizontal = 14.dp, vertical = 8.dp),
+    ) {
+        item { ListHeader { Text("Theme") } }
+
+        item {
+            Text(
+                text = selected.tagline,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+            )
+        }
+
+        items(ThemeStyle.entries) { style ->
+            RadioButton(
+                selected = style == selected,
+                onSelect = { onSelectTheme(style) },
+                label = {
+                    Text(
+                        text = style.displayName,
+                        fontWeight = if (style == selected) FontWeight.SemiBold else FontWeight.Normal,
+                    )
+                },
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+
+        item { Spacer(Modifier.height(8.dp)) }
+        item { ListHeader { Text("Phone") } }
+        item {
+            Text(
+                text = if (settings.demoMode) {
+                    "Demo mode (offline)"
+                } else if (settings.baseUrl.isNotEmpty()) {
+                    settings.baseUrl
+                } else {
+                    "Not connected"
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
+            )
+        }
+
+        item {
+            Button(
+                onClick = onBack,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.filledTonalButtonColors(),
+            ) {
+                Text("Back")
+            }
+        }
+    }
+}

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wearsync/proto/ProtoSerializers.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wearsync/proto/ProtoSerializers.kt
@@ -1,0 +1,49 @@
+package ee.schimke.terrazzo.wearsync.proto
+
+import androidx.datastore.core.Serializer
+import java.io.InputStream
+import java.io.OutputStream
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.protobuf.ProtoBuf
+import kotlinx.serialization.serializer
+
+/**
+ * Bridge `androidx.datastore.core.Serializer<T>` to
+ * `kotlinx-serialization-protobuf`. Each Proto DataStore (`/wear/...`)
+ * gets one of these.
+ *
+ * Defensive read: if the file is empty (first read) or corrupt, we
+ * return [defaultValue] rather than throwing — DataStore would otherwise
+ * propagate as `CorruptionException` and crash the activity.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+class ProtoBufSerializer<T : Any>(
+    private val ksz: KSerializer<T>,
+    override val defaultValue: T,
+) : Serializer<T> {
+    override suspend fun readFrom(input: InputStream): T {
+        val bytes = input.readBytes()
+        if (bytes.isEmpty()) return defaultValue
+        return runCatching { ProtoBuf.decodeFromByteArray(ksz, bytes) }
+            .getOrDefault(defaultValue)
+    }
+
+    override suspend fun writeTo(t: T, output: OutputStream) {
+        output.write(ProtoBuf.encodeToByteArray(ksz, t))
+    }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+inline fun <reified T : Any> protoBufSerializer(default: T): ProtoBufSerializer<T> =
+    ProtoBufSerializer(serializer(), default)
+
+/** Encode an arbitrary @Serializable value to proto bytes. */
+@OptIn(ExperimentalSerializationApi::class)
+inline fun <reified T> encodeProto(value: T): ByteArray =
+    ProtoBuf.encodeToByteArray(serializer(), value)
+
+/** Decode proto bytes back into [T]. Returns null on corruption. */
+@OptIn(ExperimentalSerializationApi::class)
+inline fun <reified T> decodeProto(bytes: ByteArray): T? =
+    runCatching { ProtoBuf.decodeFromByteArray(serializer<T>(), bytes) }.getOrNull()

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wearsync/proto/WearSyncProto.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wearsync/proto/WearSyncProto.kt
@@ -1,0 +1,140 @@
+package ee.schimke.terrazzo.wearsync.proto
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Wear ↔ phone sync schema. The same file is duplicated in the `app`
+ * module — both copies must stay byte-for-byte identical so DataItem
+ * payloads and MessageClient frames decode on the peer.
+ *
+ * The values are encoded with `kotlinx.serialization.protobuf.ProtoBuf`,
+ * which produces standard proto3 wire bytes — i.e. the same bytes that
+ * `protoc`/Wire would write. We choose this approach (rather than
+ * generated classes via Wire's Gradle plugin) so the build stays
+ * self-contained on AGP 9 / Gradle 9.3, which Wire's plugin doesn't yet
+ * recognise as a Kotlin host. The `.proto` file in `src/main/proto/`
+ * documents the schema and stays the source of truth.
+ *
+ * Path conventions (mirrored in [WearSyncPaths]):
+ *   - DataClient:
+ *     - `/wear/settings`            — [WearSettings]
+ *     - `/wear/pinned`              — [PinnedCardSet]
+ *     - `/wear/values`              — [LiveValues]
+ *     - `/wear/dashboard/<urlPath>` — [DashboardData]
+ *   - MessageClient (ephemeral):
+ *     - `/wear/lease`   — [WearLease]   (wear → phone heartbeat)
+ *     - `/wear/stream`  — [StreamUpdate] (phone → wear delta push)
+ */
+
+/** Wear-side settings written by the phone. Drives demo badge and routing. */
+@Serializable
+data class WearSettings(
+    val demoMode: Boolean = false,
+    val baseUrl: String = "",
+    val updatedAtMs: Long = 0L,
+)
+
+/** Card extract phone-side; wear renders a list row from this. */
+@Serializable
+data class CardSummary(
+    val type: String = "",
+    val title: String = "",
+    val primaryEntityId: String = "",
+    val rawJson: String = "",
+)
+
+/** One DataStore Proto entry per dashboard, keyed by `urlPath`. */
+@Serializable
+data class DashboardData(
+    val urlPath: String = "",
+    val title: String = "",
+    val cards: List<CardSummary> = emptyList(),
+    val updatedAtMs: Long = 0L,
+)
+
+/** Single DataStore entry holding the latest entity values. */
+@Serializable
+data class LiveValues(
+    val values: Map<String, EntityValue> = emptyMap(),
+    val capturedAtMs: Long = 0L,
+)
+
+@Serializable
+data class EntityValue(
+    val state: String = "",
+    val friendlyName: String = "",
+    val unit: String = "",
+    val deviceClass: String = "",
+)
+
+/** MessageClient stream frame — only entities that changed. */
+@Serializable
+data class StreamUpdate(
+    val deltas: List<EntityDelta> = emptyList(),
+    val capturedAtMs: Long = 0L,
+)
+
+@Serializable
+data class EntityDelta(
+    val entityId: String = "",
+    val value: EntityValue = EntityValue(),
+)
+
+/** Mirror of phone's WidgetStore — drives wear's home screen. */
+@Serializable
+data class PinnedCardSet(
+    val cards: List<PinnedCard> = emptyList(),
+    val updatedAtMs: Long = 0L,
+)
+
+@Serializable
+data class PinnedCard(
+    val baseUrl: String = "",
+    val card: CardSummary = CardSummary(),
+)
+
+/**
+ * Heartbeat sent from wear → phone over MessageClient. Phone treats the
+ * arrival time as a lease window; while a recent lease is active phone
+ * pushes [StreamUpdate]s, otherwise it batches into [LiveValues].
+ */
+@Serializable
+data class WearLease(
+    val sentAtMs: Long = 0L,
+    val foreground: Boolean = false,
+)
+
+/**
+ * Phone-local diagnostics. Stored at `terrazzo_sync_stats.pb` and
+ * surfaced in Settings → Diagnostics.
+ */
+@Serializable
+data class SyncStats(
+    val datastoreWrites: Long = 0L,
+    val messageSends: Long = 0L,
+    val lastLeaseAtMs: Long = 0L,
+    val lastWriteAtMs: Long = 0L,
+    val lastMessageAtMs: Long = 0L,
+    /** Bounded ring (last 32 send timestamps in ms) for rolling-window frequency. */
+    val recentSendMs: List<Long> = emptyList(),
+)
+
+/** Path constants — keep mirrored across modules. */
+object WearSyncPaths {
+    const val SETTINGS: String = "/wear/settings"
+    const val PINNED: String = "/wear/pinned"
+    const val VALUES: String = "/wear/values"
+    const val DASHBOARD_PREFIX: String = "/wear/dashboard/"
+    const val LEASE_MESSAGE: String = "/wear/lease"
+    const val STREAM_MESSAGE: String = "/wear/stream"
+
+    /** Encode a urlPath (which may be null for HA's default dashboard) into a DataItem path. */
+    fun dashboardPath(urlPath: String?): String =
+        DASHBOARD_PREFIX + (urlPath?.takeIf { it.isNotEmpty() }?.replace('/', '_') ?: "_default")
+
+    /**
+     * Lease window before phone falls back to batched DataStore writes.
+     * Tuned for 30 s of wall-clock; wear sends a heartbeat every 10 s.
+     */
+    const val LEASE_WINDOW_MS: Long = 30_000L
+}

--- a/wear/src/main/proto/wear_sync.proto
+++ b/wear/src/main/proto/wear_sync.proto
@@ -1,0 +1,114 @@
+// Wear ↔ phone sync schema. Identical copy lives in `app/src/main/proto/`
+// — Wire compiles each module's .proto separately, the wire format is
+// what's on the wire so duplicate generation is intentional.
+//
+// Path conventions (mirrored in WearSyncPaths.kt):
+//   /wear/settings              — WearSettings (phone → wear; demo flag, baseUrl)
+//   /wear/pinned                — PinnedCardSet (phone → wear; mobile widget list)
+//   /wear/values                — LiveValues (phone → wear; current entity values)
+//   /wear/dashboard/<urlPath>   — DashboardData (phone → wear; one entry per dashboard)
+//   /wear/lease   (MessageClient) — WearLease (wear → phone; foreground heartbeat)
+//   /wear/stream  (MessageClient) — StreamUpdate (phone → wear; ephemeral deltas)
+syntax = "proto3";
+
+package terrazzo.wearsync;
+
+option java_package = "ee.schimke.terrazzo.wearsync.proto";
+option java_multiple_files = true;
+
+// Cross-device wear settings. Phone is the source of truth; wear reads
+// to drive its UI (e.g. show "Demo" badge, route to demo data).
+message WearSettings {
+    // True when phone has demo mode enabled — wear falls back to its
+    // own DemoData fixture and stops expecting live values.
+    bool demo_mode = 1;
+    // The HA base URL phone is connected to (informational; wear shows
+    // it on the about screen). Empty when signed-out / demo.
+    string base_url = 2;
+    // Wall-clock time of the last write, for diagnostics.
+    int64 updated_at_ms = 3;
+}
+
+// Card surfaces shown on Wear. Phone extracts the minimum each row
+// needs (title + primary entity + raw config blob).
+message CardSummary {
+    string type = 1;
+    string title = 2;
+    string primary_entity_id = 3;
+    string raw_json = 4;
+}
+
+// One DataStore Proto entry per dashboard (path
+// `/wear/dashboard/<urlPath>`). Wear's "browse" screen lists titles +
+// loads the chosen entry on demand.
+message DashboardData {
+    string url_path = 1;
+    string title = 2;
+    repeated CardSummary cards = 3;
+    int64 updated_at_ms = 4;
+}
+
+// Single DataStore Proto entry at `/wear/values`. Phone writes the
+// snapshot here when streaming is OFF (no Wear lease). Cheaper than
+// MessageClient for cold reads / activity bootstraps.
+message LiveValues {
+    map<string, EntityValue> values = 1;
+    int64 captured_at_ms = 2;
+}
+
+message EntityValue {
+    string state = 1;
+    string friendly_name = 2;
+    string unit = 3;
+    string device_class = 4;
+}
+
+// Sent via MessageClient at `/wear/stream` when phone has a live lease
+// from wear (or pinned cards force a stream). Carries only changed
+// entities to keep traffic small.
+message StreamUpdate {
+    repeated EntityDelta deltas = 1;
+    int64 captured_at_ms = 2;
+}
+
+message EntityDelta {
+    string entity_id = 1;
+    EntityValue value = 2;
+}
+
+// Pinned-cards mirror of phone's WidgetStore. Wear shows these as the
+// default home screen so the watch surfaces what the user has already
+// curated.
+message PinnedCardSet {
+    repeated PinnedCard cards = 1;
+    int64 updated_at_ms = 2;
+}
+
+message PinnedCard {
+    string base_url = 1;
+    CardSummary card = 2;
+}
+
+// Wear → phone heartbeat (MessageClient at `/wear/lease`). Phone uses
+// the most-recent arrival time as the lease window: while a recent
+// heartbeat exists, phone streams; otherwise it batches to the
+// `/wear/values` DataStore.
+message WearLease {
+    int64 sent_at_ms = 1;
+    bool foreground = 2;
+}
+
+// Phone-local diagnostics. Stored in a phone-only Proto DataStore at
+// `terrazzo_sync_stats.pb` and surfaced in Settings → Diagnostics so
+// users can sanity-check sync chatter.
+message SyncStats {
+    int64 datastore_writes = 1;
+    int64 message_sends = 2;
+    int64 last_lease_at_ms = 3;
+    int64 last_write_at_ms = 4;
+    int64 last_message_at_ms = 5;
+    // Bounded ring buffer (last 32 send timestamps in ms) so we can
+    // compute a rolling-window frequency without persisting unbounded
+    // history.
+    repeated int64 recent_send_ms = 6;
+}


### PR DESCRIPTION
## Summary

- **Wear ↔ phone data layer.** Schema lives in `wear_sync.proto` (mirrored on phone + watch); Kotlin shim is `@Serializable` data classes encoded as proto3 wire bytes via `kotlinx-serialization-protobuf` (the `protobuf-gradle` and Wire plugins both fail against AGP 9.1 right now — `.proto` is still the source of truth so swapping later is mechanical). Horologist's `WearDataLayerRegistry` plus the underlying `DataClient` / `MessageClient` carry the bytes.
- **Phone (`MobileWearSyncManager`).** Mirrors `PreferencesStore.demoMode` → `/wear/settings`, one DataItem per dashboard at `/wear/dashboard/<urlPath>`, `WidgetStore` → `/wear/pinned`. Snapshot pump batches `LiveValues` into `/wear/values` when no lease, streams `StreamUpdate` deltas via MessageClient when wear holds a lease (heartbeat) or pinned cards force a stream. Every write/send updates `MobileSyncStatsStore` (Proto DataStore) so chatter is auditable.
- **Wear (`WearSyncRepository` + `WearLeaseController`).** Subscribes to all `/wear/...` paths, merges stream deltas into a single live values map, sends `/wear/lease` heartbeats every 10 s while the activity is foreground (releases on stop). Default home screen surfaces phone's pinned cards; Browse drills into per-dashboard views; Settings keeps the theme picker. Demo state is **phone-driven** — wear shows a "Phone is in demo mode" banner when `WearSettings.demoMode` is set; no toggle on the watch.
- **TV.** Local `demoMode` flag in `TvPrefs`; kiosk preview shows animated `TvDemoData` + DEMO badge when on, static placeholder otherwise.
- **Phone Settings → Sync diagnostics.** DataItem-write / MessageClient-send counters, last lease/write/send timestamps, rolling-window send frequency from a 32-entry ring, reset.
- **Previews via the compose-preview skill.** 6 wear captures at 384×384 (live / demo / empty home, dashboards, dashboard, settings) and 3 TV kiosk captures at 1785×1008 (under the 1800 px ceiling).

## Test plan

- [ ] Phone build (`./gradlew :app:assembleDebug`).
- [ ] Wear build (`./gradlew :wear:assembleDebug`).
- [ ] TV build (`./gradlew :tv:assembleDebug`).
- [ ] Pair a watch and toggle Settings → Demo mode on the phone — confirm watch home screen flips banner + values within ~2 s.
- [ ] Long-press a card on the phone, install widget, confirm it appears in the wear pinned list.
- [ ] Open Wear app: confirm Settings → Sync diagnostics on phone shows MessageClient sends ticking up while watch is foreground; pause watch → counts stop / lease window goes stale within 30 s.
- [ ] TV: toggle Demo mode, confirm the kiosk preview animates and the DEMO badge appears.
- [ ] Re-render previews: `compose-preview render --module wear` and `--module tv`; eyeball the PNGs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FFwbn53fnRe5G9ZbMvxAYj)_