### PR TITLE
ci: add Renovate config for Gradle, GitHub Actions, and Docker

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits"
+  ],
+  "labels": ["dependencies"],
+  "schedule": ["before 6am on monday"],
+  "timezone": "Europe/London",
+  "packageRules": [
+    {
+      "matchPackageNames": ["/^io\\.ktor:/"],
+      "groupName": "ktor"
+    },
+    {
+      "matchPackageNames": ["/^org\\.jetbrains\\.kotlinx:/"],
+      "groupName": "kotlinx"
+    },
+    {
+      "matchPackageNames": [
+        "/^androidx\\.compose($|\\.)/",
+        "/^androidx\\.activity:activity-compose/"
+      ],
+      "groupName": "androidx-compose"
+    },
+    {
+      "matchPackageNames": ["/^androidx\\.wear($|\\.)/", "/^androidx\\.tv\\./"],
+      "groupName": "androidx-wear-tv"
+    },
+    {
+      "matchPackageNames": ["/^com\\.google\\.android\\.horologist:/"],
+      "groupName": "horologist"
+    },
+    {
+      "matchPackageNames": [
+        "/^androidx\\.compose\\.remote:/",
+        "/^androidx\\.wear\\.compose\\.remote:/"
+      ],
+      "groupName": "remote-compose"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `renovate.json` so Renovate can open dependency-update PRs against this repo.
- Covers all dependency sources already in the tree: Gradle version catalog (`gradle/libs.versions.toml` + module `build.gradle.kts`), GitHub Actions in `.github/workflows` and `.github/actions`, and the Dockerfile in `addon-server/addon` — Renovate's default managers handle each natively.
- Extends `config:recommended` plus `:dependencyDashboard` (creates a tracking issue) and `:semanticCommits` (matches the `ci:` / `feat:` style already in `git log`).
- Schedules runs to Monday early-morning Europe/London to keep PR noise off weekdays.
- Groups noisy dep families so each gets one PR instead of N: Ktor, kotlinx, AndroidX Compose (incl. `activity-compose`), AndroidX Wear/TV, Horologist, Compose-Remote (alpha — kept separate so its alpha bumps don't drag the rest), and GitHub Actions.

## Test plan

- [ ] Enable the Renovate GitHub App on the repo (one-time, in repo settings → Integrations).
- [ ] Confirm Renovate's onboarding PR / dependency dashboard issue appears within an hour of merge.
- [ ] Verify the first scheduled run (Monday) raises grouped PRs for at least one of: ktor, kotlinx, androidx-compose, github-actions.
- [ ] Spot-check that the Dockerfile `ARG BUILD_FROM` / `ARG RUN_FROM` defaults get tracked (Renovate's `dockerfile` manager picks up ARG defaults).

---
_Generated by [Claude Code](https://claude.ai/code/session_0115pFnyM73e6MV13mCumvHM)_