### PR TITLE
Add ktfmt (Google style) with editorconfig, pre-commit hook, and CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,98 @@
+root = true
+
+# This .editorconfig section approximates ktfmt's formatting rules. Sourced from
+# https://github.com/facebook/ktfmt/blob/main/docs/editorconfig/.editorconfig-google
+#
+# It includes editor-specific config options for IntelliJ IDEA.
+#
+# If any option is wrong, PR are welcome
+
+[{*.kt,*.kts}]
+indent_style = space
+insert_final_newline = true
+max_line_length = 100
+indent_size = 2
+ij_continuation_indent_size = 2
+ij_java_names_count_to_use_import_on_demand = 9999
+ij_kotlin_align_in_columns_case_branch = false
+ij_kotlin_align_multiline_binary_operation = false
+ij_kotlin_align_multiline_extends_list = false
+ij_kotlin_align_multiline_method_parentheses = false
+ij_kotlin_align_multiline_parameters = true
+ij_kotlin_align_multiline_parameters_in_calls = false
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = true
+ij_kotlin_assignment_wrap = normal
+ij_kotlin_blank_lines_after_class_header = 0
+ij_kotlin_blank_lines_around_block_when_branches = 0
+ij_kotlin_blank_lines_before_declaration_with_comment_or_annotation_on_separate_line = 1
+ij_kotlin_block_comment_at_first_column = true
+ij_kotlin_call_parameters_new_line_after_left_paren = true
+ij_kotlin_call_parameters_right_paren_on_new_line = false
+ij_kotlin_call_parameters_wrap = on_every_item
+ij_kotlin_catch_on_new_line = false
+ij_kotlin_class_annotation_wrap = split_into_lines
+ij_kotlin_code_style_defaults = KOTLIN_OFFICIAL
+ij_kotlin_continuation_indent_for_chained_calls = true
+ij_kotlin_continuation_indent_for_expression_bodies = true
+ij_kotlin_continuation_indent_in_argument_lists = true
+ij_kotlin_continuation_indent_in_elvis = false
+ij_kotlin_continuation_indent_in_if_conditions = false
+ij_kotlin_continuation_indent_in_parameter_lists = false
+ij_kotlin_continuation_indent_in_supertype_lists = false
+ij_kotlin_continuation_indent_size = 2
+ij_kotlin_else_on_new_line = false
+ij_kotlin_enum_constants_wrap = off
+ij_kotlin_extends_list_wrap = normal
+ij_kotlin_field_annotation_wrap = split_into_lines
+ij_kotlin_finally_on_new_line = false
+ij_kotlin_if_rparen_on_new_line = false
+ij_kotlin_import_nested_classes = false
+ij_kotlin_imports_layout = *
+ij_kotlin_indent_size = 2
+ij_kotlin_insert_whitespaces_in_simple_one_line_method = true
+ij_kotlin_keep_blank_lines_before_right_brace = 2
+ij_kotlin_keep_blank_lines_in_code = 2
+ij_kotlin_keep_blank_lines_in_declarations = 2
+ij_kotlin_keep_first_column_comment = true
+ij_kotlin_keep_indents_on_empty_lines = false
+ij_kotlin_keep_line_breaks = true
+ij_kotlin_lbrace_on_next_line = false
+ij_kotlin_line_comment_add_space = false
+ij_kotlin_line_comment_at_first_column = true
+ij_kotlin_method_annotation_wrap = split_into_lines
+ij_kotlin_method_call_chain_wrap = normal
+ij_kotlin_method_parameters_new_line_after_left_paren = true
+ij_kotlin_method_parameters_right_paren_on_new_line = true
+ij_kotlin_method_parameters_wrap = on_every_item
+ij_kotlin_name_count_to_use_star_import = 9999
+ij_kotlin_name_count_to_use_star_import_for_members = 9999
+ij_kotlin_parameter_annotation_wrap = off
+ij_kotlin_space_after_comma = true
+ij_kotlin_space_after_extend_colon = true
+ij_kotlin_space_after_type_colon = true
+ij_kotlin_space_before_catch_parentheses = true
+ij_kotlin_space_before_comma = false
+ij_kotlin_space_before_extend_colon = true
+ij_kotlin_space_before_for_parentheses = true
+ij_kotlin_space_before_if_parentheses = true
+ij_kotlin_space_before_lambda_arrow = true
+ij_kotlin_space_before_type_colon = false
+ij_kotlin_space_before_when_parentheses = true
+ij_kotlin_space_before_while_parentheses = true
+ij_kotlin_spaces_around_additive_operators = true
+ij_kotlin_spaces_around_assignment_operators = true
+ij_kotlin_spaces_around_equality_operators = true
+ij_kotlin_spaces_around_function_type_arrow = true
+ij_kotlin_spaces_around_logical_operators = true
+ij_kotlin_spaces_around_multiplicative_operators = true
+ij_kotlin_spaces_around_range = false
+ij_kotlin_spaces_around_relational_operators = true
+ij_kotlin_spaces_around_unary_operator = false
+ij_kotlin_spaces_around_when_arrow = true
+ij_kotlin_variable_annotation_wrap = off
+ij_kotlin_while_on_new_line = false
+ij_kotlin_wrap_elvis_expressions = 1
+ij_kotlin_wrap_expression_body_functions = 1
+ij_kotlin_wrap_first_method_in_call_chain = false
+ktfmt_trailing_comma_management_strategy = complete

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# ktfmt check on staged Kotlin files. Bypass with `git commit --no-verify`.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+staged="$(git diff --cached --name-only --diff-filter=ACMR -z \
+  | tr '\0' '\n' \
+  | grep -E '\.(kt|kts)$' || true)"
+
+if [ -z "$staged" ]; then
+  exit 0
+fi
+
+include_only="$(printf '%s' "$staged" | paste -sd: -)"
+
+echo "Running ktfmtCheck on staged Kotlin files..."
+if ! ./gradlew --quiet ktfmtCheck "--include-only=$include_only"; then
+  echo
+  echo "ktfmt check failed. Fix with:"
+  echo "  ./gradlew ktfmtFormat --include-only=$include_only"
+  echo "Then re-stage and commit again."
+  exit 1
+fi

