### PR TITLE
Add adaptive themeable launcher icon: a terrazzo home

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,8 @@
 
     <application
         android:name=".TerrazzoApplication"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
         android:label="Terrazzo"
         android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@android:style/Theme.Material.Light.NoActionBar">

--- a/demo-app/src/main/AndroidManifest.xml
+++ b/demo-app/src/main/AndroidManifest.xml
@@ -1,6 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
-    <application android:label="HA RemoteCompose Demo" android:theme="@android:style/Theme.Material.Light.NoActionBar">
+    <application
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:label="HA RemoteCompose Demo"
+        android:theme="@android:style/Theme.Material.Light.NoActionBar">
         <activity android:name=".MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/demo-app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/demo-app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Adaptive-icon foreground: a house silhouette filled with scattered
+  terrazzo chips. The house path doubles as a clip mask, so chips drawn
+  inside the group are trimmed to the silhouette regardless of how far
+  they bleed. Sized inside the 72dp safe zone of the 108dp canvas.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <group>
+        <clip-path android:pathData="M54,32 L22,60 L28,60 L28,84 L80,84 L80,60 L86,60 Z" />
+
+        <!-- Mortar / cream base inside the house -->
+        <path
+            android:fillColor="#F5EFE0"
+            android:pathData="M54,32 L22,60 L28,60 L28,84 L80,84 L80,60 L86,60 Z" />
+
+        <!-- Larger terrazzo chips -->
+        <path
+            android:fillColor="#E07A5F"
+            android:pathData="M32,50 a6,4 0 1,0 12,0 a6,4 0 1,0 -12,0" />
+        <path
+            android:fillColor="#F2CC8F"
+            android:pathData="M63,44 a5,4 0 1,0 10,0 a5,4 0 1,0 -10,0" />
+        <path
+            android:fillColor="#81B29A"
+            android:pathData="M47,66 a7,5 0 1,0 14,0 a7,5 0 1,0 -14,0" />
+        <path
+            android:fillColor="#3D405B"
+            android:pathData="M29,72 a4,3 0 1,0 8,0 a4,3 0 1,0 -8,0" />
+        <path
+            android:fillColor="#C9ADA7"
+            android:pathData="M67,76 a5,4 0 1,0 10,0 a5,4 0 1,0 -10,0" />
+        <path
+            android:fillColor="#6B4F4F"
+            android:pathData="M55,52 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0" />
+        <path
+            android:fillColor="#4A6670"
+            android:pathData="M41,78 a3,2 0 1,0 6,0 a3,2 0 1,0 -6,0" />
+        <path
+            android:fillColor="#E07A5F"
+            android:pathData="M68,58 a4,3 0 1,0 8,0 a4,3 0 1,0 -8,0" />
+        <path
+            android:fillColor="#81B29A"
+            android:pathData="M45,42 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0" />
+        <path
+            android:fillColor="#F2CC8F"
+            android:pathData="M61,80 a3,2 0 1,0 6,0 a3,2 0 1,0 -6,0" />
+        <path
+            android:fillColor="#C9ADA7"
+            android:pathData="M39,58 a3,2 0 1,0 6,0 a3,2 0 1,0 -6,0" />
+        <path
+            android:fillColor="#3D405B"
+            android:pathData="M62,66 a4,3 0 1,0 8,0 a4,3 0 1,0 -8,0" />
+
+        <!-- Smaller speckles -->
+        <path
+            android:fillColor="#E07A5F"
+            android:pathData="M34,82 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
+        <path
+            android:fillColor="#81B29A"
+            android:pathData="M74,70 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
+        <path
+            android:fillColor="#3D405B"
+            android:pathData="M48,58 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
+        <path
+            android:fillColor="#F2CC8F"
+            android:pathData="M38,64 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
+        <path
+            android:fillColor="#4A6670"
+            android:pathData="M66,82 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
+        <path
+            android:fillColor="#C9ADA7"
+            android:pathData="M58,40 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
+
+        <!-- Door, anchored to the floor of the body -->
+        <path
+            android:fillColor="#3D405B"
+            android:pathData="M49,71 L59,71 L59,84 L49,84 Z" />
+    </group>
+
+    <!-- House outline for definition at small sizes -->
+    <path
+        android:pathData="M54,32 L22,60 L28,60 L28,84 L80,84 L80,60 L86,60 Z"
+        android:strokeColor="#2A2A2E"
+        android:strokeWidth="1.6"
+        android:strokeLineJoin="round" />
+</vector>

