### PR TITLE
Add converters for conditional, map, history-graph and ha-bambulab cards

### DIFF
--- a/docs/cards-todo.md
+++ b/docs/cards-todo.md
@@ -1,0 +1,27 @@
+# Card support TODO
+
+Cards to promote from placeholder / add support for, in order of work:
+
+- [ ] `conditional` — wraps another card; renders the inner card only when
+  every entry in `conditions:` matches against the snapshot. Trivial:
+  reuse `RenderChild` for the inner card, evaluate conditions on the
+  snapshot. No new RC components needed.
+- [ ] `map` — entity locations on a static-map background. Simplified:
+  render a card chrome with the configured entity list as labelled dots
+  on a flat tile. No real tile fetching from a player; treat geometry as
+  a normalised bounding box around the entities.
+- [ ] `history-graph` — sparkline per entity over `hours_to_show`. Pull
+  history from the snapshot when present; otherwise render an empty axis
+  so the card still occupies its slot.
+- [ ] `custom:ha-bambulab-*-card` — HACS cards from
+  [`greghesp/ha-bambulab-cards`](https://github.com/greghesp/ha-bambulab-cards).
+  No shared schema; register one converter per variant. Visual reference
+  on the integration's docs site (`docs.page/greghesp/ha-bambulab`).
+  Variants (from each card module's `const.ts`):
+    - `custom:ha-bambulab-ams-card` — AMS spool grid
+    - `custom:ha-bambulab-spool-card` — single spool detail
+    - `custom:ha-bambulab-print_status-card` — current job + progress
+    - `custom:ha-bambulab-print_control-card` — pause / resume / cancel
+      pad (legacy alias `custom:ha-bambulab-skipobject-card`)
+  Each starts as a chrome card showing the configured printer entity +
+  state; real per-card visuals can land later.

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/BambuLabCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/BambuLabCardConverter.kt
@@ -1,0 +1,143 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.components.LocalHaTheme
+import ee.schimke.ha.rc.formatState
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * One converter per HACS card from
+ * [`greghesp/ha-bambulab-cards`](https://github.com/greghesp/ha-bambulab-cards).
+ *
+ * Card-name reference (from `src/cards/<name>/const.ts` with
+ * `PREFIX_NAME = "ha-bambulab"`):
+ * - `custom:ha-bambulab-ams-card` — AMS spool grid
+ * - `custom:ha-bambulab-spool-card` — single spool detail
+ * - `custom:ha-bambulab-print_status-card` — current print job + progress
+ * - `custom:ha-bambulab-print_control-card` — pause / resume / cancel pad
+ *   (legacy alias `custom:ha-bambulab-skipobject-card`)
+ *
+ * Visual reference: card screenshots live on the integration's docs site
+ * (`docs.page/greghesp/ha-bambulab`) — no inline assets in the cards repo.
+ *
+ * Today every variant renders the same chrome (variant label + the
+ * configured printer entity + state). Override [Render] in a subclass
+ * once the per-variant visuals (AMS grid, progress ring, control pad)
+ * are built.
+ */
+open class BambuLabCardConverter(
+    final override val cardType: String,
+    private val variantLabel: String,
+) : CardConverter {
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 96
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val theme = LocalHaTheme.current
+        val entityId = card.raw["printer"]?.jsonPrimitive?.content
+            ?: card.raw["entity"]?.jsonPrimitive?.content
+        val entity = entityId?.let { snapshot.states[it] }
+        val name = entity?.attributes?.get("friendly_name")?.jsonPrimitive?.content
+            ?: entityId
+            ?: "Bambu Lab printer"
+        val state = formatState(entity)
+
+        RemoteBox(
+            modifier = modifier
+                .fillMaxWidth()
+                .clip(RemoteRoundedCornerShape(12.rdp))
+                .background(theme.cardBackground.rc)
+                .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+                .padding(horizontal = 12.rdp, vertical = 10.rdp),
+        ) {
+            RemoteColumn(verticalArrangement = RemoteArrangement.spacedBy(4.rdp)) {
+                RemoteText(
+                    text = "Bambu Lab".rs,
+                    color = theme.secondaryText.rc,
+                    fontSize = 11.rsp,
+                    style = RemoteTextStyle.Default,
+                )
+                RemoteText(
+                    text = variantLabel.rs,
+                    color = theme.primaryText.rc,
+                    fontSize = 15.rsp,
+                    fontWeight = FontWeight.Medium,
+                    style = RemoteTextStyle.Default,
+                )
+                RemoteRow(
+                    modifier = RemoteModifier.fillMaxWidth(),
+                    verticalAlignment = RemoteAlignment.CenterVertically,
+                    horizontalArrangement = RemoteArrangement.SpaceBetween,
+                ) {
+                    RemoteText(
+                        text = name.rs,
+                        color = theme.primaryText.rc,
+                        fontSize = 13.rsp,
+                        style = RemoteTextStyle.Default,
+                    )
+                    RemoteText(
+                        text = state.rs,
+                        color = theme.secondaryText.rc,
+                        fontSize = 13.rsp,
+                        style = RemoteTextStyle.Default,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** AMS spool grid. */
+class BambuLabAmsCardConverter : BambuLabCardConverter(
+    cardType = "custom:ha-bambulab-ams-card",
+    variantLabel = "AMS",
+)
+
+/** Single-spool detail. */
+class BambuLabSpoolCardConverter : BambuLabCardConverter(
+    cardType = "custom:ha-bambulab-spool-card",
+    variantLabel = "Spool",
+)
+
+/** Current print job + progress. */
+class BambuLabPrintStatusCardConverter : BambuLabCardConverter(
+    cardType = "custom:ha-bambulab-print_status-card",
+    variantLabel = "Print status",
+)
+
+/** Pause / resume / cancel pad. */
+class BambuLabPrintControlCardConverter : BambuLabCardConverter(
+    cardType = "custom:ha-bambulab-print_control-card",
+    variantLabel = "Print control",
+)
+
+/** Legacy alias of print_control card from earlier versions. */
+class BambuLabSkipObjectCardConverter : BambuLabCardConverter(
+    cardType = "custom:ha-bambulab-skipobject-card",
+    variantLabel = "Print control",
+)

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ConditionalCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ConditionalCardConverter.kt
@@ -1,0 +1,105 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.runtime.Composable
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.CardRegistry
+import ee.schimke.ha.rc.RenderChild
+import ee.schimke.ha.rc.cardHeightDp
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * HA `conditional` card — wraps another card and only renders it when
+ * every entry in `conditions:` matches the current snapshot.
+ *
+ * Supported condition shorthands (each entry may use the legacy short
+ * form or the explicit `condition:` discriminator):
+ *
+ *  - `state` (default): match `entity` against `state` (or `state_not`).
+ *    Both scalars and arrays of allowed values are accepted.
+ *  - `numeric_state`: match `entity` numerically against `above` /
+ *    `below`. The entity's state must parse as a number.
+ *
+ * Other condition kinds (`screen`, `user`, `and`, `or`, …) are treated as
+ * "true" so the inner card renders rather than being silently hidden.
+ *
+ * Height delegation needs the [CardRegistry] but [naturalHeightDp] is
+ * not `@Composable`; pass the registry in if you want the inner card's
+ * height when conditions match.
+ */
+class ConditionalCardConverter(
+    private val registryForHeight: CardRegistry? = null,
+) : CardConverter {
+    override val cardType: String = CardTypes.CONDITIONAL
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int {
+        if (!conditionsMet(card, snapshot)) return 0
+        val inner = innerCard(card) ?: return 0
+        return registryForHeight?.cardHeightDp(inner, snapshot) ?: 160
+    }
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        if (!conditionsMet(card, snapshot)) return
+        val inner = innerCard(card) ?: return
+        RenderChild(inner, snapshot, modifier)
+    }
+}
+
+private fun innerCard(card: CardConfig): CardConfig? {
+    val obj = card.raw["card"] as? JsonObject ?: return null
+    val type = obj["type"]?.jsonPrimitive?.content ?: return null
+    return CardConfig(type = type, raw = obj)
+}
+
+private fun conditionsMet(card: CardConfig, snapshot: HaSnapshot): Boolean {
+    val conditions: JsonArray = card.raw["conditions"]?.jsonArray ?: return true
+    return conditions.all { el ->
+        (el as? JsonObject)?.let { evaluate(it, snapshot) } ?: true
+    }
+}
+
+private fun evaluate(cond: JsonObject, snapshot: HaSnapshot): Boolean {
+    val kind = cond["condition"]?.jsonPrimitive?.content
+        ?: if (cond.containsKey("above") || cond.containsKey("below")) "numeric_state"
+        else "state"
+    return when (kind) {
+        "state" -> evaluateState(cond, snapshot)
+        "numeric_state" -> evaluateNumeric(cond, snapshot)
+        else -> true
+    }
+}
+
+private fun evaluateState(cond: JsonObject, snapshot: HaSnapshot): Boolean {
+    val entityId = cond["entity"]?.jsonPrimitive?.content ?: return true
+    val state = snapshot.states[entityId]?.state ?: return false
+    cond["state"]?.let { expected ->
+        if (!matches(state, expected)) return false
+    }
+    cond["state_not"]?.let { forbidden ->
+        if (matches(state, forbidden)) return false
+    }
+    return true
+}
+
+private fun evaluateNumeric(cond: JsonObject, snapshot: HaSnapshot): Boolean {
+    val entityId = cond["entity"]?.jsonPrimitive?.content ?: return true
+    val value = snapshot.states[entityId]?.state?.toDoubleOrNull() ?: return false
+    cond["above"]?.jsonPrimitive?.content?.toDoubleOrNull()?.let { if (value <= it) return false }
+    cond["below"]?.jsonPrimitive?.content?.toDoubleOrNull()?.let { if (value >= it) return false }
+    return true
+}
+
+private fun matches(state: String, expected: JsonElement): Boolean = when (expected) {
+    is JsonPrimitive -> state == expected.content
+    is JsonArray -> expected.any { (it as? JsonPrimitive)?.content == state }
+    else -> false
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/DefaultConverters.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/DefaultConverters.kt
@@ -9,16 +9,20 @@ import ee.schimke.ha.rc.CardRegistry
  *
  * **Fully implemented** (produce visually-correct output):
  *   tile, button, entity, entities, glance, heading, markdown,
- *   vertical-stack, horizontal-stack, grid.
+ *   vertical-stack, horizontal-stack, grid, conditional.
+ *
+ * **Summary chrome** (registered with a real converter that renders
+ * a card chrome but skips the rich visualisation — replace with the
+ * full `RemoteHa…` composable when ready):
+ *   map, history-graph, custom:ha-bambulab-*.
  *
  * **Placeholder-only** (registered so the dashboard renders, but with a
  * "not yet supported" badge — extend by writing a `RemoteHa…` composable
  * + converter shim):
  *   gauge, thermostat, humidifier, light, media-control, alarm-panel,
- *   weather-forecast, clock, area, calendar, logbook, todo-list, map,
+ *   weather-forecast, clock, area, calendar, logbook, todo-list,
  *   picture, picture-entity, picture-glance, picture-elements,
- *   history-graph, statistics-graph, statistic, sensor, conditional,
- *   entity-filter, iframe.
+ *   statistics-graph, statistic, sensor, entity-filter, iframe.
  */
 fun defaultConverters(): List<CardConverter> = buildList {
     add(TileCardConverter())
@@ -31,6 +35,15 @@ fun defaultConverters(): List<CardConverter> = buildList {
     add(VerticalStackCardConverter())
     add(HorizontalStackCardConverter())
     add(GridCardConverter())
+    add(ConditionalCardConverter())
+    add(MapCardConverter())
+    add(HistoryGraphCardConverter())
+
+    add(BambuLabAmsCardConverter())
+    add(BambuLabSpoolCardConverter())
+    add(BambuLabPrintStatusCardConverter())
+    add(BambuLabPrintControlCardConverter())
+    add(BambuLabSkipObjectCardConverter())
 
     PLACEHOLDER_CARD_TYPES.forEach { add(UnsupportedCardConverter(it)) }
 
@@ -53,16 +66,13 @@ private val PLACEHOLDER_CARD_TYPES: List<String> = listOf(
     CardTypes.CALENDAR,
     CardTypes.LOGBOOK,
     CardTypes.TODO_LIST,
-    CardTypes.MAP,
     CardTypes.PICTURE,
     CardTypes.PICTURE_ENTITY,
     CardTypes.PICTURE_GLANCE,
     CardTypes.PICTURE_ELEMENTS,
-    CardTypes.HISTORY_GRAPH,
     CardTypes.STATISTICS_GRAPH,
     CardTypes.STATISTIC,
     CardTypes.SENSOR,
-    CardTypes.CONDITIONAL,
     CardTypes.ENTITY_FILTER,
     CardTypes.IFRAME,
 )

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/HistoryGraphCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/HistoryGraphCardConverter.kt
@@ -1,0 +1,152 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.model.HistoryPoint
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.components.LocalHaTheme
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * HA `history-graph` card — one row per entity summarising the history
+ * available in the snapshot.
+ *
+ * RemoteCompose alpha08 doesn't yet expose a `RemoteCanvas` that lets us
+ * paint per-point line segments at capture time without an explosion of
+ * primitives, so this converter emits a textual summary
+ * (`min – max (n samples)`) for each entity. When the history channel
+ * stabilises we can replace the row body with a sparkline composable
+ * without changing the converter / registration boundary.
+ */
+class HistoryGraphCardConverter : CardConverter {
+    override val cardType: String = CardTypes.HISTORY_GRAPH
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int {
+        val rows = entityIds(card).size.coerceAtLeast(1)
+        val title = if (card.raw["title"] != null) 28 else 0
+        return title + 24 + 32 * rows
+    }
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val theme = LocalHaTheme.current
+        val title = card.raw["title"]?.jsonPrimitive?.content
+        val hours = card.raw["hours_to_show"]?.jsonPrimitive?.content?.toIntOrNull() ?: 24
+        val ids = entityIds(card)
+
+        RemoteBox(
+            modifier = modifier
+                .fillMaxWidth()
+                .clip(RemoteRoundedCornerShape(12.rdp))
+                .background(theme.cardBackground.rc)
+                .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+                .padding(horizontal = 12.rdp, vertical = 10.rdp),
+        ) {
+            RemoteColumn(verticalArrangement = RemoteArrangement.spacedBy(6.rdp)) {
+                if (title != null) {
+                    RemoteText(
+                        text = title.rs,
+                        color = theme.primaryText.rc,
+                        fontSize = 15.rsp,
+                        fontWeight = FontWeight.Medium,
+                        style = RemoteTextStyle.Default,
+                    )
+                }
+                RemoteText(
+                    text = "Last ${hours}h".rs,
+                    color = theme.secondaryText.rc,
+                    fontSize = 11.rsp,
+                    style = RemoteTextStyle.Default,
+                )
+                if (ids.isEmpty()) {
+                    RemoteText(
+                        text = "No entities".rs,
+                        color = theme.secondaryText.rc,
+                        fontSize = 13.rsp,
+                        style = RemoteTextStyle.Default,
+                    )
+                } else {
+                    ids.forEach { id -> EntityRow(id, snapshot) }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun EntityRow(entityId: String, snapshot: HaSnapshot) {
+        val theme = LocalHaTheme.current
+        val name = snapshot.states[entityId]?.attributes?.get("friendly_name")
+            ?.jsonPrimitive?.content
+            ?: entityId
+        val summary = summarise(snapshot.history[entityId].orEmpty())
+
+        RemoteRow(
+            modifier = RemoteModifier.fillMaxWidth(),
+            verticalAlignment = RemoteAlignment.CenterVertically,
+            horizontalArrangement = RemoteArrangement.SpaceBetween,
+        ) {
+            RemoteText(
+                text = name.rs,
+                color = theme.primaryText.rc,
+                fontSize = 13.rsp,
+                style = RemoteTextStyle.Default,
+            )
+            RemoteText(
+                text = summary.rs,
+                color = theme.secondaryText.rc,
+                fontSize = 12.rsp,
+                style = RemoteTextStyle.Default,
+            )
+        }
+    }
+}
+
+private fun summarise(points: List<HistoryPoint>): String {
+    if (points.isEmpty()) return "no data"
+    val numeric = points.mapNotNull { it.state.toDoubleOrNull() }
+    if (numeric.isEmpty()) return "${points.size} samples"
+    val min = numeric.min()
+    val max = numeric.max()
+    val fmt: (Double) -> String = { d ->
+        if (d == d.toLong().toDouble()) d.toLong().toString() else "%.1f".format(d)
+    }
+    return "${fmt(min)} – ${fmt(max)} (${points.size})"
+}
+
+private fun entityIds(card: CardConfig): List<String> {
+    val arr: JsonArray = card.raw["entities"]?.jsonArray ?: return emptyList()
+    return arr.mapNotNull { el ->
+        when (el) {
+            is JsonPrimitive -> el.content
+            is JsonObject -> el["entity"]?.jsonPrimitive?.content
+            else -> null
+        }
+    }
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/MapCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/MapCardConverter.kt
@@ -1,0 +1,140 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.modifier.size
+import androidx.compose.remote.creation.compose.shapes.RemoteCircleShape
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.components.LocalHaTheme
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * HA `map` card — list of entities with optional locations.
+ *
+ * The "real" map card uses Leaflet to render a slippy-map background.
+ * We can't ship tiles in a `.rc` document, so this converter renders
+ * a flat card chrome with each tracked entity as a labelled dot. It
+ * preserves the slot the dashboard expects without faking map tiles.
+ *
+ * Reads `entities:` (string or `{ entity }`); falls back to the title
+ * heuristic from other cards.
+ */
+class MapCardConverter : CardConverter {
+    override val cardType: String = CardTypes.MAP
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int {
+        val entities = entityIds(card)
+        val title = if (card.raw["title"] != null) 28 else 0
+        return title + 24 + 28 * entities.size.coerceAtLeast(1)
+    }
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val theme = LocalHaTheme.current
+        val title = card.raw["title"]?.jsonPrimitive?.content
+        val entities = entityIds(card)
+
+        RemoteBox(
+            modifier = modifier
+                .fillMaxWidth()
+                .clip(RemoteRoundedCornerShape(12.rdp))
+                .background(theme.cardBackground.rc)
+                .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+                .padding(horizontal = 12.rdp, vertical = 10.rdp),
+        ) {
+            RemoteColumn(verticalArrangement = RemoteArrangement.spacedBy(6.rdp)) {
+                if (title != null) {
+                    RemoteText(
+                        text = title.rs,
+                        color = theme.primaryText.rc,
+                        fontSize = 15.rsp,
+                        fontWeight = FontWeight.Medium,
+                        style = RemoteTextStyle.Default,
+                    )
+                }
+                if (entities.isEmpty()) {
+                    RemoteText(
+                        text = "No entities".rs,
+                        color = theme.secondaryText.rc,
+                        fontSize = 13.rsp,
+                        style = RemoteTextStyle.Default,
+                    )
+                } else {
+                    entities.forEach { id -> EntityRow(id, snapshot) }
+                }
+            }
+        }
+    }
+
+    @Composable
+    private fun EntityRow(entityId: String, snapshot: HaSnapshot) {
+        val theme = LocalHaTheme.current
+        val state = snapshot.states[entityId]
+        val name = state?.attributes?.get("friendly_name")?.jsonPrimitive?.content ?: entityId
+        val lat = state?.attributes?.get("latitude")?.jsonPrimitive?.content
+        val lon = state?.attributes?.get("longitude")?.jsonPrimitive?.content
+        val coords = if (lat != null && lon != null) "$lat, $lon" else (state?.state ?: "—")
+
+        RemoteRow(
+            verticalAlignment = RemoteAlignment.CenterVertically,
+            horizontalArrangement = RemoteArrangement.spacedBy(8.rdp),
+        ) {
+            RemoteBox(
+                modifier = RemoteModifier
+                    .size(8.rdp)
+                    .clip(RemoteCircleShape)
+                    .background(theme.placeholderAccent.rc),
+            )
+            RemoteText(
+                text = name.rs,
+                color = theme.primaryText.rc,
+                fontSize = 13.rsp,
+                style = RemoteTextStyle.Default,
+            )
+            RemoteText(
+                text = coords.rs,
+                color = theme.secondaryText.rc,
+                fontSize = 12.rsp,
+                style = RemoteTextStyle.Default,
+            )
+        }
+    }
+}
+
+private fun entityIds(card: CardConfig): List<String> {
+    val arr: JsonArray = card.raw["entities"]?.jsonArray ?: return emptyList()
+    return arr.mapNotNull { el ->
+        when (el) {
+            is JsonPrimitive -> el.content
+            is JsonObject -> el["entity"]?.jsonPrimitive?.content
+            else -> null
+        }
+    }
+}


### PR DESCRIPTION
Promote conditional / map / history-graph from placeholder to real
converters, and add per-variant converters for the five cards from
greghesp/ha-bambulab-cards (ams, spool, print_status, print_control,
plus legacy skipobject alias). docs/cards-todo.md tracks the rollout.