--- a/.github/workflows/ktfmt.yml
+++ b/.github/workflows/ktfmt.yml
@@ -1,0 +1,31 @@
+name: ktfmt
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ktfmt-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: ktfmt check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Gradle itself (and the Metro plugin's buildscript) need JVM 21+.
+      # The Kotlin toolchain stays pinned to 17 (libs.versions.toml), and
+      # setup-java installs both so Gradle's toolchain discovery finds 17
+      # via JAVA_HOME_17_X64 while the daemon runs on 21.
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: |
+            17
+            21
+      - uses: gradle/actions/setup-gradle@v4
+      - run: ./gradlew ktfmtCheck --stacktrace

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.ncorti.ktfmt.gradle.KtfmtExtension
+
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
@@ -6,4 +8,21 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.ktfmt) apply false
+}
+
+allprojects {
+    apply(plugin = "com.ncorti.ktfmt.gradle")
+    extensions.configure<KtfmtExtension> {
+        googleStyle()
+    }
+}
+
+// Wires .githooks/ as the repository's hooks directory, so the pre-commit
+// ktfmt check runs locally. One-time bootstrap: `./gradlew installGitHooks`.
+tasks.register<Exec>("installGitHooks") {
+    group = "git hooks"
+    description = "Configure git to use the .githooks directory in this repo."
+    workingDir = rootDir
+    commandLine("git", "config", "core.hooksPath", ".githooks")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,9 @@ junit-jupiter-bom = "5.14.3"
 # Preview tooling
 compose-preview-plugin = "0.8.0"
 
+# Formatting
+ktfmt-gradle = "0.26.0"
+
 # Wear data layer + Proto DataStore + Horologist
 horologist = "0.8.3-alpha"
 play-services-wearable = "19.0.0"
@@ -146,3 +149,4 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 compose-preview = { id = "ee.schimke.composeai.preview", version.ref = "compose-preview-plugin" }
 metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
+ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt-gradle" }


### PR DESCRIPTION
## Summary

- Adds `.editorconfig` at repo root, copied from [facebook/ktfmt's `docs/editorconfig/.editorconfig-google`](https://github.com/facebook/ktfmt/blob/main/docs/editorconfig/.editorconfig-google) — Google style, 2-space indent, 100-char max line.
- Applies `com.ncorti.ktfmt.gradle` 0.26.0 to all projects with `googleStyle()` (root `build.gradle.kts`, alias in `libs.versions.toml`).
- Adds a tracked `.githooks/pre-commit` that runs `./gradlew ktfmtCheck --include-only=<staged>` against only the `.kt`/`.kts` files staged for the commit, so it stays fast and won't trip on unrelated unformatted files in the tree. Install once with `./gradlew installGitHooks` (registered task wires `core.hooksPath` to `.githooks`).
- Adds `.github/workflows/ktfmt.yml` running `./gradlew ktfmtCheck` on push/PR to `main`.

The codebase is intentionally **not** reformatted in this PR — that's a separate, large diff. The CI workflow will fail until the existing code is formatted (run `./gradlew ktfmtFormat`).

## Test plan

- [ ] `./gradlew installGitHooks` succeeds and `git config core.hooksPath` reports `.githooks`
- [ ] `./gradlew ktfmtCheck` task is registered for every subproject (verified locally via `./gradlew help --task ktfmtCheck`)
- [ ] Staging a deliberately misformatted `.kt` file and committing surfaces the ktfmt failure with the suggested `ktfmtFormat` command
- [ ] Staging only non-Kotlin files commits without invoking gradle
- [ ] `ktfmt` GitHub Actions workflow runs on this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_014HpHfoA7MhRHBeYuiW7F2v)_