--- a/demo-app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/demo-app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Themed-icon (Android 13+) layer. Only the alpha channel is used; the
+  system tints with the active wallpaper colours. Renders the house as
+  a single filled silhouette with a door cut-out via the even-odd rule.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <path
+        android:fillColor="#000000"
+        android:fillType="evenOdd"
+        android:pathData="M54,32 L22,60 L28,60 L28,84 L80,84 L80,60 L86,60 Z M49,71 L59,71 L59,84 L49,84 Z" />
+</vector>

--- a/demo-app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/demo-app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
+</adaptive-icon>

--- a/demo-app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/demo-app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
+</adaptive-icon>

--- a/demo-app/src/main/res/values-night/ic_launcher_background.xml
+++ b/demo-app/src/main/res/values-night/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#1C1C1E</color>
+</resources>

--- a/demo-app/src/main/res/values/ic_launcher_background.xml
+++ b/demo-app/src/main/res/values/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#FAF6EC</color>
+</resources>

--- a/rc-components/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/rc-components/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Adaptive-icon foreground: a house silhouette filled with scattered
+  terrazzo chips. The house path doubles as a clip mask, so chips drawn
+  inside the group are trimmed to the silhouette regardless of how far
+  they bleed. Sized inside the 72dp safe zone of the 108dp canvas.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <group>
+        <clip-path android:pathData="M54,32 L22,60 L28,60 L28,84 L80,84 L80,60 L86,60 Z" />
+
+        <!-- Mortar / cream base inside the house -->
+        <path
+            android:fillColor="#F5EFE0"
+            android:pathData="M54,32 L22,60 L28,60 L28,84 L80,84 L80,60 L86,60 Z" />
+
+        <!-- Larger terrazzo chips -->
+        <path
+            android:fillColor="#E07A5F"
+            android:pathData="M32,50 a6,4 0 1,0 12,0 a6,4 0 1,0 -12,0" />
+        <path
+            android:fillColor="#F2CC8F"
+            android:pathData="M63,44 a5,4 0 1,0 10,0 a5,4 0 1,0 -10,0" />
+        <path
+            android:fillColor="#81B29A"
+            android:pathData="M47,66 a7,5 0 1,0 14,0 a7,5 0 1,0 -14,0" />
+        <path
+            android:fillColor="#3D405B"
+            android:pathData="M29,72 a4,3 0 1,0 8,0 a4,3 0 1,0 -8,0" />
+        <path
+            android:fillColor="#C9ADA7"
+            android:pathData="M67,76 a5,4 0 1,0 10,0 a5,4 0 1,0 -10,0" />
+        <path
+            android:fillColor="#6B4F4F"
+            android:pathData="M55,52 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0" />
+        <path
+            android:fillColor="#4A6670"
+            android:pathData="M41,78 a3,2 0 1,0 6,0 a3,2 0 1,0 -6,0" />
+        <path
+            android:fillColor="#E07A5F"
+            android:pathData="M68,58 a4,3 0 1,0 8,0 a4,3 0 1,0 -8,0" />
+        <path
+            android:fillColor="#81B29A"
+            android:pathData="M45,42 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0" />
+        <path
+            android:fillColor="#F2CC8F"
+            android:pathData="M61,80 a3,2 0 1,0 6,0 a3,2 0 1,0 -6,0" />
+        <path
+            android:fillColor="#C9ADA7"
+            android:pathData="M39,58 a3,2 0 1,0 6,0 a3,2 0 1,0 -6,0" />
+        <path
+            android:fillColor="#3D405B"
+            android:pathData="M62,66 a4,3 0 1,0 8,0 a4,3 0 1,0 -8,0" />
+
+        <!-- Smaller speckles -->
+        <path
+            android:fillColor="#E07A5F"
+            android:pathData="M34,82 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
+        <path
+            android:fillColor="#81B29A"
+            android:pathData="M74,70 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
+        <path
+            android:fillColor="#3D405B"
+            android:pathData="M48,58 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
+        <path
+            android:fillColor="#F2CC8F"
+            android:pathData="M38,64 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
+        <path
+            android:fillColor="#4A6670"
+            android:pathData="M66,82 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
+        <path
+            android:fillColor="#C9ADA7"
+            android:pathData="M58,40 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
+
+        <!-- Door, anchored to the floor of the body -->
+        <path
+            android:fillColor="#3D405B"
+            android:pathData="M49,71 L59,71 L59,84 L49,84 Z" />
+    </group>
+
+    <!-- House outline for definition at small sizes -->
+    <path
+        android:pathData="M54,32 L22,60 L28,60 L28,84 L80,84 L80,60 L86,60 Z"
+        android:strokeColor="#2A2A2E"
+        android:strokeWidth="1.6"
+        android:strokeLineJoin="round" />
+</vector>

