### PR TITLE
Stabilize @Preview renders + bump install-cli to 0.8.1

### DIFF
--- a/.github/actions/install-cli/action.yml
+++ b/.github/actions/install-cli/action.yml
@@ -9,7 +9,7 @@ description: >
 inputs:
   version:
     description: 'compose-ai-tools release version'
-    default: '0.7.8'
+    default: '0.8.1'
 
 runs:
   using: 'composite'

--- a/tv/src/main/kotlin/ee/schimke/terrazzo/tv/ui/TvKioskPreview.kt
+++ b/tv/src/main/kotlin/ee/schimke/terrazzo/tv/ui/TvKioskPreview.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
 import ee.schimke.ha.rc.components.ThemeStyle
 import kotlinx.coroutines.delay
@@ -37,9 +38,15 @@ import kotlinx.coroutines.delay
 fun TvKioskPreview(style: ThemeStyle, demoMode: Boolean, modifier: Modifier = Modifier) {
     val cs = MaterialTheme.colorScheme
 
-    var nowMs by remember { mutableLongStateOf(System.currentTimeMillis()) }
-    LaunchedEffect(demoMode) {
-        if (!demoMode) return@LaunchedEffect
+    // In `@Preview` rendering, freeze the clock to a fixed instant so the
+    // PNG is byte-stable across captures — sine-driven values in
+    // TvDemoData.tiles(nowMs) would otherwise drift between runs.
+    val inInspection = LocalInspectionMode.current
+    var nowMs by remember {
+        mutableLongStateOf(if (inInspection) PREVIEW_NOW_MS else System.currentTimeMillis())
+    }
+    LaunchedEffect(demoMode, inInspection) {
+        if (!demoMode || inInspection) return@LaunchedEffect
         while (true) {
             nowMs = System.currentTimeMillis()
             delay(2_000)
@@ -143,6 +150,12 @@ private val PLACEHOLDER_TILES = listOf(
     TvDemoData.Tile("Climate", "—"),
     TvDemoData.Tile("Media", "—"),
 )
+
+// Fixed wall-clock instant used when rendering inside `@Preview` so
+// TvDemoData's sine-driven values land on the same numbers every run.
+// 2024-01-01T12:00:00Z — not 0L, since the lights/media indices land on
+// the same bucket that production demo mode is most often in.
+private const val PREVIEW_NOW_MS: Long = 1_704_110_400_000L
 
 @Composable
 private fun Tile(

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearPreviews.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearPreviews.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.wear.compose.material3.AppScaffold
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.TimeSource
 import androidx.wear.compose.material3.TimeText
 import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.terrazzo.wearsync.proto.CardSummary
@@ -175,8 +176,15 @@ private fun WearPreviewFrame(content: @Composable () -> Unit) {
         colorScheme = terrazzoWearColorScheme(ThemeStyle.TerrazzoHome),
         typography = wearTypographyFor(ThemeStyle.TerrazzoHome),
     ) {
-        AppScaffold(timeText = { TimeText() }) {
+        AppScaffold(timeText = { TimeText(timeSource = PreviewTimeSource) }) {
             ScreenScaffold { content() }
         }
     }
+}
+
+// Frozen clock so previews are byte-stable across renders. The runtime
+// scaffold in WearMainActivity still uses the real system clock.
+private object PreviewTimeSource : TimeSource {
+    override val currentTime: String
+        @Composable get() = "10:08"
 }


### PR DESCRIPTION
## Summary

Two unrelated sources of non-determinism made every `preview-baselines` run produce different bytes for the same code, defeating the diff workflow. Fixes #25.

- **Wear `TimeText()`** in `WearPreviewFrame` reads the wall clock and renders e.g. `10:42` / `10:43` depending on capture time. Pass a fixed-string `TimeSource` (`10:08`) via `TimeText(timeSource = …)`. Runtime `WearMainActivity` keeps the default system clock.
- **`TvKioskPreview`** seeded `nowMs` from `System.currentTimeMillis()` and fed it into `TvDemoData.tiles(nowMs)`, whose sine waves and modulo buckets yield different temperature / humidity / power / lights / media values per capture. Detect `LocalInspectionMode.current`, freeze `nowMs` to `2024-01-01T12:00:00Z`, and skip the 2 s ticker in preview rendering only.

Also bumps the `install-cli` composite action default from `0.7.8` → `0.8.1`. PR #23 already bumped the Gradle plugin to 0.8.1 in `libs.versions.toml`, and the action header documents that the CLI version must move in lockstep with it.

## Test plan

- [ ] `compose-preview show --json` renders cleanly on a clean checkout.
- [ ] Re-run `compose-preview show --json` immediately afterwards: every entry's `changed` is `false` and every `sha256` matches the prior run (no PNG drift across captures).
- [ ] Spot-check rendered PNGs:
  - Wear home/dashboards/dashboard/settings show `10:08` in the curved time badge.
  - TV kiosk demo previews show identical Climate / Humidity / Power / Lights / Media values across two consecutive runs.
- [ ] CI green: `assembleDebug`, unit tests, lint, instrumented tests.
- [ ] On `main`, the `Preview Baselines` workflow either skips the push (tree unchanged) or commits a one-time settling diff that subsequent runs do not re-touch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T19EAt7pCh1rxJ1x8oC64D)_