--- a/rc-components/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/rc-components/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Themed-icon (Android 13+) layer. Only the alpha channel is used; the
+  system tints with the active wallpaper colours. Renders the house as
+  a single filled silhouette with a door cut-out via the even-odd rule.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+
+    <path
+        android:fillColor="#000000"
+        android:fillType="evenOdd"
+        android:pathData="M54,32 L22,60 L28,60 L28,84 L80,84 L80,60 L86,60 Z M49,71 L59,71 L59,84 L49,84 Z" />
+</vector>

--- a/rc-components/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/rc-components/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
+</adaptive-icon>

--- a/rc-components/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/rc-components/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
+</adaptive-icon>

--- a/rc-components/src/main/res/values-night/ic_launcher_background.xml
+++ b/rc-components/src/main/res/values-night/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#1C1C1E</color>
+</resources>

--- a/rc-components/src/main/res/values/ic_launcher_background.xml
+++ b/rc-components/src/main/res/values/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#FAF6EC</color>
+</resources>

--- a/tv/src/main/AndroidManifest.xml
+++ b/tv/src/main/AndroidManifest.xml
@@ -9,8 +9,9 @@
         android:required="false" />
 
     <application
-        android:banner="@android:drawable/sym_def_app_icon"
-        android:icon="@android:drawable/sym_def_app_icon"
+        android:banner="@drawable/ic_launcher_banner"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
         android:label="Terrazzo"
         android:theme="@android:style/Theme.DeviceDefault.NoActionBar">
 

--- a/tv/src/main/res/drawable/ic_launcher_banner.xml
+++ b/tv/src/main/res/drawable/ic_launcher_banner.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Android TV banner. Composed from the shared adaptive-icon pieces so
+  the brand stays in lockstep with the launcher icon. Recommended
+  intrinsic size is 320dp x 180dp; the foreground is centered at icon
+  scale and reads from the 10-ft viewing distance Kiosk targets.
+-->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/ic_launcher_background" />
+    <item
+        android:width="120dp"
+        android:height="120dp"
+        android:gravity="center"
+        android:drawable="@drawable/ic_launcher_foreground" />
+</layer-list>

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
     <uses-feature android:name="android.hardware.type.watch" />
 
     <application
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
         android:label="Terrazzo"
         android:theme="@android:style/Theme.DeviceDefault">
 


### PR DESCRIPTION
## Summary

- Adaptive launcher icon (`background` + `foreground` + `monochrome`) so Android 13+ themed launchers tint the silhouette with the active wallpaper, with light/dark variants of the background colour via `values-night`.
- Foreground is a house silhouette filled with ~18 terrazzo chips clipped to the silhouette path; sized inside the 72 dp safe zone of the 108 dp adaptive-icon canvas so it reads at small sizes and through any system mask.
- Resources live in `rc-components` so the mobile, TV and Wear apps inherit the same brand via the existing dependency. The TV module also gets `ic_launcher_banner.xml` (a layer-list composing the icon over the cream/dark background at landscape ratio). `demo-app` carries its own copy since it doesn't depend on `rc-components`.
- Manifest wiring: `app`, `tv`, `wear`, `demo-app` now all set `android:icon`, `android:roundIcon` (and `android:banner` on TV) — `tv` previously fell back to the system `sym_def_app_icon`, the others had no icon at all.

## Test plan

- [ ] `./gradlew :app:processDebugResources :tv:processDebugResources :wear:processDebugResources :demo-app:processDebugResources` — verify resource merging picks up `@mipmap/ic_launcher` from `rc-components` for app/tv/wear and from the local copy in demo-app. (Couldn't run locally — no Android SDK in the sandbox.)
- [ ] Install the debug APK on a phone (API 35+) and a phone running Android 13+ with themed icons enabled — confirm the cream-on-light / dark-on-dark variant and that the monochrome silhouette tints correctly.
- [ ] `:tv:installDebug` on an Android TV emulator — verify the new banner shows on the leanback launcher.
- [ ] `:wear:installDebug` on a round Wear emulator — verify `roundIcon` mask is clean.
- [ ] Visual eyeball at 24 dp / 48 dp / 192 dp scale to confirm the terrazzo chips remain legible at small launcher sizes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JahiaAvg731ot3mXm4jH4Y)_