### PR TITLE
Reformat codebase with ktfmt (Google style)

### DIFF
--- a/addon-server/build.gradle.kts
+++ b/addon-server/build.gradle.kts
@@ -1,46 +1,44 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.kotlin.serialization)
-    application
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+  application
 }
 
 kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
 
-application {
-    mainClass.set("ee.schimke.ha.addon.MainKt")
-}
+application { mainClass.set("ee.schimke.ha.addon.MainKt") }
 
 dependencies {
-    implementation(project(":ha-model"))
-    implementation(project(":ha-client"))
+  implementation(project(":ha-model"))
+  implementation(project(":ha-client"))
 
-    implementation(libs.ktor.server.core)
-    implementation(libs.ktor.server.cio)
-    implementation(libs.ktor.server.websockets)
-    implementation(libs.ktor.server.content.negotiation)
-    implementation(libs.ktor.server.status.pages)
-    implementation(libs.ktor.server.call.logging)
-    implementation(libs.ktor.server.default.headers)
-    implementation(libs.ktor.server.auth)
-    implementation(libs.ktor.serialization.kotlinx.json)
+  implementation(libs.ktor.server.core)
+  implementation(libs.ktor.server.cio)
+  implementation(libs.ktor.server.websockets)
+  implementation(libs.ktor.server.content.negotiation)
+  implementation(libs.ktor.server.status.pages)
+  implementation(libs.ktor.server.call.logging)
+  implementation(libs.ktor.server.default.headers)
+  implementation(libs.ktor.server.auth)
+  implementation(libs.ktor.serialization.kotlinx.json)
 
-    // Client used by the supervisor bridge. CIO keeps things native-image
-    // friendly; OkHttp would pull in Android artifacts we don't want.
-    implementation(libs.ktor.client.core)
-    implementation(libs.ktor.client.cio)
-    implementation(libs.ktor.client.websockets)
-    implementation(libs.ktor.client.content.negotiation)
+  // Client used by the supervisor bridge. CIO keeps things native-image
+  // friendly; OkHttp would pull in Android artifacts we don't want.
+  implementation(libs.ktor.client.core)
+  implementation(libs.ktor.client.cio)
+  implementation(libs.ktor.client.websockets)
+  implementation(libs.ktor.client.content.negotiation)
 
-    implementation(libs.kotlinx.coroutines.core)
-    implementation(libs.kotlinx.serialization.json)
+  implementation(libs.kotlinx.coroutines.core)
+  implementation(libs.kotlinx.serialization.json)
 
-    runtimeOnly(libs.logback.classic)
+  runtimeOnly(libs.logback.classic)
 
-    testImplementation(libs.kotlin.test)
-    testImplementation(libs.kotlinx.coroutines.test)
-    testImplementation(platform(libs.junit.jupiter.bom))
-    testImplementation(libs.junit.jupiter)
-    testRuntimeOnly(libs.junit.platform.launcher)
+  testImplementation(libs.kotlin.test)
+  testImplementation(libs.kotlinx.coroutines.test)
+  testImplementation(platform(libs.junit.jupiter.bom))
+  testImplementation(libs.junit.jupiter)
+  testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 tasks.test { useJUnitPlatform() }

--- a/addon-server/src/main/kotlin/ee/schimke/ha/addon/Config.kt
+++ b/addon-server/src/main/kotlin/ee/schimke/ha/addon/Config.kt
@@ -3,39 +3,38 @@ package ee.schimke.ha.addon
 /**
  * Runtime configuration, assembled from env + add-on options.
  *
- * HA supervisor contract for add-ons: `SUPERVISOR_TOKEN` is injected by
- * the supervisor when `hassio_api` / `homeassistant_api` is requested in
- * `config.yaml`. When that's present we address Core at
- * `http://supervisor/core` (REST) and `ws://supervisor/core/websocket`
- * (WS). For local development outside the supervisor we fall through to
- * `HA_BASE_URL` + `HA_TOKEN` — same shape `HaClient` already uses.
+ * HA supervisor contract for add-ons: `SUPERVISOR_TOKEN` is injected by the supervisor when
+ * `hassio_api` / `homeassistant_api` is requested in `config.yaml`. When that's present we address
+ * Core at `http://supervisor/core` (REST) and `ws://supervisor/core/websocket` (WS). For local
+ * development outside the supervisor we fall through to `HA_BASE_URL` + `HA_TOKEN` — same shape
+ * `HaClient` already uses.
  */
 data class AddonConfig(
-    val port: Int,
-    val haBaseUrl: String,
-    val haAccessToken: String,
-    val logLevel: String,
+  val port: Int,
+  val haBaseUrl: String,
+  val haAccessToken: String,
+  val logLevel: String,
 ) {
-    companion object {
-        private const val SUPERVISOR_URL = "http://supervisor/core"
+  companion object {
+    private const val SUPERVISOR_URL = "http://supervisor/core"
 
-        fun fromEnv(env: Map<String, String> = System.getenv()): AddonConfig {
-            val supervisor = env["SUPERVISOR_TOKEN"]
-            val baseUrl = env["HA_BASE_URL"]
-                ?: if (supervisor != null) SUPERVISOR_URL else error(
-                    "no HA endpoint: set SUPERVISOR_TOKEN (add-on) or HA_BASE_URL+HA_TOKEN (local)",
-                )
-            val token = supervisor
-                ?: env["HA_TOKEN"]
-                ?: error("no HA auth: set SUPERVISOR_TOKEN or HA_TOKEN")
-            val port = env["PORT"]?.toIntOrNull() ?: 8099
-            val logLevel = env["LOG_LEVEL"] ?: "info"
-            return AddonConfig(
-                port = port,
-                haBaseUrl = baseUrl,
-                haAccessToken = token,
-                logLevel = logLevel,
-            )
-        }
+    fun fromEnv(env: Map<String, String> = System.getenv()): AddonConfig {
+      val supervisor = env["SUPERVISOR_TOKEN"]
+      val baseUrl =
+        env["HA_BASE_URL"]
+          ?: if (supervisor != null) SUPERVISOR_URL
+          else
+            error("no HA endpoint: set SUPERVISOR_TOKEN (add-on) or HA_BASE_URL+HA_TOKEN (local)")
+      val token =
+        supervisor ?: env["HA_TOKEN"] ?: error("no HA auth: set SUPERVISOR_TOKEN or HA_TOKEN")
+      val port = env["PORT"]?.toIntOrNull() ?: 8099
+      val logLevel = env["LOG_LEVEL"] ?: "info"
+      return AddonConfig(
+        port = port,
+        haBaseUrl = baseUrl,
+        haAccessToken = token,
+        logLevel = logLevel,
+      )
     }
+  }
 }

--- a/addon-server/src/main/kotlin/ee/schimke/ha/addon/Main.kt
+++ b/addon-server/src/main/kotlin/ee/schimke/ha/addon/Main.kt
@@ -4,6 +4,7 @@ import ee.schimke.ha.addon.bridge.HaSupervisorBridge
 import ee.schimke.ha.addon.routes.dashboardRoutes
 import ee.schimke.ha.addon.routes.healthRoutes
 import ee.schimke.ha.addon.routes.streamRoute
+import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
@@ -16,56 +17,57 @@ import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.routing
 import io.ktor.server.websocket.WebSockets
-import io.ktor.http.HttpStatusCode
+import java.util.concurrent.TimeUnit
 import kotlinx.serialization.json.Json
 import org.slf4j.LoggerFactory
-import java.util.concurrent.TimeUnit
 
 private val log = LoggerFactory.getLogger("ee.schimke.ha.addon.Main")
 
 fun main() {
-    val cfg = AddonConfig.fromEnv()
-    log.info("starting addon-server on :{}, ha={}", cfg.port, cfg.haBaseUrl)
+  val cfg = AddonConfig.fromEnv()
+  log.info("starting addon-server on :{}, ha={}", cfg.port, cfg.haBaseUrl)
 
-    val bridge = HaSupervisorBridge(cfg.haBaseUrl, cfg.haAccessToken)
-    bridge.start()
+  val bridge = HaSupervisorBridge(cfg.haBaseUrl, cfg.haAccessToken)
+  bridge.start()
 
-    val server = embeddedServer(CIO, port = cfg.port, host = "0.0.0.0") {
-        configure(bridge)
-    }
-    Runtime.getRuntime().addShutdownHook(
-        Thread {
-            log.info("shutdown: stopping server + bridge")
-            server.stop(1, 5, TimeUnit.SECONDS)
-            kotlinx.coroutines.runBlocking { bridge.close() }
-        },
+  val server = embeddedServer(CIO, port = cfg.port, host = "0.0.0.0") { configure(bridge) }
+  Runtime.getRuntime()
+    .addShutdownHook(
+      Thread {
+        log.info("shutdown: stopping server + bridge")
+        server.stop(1, 5, TimeUnit.SECONDS)
+        kotlinx.coroutines.runBlocking { bridge.close() }
+      }
     )
-    server.start(wait = true)
+  server.start(wait = true)
 }
 
 internal fun Application.configure(bridge: HaSupervisorBridge) {
-    install(DefaultHeaders) {
-        header("X-Powered-By", "ha-remotecompose")
+  install(DefaultHeaders) { header("X-Powered-By", "ha-remotecompose") }
+  install(CallLogging)
+  install(WebSockets)
+  install(ContentNegotiation) {
+    json(
+      Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+      }
+    )
+  }
+  install(StatusPages) {
+    exception<Throwable> { call, cause ->
+      log.error("unhandled error", cause)
+      call.respondText(
+        text = """{"error":"${cause.message?.replace("\"", "\\\"")}"}""",
+        contentType = io.ktor.http.ContentType.Application.Json,
+        status = HttpStatusCode.InternalServerError,
+      )
     }
-    install(CallLogging)
-    install(WebSockets)
-    install(ContentNegotiation) {
-        json(Json { ignoreUnknownKeys = true; isLenient = true })
-    }
-    install(StatusPages) {
-        exception<Throwable> { call, cause ->
-            log.error("unhandled error", cause)
-            call.respondText(
-                text = """{"error":"${cause.message?.replace("\"", "\\\"")}"}""",
-                contentType = io.ktor.http.ContentType.Application.Json,
-                status = HttpStatusCode.InternalServerError,
-            )
-        }
-    }
+  }
 
-    routing {
-        healthRoutes(bridge)
-        dashboardRoutes(bridge)
-        streamRoute(bridge)
-    }
+  routing {
+    healthRoutes(bridge)
+    dashboardRoutes(bridge)
+    streamRoute(bridge)
+  }
 }

--- a/addon-server/src/main/kotlin/ee/schimke/ha/addon/bridge/HaSupervisorBridge.kt
+++ b/addon-server/src/main/kotlin/ee/schimke/ha/addon/bridge/HaSupervisorBridge.kt
@@ -44,291 +44,305 @@ import org.slf4j.LoggerFactory
 /**
  * One long-lived WebSocket session to the Home Assistant Core API. Owns:
  *
- * - auth handshake (`SUPERVISOR_TOKEN` when running as an HA add-on, or a
- *   long-lived access token for local dev)
+ * - auth handshake (`SUPERVISOR_TOKEN` when running as an HA add-on, or a long-lived access token
+ *   for local dev)
  * - request/response commands multiplexed by monotonic `id`
- * - `state_changed` / `lovelace_updated` event subscriptions, materialised
- *   as a [StateCache] (latest per entity) and a [SharedFlow] of raw events
+ * - `state_changed` / `lovelace_updated` event subscriptions, materialised as a [StateCache]
+ *   (latest per entity) and a [SharedFlow] of raw events
  *
- * This is intentionally a superset of `ha-client`'s [HaClient]: that class
- * is shared with the Android client and only needs request/response; the
- * server also needs long-running event subscriptions, so we open a second
- * kind of connection here rather than widen the shared API.
+ * This is intentionally a superset of `ha-client`'s [HaClient]: that class is shared with the
+ * Android client and only needs request/response; the server also needs long-running event
+ * subscriptions, so we open a second kind of connection here rather than widen the shared API.
  *
- * Reconnect policy is exponential-backoff with a cap; on reconnect we
- * re-subscribe and refresh the state snapshot so downstream clients just
- * see a brief gap, not an incoherent cache.
+ * Reconnect policy is exponential-backoff with a cap; on reconnect we re-subscribe and refresh the
+ * state snapshot so downstream clients just see a brief gap, not an incoherent cache.
  */
 class HaSupervisorBridge(
-    private val baseUrl: String,
-    private val accessToken: String,
-    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default + CoroutineName("ha-bridge")),
+  private val baseUrl: String,
+  private val accessToken: String,
+  private val scope: CoroutineScope =
+    CoroutineScope(SupervisorJob() + Dispatchers.Default + CoroutineName("ha-bridge")),
 ) {
-    private val log = LoggerFactory.getLogger(HaSupervisorBridge::class.java)
-    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
-    private val http = HttpClient(CIO) { install(WebSockets) }
+  private val log = LoggerFactory.getLogger(HaSupervisorBridge::class.java)
+  private val json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+  }
+  private val http = HttpClient(CIO) { install(WebSockets) }
 
-    private val idMutex = Mutex()
-    private var nextId = 1
-    private val pending = mutableMapOf<Int, CompletableDeferred<JsonObject>>()
-    private val pendingMutex = Mutex()
+  private val idMutex = Mutex()
+  private var nextId = 1
+  private val pending = mutableMapOf<Int, CompletableDeferred<JsonObject>>()
+  private val pendingMutex = Mutex()
 
-    @Volatile private var session: DefaultWebSocketSession? = null
-    private var receiveJob: Job? = null
-    private var connectJob: Job? = null
+  @Volatile private var session: DefaultWebSocketSession? = null
+  private var receiveJob: Job? = null
+  private var connectJob: Job? = null
 
-    private val _state = MutableStateFlow(ConnectionState.Disconnected)
-    val state: StateFlow<ConnectionState> = _state.asStateFlow()
+  private val _state = MutableStateFlow(ConnectionState.Disconnected)
+  val state: StateFlow<ConnectionState> = _state.asStateFlow()
 
-    val cache = StateCache()
+  val cache = StateCache()
 
-    private val _events = MutableSharedFlow<HaEvent>(
-        replay = 0, extraBufferCapacity = 256,
+  private val _events = MutableSharedFlow<HaEvent>(replay = 0, extraBufferCapacity = 256)
+  val events: SharedFlow<HaEvent> = _events.asSharedFlow()
+
+  enum class ConnectionState {
+    Disconnected,
+    Connecting,
+    Authenticating,
+    Ready,
+    Error,
+  }
+
+  fun start() {
+    if (connectJob != null) return
+    connectJob = scope.launch { runWithReconnect() }
+  }
+
+  suspend fun close() {
+    connectJob?.cancel()
+    receiveJob?.cancel()
+    runCatching { session?.close(CloseReason(CloseReason.Codes.NORMAL, "bye")) }
+    session = null
+    http.close()
+    scope.cancel()
+    _state.value = ConnectionState.Disconnected
+  }
+
+  /** Snapshot of dashboards registered in the Lovelace storage layer. */
+  suspend fun listDashboards(): JsonArray = runCommandArray("lovelace/dashboards/list")
+
+  /**
+   * Resolved Lovelace dashboard. `urlPath=null` asks HA for the default dashboard (i.e. the one
+   * mounted at `/lovelace`).
+   */
+  suspend fun fetchDashboard(urlPath: String?): Dashboard {
+    val obj = runCommand("lovelace/config") { if (urlPath != null) put("url_path", urlPath) }
+    return json.decodeFromJsonElement(Dashboard.serializer(), obj)
+  }
+
+  /** Passthrough `call_service` — runs under the supervisor identity. */
+  suspend fun callService(
+    domain: String,
+    service: String,
+    entityId: String?,
+    data: JsonObject?,
+  ): JsonObject =
+    runCommand("call_service") {
+      put("domain", domain)
+      put("service", service)
+      if (entityId != null) {
+        put("target", buildJsonObject { put("entity_id", entityId) })
+      }
+      if (data != null) put("service_data", data)
+    }
+
+  private suspend fun runWithReconnect() {
+    var backoffMs = 1_000L
+    while (true) {
+      try {
+        connectOnce()
+        backoffMs = 1_000L
+        receiveJob?.join()
+      } catch (t: Throwable) {
+        log.warn("HA bridge disconnected: {}", t.message)
+        _state.value = ConnectionState.Error
+      }
+      _state.value = ConnectionState.Disconnected
+      delay(backoffMs)
+      backoffMs = (backoffMs * 2).coerceAtMost(30_000L)
+    }
+  }
+
+  private suspend fun connectOnce() {
+    _state.value = ConnectionState.Connecting
+    // Same path whether we hit HA directly (http://ha:8123) or via the
+    // supervisor proxy (http://supervisor/core) — the proxy is path-
+    // transparent, so `/api/websocket` lands at HA's WS handler in both.
+    val wsUrl = baseUrl.toWsUrl() + "/api/websocket"
+    val s = http.webSocketSession { url(wsUrl) }
+    session = s
+
+    val authRequired = readMessage(s)
+    require(authRequired["type"]?.jsonPrimitive?.content == "auth_required") {
+      "expected auth_required, got $authRequired"
+    }
+    _state.value = ConnectionState.Authenticating
+    s.send(
+      json.encodeToString(
+        JsonObject.serializer(),
+        buildJsonObject {
+          put("type", "auth")
+          put("access_token", accessToken)
+        },
+      )
     )
-    val events: SharedFlow<HaEvent> = _events.asSharedFlow()
-
-    enum class ConnectionState { Disconnected, Connecting, Authenticating, Ready, Error }
-
-    fun start() {
-        if (connectJob != null) return
-        connectJob = scope.launch { runWithReconnect() }
+    val authResult = readMessage(s)
+    if (authResult["type"]?.jsonPrimitive?.content != "auth_ok") {
+      error("HA auth rejected: $authResult")
     }
+    _state.value = ConnectionState.Ready
+    log.info("HA bridge authenticated")
 
-    suspend fun close() {
-        connectJob?.cancel()
-        receiveJob?.cancel()
-        runCatching { session?.close(CloseReason(CloseReason.Codes.NORMAL, "bye")) }
-        session = null
-        http.close()
-        scope.cancel()
-        _state.value = ConnectionState.Disconnected
+    // Start receive loop before sending subscriptions so their results
+    // aren't dropped.
+    receiveJob = scope.launch { receiveLoop(s) }
+
+    hydrateStates()
+    subscribe("state_changed")
+    subscribe("lovelace_updated")
+  }
+
+  private suspend fun hydrateStates() {
+    val arr = runCommandArray("get_states")
+    val map = LinkedHashMap<String, EntityState>(arr.size)
+    for (el in arr) {
+      val obj = el.jsonObject
+      val id = obj["entity_id"]?.jsonPrimitive?.content ?: continue
+      map[id] = json.decodeFromJsonElement(EntityState.serializer(), camelizeState(obj))
     }
+    cache.replaceAll(map)
+    log.info("hydrated {} entities", map.size)
+  }
 
-    /** Snapshot of dashboards registered in the Lovelace storage layer. */
-    suspend fun listDashboards(): JsonArray = runCommandArray("lovelace/dashboards/list")
+  private suspend fun subscribe(eventType: String): Int {
+    val id = idMutex.withLock { nextId++ }
+    val deferred = CompletableDeferred<JsonObject>()
+    pendingMutex.withLock { pending[id] = deferred }
+    val frame =
+      json.encodeToString(
+        JsonObject.serializer(),
+        buildJsonObject {
+          put("id", id)
+          put("type", "subscribe_events")
+          put("event_type", eventType)
+        },
+      )
+    session!!.send(frame)
+    withTimeout(10_000) {
+      val resp = deferred.await()
+      require(resp["success"]?.jsonPrimitive?.content != "false") {
+        "subscribe $eventType failed: $resp"
+      }
+    }
+    return id
+  }
 
-    /**
-     * Resolved Lovelace dashboard. `urlPath=null` asks HA for the default
-     * dashboard (i.e. the one mounted at `/lovelace`).
-     */
-    suspend fun fetchDashboard(urlPath: String?): Dashboard {
-        val obj = runCommand("lovelace/config") {
-            if (urlPath != null) put("url_path", urlPath)
+  private suspend fun runCommand(
+    type: String,
+    extra: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit = {},
+  ): JsonObject {
+    val response = awaitCommand(type, extra)
+    return response["result"]?.jsonObject ?: JsonObject(emptyMap())
+  }
+
+  private suspend fun runCommandArray(
+    type: String,
+    extra: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit = {},
+  ): JsonArray {
+    val response = awaitCommand(type, extra)
+    return response["result"]?.jsonArray ?: JsonArray(emptyList())
+  }
+
+  private suspend fun awaitCommand(
+    type: String,
+    extra: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit,
+  ): JsonObject {
+    val s = session ?: error("HA bridge not connected")
+    val id = idMutex.withLock { nextId++ }
+    val deferred = CompletableDeferred<JsonObject>()
+    pendingMutex.withLock { pending[id] = deferred }
+    val msg = buildJsonObject {
+      put("id", id)
+      put("type", type)
+      extra()
+    }
+    s.send(json.encodeToString(JsonObject.serializer(), msg))
+    return withTimeout(30_000) {
+      val resp = deferred.await()
+      val success = resp["success"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: true
+      if (!success) {
+        val err = resp["error"]?.jsonObject?.get("message")?.jsonPrimitive?.content ?: "unknown"
+        error("HA command $type failed: $err")
+      }
+      resp
+    }
+  }
+
+  private suspend fun receiveLoop(s: DefaultWebSocketSession) {
+    try {
+      for (frame in s.incoming) {
+        val text = (frame as? Frame.Text)?.readText() ?: continue
+        val obj = json.parseToJsonElement(text).jsonObject
+        when (obj["type"]?.jsonPrimitive?.content) {
+          "event" -> handleEvent(obj["event"]?.jsonObject ?: continue)
+          else -> {
+            val id = obj["id"]?.jsonPrimitive?.content?.toIntOrNull() ?: continue
+            pendingMutex.withLock { pending.remove(id) }?.complete(obj)
+          }
         }
-        return json.decodeFromJsonElement(Dashboard.serializer(), obj)
+      }
+    } catch (t: Throwable) {
+      pendingMutex.withLock {
+        pending.values.forEach { it.completeExceptionally(t) }
+        pending.clear()
+      }
+      _state.value = ConnectionState.Error
     }
+  }
 
-    /** Passthrough `call_service` — runs under the supervisor identity. */
-    suspend fun callService(domain: String, service: String, entityId: String?, data: JsonObject?): JsonObject =
-        runCommand("call_service") {
-            put("domain", domain)
-            put("service", service)
-            if (entityId != null) {
-                put("target", buildJsonObject { put("entity_id", entityId) })
-            }
-            if (data != null) put("service_data", data)
+  private suspend fun handleEvent(event: JsonObject) {
+    val eventType = event["event_type"]?.jsonPrimitive?.content ?: return
+    val data = event["data"]?.jsonObject ?: JsonObject(emptyMap())
+    when (eventType) {
+      "state_changed" -> {
+        val entityId = data["entity_id"]?.jsonPrimitive?.content ?: return
+        val newState = data["new_state"]?.jsonObject
+        if (newState == null) {
+          cache.remove(entityId)
+        } else {
+          val typed = json.decodeFromJsonElement(EntityState.serializer(), camelizeState(newState))
+          cache.put(entityId, typed)
         }
-
-    private suspend fun runWithReconnect() {
-        var backoffMs = 1_000L
-        while (true) {
-            try {
-                connectOnce()
-                backoffMs = 1_000L
-                receiveJob?.join()
-            } catch (t: Throwable) {
-                log.warn("HA bridge disconnected: {}", t.message)
-                _state.value = ConnectionState.Error
-            }
-            _state.value = ConnectionState.Disconnected
-            delay(backoffMs)
-            backoffMs = (backoffMs * 2).coerceAtMost(30_000L)
-        }
+        _events.tryEmit(HaEvent.StateChanged(entityId))
+      }
+      "lovelace_updated" -> {
+        val urlPath = data["url_path"]?.jsonPrimitive?.content
+        _events.tryEmit(HaEvent.LovelaceUpdated(urlPath))
+      }
+      else -> Unit
     }
+  }
 
-    private suspend fun connectOnce() {
-        _state.value = ConnectionState.Connecting
-        // Same path whether we hit HA directly (http://ha:8123) or via the
-        // supervisor proxy (http://supervisor/core) — the proxy is path-
-        // transparent, so `/api/websocket` lands at HA's WS handler in both.
-        val wsUrl = baseUrl.toWsUrl() + "/api/websocket"
-        val s = http.webSocketSession { url(wsUrl) }
-        session = s
+  private suspend fun readMessage(s: DefaultWebSocketSession): JsonObject {
+    val frame = s.incoming.receive() as? Frame.Text ?: error("expected text frame")
+    return json.parseToJsonElement(frame.readText()).jsonObject
+  }
 
-        val authRequired = readMessage(s)
-        require(authRequired["type"]?.jsonPrimitive?.content == "auth_required") {
-            "expected auth_required, got $authRequired"
-        }
-        _state.value = ConnectionState.Authenticating
-        s.send(
-            json.encodeToString(
-                JsonObject.serializer(),
-                buildJsonObject {
-                    put("type", "auth")
-                    put("access_token", accessToken)
-                },
-            ),
-        )
-        val authResult = readMessage(s)
-        if (authResult["type"]?.jsonPrimitive?.content != "auth_ok") {
-            error("HA auth rejected: $authResult")
-        }
-        _state.value = ConnectionState.Ready
-        log.info("HA bridge authenticated")
-
-        // Start receive loop before sending subscriptions so their results
-        // aren't dropped.
-        receiveJob = scope.launch { receiveLoop(s) }
-
-        hydrateStates()
-        subscribe("state_changed")
-        subscribe("lovelace_updated")
+  /** HA returns snake_case; our `EntityState` is camelCase. */
+  private fun camelizeState(obj: JsonObject): JsonObject = buildJsonObject {
+    for ((k, v) in obj) {
+      when (k) {
+        "entity_id" -> put("entityId", v)
+        "last_changed" -> put("lastChanged", v)
+        "last_updated" -> put("lastUpdated", v)
+        else -> put(k, v)
+      }
     }
+  }
 
-    private suspend fun hydrateStates() {
-        val arr = runCommandArray("get_states")
-        val map = LinkedHashMap<String, EntityState>(arr.size)
-        for (el in arr) {
-            val obj = el.jsonObject
-            val id = obj["entity_id"]?.jsonPrimitive?.content ?: continue
-            map[id] = json.decodeFromJsonElement(EntityState.serializer(), camelizeState(obj))
-        }
-        cache.replaceAll(map)
-        log.info("hydrated {} entities", map.size)
-    }
-
-    private suspend fun subscribe(eventType: String): Int {
-        val id = idMutex.withLock { nextId++ }
-        val deferred = CompletableDeferred<JsonObject>()
-        pendingMutex.withLock { pending[id] = deferred }
-        val frame = json.encodeToString(
-            JsonObject.serializer(),
-            buildJsonObject {
-                put("id", id)
-                put("type", "subscribe_events")
-                put("event_type", eventType)
-            },
-        )
-        session!!.send(frame)
-        withTimeout(10_000) {
-            val resp = deferred.await()
-            require(resp["success"]?.jsonPrimitive?.content != "false") { "subscribe $eventType failed: $resp" }
-        }
-        return id
-    }
-
-    private suspend fun runCommand(
-        type: String,
-        extra: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit = {},
-    ): JsonObject {
-        val response = awaitCommand(type, extra)
-        return response["result"]?.jsonObject ?: JsonObject(emptyMap())
-    }
-
-    private suspend fun runCommandArray(
-        type: String,
-        extra: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit = {},
-    ): JsonArray {
-        val response = awaitCommand(type, extra)
-        return response["result"]?.jsonArray ?: JsonArray(emptyList())
-    }
-
-    private suspend fun awaitCommand(
-        type: String,
-        extra: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit,
-    ): JsonObject {
-        val s = session ?: error("HA bridge not connected")
-        val id = idMutex.withLock { nextId++ }
-        val deferred = CompletableDeferred<JsonObject>()
-        pendingMutex.withLock { pending[id] = deferred }
-        val msg = buildJsonObject {
-            put("id", id)
-            put("type", type)
-            extra()
-        }
-        s.send(json.encodeToString(JsonObject.serializer(), msg))
-        return withTimeout(30_000) {
-            val resp = deferred.await()
-            val success = resp["success"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: true
-            if (!success) {
-                val err = resp["error"]?.jsonObject?.get("message")?.jsonPrimitive?.content ?: "unknown"
-                error("HA command $type failed: $err")
-            }
-            resp
-        }
-    }
-
-    private suspend fun receiveLoop(s: DefaultWebSocketSession) {
-        try {
-            for (frame in s.incoming) {
-                val text = (frame as? Frame.Text)?.readText() ?: continue
-                val obj = json.parseToJsonElement(text).jsonObject
-                when (obj["type"]?.jsonPrimitive?.content) {
-                    "event" -> handleEvent(obj["event"]?.jsonObject ?: continue)
-                    else -> {
-                        val id = obj["id"]?.jsonPrimitive?.content?.toIntOrNull() ?: continue
-                        pendingMutex.withLock { pending.remove(id) }?.complete(obj)
-                    }
-                }
-            }
-        } catch (t: Throwable) {
-            pendingMutex.withLock {
-                pending.values.forEach { it.completeExceptionally(t) }
-                pending.clear()
-            }
-            _state.value = ConnectionState.Error
-        }
-    }
-
-    private suspend fun handleEvent(event: JsonObject) {
-        val eventType = event["event_type"]?.jsonPrimitive?.content ?: return
-        val data = event["data"]?.jsonObject ?: JsonObject(emptyMap())
-        when (eventType) {
-            "state_changed" -> {
-                val entityId = data["entity_id"]?.jsonPrimitive?.content ?: return
-                val newState = data["new_state"]?.jsonObject
-                if (newState == null) {
-                    cache.remove(entityId)
-                } else {
-                    val typed = json.decodeFromJsonElement(EntityState.serializer(), camelizeState(newState))
-                    cache.put(entityId, typed)
-                }
-                _events.tryEmit(HaEvent.StateChanged(entityId))
-            }
-            "lovelace_updated" -> {
-                val urlPath = data["url_path"]?.jsonPrimitive?.content
-                _events.tryEmit(HaEvent.LovelaceUpdated(urlPath))
-            }
-            else -> Unit
-        }
-    }
-
-    private suspend fun readMessage(s: DefaultWebSocketSession): JsonObject {
-        val frame = s.incoming.receive() as? Frame.Text ?: error("expected text frame")
-        return json.parseToJsonElement(frame.readText()).jsonObject
-    }
-
-    /** HA returns snake_case; our `EntityState` is camelCase. */
-    private fun camelizeState(obj: JsonObject): JsonObject = buildJsonObject {
-        for ((k, v) in obj) {
-            when (k) {
-                "entity_id" -> put("entityId", v)
-                "last_changed" -> put("lastChanged", v)
-                "last_updated" -> put("lastUpdated", v)
-                else -> put(k, v)
-            }
-        }
-    }
-
-    private fun String.toWsUrl(): String = when {
-        startsWith("https://") -> "wss://" + removePrefix("https://").removeSuffix("/")
-        startsWith("http://") -> "ws://" + removePrefix("http://").removeSuffix("/")
-        startsWith("wss://") || startsWith("ws://") -> removeSuffix("/")
-        else -> "ws://" + removeSuffix("/")
+  private fun String.toWsUrl(): String =
+    when {
+      startsWith("https://") -> "wss://" + removePrefix("https://").removeSuffix("/")
+      startsWith("http://") -> "ws://" + removePrefix("http://").removeSuffix("/")
+      startsWith("wss://") || startsWith("ws://") -> removeSuffix("/")
+      else -> "ws://" + removeSuffix("/")
     }
 }
 
 sealed interface HaEvent {
-    data class StateChanged(val entityId: String) : HaEvent
-    data class LovelaceUpdated(val urlPath: String?) : HaEvent
+  data class StateChanged(val entityId: String) : HaEvent
+
+  data class LovelaceUpdated(val urlPath: String?) : HaEvent
 }

--- a/addon-server/src/main/kotlin/ee/schimke/ha/addon/bridge/StateCache.kt
+++ b/addon-server/src/main/kotlin/ee/schimke/ha/addon/bridge/StateCache.kt
@@ -6,31 +6,30 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 /**
- * Latest [EntityState] per `entity_id`, mirroring what HA's frontend
- * holds in `hass.states`. The whole map is wrapped in a [StateFlow] so
- * routes can publish read-only views; updates from the bridge mutate the
- * underlying map under a structural-equality check that keeps the flow
- * from emitting on no-op writes.
+ * Latest [EntityState] per `entity_id`, mirroring what HA's frontend holds in `hass.states`. The
+ * whole map is wrapped in a [StateFlow] so routes can publish read-only views; updates from the
+ * bridge mutate the underlying map under a structural-equality check that keeps the flow from
+ * emitting on no-op writes.
  */
 class StateCache {
-    private val _states = MutableStateFlow<Map<String, EntityState>>(emptyMap())
-    val states: StateFlow<Map<String, EntityState>> = _states.asStateFlow()
+  private val _states = MutableStateFlow<Map<String, EntityState>>(emptyMap())
+  val states: StateFlow<Map<String, EntityState>> = _states.asStateFlow()
 
-    fun get(entityId: String): EntityState? = _states.value[entityId]
+  fun get(entityId: String): EntityState? = _states.value[entityId]
 
-    fun replaceAll(map: Map<String, EntityState>) {
-        _states.value = map.toMap()
-    }
+  fun replaceAll(map: Map<String, EntityState>) {
+    _states.value = map.toMap()
+  }
 
-    fun put(entityId: String, value: EntityState) {
-        val current = _states.value
-        if (current[entityId] == value) return
-        _states.value = current + (entityId to value)
-    }
+  fun put(entityId: String, value: EntityState) {
+    val current = _states.value
+    if (current[entityId] == value) return
+    _states.value = current + (entityId to value)
+  }
 
-    fun remove(entityId: String) {
-        val current = _states.value
-        if (entityId !in current) return
-        _states.value = current - entityId
-    }
+  fun remove(entityId: String) {
+    val current = _states.value
+    if (entityId !in current) return
+    _states.value = current - entityId
+  }
 }

--- a/addon-server/src/main/kotlin/ee/schimke/ha/addon/routes/DashboardRoutes.kt
+++ b/addon-server/src/main/kotlin/ee/schimke/ha/addon/routes/DashboardRoutes.kt
@@ -16,38 +16,34 @@ import kotlinx.serialization.json.JsonArray
  *
  * - `/v1/dashboards` — list registered Lovelace dashboards
  * - `/v1/dashboards/{path}` — resolved dashboard config
- * - `/v1/snapshot` — current state cache (debug + fallback for clients
- *   that don't speak the WS stream yet)
+ * - `/v1/snapshot` — current state cache (debug + fallback for clients that don't speak the WS
+ *   stream yet)
  *
- * The `.rc`-byte endpoint is intentionally omitted at this milestone —
- * see PLAN.md (M3). Card rendering on the JVM lands once the
- * `rc-converter-jvm` port exists.
+ * The `.rc`-byte endpoint is intentionally omitted at this milestone — see PLAN.md (M3). Card
+ * rendering on the JVM lands once the `rc-converter-jvm` port exists.
  */
 fun Routing.dashboardRoutes(bridge: HaSupervisorBridge) {
-    route("/v1") {
-        get("/dashboards") {
-            val arr: JsonArray = bridge.listDashboards()
-            call.respond(arr)
-        }
-        get("/dashboards/{path}") {
-            val path = call.parameters["path"]
-            val dashboard: Dashboard = bridge.fetchDashboard(path)
-            call.respond(dashboard)
-        }
-        get("/snapshot") {
-            call.respond(SnapshotResponse(bridge.cache.states.value))
-        }
-        get("/cards/{cardId}.rc") {
-            // M3 — encoder lives in `rc-converter-jvm`, not yet wired.
-            // Returning a typed 501 lets clients surface an "unsupported
-            // server build" rather than a generic transport error.
-            call.respond(
-                HttpStatusCode.NotImplemented,
-                mapOf("error" to "rc encoder not yet available in this build"),
-            )
-        }
+  route("/v1") {
+    get("/dashboards") {
+      val arr: JsonArray = bridge.listDashboards()
+      call.respond(arr)
     }
+    get("/dashboards/{path}") {
+      val path = call.parameters["path"]
+      val dashboard: Dashboard = bridge.fetchDashboard(path)
+      call.respond(dashboard)
+    }
+    get("/snapshot") { call.respond(SnapshotResponse(bridge.cache.states.value)) }
+    get("/cards/{cardId}.rc") {
+      // M3 — encoder lives in `rc-converter-jvm`, not yet wired.
+      // Returning a typed 501 lets clients surface an "unsupported
+      // server build" rather than a generic transport error.
+      call.respond(
+        HttpStatusCode.NotImplemented,
+        mapOf("error" to "rc encoder not yet available in this build"),
+      )
+    }
+  }
 }
 
-@Serializable
-private data class SnapshotResponse(val states: Map<String, EntityState>)
+@Serializable private data class SnapshotResponse(val states: Map<String, EntityState>)

--- a/addon-server/src/main/kotlin/ee/schimke/ha/addon/routes/HealthRoutes.kt
+++ b/addon-server/src/main/kotlin/ee/schimke/ha/addon/routes/HealthRoutes.kt
@@ -8,24 +8,21 @@ import io.ktor.server.routing.Routing
 import io.ktor.server.routing.get
 
 /**
- * Liveness + readiness for the HA supervisor's healthcheck. Liveness is
- * always 200 once the JVM is up; readiness only flips green when the HA
- * bridge has authenticated and hydrated its state cache.
+ * Liveness + readiness for the HA supervisor's healthcheck. Liveness is always 200 once the JVM is
+ * up; readiness only flips green when the HA bridge has authenticated and hydrated its state cache.
  */
 fun Routing.healthRoutes(bridge: HaSupervisorBridge) {
-    get("/healthz") {
-        call.respondText("ok", ContentType.Text.Plain)
+  get("/healthz") { call.respondText("ok", ContentType.Text.Plain) }
+  get("/readyz") {
+    val ready = bridge.state.value == HaSupervisorBridge.ConnectionState.Ready
+    if (ready) {
+      call.respondText("ready", ContentType.Text.Plain)
+    } else {
+      call.respondText(
+        bridge.state.value.name,
+        ContentType.Text.Plain,
+        HttpStatusCode.ServiceUnavailable,
+      )
     }
-    get("/readyz") {
-        val ready = bridge.state.value == HaSupervisorBridge.ConnectionState.Ready
-        if (ready) {
-            call.respondText("ready", ContentType.Text.Plain)
-        } else {
-            call.respondText(
-                bridge.state.value.name,
-                ContentType.Text.Plain,
-                HttpStatusCode.ServiceUnavailable,
-            )
-        }
-    }
+  }
 }

--- a/addon-server/src/main/kotlin/ee/schimke/ha/addon/routes/StreamRoute.kt
+++ b/addon-server/src/main/kotlin/ee/schimke/ha/addon/routes/StreamRoute.kt
@@ -23,150 +23,154 @@ import org.slf4j.LoggerFactory
 /**
  * Per-client WebSocket. Wire format mirrors PLAN.md §"WebSocket /v1/stream".
  *
- * Client subscribes to a set of `entity_id`s; server pushes state updates
- * keyed by the same names that `LiveBindings` bakes into the `.rc`
- * document, so the client can hand the map straight to its
+ * Client subscribes to a set of `entity_id`s; server pushes state updates keyed by the same names
+ * that `LiveBindings` bakes into the `.rc` document, so the client can hand the map straight to its
  * `RemoteDocumentPlayer` named-state setter.
  *
- * Per-client filtering is done in-process — the bridge holds a global
- * `state_changed` subscription against HA, so the cost of a new client is
- * a Set membership check per event.
+ * Per-client filtering is done in-process — the bridge holds a global `state_changed` subscription
+ * against HA, so the cost of a new client is a Set membership check per event.
  */
 fun Routing.streamRoute(bridge: HaSupervisorBridge) {
-    val log = LoggerFactory.getLogger("ee.schimke.ha.addon.StreamRoute")
-    val json = Json { ignoreUnknownKeys = true; isLenient = true }
+  val log = LoggerFactory.getLogger("ee.schimke.ha.addon.StreamRoute")
+  val json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+  }
 
-    webSocket("/v1/stream") {
-        val subscribed = mutableSetOf<String>()
-        val mutex = kotlinx.coroutines.sync.Mutex()
+  webSocket("/v1/stream") {
+    val subscribed = mutableSetOf<String>()
+    val mutex = kotlinx.coroutines.sync.Mutex()
 
-        send(Frame.Text("""{"type":"ready"}"""))
+    send(Frame.Text("""{"type":"ready"}"""))
 
-        // Fan-out coroutine: every HA event we care about → filtered push.
-        val pump = launch {
-            bridge.events.collect { event ->
-                when (event) {
-                    is HaEvent.StateChanged -> {
-                        val match = mutex.withLockReturn { event.entityId in subscribed }
-                        if (!match) return@collect
-                        val state = bridge.cache.get(event.entityId) ?: return@collect
-                        val msg = buildJsonObject {
-                            put("type", "state")
-                            put(
-                                "bindings",
-                                buildJsonObject {
-                                    put("${state.entityId}.state", JsonPrimitive(state.state))
-                                    // `is_on` is the only typed binding the
-                                    // client knows by default; emitting it
-                                    // for everything is harmless — clients
-                                    // ignore unknown names.
-                                    put(
-                                        "${state.entityId}.is_on",
-                                        JsonPrimitive(state.state == "on"),
-                                    )
-                                },
-                            )
-                        }
-                        send(Frame.Text(msg.toString()))
-                    }
-                    is HaEvent.LovelaceUpdated -> {
-                        send(
-                            Frame.Text(
-                                buildJsonObject {
-                                    put("type", "lovelace_updated")
-                                    if (event.urlPath != null) put("url_path", event.urlPath)
-                                }.toString(),
-                            ),
-                        )
-                    }
-                }
+    // Fan-out coroutine: every HA event we care about → filtered push.
+    val pump = launch {
+      bridge.events.collect { event ->
+        when (event) {
+          is HaEvent.StateChanged -> {
+            val match = mutex.withLockReturn { event.entityId in subscribed }
+            if (!match) return@collect
+            val state = bridge.cache.get(event.entityId) ?: return@collect
+            val msg = buildJsonObject {
+              put("type", "state")
+              put(
+                "bindings",
+                buildJsonObject {
+                  put("${state.entityId}.state", JsonPrimitive(state.state))
+                  // `is_on` is the only typed binding the
+                  // client knows by default; emitting it
+                  // for everything is harmless — clients
+                  // ignore unknown names.
+                  put("${state.entityId}.is_on", JsonPrimitive(state.state == "on"))
+                },
+              )
             }
+            send(Frame.Text(msg.toString()))
+          }
+          is HaEvent.LovelaceUpdated -> {
+            send(
+              Frame.Text(
+                buildJsonObject {
+                    put("type", "lovelace_updated")
+                    if (event.urlPath != null) put("url_path", event.urlPath)
+                  }
+                  .toString()
+              )
+            )
+          }
         }
-
-        try {
-            for (frame in incoming) {
-                if (frame !is Frame.Text) continue
-                val text = frame.readText()
-                val obj = runCatching { json.parseToJsonElement(text).jsonObject }.getOrNull() ?: continue
-                handleClientFrame(obj, subscribed, mutex, bridge)?.let { reply ->
-                    send(Frame.Text(reply.toString()))
-                }
-            }
-        } catch (t: Throwable) {
-            log.warn("stream client error: {}", t.message)
-        } finally {
-            pump.cancel()
-        }
+      }
     }
+
+    try {
+      for (frame in incoming) {
+        if (frame !is Frame.Text) continue
+        val text = frame.readText()
+        val obj = runCatching { json.parseToJsonElement(text).jsonObject }.getOrNull() ?: continue
+        handleClientFrame(obj, subscribed, mutex, bridge)?.let { reply ->
+          send(Frame.Text(reply.toString()))
+        }
+      }
+    } catch (t: Throwable) {
+      log.warn("stream client error: {}", t.message)
+    } finally {
+      pump.cancel()
+    }
+  }
 }
 
 private suspend fun handleClientFrame(
-    obj: JsonObject,
-    subscribed: MutableSet<String>,
-    mutex: kotlinx.coroutines.sync.Mutex,
-    bridge: HaSupervisorBridge,
+  obj: JsonObject,
+  subscribed: MutableSet<String>,
+  mutex: kotlinx.coroutines.sync.Mutex,
+  bridge: HaSupervisorBridge,
 ): JsonObject? {
-    val id = obj["id"]?.jsonPrimitive?.intOrNull
-    val type = obj["type"]?.jsonPrimitive?.content ?: return errorReply(id, "missing type")
-    return when (type) {
-        "subscribe" -> {
-            val entities = obj["entities"]?.jsonArray
-                ?.mapNotNull { it.jsonPrimitive.contentOrNull }
-                ?: return errorReply(id, "missing entities")
-            mutex.withLockReturn { subscribed.addAll(entities) }
-            // Hydrate: send current state for newly-subscribed entities so
-            // the client doesn't have to wait for the next `state_changed`
-            // before its document looks right.
-            val bindings = entities.mapNotNull { entityId ->
-                val s = bridge.cache.get(entityId) ?: return@mapNotNull null
-                entityId to s
+  val id = obj["id"]?.jsonPrimitive?.intOrNull
+  val type = obj["type"]?.jsonPrimitive?.content ?: return errorReply(id, "missing type")
+  return when (type) {
+    "subscribe" -> {
+      val entities =
+        obj["entities"]?.jsonArray?.mapNotNull { it.jsonPrimitive.contentOrNull }
+          ?: return errorReply(id, "missing entities")
+      mutex.withLockReturn { subscribed.addAll(entities) }
+      // Hydrate: send current state for newly-subscribed entities so
+      // the client doesn't have to wait for the next `state_changed`
+      // before its document looks right.
+      val bindings = entities.mapNotNull { entityId ->
+        val s = bridge.cache.get(entityId) ?: return@mapNotNull null
+        entityId to s
+      }
+      buildJsonObject {
+        put("type", "state")
+        put(
+          "bindings",
+          buildJsonObject {
+            for ((entityId, state) in bindings) {
+              put("$entityId.state", JsonPrimitive(state.state))
+              put("$entityId.is_on", JsonPrimitive(state.state == "on"))
             }
-            buildJsonObject {
-                put("type", "state")
-                put(
-                    "bindings",
-                    buildJsonObject {
-                        for ((entityId, state) in bindings) {
-                            put("$entityId.state", JsonPrimitive(state.state))
-                            put("$entityId.is_on", JsonPrimitive(state.state == "on"))
-                        }
-                    },
-                )
-            }
-        }
-        "unsubscribe" -> {
-            val entities = obj["entities"]?.jsonArray
-                ?.mapNotNull { it.jsonPrimitive.contentOrNull }
-                ?: return errorReply(id, "missing entities")
-            mutex.withLockReturn { subscribed.removeAll(entities.toSet()) }
-            null
-        }
-        "call_service" -> {
-            val domain = obj["domain"]?.jsonPrimitive?.content ?: return errorReply(id, "missing domain")
-            val service = obj["service"]?.jsonPrimitive?.content ?: return errorReply(id, "missing service")
-            val target = obj["target"]?.jsonObject
-            val entityId = target?.get("entity_id")?.jsonPrimitive?.content
-            val data = obj["service_data"]?.jsonObject
-            val result = bridge.callService(domain, service, entityId, data)
-            buildJsonObject {
-                if (id != null) put("id", JsonPrimitive(id))
-                put("type", "result")
-                put("result", result)
-            }
-        }
-        else -> errorReply(id, "unknown type=$type")
+          },
+        )
+      }
     }
+    "unsubscribe" -> {
+      val entities =
+        obj["entities"]?.jsonArray?.mapNotNull { it.jsonPrimitive.contentOrNull }
+          ?: return errorReply(id, "missing entities")
+      mutex.withLockReturn { subscribed.removeAll(entities.toSet()) }
+      null
+    }
+    "call_service" -> {
+      val domain = obj["domain"]?.jsonPrimitive?.content ?: return errorReply(id, "missing domain")
+      val service =
+        obj["service"]?.jsonPrimitive?.content ?: return errorReply(id, "missing service")
+      val target = obj["target"]?.jsonObject
+      val entityId = target?.get("entity_id")?.jsonPrimitive?.content
+      val data = obj["service_data"]?.jsonObject
+      val result = bridge.callService(domain, service, entityId, data)
+      buildJsonObject {
+        if (id != null) put("id", JsonPrimitive(id))
+        put("type", "result")
+        put("result", result)
+      }
+    }
+    else -> errorReply(id, "unknown type=$type")
+  }
 }
 
 private fun errorReply(id: Int?, message: String): JsonObject = buildJsonObject {
-    if (id != null) put("id", JsonPrimitive(id))
-    put("type", "error")
-    put("message", message)
+  if (id != null) put("id", JsonPrimitive(id))
+  put("type", "error")
+  put("message", message)
 }
 
 // Minimal lock helper that returns the block's result. The stdlib has
 // `withLock` already; this just keeps the call-sites a little tidier.
 private suspend fun <T> kotlinx.coroutines.sync.Mutex.withLockReturn(block: () -> T): T {
-    lock()
-    return try { block() } finally { unlock() }
+  lock()
+  return try {
+    block()
+  } finally {
+    unlock()
+  }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,109 +1,109 @@
 plugins {
-    alias(libs.plugins.android.application)
-    alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.compose.preview)
-    alias(libs.plugins.metro)
-    alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.android.application)
+  alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.compose.preview)
+  alias(libs.plugins.metro)
+  alias(libs.plugins.kotlin.serialization)
 }
 
 android {
-    namespace = "ee.schimke.terrazzo"
-    compileSdk = libs.versions.android.compileSdk.get().toInt()
-    defaultConfig {
-        applicationId = "ee.schimke.terrazzo"
-        // Widget playback via RemoteViews.DrawInstructions needs API 35+
-        // (VANILLA_ICE_CREAM). We still compile / target the newest
-        // available SDK via `compileSdk` / `targetSdk`. Keeping minSdk
-        // at 35 (not 36) lets Robolectric's SDK-35 framework — which
-        // compose-preview 0.7.8 tops out at — parse this module's
-        // apk-for-local-test during renderPreviews.
-        minSdk = 35
-        targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 1
-        versionName = "0.1.0"
+  namespace = "ee.schimke.terrazzo"
+  compileSdk = libs.versions.android.compileSdk.get().toInt()
+  defaultConfig {
+    applicationId = "ee.schimke.terrazzo"
+    // Widget playback via RemoteViews.DrawInstructions needs API 35+
+    // (VANILLA_ICE_CREAM). We still compile / target the newest
+    // available SDK via `compileSdk` / `targetSdk`. Keeping minSdk
+    // at 35 (not 36) lets Robolectric's SDK-35 framework — which
+    // compose-preview 0.7.8 tops out at — parse this module's
+    // apk-for-local-test during renderPreviews.
+    minSdk = 35
+    targetSdk = libs.versions.android.targetSdk.get().toInt()
+    versionCode = 1
+    versionName = "0.1.0"
 
-        // Exposed to AndroidManifest via placeholders so the IndieAuth
-        // redirect scheme is declared in one place.
-        manifestPlaceholders["appAuthRedirectScheme"] = "rcha"
+    // Exposed to AndroidManifest via placeholders so the IndieAuth
+    // redirect scheme is declared in one place.
+    manifestPlaceholders["appAuthRedirectScheme"] = "rcha"
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-    buildFeatures {
-        compose = true
-        buildConfig = true
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-        targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-    }
-    kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+  }
+  buildFeatures {
+    compose = true
+    buildConfig = true
+  }
+  compileOptions {
+    sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+    targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+  }
+  kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
 }
 
 composePreview {
-    variant.set("debug")
-    sdkVersion.set(35)
-    enabled.set(true)
+  variant.set("debug")
+  sdkVersion.set(35)
+  enabled.set(true)
 }
 
 dependencies {
-    implementation(project(":ha-model"))
-    implementation(project(":ha-client"))
-    implementation(project(":rc-converter"))
-    implementation(project(":rc-components"))
-    implementation(project(":terrazzo-core"))
+  implementation(project(":ha-model"))
+  implementation(project(":ha-client"))
+  implementation(project(":rc-converter"))
+  implementation(project(":rc-components"))
+  implementation(project(":terrazzo-core"))
 
-    implementation(platform(libs.compose.bom))
-    implementation(libs.compose.ui)
-    implementation(libs.compose.foundation)
-    implementation(libs.compose.material3)
-    implementation(libs.compose.material.icons.extended)
-    implementation(libs.compose.ui.text.google.fonts)
-    implementation(libs.compose.ui.tooling.preview)
-    debugImplementation(libs.compose.ui.tooling)
-    implementation(libs.activity.compose)
-    implementation(libs.materialkolor)
+  implementation(platform(libs.compose.bom))
+  implementation(libs.compose.ui)
+  implementation(libs.compose.foundation)
+  implementation(libs.compose.material3)
+  implementation(libs.compose.material.icons.extended)
+  implementation(libs.compose.ui.text.google.fonts)
+  implementation(libs.compose.ui.tooling.preview)
+  debugImplementation(libs.compose.ui.tooling)
+  implementation(libs.activity.compose)
+  implementation(libs.materialkolor)
 
-    implementation(libs.remote.creation.compose)
-    implementation(libs.remote.creation.core)
-    implementation(libs.remote.player.compose)
-    implementation(libs.remote.tooling.preview)
+  implementation(libs.remote.creation.compose)
+  implementation(libs.remote.creation.core)
+  implementation(libs.remote.player.compose)
+  implementation(libs.remote.tooling.preview)
 
-    implementation(libs.androidx.browser)
-    // Proto DataStore for the wear sync layer. Schema is documented
-    // in `src/main/proto/wear_sync.proto`; we encode @Serializable
-    // Kotlin data classes to the same proto wire format via
-    // kotlinx-serialization-protobuf. (TODO: switch to Wire once its
-    // Gradle plugin recognises AGP 9's built-in Kotlin.)
-    implementation(libs.androidx.datastore)
-    implementation(libs.androidx.datastore.preferences)
-    implementation(libs.kotlinx.serialization.protobuf)
-    implementation(libs.play.services.wearable)
-    implementation(libs.horologist.datalayer)
-    implementation(libs.horologist.datalayer.phone)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.lifecycle.process)
-    implementation(libs.androidx.work.runtime)
-    implementation(libs.androidx.navigation3.runtime)
-    implementation(libs.androidx.navigation3.ui)
-    implementation(libs.androidx.material3.adaptive.navigation.suite)
-    implementation(libs.appauth)
+  implementation(libs.androidx.browser)
+  // Proto DataStore for the wear sync layer. Schema is documented
+  // in `src/main/proto/wear_sync.proto`; we encode @Serializable
+  // Kotlin data classes to the same proto wire format via
+  // kotlinx-serialization-protobuf. (TODO: switch to Wire once its
+  // Gradle plugin recognises AGP 9's built-in Kotlin.)
+  implementation(libs.androidx.datastore)
+  implementation(libs.androidx.datastore.preferences)
+  implementation(libs.kotlinx.serialization.protobuf)
+  implementation(libs.play.services.wearable)
+  implementation(libs.horologist.datalayer)
+  implementation(libs.horologist.datalayer.phone)
+  implementation(libs.androidx.lifecycle.runtime.ktx)
+  implementation(libs.androidx.lifecycle.process)
+  implementation(libs.androidx.work.runtime)
+  implementation(libs.androidx.navigation3.runtime)
+  implementation(libs.androidx.navigation3.ui)
+  implementation(libs.androidx.material3.adaptive.navigation.suite)
+  implementation(libs.appauth)
 
-    implementation(libs.kotlinx.coroutines.core)
-    implementation(libs.kotlinx.serialization.json)
+  implementation(libs.kotlinx.coroutines.core)
+  implementation(libs.kotlinx.serialization.json)
 
-    testImplementation(libs.kotlin.test.junit)
-    testImplementation(libs.kotlinx.coroutines.test)
+  testImplementation(libs.kotlin.test.junit)
+  testImplementation(libs.kotlinx.coroutines.test)
 
-    androidTestImplementation(libs.androidx.test.ext.junit)
-    androidTestImplementation(libs.androidx.test.runner)
-    androidTestImplementation(platform(libs.compose.bom))
-    androidTestImplementation(libs.compose.ui.test.junit4)
-    // uiautomator drives the long-press install flow via the actual
-    // Android input pipeline — Compose UI tests can't reliably exercise
-    // the Initial-pass pointer-input path that pre-empts the RC player.
-    androidTestImplementation(libs.androidx.test.uiautomator)
-    // ui-test-manifest bundles a ComponentActivity into the debug APK so
-    // `createComposeRule()` can host @Composable content without an
-    // Activity of our own.
-    debugImplementation(libs.compose.ui.test.manifest)
+  androidTestImplementation(libs.androidx.test.ext.junit)
+  androidTestImplementation(libs.androidx.test.runner)
+  androidTestImplementation(platform(libs.compose.bom))
+  androidTestImplementation(libs.compose.ui.test.junit4)
+  // uiautomator drives the long-press install flow via the actual
+  // Android input pipeline — Compose UI tests can't reliably exercise
+  // the Initial-pass pointer-input path that pre-empts the RC player.
+  androidTestImplementation(libs.androidx.test.uiautomator)
+  // ui-test-manifest bundles a ComponentActivity into the debug APK so
+  // `createComposeRule()` can host @Composable content without an
+  // Activity of our own.
+  debugImplementation(libs.compose.ui.test.manifest)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,28 +1,26 @@
 import com.ncorti.ktfmt.gradle.KtfmtExtension
 
 plugins {
-    alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.android.kmp.library) apply false
-    alias(libs.plugins.kotlin.multiplatform) apply false
-    alias(libs.plugins.kotlin.jvm) apply false
-    alias(libs.plugins.kotlin.serialization) apply false
-    alias(libs.plugins.compose.compiler) apply false
-    alias(libs.plugins.ktfmt) apply false
+  alias(libs.plugins.android.application) apply false
+  alias(libs.plugins.android.library) apply false
+  alias(libs.plugins.android.kmp.library) apply false
+  alias(libs.plugins.kotlin.multiplatform) apply false
+  alias(libs.plugins.kotlin.jvm) apply false
+  alias(libs.plugins.kotlin.serialization) apply false
+  alias(libs.plugins.compose.compiler) apply false
+  alias(libs.plugins.ktfmt) apply false
 }
 
 allprojects {
-    apply(plugin = "com.ncorti.ktfmt.gradle")
-    extensions.configure<KtfmtExtension> {
-        googleStyle()
-    }
+  apply(plugin = "com.ncorti.ktfmt.gradle")
+  extensions.configure<KtfmtExtension> { googleStyle() }
 }
 
 // Wires .githooks/ as the repository's hooks directory, so the pre-commit
 // ktfmt check runs locally. One-time bootstrap: `./gradlew installGitHooks`.
 tasks.register<Exec>("installGitHooks") {
-    group = "git hooks"
-    description = "Configure git to use the .githooks directory in this repo."
-    workingDir = rootDir
-    commandLine("git", "config", "core.hooksPath", ".githooks")
+  group = "git hooks"
+  description = "Configure git to use the .githooks directory in this repo."
+  workingDir = rootDir
+  commandLine("git", "config", "core.hooksPath", ".githooks")
 }

--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -1,38 +1,38 @@
 plugins {
-    alias(libs.plugins.android.application)
-    alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.android.application)
+  alias(libs.plugins.compose.compiler)
 }
 
 android {
-    namespace = "ee.schimke.ha.demo"
-    compileSdk = libs.versions.android.compileSdk.get().toInt()
-    defaultConfig {
-        applicationId = "ee.schimke.ha.demo"
-        minSdk = libs.versions.android.minSdk.get().toInt()
-        targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 1
-        versionName = "0.1.0"
-    }
-    buildFeatures { compose = true }
-    compileOptions {
-        sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-        targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-    }
-    kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
+  namespace = "ee.schimke.ha.demo"
+  compileSdk = libs.versions.android.compileSdk.get().toInt()
+  defaultConfig {
+    applicationId = "ee.schimke.ha.demo"
+    minSdk = libs.versions.android.minSdk.get().toInt()
+    targetSdk = libs.versions.android.targetSdk.get().toInt()
+    versionCode = 1
+    versionName = "0.1.0"
+  }
+  buildFeatures { compose = true }
+  compileOptions {
+    sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+    targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+  }
+  kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
 }
 
 dependencies {
-    implementation(project(":ha-model"))
-    implementation(project(":ha-client"))
-    implementation(project(":rc-converter"))
-    implementation(project(":rc-card-shutter"))
+  implementation(project(":ha-model"))
+  implementation(project(":ha-client"))
+  implementation(project(":rc-converter"))
+  implementation(project(":rc-card-shutter"))
 
-    implementation(platform(libs.compose.bom))
-    implementation(libs.compose.ui)
-    implementation(libs.compose.foundation)
-    implementation(libs.compose.material3)
-    implementation(libs.activity.compose)
+  implementation(platform(libs.compose.bom))
+  implementation(libs.compose.ui)
+  implementation(libs.compose.foundation)
+  implementation(libs.compose.material3)
+  implementation(libs.activity.compose)
 
-    implementation(libs.remote.player.compose)
-    implementation(libs.remote.player.view)
+  implementation(libs.remote.player.compose)
+  implementation(libs.remote.player.view)
 }

--- a/ha-client/build.gradle.kts
+++ b/ha-client/build.gradle.kts
@@ -1,39 +1,35 @@
 plugins {
-    alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.android.kmp.library)
+  alias(libs.plugins.kotlin.multiplatform)
+  alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.android.kmp.library)
 }
 
 kotlin {
-    jvmToolchain(libs.versions.java.get().toInt())
+  jvmToolchain(libs.versions.java.get().toInt())
 
-    androidLibrary {
-        namespace = "ee.schimke.ha.client"
-        compileSdk = libs.versions.android.compileSdk.get().toInt()
-        minSdk = libs.versions.android.minSdk.get().toInt()
-    }
-    jvm()
+  androidLibrary {
+    namespace = "ee.schimke.ha.client"
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    minSdk = libs.versions.android.minSdk.get().toInt()
+  }
+  jvm()
 
-    sourceSets {
-        commonMain.dependencies {
-            implementation(project(":ha-model"))
-            implementation(libs.ktor.client.core)
-            implementation(libs.ktor.client.websockets)
-            implementation(libs.ktor.client.content.negotiation)
-            implementation(libs.ktor.serialization.kotlinx.json)
-            implementation(libs.kotlinx.coroutines.core)
-            implementation(libs.kotlinx.serialization.json)
-        }
-        commonTest.dependencies {
-            implementation(libs.kotlin.test)
-            implementation(libs.kotlinx.coroutines.test)
-            implementation(libs.ktor.client.mock)
-        }
-        androidMain.dependencies {
-            implementation(libs.ktor.client.okhttp)
-        }
-        jvmMain.dependencies {
-            implementation(libs.ktor.client.cio)
-        }
+  sourceSets {
+    commonMain.dependencies {
+      implementation(project(":ha-model"))
+      implementation(libs.ktor.client.core)
+      implementation(libs.ktor.client.websockets)
+      implementation(libs.ktor.client.content.negotiation)
+      implementation(libs.ktor.serialization.kotlinx.json)
+      implementation(libs.kotlinx.coroutines.core)
+      implementation(libs.kotlinx.serialization.json)
     }
+    commonTest.dependencies {
+      implementation(libs.kotlin.test)
+      implementation(libs.kotlinx.coroutines.test)
+      implementation(libs.ktor.client.mock)
+    }
+    androidMain.dependencies { implementation(libs.ktor.client.okhttp) }
+    jvmMain.dependencies { implementation(libs.ktor.client.cio) }
+  }
 }

--- a/ha-client/src/commonMain/kotlin/ee/schimke/ha/client/AddonCardGenerator.kt
+++ b/ha-client/src/commonMain/kotlin/ee/schimke/ha/client/AddonCardGenerator.kt
@@ -8,37 +8,33 @@ import ee.schimke.ha.model.ClientProfile
 import ee.schimke.ha.model.HaSnapshot
 
 /**
- * [CardGenerator] backed by an [AddonClient] — fetches pre-rendered
- * bytes from the HA add-on's `/v1/cards/...` endpoint.
+ * [CardGenerator] backed by an [AddonClient] — fetches pre-rendered bytes from the HA add-on's
+ * `/v1/cards/...` endpoint.
  *
- * Priority is the lowest of the built-ins (0): if an add-on is
- * configured and reachable, it gets the first crack at every card. The
- * server's typed 501 (until M3 lands) returns `null` from
- * [AddonClient.fetchCardBytes], which falls through to the next
- * generator in the chain (the local one).
+ * Priority is the lowest of the built-ins (0): if an add-on is configured and reachable, it gets
+ * the first crack at every card. The server's typed 501 (until M3 lands) returns `null` from
+ * [AddonClient.fetchCardBytes], which falls through to the next generator in the chain (the local
+ * one).
  *
- * `supports` is intentionally optimistic — there's no client-side
- * registry of which card types the server can handle. Letting the
- * server respond is the cheapest way to find out.
+ * `supports` is intentionally optimistic — there's no client-side registry of which card types the
+ * server can handle. Letting the server respond is the cheapest way to find out.
  */
-class AddonCardGenerator(
-    private val client: AddonClient,
-) : CardGenerator {
+class AddonCardGenerator(private val client: AddonClient) : CardGenerator {
 
-    override val name: String = "addon"
-    override val priority: Int = 0
+  override val name: String = "addon"
+  override val priority: Int = 0
 
-    override fun supports(card: CardConfig, profile: ClientProfile): Boolean = true
+  override fun supports(card: CardConfig, profile: ClientProfile): Boolean = true
 
-    override suspend fun generate(
-        key: CardKey,
-        card: CardConfig,
-        snapshot: HaSnapshot,
-        size: CardSize,
-        profile: ClientProfile,
-    ): CardBytes? {
-        // Snapshot is unused on the wire — the add-on holds its own
-        // state cache. State drift mitigation is a slice (b) concern.
-        return client.fetchCardBytes(key, size, profile)
-    }
+  override suspend fun generate(
+    key: CardKey,
+    card: CardConfig,
+    snapshot: HaSnapshot,
+    size: CardSize,
+    profile: ClientProfile,
+  ): CardBytes? {
+    // Snapshot is unused on the wire — the add-on holds its own
+    // state cache. State drift mitigation is a slice (b) concern.
+    return client.fetchCardBytes(key, size, profile)
+  }
 }

--- a/ha-client/src/commonMain/kotlin/ee/schimke/ha/client/AddonClient.kt
+++ b/ha-client/src/commonMain/kotlin/ee/schimke/ha/client/AddonClient.kt
@@ -25,125 +25,123 @@ import kotlinx.serialization.json.JsonArray
 /**
  * REST client for the RemoteCompose HA add-on (`/v1/...`).
  *
- * Scope is intentionally narrow: structure + state come from HA Core
- * directly via [HaClient], so this client only needs to (a) probe the
- * add-on's health and (b) fetch pre-rendered card bytes. Listing /
- * fetching dashboards is exposed for parity but the client should
- * normally read those from HA Core too — the add-on's copies are a
- * cache, not the truth.
+ * Scope is intentionally narrow: structure + state come from HA Core directly via [HaClient], so
+ * this client only needs to (a) probe the add-on's health and (b) fetch pre-rendered card bytes.
+ * Listing / fetching dashboards is exposed for parity but the client should normally read those
+ * from HA Core too — the add-on's copies are a cache, not the truth.
  *
  * Failure modes are explicit:
  *
- * - [health] returns false on any non-200 / network failure / timeout
- *   so callers can branch without a try/catch.
- * - [fetchCardBytes] returns null on 4xx/5xx (including the typed 501
- *   the server returns until M3 lands) so a [CardSource] chain can
- *   fall through to the next generator.
+ * - [health] returns false on any non-200 / network failure / timeout so callers can branch without
+ *   a try/catch.
+ * - [fetchCardBytes] returns null on 4xx/5xx (including the typed 501 the server returns until M3
+ *   lands) so a [CardSource] chain can fall through to the next generator.
  *
- * Construction takes an [HttpClientEngine] so tests can inject a
- * `MockEngine` and production code can stay engine-agnostic.
+ * Construction takes an [HttpClientEngine] so tests can inject a `MockEngine` and production code
+ * can stay engine-agnostic.
  */
 class AddonClient(
-    val baseUrl: String,
-    private val accessToken: String? = null,
-    engine: HttpClientEngine? = null,
+  val baseUrl: String,
+  private val accessToken: String? = null,
+  engine: HttpClientEngine? = null,
 ) {
-    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+  private val json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+  }
 
-    private val http: HttpClient = if (engine != null) {
-        HttpClient(engine) { installPlugins() }
+  private val http: HttpClient =
+    if (engine != null) {
+      HttpClient(engine) { installPlugins() }
     } else {
-        HttpClient { installPlugins() }
+      HttpClient { installPlugins() }
     }
 
-    /**
-     * Probes `/healthz` with a short timeout. Used by the runtime to
-     * decide whether to install [AddonCardGenerator] in the chain at
-     * session-open time.
-     */
-    suspend fun health(timeoutMs: Long = PROBE_TIMEOUT_MS): Boolean = runCatching {
-        val resp = http.get(url("/healthz")) {
+  /**
+   * Probes `/healthz` with a short timeout. Used by the runtime to decide whether to install
+   * [AddonCardGenerator] in the chain at session-open time.
+   */
+  suspend fun health(timeoutMs: Long = PROBE_TIMEOUT_MS): Boolean =
+    runCatching {
+        val resp =
+          http.get(url("/healthz")) {
             authHeader()
             timeout { requestTimeoutMillis = timeoutMs }
-        }
+          }
         resp.status.isSuccess()
-    }.getOrElse { false }
+      }
+      .getOrElse { false }
 
-    /** Wraps the add-on's `/v1/dashboards` listing. */
-    suspend fun listDashboards(): JsonArray {
-        val resp = http.get(url("/v1/dashboards")) { authHeader() }
-        if (!resp.status.isSuccess()) error("listDashboards: ${resp.status}")
-        return json.parseToJsonElement(resp.bodyAsText()) as JsonArray
-    }
+  /** Wraps the add-on's `/v1/dashboards` listing. */
+  suspend fun listDashboards(): JsonArray {
+    val resp = http.get(url("/v1/dashboards")) { authHeader() }
+    if (!resp.status.isSuccess()) error("listDashboards: ${resp.status}")
+    return json.parseToJsonElement(resp.bodyAsText()) as JsonArray
+  }
 
-    /** Wraps `/v1/dashboards/{path}`. `null` path = the default dashboard. */
-    suspend fun fetchDashboard(urlPath: String?): Dashboard {
-        val pathSegment = urlPath ?: "_default"
-        val resp = http.get(url("/v1/dashboards/$pathSegment")) { authHeader() }
-        if (!resp.status.isSuccess()) error("fetchDashboard($pathSegment): ${resp.status}")
-        return json.decodeFromString(Dashboard.serializer(), resp.bodyAsText())
-    }
+  /** Wraps `/v1/dashboards/{path}`. `null` path = the default dashboard. */
+  suspend fun fetchDashboard(urlPath: String?): Dashboard {
+    val pathSegment = urlPath ?: "_default"
+    val resp = http.get(url("/v1/dashboards/$pathSegment")) { authHeader() }
+    if (!resp.status.isSuccess()) error("fetchDashboard($pathSegment): ${resp.status}")
+    return json.decodeFromString(Dashboard.serializer(), resp.bodyAsText())
+  }
 
-    /**
-     * Fetch pre-rendered card bytes for [card] at [size] / [profile].
-     * Returns null on any HTTP error or network failure — callers should
-     * treat that as "this generator can't help, try the next one".
-     *
-     * URL layout: `/v1/cards/{cacheKey}.rc?w&h&density&profile`. The
-     * `cacheKey` is [CardKey.toCacheKey] which already encodes
-     * dashboard / view / index / type — stable across reorders only when
-     * no card moved.
-     */
-    suspend fun fetchCardBytes(
-        card: CardKey,
-        size: CardSize,
-        profile: ClientProfile,
-    ): CardBytes? = runCatching {
-        val resp: HttpResponse = http.get(url("/v1/cards/${card.toCacheKey()}.rc")) {
+  /**
+   * Fetch pre-rendered card bytes for [card] at [size] / [profile]. Returns null on any HTTP error
+   * or network failure — callers should treat that as "this generator can't help, try the next
+   * one".
+   *
+   * URL layout: `/v1/cards/{cacheKey}.rc?w&h&density&profile`. The `cacheKey` is
+   * [CardKey.toCacheKey] which already encodes dashboard / view / index / type — stable across
+   * reorders only when no card moved.
+   */
+  suspend fun fetchCardBytes(card: CardKey, size: CardSize, profile: ClientProfile): CardBytes? =
+    runCatching {
+        val resp: HttpResponse =
+          http.get(url("/v1/cards/${card.toCacheKey()}.rc")) {
             authHeader()
             parameter("w", size.widthPx)
             parameter("h", size.heightPx)
             parameter("density", size.densityDpi)
             parameter("profile", profile.wire)
-        }
+          }
         when {
-            resp.status.isSuccess() -> CardBytes(
-                bytes = resp.bodyAsBytes(),
-                widthPx = size.widthPx,
-                heightPx = size.heightPx,
-            )
-            // 501 (M3 not implemented yet), 404 (server doesn't have a
-            // converter for this card), 503 (HA bridge not ready) — all
-            // collapse into "no, fall through".
-            resp.status == HttpStatusCode.NotImplemented -> null
-            resp.status == HttpStatusCode.NotFound -> null
-            resp.status == HttpStatusCode.ServiceUnavailable -> null
-            else -> null
+          resp.status.isSuccess() ->
+            CardBytes(bytes = resp.bodyAsBytes(), widthPx = size.widthPx, heightPx = size.heightPx)
+          // 501 (M3 not implemented yet), 404 (server doesn't have a
+          // converter for this card), 503 (HA bridge not ready) — all
+          // collapse into "no, fall through".
+          resp.status == HttpStatusCode.NotImplemented -> null
+          resp.status == HttpStatusCode.NotFound -> null
+          resp.status == HttpStatusCode.ServiceUnavailable -> null
+          else -> null
         }
-    }.getOrElse { null }
+      }
+      .getOrElse { null }
 
-    fun close() {
-        http.close()
+  fun close() {
+    http.close()
+  }
+
+  private fun url(path: String): String = baseUrl.trimEnd('/') + path
+
+  private fun HttpRequestBuilder.authHeader() {
+    if (!accessToken.isNullOrEmpty()) {
+      header(HttpHeaders.Authorization, "Bearer $accessToken")
     }
+  }
 
-    private fun url(path: String): String = baseUrl.trimEnd('/') + path
-
-    private fun HttpRequestBuilder.authHeader() {
-        if (!accessToken.isNullOrEmpty()) {
-            header(HttpHeaders.Authorization, "Bearer $accessToken")
-        }
-    }
-
-    companion object {
-        const val PROBE_TIMEOUT_MS: Long = 1_500L
-        const val DEFAULT_REQUEST_TIMEOUT_MS: Long = 10_000L
-        const val DEFAULT_CONNECT_TIMEOUT_MS: Long = 5_000L
-    }
+  companion object {
+    const val PROBE_TIMEOUT_MS: Long = 1_500L
+    const val DEFAULT_REQUEST_TIMEOUT_MS: Long = 10_000L
+    const val DEFAULT_CONNECT_TIMEOUT_MS: Long = 5_000L
+  }
 }
 
 private fun io.ktor.client.HttpClientConfig<*>.installPlugins() {
-    install(HttpTimeout) {
-        requestTimeoutMillis = AddonClient.DEFAULT_REQUEST_TIMEOUT_MS
-        connectTimeoutMillis = AddonClient.DEFAULT_CONNECT_TIMEOUT_MS
-    }
+  install(HttpTimeout) {
+    requestTimeoutMillis = AddonClient.DEFAULT_REQUEST_TIMEOUT_MS
+    connectTimeoutMillis = AddonClient.DEFAULT_CONNECT_TIMEOUT_MS
+  }
 }

--- a/ha-client/src/commonMain/kotlin/ee/schimke/ha/client/CardGenerator.kt
+++ b/ha-client/src/commonMain/kotlin/ee/schimke/ha/client/CardGenerator.kt
@@ -8,100 +8,97 @@ import ee.schimke.ha.model.ClientProfile
 import ee.schimke.ha.model.HaSnapshot
 
 /**
- * One strategy for turning a [CardConfig] + [HaSnapshot] into encoded
- * RemoteCompose bytes. The runtime composes several of these into a
- * priority chain — see [CardSource].
+ * One strategy for turning a [CardConfig] + [HaSnapshot] into encoded RemoteCompose bytes. The
+ * runtime composes several of these into a priority chain — see [CardSource].
  *
- * Two impls today: an [AddonCardGenerator] talking to the HA add-on's
- * `/v1/cards/...` endpoint, and a `LocalCardGenerator` (in
- * `rc-converter`) wrapping the existing in-process converters. New
- * generators (e.g. a debug one that draws a placeholder, or a
- * profile-specific one) plug in by implementing this interface.
+ * Two impls today: an [AddonCardGenerator] talking to the HA add-on's `/v1/cards/...` endpoint, and
+ * a `LocalCardGenerator` (in `rc-converter`) wrapping the existing in-process converters. New
+ * generators (e.g. a debug one that draws a placeholder, or a profile-specific one) plug in by
+ * implementing this interface.
  *
- * Failure semantics: [generate] **must return null** for any
- * recoverable failure — bad network, server-side 501/404, unsupported
- * card type, timeout, etc. Throwing is reserved for programmer errors
- * (e.g. a precondition violation). `null` is what lets the chain fall
- * through to the next generator transparently; an exception bubbles up
- * and is treated as a bug.
+ * Failure semantics: [generate] **must return null** for any recoverable failure — bad network,
+ * server-side 501/404, unsupported card type, timeout, etc. Throwing is reserved for programmer
+ * errors (e.g. a precondition violation). `null` is what lets the chain fall through to the next
+ * generator transparently; an exception bubbles up and is treated as a bug.
  */
 interface CardGenerator {
 
-    /** Stable identifier, lower-case. Used in logs + the optional
-     *  `cards.generator` audit column in the offline store. */
-    val name: String
+  /**
+   * Stable identifier, lower-case. Used in logs + the optional `cards.generator` audit column in
+   * the offline store.
+   */
+  val name: String
 
-    /** Lower wins. Built-ins:
-     *  - [AddonCardGenerator] = 0 (try the offload first if available)
-     *  - LocalCardGenerator   = 100 (always-available safety net) */
-    val priority: Int
+  /**
+   * Lower wins. Built-ins:
+   * - [AddonCardGenerator] = 0 (try the offload first if available)
+   * - LocalCardGenerator = 100 (always-available safety net)
+   */
+  val priority: Int
 
-    /**
-     * Quick "would I bother trying?" predicate. **No I/O.** Used by
-     * [CardSource] to skip generators that obviously won't handle a
-     * card type, avoiding a wasted HTTP round-trip.
-     *
-     * The local generator returns true only for card types it has a
-     * registered converter for. The add-on generator is optimistic —
-     * it returns true for everything and lets the server's response
-     * decide.
-     */
-    fun supports(card: CardConfig, profile: ClientProfile): Boolean
+  /**
+   * Quick "would I bother trying?" predicate. **No I/O.** Used by [CardSource] to skip generators
+   * that obviously won't handle a card type, avoiding a wasted HTTP round-trip.
+   *
+   * The local generator returns true only for card types it has a registered converter for. The
+   * add-on generator is optimistic — it returns true for everything and lets the server's response
+   * decide.
+   */
+  fun supports(card: CardConfig, profile: ClientProfile): Boolean
 
-    /**
-     * Produce bytes for [card] at [size] for [profile].
-     *
-     * @return [CardBytes] on success, `null` on any recoverable failure
-     *   (network, unsupported, timeout, …). See class doc.
-     */
-    suspend fun generate(
-        key: CardKey,
-        card: CardConfig,
-        snapshot: HaSnapshot,
-        size: CardSize,
-        profile: ClientProfile,
-    ): CardBytes?
+  /**
+   * Produce bytes for [card] at [size] for [profile].
+   *
+   * @return [CardBytes] on success, `null` on any recoverable failure (network, unsupported,
+   *   timeout, …). See class doc.
+   */
+  suspend fun generate(
+    key: CardKey,
+    card: CardConfig,
+    snapshot: HaSnapshot,
+    size: CardSize,
+    profile: ClientProfile,
+  ): CardBytes?
 }
 
 /**
- * Result of a [CardSource.render] — bytes from some generator, or an
- * "unsupported" placeholder when no generator could produce them.
+ * Result of a [CardSource.render] — bytes from some generator, or an "unsupported" placeholder when
+ * no generator could produce them.
  *
- * The exact generator that won is exposed for telemetry / debug only.
- * UI must not branch on it — that would re-introduce the user-visible
- * "local vs server" distinction we're explicitly trying to hide.
+ * The exact generator that won is exposed for telemetry / debug only. UI must not branch on it —
+ * that would re-introduce the user-visible "local vs server" distinction we're explicitly trying to
+ * hide.
  */
 sealed interface CardRender {
-    data class Bytes(val card: CardBytes, val generator: String) : CardRender
-    data class Unsupported(val cardType: String) : CardRender
+  data class Bytes(val card: CardBytes, val generator: String) : CardRender
+
+  data class Unsupported(val cardType: String) : CardRender
 }
 
 /**
- * Priority chain over [CardGenerator]s. The runtime constructs one of
- * these per [ee.schimke.ha.model.HaServer] at session-open time. The
- * order isn't sticky after construction — generators that fail at
- * runtime just return null and the chain moves on, no rebuild needed.
+ * Priority chain over [CardGenerator]s. The runtime constructs one of these per
+ * [ee.schimke.ha.model.HaServer] at session-open time. The order isn't sticky after construction —
+ * generators that fail at runtime just return null and the chain moves on, no rebuild needed.
  *
- * Local generator is always last so the chain never empties. If even
- * the local generator can't handle a card (custom card with no
- * converter), [render] returns [CardRender.Unsupported].
+ * Local generator is always last so the chain never empties. If even the local generator can't
+ * handle a card (custom card with no converter), [render] returns [CardRender.Unsupported].
  */
 class CardSource(generators: List<CardGenerator>) {
 
-    val generators: List<CardGenerator> = generators.sortedBy { it.priority }
+  val generators: List<CardGenerator> = generators.sortedBy { it.priority }
 
-    suspend fun render(
-        key: CardKey,
-        card: CardConfig,
-        snapshot: HaSnapshot,
-        size: CardSize,
-        profile: ClientProfile,
-    ): CardRender {
-        for (gen in generators) {
-            if (!gen.supports(card, profile)) continue
-            val bytes = gen.generate(key, card, snapshot, size, profile) ?: continue
-            return CardRender.Bytes(bytes, generator = gen.name)
-        }
-        return CardRender.Unsupported(card.type)
+  suspend fun render(
+    key: CardKey,
+    card: CardConfig,
+    snapshot: HaSnapshot,
+    size: CardSize,
+    profile: ClientProfile,
+  ): CardRender {
+    for (gen in generators) {
+      if (!gen.supports(card, profile)) continue
+      val bytes = gen.generate(key, card, snapshot, size, profile) ?: continue
+      return CardRender.Bytes(bytes, generator = gen.name)
     }
+    return CardRender.Unsupported(card.type)
+  }
 }

--- a/ha-client/src/commonMain/kotlin/ee/schimke/ha/client/HaClient.kt
+++ b/ha-client/src/commonMain/kotlin/ee/schimke/ha/client/HaClient.kt
@@ -13,8 +13,6 @@ import io.ktor.websocket.Frame
 import io.ktor.websocket.close
 import io.ktor.websocket.readText
 import io.ktor.websocket.send
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -31,7 +29,6 @@ import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
@@ -42,216 +39,216 @@ import kotlinx.serialization.json.put
 /**
  * Config for connecting to a Home Assistant instance over its WebSocket API.
  *
- * HA does **not** expose the resolved dashboard/card JSON over REST. The only
- * way to fetch it is via the WebSocket `lovelace/config` command after auth
- * with an access token. See
+ * HA does **not** expose the resolved dashboard/card JSON over REST. The only way to fetch it is
+ * via the WebSocket `lovelace/config` command after auth with an access token. See
  * `homeassistant/components/lovelace/websocket.py`.
  */
-data class HaConfig(
-    val baseUrl: String,
-    val accessToken: String,
-)
+data class HaConfig(val baseUrl: String, val accessToken: String)
 
 /**
- * HA WebSocket client — open a connection, authenticate with an access token,
- * run commands, read results. Auth protocol:
+ * HA WebSocket client — open a connection, authenticate with an access token, run commands, read
+ * results. Auth protocol:
  *
- *   1. server → `{type:"auth_required"}`
- *   2. client → `{type:"auth", access_token:"…"}`
- *   3. server → `{type:"auth_ok"}` (or `auth_invalid`)
- *   4. client → `{id:N, type:"<cmd>", …}`
- *   5. server → `{id:N, type:"result", success:true, result:…}`
+ * 1. server → `{type:"auth_required"}`
+ * 2. client → `{type:"auth", access_token:"…"}`
+ * 3. server → `{type:"auth_ok"}` (or `auth_invalid`)
+ * 4. client → `{id:N, type:"<cmd>", …}`
+ * 5. server → `{id:N, type:"result", success:true, result:…}`
  *
- * The connection is held open; command IDs are monotonic and responses are
- * matched in a receive loop. Not a subscription client yet — cards work from
- * a point-in-time [HaSnapshot].
+ * The connection is held open; command IDs are monotonic and responses are matched in a receive
+ * loop. Not a subscription client yet — cards work from a point-in-time [HaSnapshot].
  */
 class HaClient(private val config: HaConfig) {
-    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
-    private val httpClient = HttpClient { install(WebSockets) }
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-    private val idMutex = Mutex()
-    private var nextId = 1
-    private val pending = mutableMapOf<Int, CompletableDeferred<JsonObject>>()
-    private val pendingMutex = Mutex()
-    private var session: DefaultWebSocketSession? = null
-    private var receiveJob: Job? = null
+  private val json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+  }
+  private val httpClient = HttpClient { install(WebSockets) }
+  private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+  private val idMutex = Mutex()
+  private var nextId = 1
+  private val pending = mutableMapOf<Int, CompletableDeferred<JsonObject>>()
+  private val pendingMutex = Mutex()
+  private var session: DefaultWebSocketSession? = null
+  private var receiveJob: Job? = null
 
-    private val _state = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected)
-    val state: StateFlow<ConnectionState> = _state.asStateFlow()
+  private val _state = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected)
+  val state: StateFlow<ConnectionState> = _state.asStateFlow()
 
-    enum class ConnectionState { Disconnected, Connecting, Authenticating, Ready, Error }
+  enum class ConnectionState {
+    Disconnected,
+    Connecting,
+    Authenticating,
+    Ready,
+    Error,
+  }
 
-    suspend fun connect() {
-        if (session != null) return
-        _state.value = ConnectionState.Connecting
-        val wsUrl = config.baseUrl.toWsUrl() + "/api/websocket"
-        val s = httpClient.webSocketSession { url(wsUrl) }
-        session = s
+  suspend fun connect() {
+    if (session != null) return
+    _state.value = ConnectionState.Connecting
+    val wsUrl = config.baseUrl.toWsUrl() + "/api/websocket"
+    val s = httpClient.webSocketSession { url(wsUrl) }
+    session = s
 
-        // Handshake on this coroutine — then spin up the receive loop.
-        val authRequired = readMessage(s)
-        require(authRequired["type"]?.jsonPrimitive?.content == "auth_required") {
-            "expected auth_required, got $authRequired"
-        }
-        _state.value = ConnectionState.Authenticating
-        s.send(
-            json.encodeToString(
-                JsonObject.serializer(),
-                buildJsonObject {
-                    put("type", "auth")
-                    put("access_token", config.accessToken)
-                },
-            ),
-        )
-        val authResult = readMessage(s)
-        when (authResult["type"]?.jsonPrimitive?.content) {
-            "auth_ok" -> _state.value = ConnectionState.Ready
-            else -> {
-                _state.value = ConnectionState.Error
-                throw IllegalStateException("auth rejected: $authResult")
-            }
-        }
-
-        receiveJob = scope.launch { receiveLoop(s) }
+    // Handshake on this coroutine — then spin up the receive loop.
+    val authRequired = readMessage(s)
+    require(authRequired["type"]?.jsonPrimitive?.content == "auth_required") {
+      "expected auth_required, got $authRequired"
+    }
+    _state.value = ConnectionState.Authenticating
+    s.send(
+      json.encodeToString(
+        JsonObject.serializer(),
+        buildJsonObject {
+          put("type", "auth")
+          put("access_token", config.accessToken)
+        },
+      )
+    )
+    val authResult = readMessage(s)
+    when (authResult["type"]?.jsonPrimitive?.content) {
+      "auth_ok" -> _state.value = ConnectionState.Ready
+      else -> {
+        _state.value = ConnectionState.Error
+        throw IllegalStateException("auth rejected: $authResult")
+      }
     }
 
-    suspend fun fetchDashboard(urlPath: String? = null): Dashboard {
-        val result = runCommand("lovelace/config") {
-            if (urlPath != null) put("url_path", urlPath)
-        }
-        return json.decodeFromJsonElement(Dashboard.serializer(), result)
+    receiveJob = scope.launch { receiveLoop(s) }
+  }
+
+  suspend fun fetchDashboard(urlPath: String? = null): Dashboard {
+    val result = runCommand("lovelace/config") { if (urlPath != null) put("url_path", urlPath) }
+    return json.decodeFromJsonElement(Dashboard.serializer(), result)
+  }
+
+  /** Top-level Lovelace dashboards registered in `lovelace/dashboards`. */
+  suspend fun listDashboards(): List<DashboardSummary> {
+    val result = runCommandArray("lovelace/dashboards/list")
+    return result.map {
+      val obj = it.jsonObject
+      DashboardSummary(
+        urlPath = obj["url_path"]?.jsonPrimitive?.content,
+        title = obj["title"]?.jsonPrimitive?.content ?: "(untitled)",
+        icon = obj["icon"]?.jsonPrimitive?.content,
+      )
     }
+  }
 
-    /** Top-level Lovelace dashboards registered in `lovelace/dashboards`. */
-    suspend fun listDashboards(): List<DashboardSummary> {
-        val result = runCommandArray("lovelace/dashboards/list")
-        return result.map {
-            val obj = it.jsonObject
-            DashboardSummary(
-                urlPath = obj["url_path"]?.jsonPrimitive?.content,
-                title = obj["title"]?.jsonPrimitive?.content ?: "(untitled)",
-                icon = obj["icon"]?.jsonPrimitive?.content,
-            )
-        }
+  suspend fun fetchStates(): Map<String, EntityState> {
+    val arr = runCommandArray("get_states")
+    return arr
+      .associate { el ->
+        val obj = el.jsonObject
+        val id = obj["entity_id"]?.jsonPrimitive?.content ?: return@associate "" to placeholder()
+        id to json.decodeFromJsonElement(EntityState.serializer(), camelizeState(obj))
+      }
+      .filterKeys { it.isNotEmpty() }
+  }
+
+  suspend fun snapshot(): HaSnapshot = HaSnapshot(states = fetchStates())
+
+  suspend fun close() {
+    receiveJob?.cancel()
+    runCatching { session?.close(CloseReason(CloseReason.Codes.NORMAL, "bye")) }
+    session = null
+    scope.cancel()
+    httpClient.close()
+    _state.value = ConnectionState.Disconnected
+  }
+
+  private suspend fun runCommand(
+    type: String,
+    extra: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit = {},
+  ): JsonObject {
+    val response = awaitCommand(type, extra)
+    return response["result"]?.jsonObject ?: JsonObject(emptyMap())
+  }
+
+  private suspend fun runCommandArray(
+    type: String,
+    extra: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit = {},
+  ): JsonArray {
+    val response = awaitCommand(type, extra)
+    return response["result"]?.jsonArray ?: JsonArray(emptyList())
+  }
+
+  private suspend fun awaitCommand(
+    type: String,
+    extra: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit,
+  ): JsonObject {
+    val s = session ?: error("Not connected — call connect() first")
+    val id = idMutex.withLock { nextId++ }
+    val deferred = CompletableDeferred<JsonObject>()
+    pendingMutex.withLock { pending[id] = deferred }
+    val msg = buildJsonObject {
+      put("id", id)
+      put("type", type)
+      extra()
     }
-
-    suspend fun fetchStates(): Map<String, EntityState> {
-        val arr = runCommandArray("get_states")
-        return arr.associate { el ->
-            val obj = el.jsonObject
-            val id = obj["entity_id"]?.jsonPrimitive?.content ?: return@associate "" to placeholder()
-            id to json.decodeFromJsonElement(EntityState.serializer(), camelizeState(obj))
-        }.filterKeys { it.isNotEmpty() }
+    s.send(json.encodeToString(JsonObject.serializer(), msg))
+    return withTimeout(30_000) {
+      val resp = deferred.await()
+      val success = resp["success"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: true
+      if (!success) {
+        val err = resp["error"]?.jsonObject?.get("message")?.jsonPrimitive?.content ?: "unknown"
+        error("HA command $type failed: $err")
+      }
+      resp
     }
+  }
 
-    suspend fun snapshot(): HaSnapshot = HaSnapshot(states = fetchStates())
-
-    suspend fun close() {
-        receiveJob?.cancel()
-        runCatching { session?.close(CloseReason(CloseReason.Codes.NORMAL, "bye")) }
-        session = null
-        scope.cancel()
-        httpClient.close()
-        _state.value = ConnectionState.Disconnected
+  private suspend fun receiveLoop(s: DefaultWebSocketSession) {
+    try {
+      for (frame in s.incoming) {
+        val text = (frame as? Frame.Text)?.readText() ?: continue
+        val obj = json.parseToJsonElement(text).jsonObject
+        val id = obj["id"]?.jsonPrimitive?.intOrNullSafe() ?: continue
+        pendingMutex.withLock { pending.remove(id) }?.complete(obj)
+      }
+    } catch (t: Throwable) {
+      pendingMutex.withLock {
+        pending.values.forEach { it.completeExceptionally(t) }
+        pending.clear()
+      }
+      _state.value = ConnectionState.Error
     }
+  }
 
-    private suspend fun runCommand(
-        type: String,
-        extra: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit = {},
-    ): JsonObject {
-        val response = awaitCommand(type, extra)
-        return response["result"]?.jsonObject ?: JsonObject(emptyMap())
+  private suspend fun readMessage(s: DefaultWebSocketSession): JsonObject {
+    val frame = s.incoming.receive() as? Frame.Text ?: error("expected text frame")
+    return json.parseToJsonElement(frame.readText()).jsonObject
+  }
+
+  private fun placeholder(): EntityState = EntityState(entityId = "", state = "")
+
+  /**
+   * HA returns snake_case keys; our `EntityState` uses camelCase fields. We configure Json with
+   * `ignoreUnknownKeys`, so the simplest fix is to rewrite the two keys we care about.
+   */
+  private fun camelizeState(obj: JsonObject): JsonObject = buildJsonObject {
+    for ((k, v) in obj) {
+      when (k) {
+        "entity_id" -> put("entityId", v)
+        "last_changed" -> put("lastChanged", v)
+        "last_updated" -> put("lastUpdated", v)
+        else -> put(k, v)
+      }
     }
-
-    private suspend fun runCommandArray(
-        type: String,
-        extra: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit = {},
-    ): JsonArray {
-        val response = awaitCommand(type, extra)
-        return response["result"]?.jsonArray ?: JsonArray(emptyList())
-    }
-
-    private suspend fun awaitCommand(
-        type: String,
-        extra: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit,
-    ): JsonObject {
-        val s = session ?: error("Not connected — call connect() first")
-        val id = idMutex.withLock { nextId++ }
-        val deferred = CompletableDeferred<JsonObject>()
-        pendingMutex.withLock { pending[id] = deferred }
-        val msg = buildJsonObject {
-            put("id", id)
-            put("type", type)
-            extra()
-        }
-        s.send(json.encodeToString(JsonObject.serializer(), msg))
-        return withTimeout(30_000) {
-            val resp = deferred.await()
-            val success = resp["success"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: true
-            if (!success) {
-                val err = resp["error"]?.jsonObject?.get("message")?.jsonPrimitive?.content ?: "unknown"
-                error("HA command $type failed: $err")
-            }
-            resp
-        }
-    }
-
-    private suspend fun receiveLoop(s: DefaultWebSocketSession) {
-        try {
-            for (frame in s.incoming) {
-                val text = (frame as? Frame.Text)?.readText() ?: continue
-                val obj = json.parseToJsonElement(text).jsonObject
-                val id = obj["id"]?.jsonPrimitive?.intOrNullSafe() ?: continue
-                pendingMutex.withLock { pending.remove(id) }?.complete(obj)
-            }
-        } catch (t: Throwable) {
-            pendingMutex.withLock {
-                pending.values.forEach { it.completeExceptionally(t) }
-                pending.clear()
-            }
-            _state.value = ConnectionState.Error
-        }
-    }
-
-    private suspend fun readMessage(s: DefaultWebSocketSession): JsonObject {
-        val frame = s.incoming.receive() as? Frame.Text ?: error("expected text frame")
-        return json.parseToJsonElement(frame.readText()).jsonObject
-    }
-
-    private fun placeholder(): EntityState = EntityState(entityId = "", state = "")
-
-    /**
-     * HA returns snake_case keys; our `EntityState` uses camelCase fields.
-     * We configure Json with `ignoreUnknownKeys`, so the simplest fix is to
-     * rewrite the two keys we care about.
-     */
-    private fun camelizeState(obj: JsonObject): JsonObject = buildJsonObject {
-        for ((k, v) in obj) {
-            when (k) {
-                "entity_id" -> put("entityId", v)
-                "last_changed" -> put("lastChanged", v)
-                "last_updated" -> put("lastUpdated", v)
-                else -> put(k, v)
-            }
-        }
-    }
+  }
 }
 
 private fun String.intOrNullSafe(): Int? = this.toIntOrNull()
-private fun kotlinx.serialization.json.JsonPrimitive.intOrNullSafe(): Int? =
-    content.toIntOrNull()
+
+private fun kotlinx.serialization.json.JsonPrimitive.intOrNullSafe(): Int? = content.toIntOrNull()
 
 /** Pick `ws` / `wss` from `http` / `https`. */
-private fun String.toWsUrl(): String = when {
+private fun String.toWsUrl(): String =
+  when {
     startsWith("https://") -> "wss://" + removePrefix("https://").removeSuffix("/")
     startsWith("http://") -> "ws://" + removePrefix("http://").removeSuffix("/")
     else -> "ws://" + removeSuffix("/")
-}
+  }
 
 @Serializable
-data class DashboardSummary(
-    val urlPath: String?,
-    val title: String,
-    val icon: String? = null,
-)
+data class DashboardSummary(val urlPath: String?, val title: String, val icon: String? = null)

--- a/ha-client/src/commonTest/kotlin/ee/schimke/ha/client/AddonClientTest.kt
+++ b/ha-client/src/commonTest/kotlin/ee/schimke/ha/client/AddonClientTest.kt
@@ -19,101 +19,93 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 
 /**
- * `AddonClient` is the only piece of the chain that does I/O, so its
- * failure-mode contract is what the rest of the runtime relies on. The
- * tests focus on the boundary: probe says yes/no, byte fetch says
- * yes/null. Everything above the client just composes those answers.
+ * `AddonClient` is the only piece of the chain that does I/O, so its failure-mode contract is what
+ * the rest of the runtime relies on. The tests focus on the boundary: probe says yes/no, byte fetch
+ * says yes/null. Everything above the client just composes those answers.
  */
 class AddonClientTest {
 
-    private val card = CardKey(
-        dashboardUrlPath = "lovelace",
-        viewPath = "home",
-        cardIndex = 0,
-        type = "tile",
-    )
-    private val size = CardSize(widthPx = 320, heightPx = 160, densityDpi = 320)
+  private val card =
+    CardKey(dashboardUrlPath = "lovelace", viewPath = "home", cardIndex = 0, type = "tile")
+  private val size = CardSize(widthPx = 320, heightPx = 160, densityDpi = 320)
 
-    @Test
-    fun health_returnsTrue_on200() = runTest {
-        val engine = MockEngine { respondOk("ok") }
-        val client = AddonClient("http://addon", engine = engine)
-        assertTrue(client.health())
-    }
+  @Test
+  fun health_returnsTrue_on200() = runTest {
+    val engine = MockEngine { respondOk("ok") }
+    val client = AddonClient("http://addon", engine = engine)
+    assertTrue(client.health())
+  }
 
-    @Test
-    fun health_returnsFalse_on503() = runTest {
-        val engine = MockEngine { respondError(HttpStatusCode.ServiceUnavailable) }
-        val client = AddonClient("http://addon", engine = engine)
-        assertFalse(client.health())
-    }
+  @Test
+  fun health_returnsFalse_on503() = runTest {
+    val engine = MockEngine { respondError(HttpStatusCode.ServiceUnavailable) }
+    val client = AddonClient("http://addon", engine = engine)
+    assertFalse(client.health())
+  }
 
-    @Test
-    fun health_returnsFalse_onIOException() = runTest {
-        val engine = MockEngine { throw RuntimeException("network down") }
-        val client = AddonClient("http://addon", engine = engine)
-        assertFalse(client.health())
-    }
+  @Test
+  fun health_returnsFalse_onIOException() = runTest {
+    val engine = MockEngine { throw RuntimeException("network down") }
+    val client = AddonClient("http://addon", engine = engine)
+    assertFalse(client.health())
+  }
 
-    @Test
-    fun fetchCardBytes_returnsBytes_on200() = runTest {
-        val payload = ByteArray(8) { it.toByte() }
-        val engine = MockEngine { request ->
-            // Verify the URL the client builds — width / height / density
-            // / profile in query string, cache key in path.
-            val url = request.url.toString()
-            assertTrue(url.contains("/v1/cards/"))
-            assertTrue(url.contains("w=320"))
-            assertTrue(url.contains("h=160"))
-            assertTrue(url.contains("density=320"))
-            assertTrue(url.contains("profile=phone"))
-            respond(
-                content = ByteReadChannel(payload),
-                status = HttpStatusCode.OK,
-                headers = headersOf("Content-Type", "application/x-remote-compose"),
-            )
-        }
-        val client = AddonClient("http://addon", engine = engine)
-        val bytes = client.fetchCardBytes(card, size, ClientProfile.Phone)
-        assertNotNull(bytes)
-        assertEquals(8, bytes.bytes.size)
-        assertEquals(320, bytes.widthPx)
-        assertEquals(160, bytes.heightPx)
+  @Test
+  fun fetchCardBytes_returnsBytes_on200() = runTest {
+    val payload = ByteArray(8) { it.toByte() }
+    val engine = MockEngine { request ->
+      // Verify the URL the client builds — width / height / density
+      // / profile in query string, cache key in path.
+      val url = request.url.toString()
+      assertTrue(url.contains("/v1/cards/"))
+      assertTrue(url.contains("w=320"))
+      assertTrue(url.contains("h=160"))
+      assertTrue(url.contains("density=320"))
+      assertTrue(url.contains("profile=phone"))
+      respond(
+        content = ByteReadChannel(payload),
+        status = HttpStatusCode.OK,
+        headers = headersOf("Content-Type", "application/x-remote-compose"),
+      )
     }
+    val client = AddonClient("http://addon", engine = engine)
+    val bytes = client.fetchCardBytes(card, size, ClientProfile.Phone)
+    assertNotNull(bytes)
+    assertEquals(8, bytes.bytes.size)
+    assertEquals(320, bytes.widthPx)
+    assertEquals(160, bytes.heightPx)
+  }
 
-    @Test
-    fun fetchCardBytes_returnsNull_on501() = runTest {
-        val engine = MockEngine { respondError(HttpStatusCode.NotImplemented) }
-        val client = AddonClient("http://addon", engine = engine)
-        assertNull(client.fetchCardBytes(card, size, ClientProfile.Phone))
-    }
+  @Test
+  fun fetchCardBytes_returnsNull_on501() = runTest {
+    val engine = MockEngine { respondError(HttpStatusCode.NotImplemented) }
+    val client = AddonClient("http://addon", engine = engine)
+    assertNull(client.fetchCardBytes(card, size, ClientProfile.Phone))
+  }
 
-    @Test
-    fun fetchCardBytes_returnsNull_on404() = runTest {
-        val engine = MockEngine { respondError(HttpStatusCode.NotFound) }
-        val client = AddonClient("http://addon", engine = engine)
-        assertNull(client.fetchCardBytes(card, size, ClientProfile.Phone))
-    }
+  @Test
+  fun fetchCardBytes_returnsNull_on404() = runTest {
+    val engine = MockEngine { respondError(HttpStatusCode.NotFound) }
+    val client = AddonClient("http://addon", engine = engine)
+    assertNull(client.fetchCardBytes(card, size, ClientProfile.Phone))
+  }
 
-    @Test
-    fun fetchCardBytes_returnsNull_onNetworkError() = runTest {
-        val engine = MockEngine { throw RuntimeException("dns") }
-        val client = AddonClient("http://addon", engine = engine)
-        assertNull(client.fetchCardBytes(card, size, ClientProfile.Phone))
-    }
+  @Test
+  fun fetchCardBytes_returnsNull_onNetworkError() = runTest {
+    val engine = MockEngine { throw RuntimeException("dns") }
+    val client = AddonClient("http://addon", engine = engine)
+    assertNull(client.fetchCardBytes(card, size, ClientProfile.Phone))
+  }
 
-    @Test
-    fun fetchCardBytes_sendsBearerToken_whenConfigured() = runTest {
-        var sawAuth: String? = null
-        val engine = MockEngine { request ->
-            sawAuth = request.headers["Authorization"]
-            respond(
-                content = ByteReadChannel(ByteArray(0)),
-                status = HttpStatusCode.OK,
-            )
-        }
-        val client = AddonClient("http://addon", accessToken = "secret", engine = engine)
-        client.fetchCardBytes(card, size, ClientProfile.Phone)
-        assertEquals("Bearer secret", sawAuth)
+  @Test
+  fun fetchCardBytes_sendsBearerToken_whenConfigured() = runTest {
+    var sawAuth: String? = null
+    val engine = MockEngine { request ->
+      sawAuth = request.headers["Authorization"]
+      respond(content = ByteReadChannel(ByteArray(0)), status = HttpStatusCode.OK)
     }
+    val client = AddonClient("http://addon", accessToken = "secret", engine = engine)
+    client.fetchCardBytes(card, size, ClientProfile.Phone)
+    assertEquals("Bearer secret", sawAuth)
+  }
 }

--- a/ha-client/src/commonTest/kotlin/ee/schimke/ha/client/CardSourceTest.kt
+++ b/ha-client/src/commonTest/kotlin/ee/schimke/ha/client/CardSourceTest.kt
@@ -6,139 +6,150 @@ import ee.schimke.ha.model.CardKey
 import ee.schimke.ha.model.CardSize
 import ee.schimke.ha.model.ClientProfile
 import ee.schimke.ha.model.HaSnapshot
-import kotlinx.serialization.json.JsonObject
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
 
 /**
- * The chain has only a handful of behaviours but each one is the load-
- * bearing assumption for "generator choice is invisible to the user".
+ * The chain has only a handful of behaviours but each one is the load- bearing assumption for
+ * "generator choice is invisible to the user".
  *
  * - first-supports-and-produces wins;
  * - first-supports-but-returns-null falls through;
  * - !supports() skips without I/O;
  * - all-null → Unsupported (never throw).
  *
- * Priority is honoured by sorting at construction time, not at every
- * render — a fake with a low number must execute before one with a
- * high number regardless of insertion order.
+ * Priority is honoured by sorting at construction time, not at every render — a fake with a low
+ * number must execute before one with a high number regardless of insertion order.
  */
 class CardSourceTest {
 
-    private val key = CardKey(
-        dashboardUrlPath = "lovelace",
-        viewPath = "home",
-        cardIndex = 0,
-        type = "tile",
-    )
-    private val card = CardConfig(type = "tile", raw = JsonObject(emptyMap()))
-    private val snapshot = HaSnapshot()
-    private val size = CardSize(widthPx = 320, heightPx = 160)
+  private val key =
+    CardKey(dashboardUrlPath = "lovelace", viewPath = "home", cardIndex = 0, type = "tile")
+  private val card = CardConfig(type = "tile", raw = JsonObject(emptyMap()))
+  private val snapshot = HaSnapshot()
+  private val size = CardSize(widthPx = 320, heightPx = 160)
 
-    @Test
-    fun render_picksLowestPriorityThatProduces() = runTest {
-        val firstBytes = CardBytes(byteArrayOf(1), 320, 160)
-        val secondBytes = CardBytes(byteArrayOf(2), 320, 160)
-        val source = CardSource(
-            listOf(
-                fake("second", priority = 100, result = secondBytes),
-                fake("first", priority = 0, result = firstBytes),
-            ),
+  @Test
+  fun render_picksLowestPriorityThatProduces() = runTest {
+    val firstBytes = CardBytes(byteArrayOf(1), 320, 160)
+    val secondBytes = CardBytes(byteArrayOf(2), 320, 160)
+    val source =
+      CardSource(
+        listOf(
+          fake("second", priority = 100, result = secondBytes),
+          fake("first", priority = 0, result = firstBytes),
         )
-        val result = source.render(key, card, snapshot, size, ClientProfile.Phone)
-        assertIs<CardRender.Bytes>(result)
-        assertEquals("first", result.generator)
-        assertEquals(firstBytes, result.card)
-    }
+      )
+    val result = source.render(key, card, snapshot, size, ClientProfile.Phone)
+    assertIs<CardRender.Bytes>(result)
+    assertEquals("first", result.generator)
+    assertEquals(firstBytes, result.card)
+  }
 
-    @Test
-    fun render_fallsThrough_whenHigherPriorityReturnsNull() = runTest {
-        val secondBytes = CardBytes(byteArrayOf(2), 320, 160)
-        val source = CardSource(
-            listOf(
-                fake("addon", priority = 0, result = null),
-                fake("local", priority = 100, result = secondBytes),
-            ),
+  @Test
+  fun render_fallsThrough_whenHigherPriorityReturnsNull() = runTest {
+    val secondBytes = CardBytes(byteArrayOf(2), 320, 160)
+    val source =
+      CardSource(
+        listOf(
+          fake("addon", priority = 0, result = null),
+          fake("local", priority = 100, result = secondBytes),
         )
-        val result = source.render(key, card, snapshot, size, ClientProfile.Phone)
-        assertIs<CardRender.Bytes>(result)
-        assertEquals("local", result.generator)
-    }
+      )
+    val result = source.render(key, card, snapshot, size, ClientProfile.Phone)
+    assertIs<CardRender.Bytes>(result)
+    assertEquals("local", result.generator)
+  }
 
-    @Test
-    fun render_skipsGeneratorsThatDontSupport() = runTest {
-        val callRecord = mutableListOf<String>()
-        val notSupporting = object : CardGenerator {
-            override val name: String = "no-support"
-            override val priority: Int = 0
-            override fun supports(card: CardConfig, profile: ClientProfile): Boolean = false
-            override suspend fun generate(
-                key: CardKey, card: CardConfig, snapshot: HaSnapshot,
-                size: CardSize, profile: ClientProfile,
-            ): CardBytes? {
-                callRecord += "no-support"
-                return null
-            }
-        }
-        val supporting = fake("local", priority = 100, result = CardBytes(byteArrayOf(7), 1, 1)) {
-            callRecord += "local"
-        }
-        val source = CardSource(listOf(notSupporting, supporting))
-        val result = source.render(key, card, snapshot, size, ClientProfile.Phone)
-        assertIs<CardRender.Bytes>(result)
-        assertEquals(listOf("local"), callRecord)
-    }
+  @Test
+  fun render_skipsGeneratorsThatDontSupport() = runTest {
+    val callRecord = mutableListOf<String>()
+    val notSupporting =
+      object : CardGenerator {
+        override val name: String = "no-support"
+        override val priority: Int = 0
 
-    @Test
-    fun render_returnsUnsupported_whenNoGeneratorProduces() = runTest {
-        val source = CardSource(
-            listOf(
-                fake("addon", priority = 0, result = null),
-                fake("local", priority = 100, result = null),
-            ),
-        )
-        val result = source.render(key, card, snapshot, size, ClientProfile.Phone)
-        assertIs<CardRender.Unsupported>(result)
-        assertEquals("tile", result.cardType)
-    }
+        override fun supports(card: CardConfig, profile: ClientProfile): Boolean = false
 
-    @Test
-    fun render_returnsUnsupported_whenChainEmpty() = runTest {
-        val source = CardSource(emptyList())
-        val result = source.render(key, card, snapshot, size, ClientProfile.Phone)
-        assertIs<CardRender.Unsupported>(result)
-    }
-
-    @Test
-    fun generators_areSortedByPriorityAtConstruction() {
-        val source = CardSource(
-            listOf(
-                fake("c", priority = 100, result = null),
-                fake("a", priority = 0, result = null),
-                fake("b", priority = 50, result = null),
-            ),
-        )
-        assertEquals(listOf("a", "b", "c"), source.generators.map { it.name })
-    }
-
-    private fun fake(
-        name: String,
-        priority: Int,
-        result: CardBytes?,
-        onGenerate: () -> Unit = {},
-    ): CardGenerator = object : CardGenerator {
-        override val name: String = name
-        override val priority: Int = priority
-        override fun supports(card: CardConfig, profile: ClientProfile): Boolean = true
         override suspend fun generate(
-            key: CardKey, card: CardConfig, snapshot: HaSnapshot,
-            size: CardSize, profile: ClientProfile,
+          key: CardKey,
+          card: CardConfig,
+          snapshot: HaSnapshot,
+          size: CardSize,
+          profile: ClientProfile,
         ): CardBytes? {
-            onGenerate()
-            return result
+          callRecord += "no-support"
+          return null
         }
+      }
+    val supporting =
+      fake("local", priority = 100, result = CardBytes(byteArrayOf(7), 1, 1)) {
+        callRecord += "local"
+      }
+    val source = CardSource(listOf(notSupporting, supporting))
+    val result = source.render(key, card, snapshot, size, ClientProfile.Phone)
+    assertIs<CardRender.Bytes>(result)
+    assertEquals(listOf("local"), callRecord)
+  }
+
+  @Test
+  fun render_returnsUnsupported_whenNoGeneratorProduces() = runTest {
+    val source =
+      CardSource(
+        listOf(
+          fake("addon", priority = 0, result = null),
+          fake("local", priority = 100, result = null),
+        )
+      )
+    val result = source.render(key, card, snapshot, size, ClientProfile.Phone)
+    assertIs<CardRender.Unsupported>(result)
+    assertEquals("tile", result.cardType)
+  }
+
+  @Test
+  fun render_returnsUnsupported_whenChainEmpty() = runTest {
+    val source = CardSource(emptyList())
+    val result = source.render(key, card, snapshot, size, ClientProfile.Phone)
+    assertIs<CardRender.Unsupported>(result)
+  }
+
+  @Test
+  fun generators_areSortedByPriorityAtConstruction() {
+    val source =
+      CardSource(
+        listOf(
+          fake("c", priority = 100, result = null),
+          fake("a", priority = 0, result = null),
+          fake("b", priority = 50, result = null),
+        )
+      )
+    assertEquals(listOf("a", "b", "c"), source.generators.map { it.name })
+  }
+
+  private fun fake(
+    name: String,
+    priority: Int,
+    result: CardBytes?,
+    onGenerate: () -> Unit = {},
+  ): CardGenerator =
+    object : CardGenerator {
+      override val name: String = name
+      override val priority: Int = priority
+
+      override fun supports(card: CardConfig, profile: ClientProfile): Boolean = true
+
+      override suspend fun generate(
+        key: CardKey,
+        card: CardConfig,
+        snapshot: HaSnapshot,
+        size: CardSize,
+        profile: ClientProfile,
+      ): CardBytes? {
+        onGenerate()
+        return result
+      }
     }
 }

--- a/ha-model/build.gradle.kts
+++ b/ha-model/build.gradle.kts
@@ -1,26 +1,24 @@
 plugins {
-    alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.android.kmp.library)
+  alias(libs.plugins.kotlin.multiplatform)
+  alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.android.kmp.library)
 }
 
 kotlin {
-    jvmToolchain(libs.versions.java.get().toInt())
+  jvmToolchain(libs.versions.java.get().toInt())
 
-    androidLibrary {
-        namespace = "ee.schimke.ha.model"
-        compileSdk = libs.versions.android.compileSdk.get().toInt()
-        minSdk = libs.versions.android.minSdk.get().toInt()
-    }
-    jvm()
+  androidLibrary {
+    namespace = "ee.schimke.ha.model"
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    minSdk = libs.versions.android.minSdk.get().toInt()
+  }
+  jvm()
 
-    sourceSets {
-        commonMain.dependencies {
-            api(libs.kotlinx.serialization.json)
-            api(libs.kotlinx.datetime)
-        }
-        commonTest.dependencies {
-            implementation(libs.kotlin.test)
-        }
+  sourceSets {
+    commonMain.dependencies {
+      api(libs.kotlinx.serialization.json)
+      api(libs.kotlinx.datetime)
     }
+    commonTest.dependencies { implementation(libs.kotlin.test) }
+  }
 }

--- a/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/CardBytes.kt
+++ b/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/CardBytes.kt
@@ -1,30 +1,23 @@
 package ee.schimke.ha.model
 
 /**
- * Encoded RemoteCompose document bytes, sized for a specific surface.
- * Storage format on disk (Room blob), wire format on the network
- * (`application/x-remote-compose`), and the value type generators
+ * Encoded RemoteCompose document bytes, sized for a specific surface. Storage format on disk (Room
+ * blob), wire format on the network (`application/x-remote-compose`), and the value type generators
  * return.
  *
- * Kept in `ha-model` so both the JVM add-on and KMP client targets can
- * see it; `rc-converter` (Android) keeps its own `CardDocument` for the
- * `decode() → CoreDocument` convenience but is structurally a superset
- * of this.
+ * Kept in `ha-model` so both the JVM add-on and KMP client targets can see it; `rc-converter`
+ * (Android) keeps its own `CardDocument` for the `decode() → CoreDocument` convenience but is
+ * structurally a superset of this.
  */
-class CardBytes(
-    val bytes: ByteArray,
-    val widthPx: Int,
-    val heightPx: Int,
-) {
-    override fun equals(other: Any?): Boolean =
-        other is CardBytes &&
-            bytes.contentEquals(other.bytes) &&
-            widthPx == other.widthPx &&
-            heightPx == other.heightPx
+class CardBytes(val bytes: ByteArray, val widthPx: Int, val heightPx: Int) {
+  override fun equals(other: Any?): Boolean =
+    other is CardBytes &&
+      bytes.contentEquals(other.bytes) &&
+      widthPx == other.widthPx &&
+      heightPx == other.heightPx
 
-    override fun hashCode(): Int =
-        (bytes.contentHashCode() * 31 + widthPx) * 31 + heightPx
+  override fun hashCode(): Int = (bytes.contentHashCode() * 31 + widthPx) * 31 + heightPx
 
-    override fun toString(): String =
-        "CardBytes(bytes=${bytes.size}B, width=$widthPx, height=$heightPx)"
+  override fun toString(): String =
+    "CardBytes(bytes=${bytes.size}B, width=$widthPx, height=$heightPx)"
 }

--- a/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/CardKey.kt
+++ b/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/CardKey.kt
@@ -3,34 +3,33 @@ package ee.schimke.ha.model
 import kotlinx.serialization.Serializable
 
 /**
- * Stable identity for a single card within a dashboard, so a widget or
- * cache entry can keep pointing at the same card as dashboards evolve.
+ * Stable identity for a single card within a dashboard, so a widget or cache entry can keep
+ * pointing at the same card as dashboards evolve.
  *
- * HA does not assign per-card UUIDs, so we key by the user-facing path
- * (`dashboard url_path` + `view path` + `section/card index`) plus the
- * `type` as a sanity field. If the user reorders cards the key changes,
- * which is intentional — treat a reordered layout as a new widget target.
+ * HA does not assign per-card UUIDs, so we key by the user-facing path (`dashboard url_path` +
+ * `view path` + `section/card index`) plus the `type` as a sanity field. If the user reorders cards
+ * the key changes, which is intentional — treat a reordered layout as a new widget target.
  */
 @Serializable
 data class CardKey(
-    val dashboardUrlPath: String?,
-    val viewPath: String?,
-    val sectionIndex: Int? = null,
-    val cardIndex: Int,
-    val type: String,
+  val dashboardUrlPath: String?,
+  val viewPath: String?,
+  val sectionIndex: Int? = null,
+  val cardIndex: Int,
+  val type: String,
 ) {
-    fun toCacheKey(): String = buildString {
-        append(dashboardUrlPath ?: "_default")
-        append('/')
-        append(viewPath ?: "_default")
-        if (sectionIndex != null) {
-            append('/')
-            append('s')
-            append(sectionIndex)
-        }
-        append('/')
-        append(cardIndex)
-        append('#')
-        append(type)
+  fun toCacheKey(): String = buildString {
+    append(dashboardUrlPath ?: "_default")
+    append('/')
+    append(viewPath ?: "_default")
+    if (sectionIndex != null) {
+      append('/')
+      append('s')
+      append(sectionIndex)
     }
+    append('/')
+    append(cardIndex)
+    append('#')
+    append(type)
+  }
 }

--- a/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/CardSize.kt
+++ b/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/CardSize.kt
@@ -1,19 +1,20 @@
 package ee.schimke.ha.model
 
 /**
- * Pixel size + density that a renderer should target when emitting a
- * `.rc` document. Travels with every card request so an add-on or local
- * generator can size text/icons against the surface that will play the
- * document.
+ * Pixel size + density that a renderer should target when emitting a `.rc` document. Travels with
+ * every card request so an add-on or local generator can size text/icons against the surface that
+ * will play the document.
  */
 data class CardSize(
-    val widthPx: Int,
-    val heightPx: Int,
-    val densityDpi: Int = DEFAULT_DENSITY_DPI,
+  val widthPx: Int,
+  val heightPx: Int,
+  val densityDpi: Int = DEFAULT_DENSITY_DPI,
 ) {
-    companion object {
-        /** Roughly mdpi×2 — matches xhdpi launchers and is a sane default
-         *  when a caller has no real surface to measure against. */
-        const val DEFAULT_DENSITY_DPI: Int = 320
-    }
+  companion object {
+    /**
+     * Roughly mdpi×2 — matches xhdpi launchers and is a sane default when a caller has no real
+     * surface to measure against.
+     */
+    const val DEFAULT_DENSITY_DPI: Int = 320
+  }
 }

--- a/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/CardTypes.kt
+++ b/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/CardTypes.kt
@@ -1,45 +1,45 @@
 package ee.schimke.ha.model
 
 /**
- * Canonical identifiers for built-in Lovelace card types. Custom cards
- * arrive as `"custom:<name>"` and are not enumerated here.
+ * Canonical identifiers for built-in Lovelace card types. Custom cards arrive as `"custom:<name>"`
+ * and are not enumerated here.
  *
- * Converters register themselves by string id; this object is a typo-check
- * aid, not a schema constraint.
+ * Converters register themselves by string id; this object is a typo-check aid, not a schema
+ * constraint.
  */
 object CardTypes {
-    const val ENTITIES = "entities"
-    const val GLANCE = "glance"
-    const val TILE = "tile"
-    const val BUTTON = "button"
-    const val ENTITY = "entity"
-    const val GAUGE = "gauge"
-    const val SENSOR = "sensor"
-    const val HISTORY_GRAPH = "history-graph"
-    const val STATISTICS_GRAPH = "statistics-graph"
-    const val STATISTIC = "statistic"
-    const val MAP = "map"
-    const val PICTURE = "picture"
-    const val PICTURE_ENTITY = "picture-entity"
-    const val PICTURE_GLANCE = "picture-glance"
-    const val PICTURE_ELEMENTS = "picture-elements"
-    const val MARKDOWN = "markdown"
-    const val IFRAME = "iframe"
-    const val WEATHER_FORECAST = "weather-forecast"
-    const val THERMOSTAT = "thermostat"
-    const val HUMIDIFIER = "humidifier"
-    const val LIGHT = "light"
-    const val MEDIA_CONTROL = "media-control"
-    const val ALARM_PANEL = "alarm-panel"
-    const val AREA = "area"
-    const val CALENDAR = "calendar"
-    const val LOGBOOK = "logbook"
-    const val CLOCK = "clock"
-    const val TODO_LIST = "todo-list"
-    const val CONDITIONAL = "conditional"
-    const val ENTITY_FILTER = "entity-filter"
-    const val VERTICAL_STACK = "vertical-stack"
-    const val HORIZONTAL_STACK = "horizontal-stack"
-    const val GRID = "grid"
-    const val HEADING = "heading"
+  const val ENTITIES = "entities"
+  const val GLANCE = "glance"
+  const val TILE = "tile"
+  const val BUTTON = "button"
+  const val ENTITY = "entity"
+  const val GAUGE = "gauge"
+  const val SENSOR = "sensor"
+  const val HISTORY_GRAPH = "history-graph"
+  const val STATISTICS_GRAPH = "statistics-graph"
+  const val STATISTIC = "statistic"
+  const val MAP = "map"
+  const val PICTURE = "picture"
+  const val PICTURE_ENTITY = "picture-entity"
+  const val PICTURE_GLANCE = "picture-glance"
+  const val PICTURE_ELEMENTS = "picture-elements"
+  const val MARKDOWN = "markdown"
+  const val IFRAME = "iframe"
+  const val WEATHER_FORECAST = "weather-forecast"
+  const val THERMOSTAT = "thermostat"
+  const val HUMIDIFIER = "humidifier"
+  const val LIGHT = "light"
+  const val MEDIA_CONTROL = "media-control"
+  const val ALARM_PANEL = "alarm-panel"
+  const val AREA = "area"
+  const val CALENDAR = "calendar"
+  const val LOGBOOK = "logbook"
+  const val CLOCK = "clock"
+  const val TODO_LIST = "todo-list"
+  const val CONDITIONAL = "conditional"
+  const val ENTITY_FILTER = "entity-filter"
+  const val VERTICAL_STACK = "vertical-stack"
+  const val HORIZONTAL_STACK = "horizontal-stack"
+  const val GRID = "grid"
+  const val HEADING = "heading"
 }

--- a/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/ClientProfile.kt
+++ b/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/ClientProfile.kt
@@ -1,33 +1,32 @@
 package ee.schimke.ha.model
 
 /**
- * Which kind of surface a rendered card is destined for. Generators
- * read this to pick layout variants (compact for wear, focusable for tv,
- * etc.); the player passes its own profile when fetching from a server,
- * so the server can return a profile-tuned `.rc` document.
+ * Which kind of surface a rendered card is destined for. Generators read this to pick layout
+ * variants (compact for wear, focusable for tv, etc.); the player passes its own profile when
+ * fetching from a server, so the server can return a profile-tuned `.rc` document.
  *
- * Kept here in `ha-model` rather than in either side because the value
- * has to round-trip across client ↔ add-on as a query parameter — both
- * ends must agree on the spelling.
+ * Kept here in `ha-model` rather than in either side because the value has to round-trip across
+ * client ↔ add-on as a query parameter — both ends must agree on the spelling.
  */
 enum class ClientProfile {
-    /** Phone / tablet — the default. Material3, full Lovelace fidelity. */
-    Phone,
-    /** Wear OS launcher tile / app — compact, AOD-safe, no shadows. */
-    Wear,
-    /** Android TV — large typography, focusable affordances, 10-ft margins. */
-    Tv,
-    /** Glance launcher widget — single-card, no nested players. */
-    Glance,
-    /** 1-bit colour for e-paper / ESP32. */
-    Mono,
-    ;
+  /** Phone / tablet — the default. Material3, full Lovelace fidelity. */
+  Phone,
+  /** Wear OS launcher tile / app — compact, AOD-safe, no shadows. */
+  Wear,
+  /** Android TV — large typography, focusable affordances, 10-ft margins. */
+  Tv,
+  /** Glance launcher widget — single-card, no nested players. */
+  Glance,
+  /** 1-bit colour for e-paper / ESP32. */
+  Mono;
 
-    /** Wire form, lower-case. Kept stable; do not localise. */
-    val wire: String get() = name.lowercase()
+  /** Wire form, lower-case. Kept stable; do not localise. */
+  val wire: String
+    get() = name.lowercase()
 
-    companion object {
-        fun parse(s: String?): ClientProfile? =
-            s?.let { value -> entries.firstOrNull { it.wire == value.lowercase() } }
+  companion object {
+    fun parse(s: String?): ClientProfile? = s?.let { value ->
+      entries.firstOrNull { it.wire == value.lowercase() }
     }
+  }
 }

--- a/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/Dashboard.kt
+++ b/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/Dashboard.kt
@@ -1,50 +1,40 @@
 package ee.schimke.ha.model
 
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 
 /**
- * Resolved Lovelace dashboard config, matching the payload returned by the
- * HA WebSocket command `lovelace/config`.
+ * Resolved Lovelace dashboard config, matching the payload returned by the HA WebSocket command
+ * `lovelace/config`.
  *
- * The schema is intentionally loose: HA treats any unknown field on a card as
- * opaque, and the frontend's TypeScript types carry an `[key: string]: any`
- * escape hatch. We surface `extra: JsonObject` on every config node so
- * converters can read card-specific fields without us having to model them
- * up front.
+ * The schema is intentionally loose: HA treats any unknown field on a card as opaque, and the
+ * frontend's TypeScript types carry an `[key: string]: any` escape hatch. We surface `extra:
+ * JsonObject` on every config node so converters can read card-specific fields without us having to
+ * model them up front.
  */
-@Serializable
-data class Dashboard(
-    val title: String? = null,
-    val views: List<View> = emptyList(),
-)
+@Serializable data class Dashboard(val title: String? = null, val views: List<View> = emptyList())
 
 @Serializable
 data class View(
-    val title: String? = null,
-    val path: String? = null,
-    val icon: String? = null,
-    val theme: String? = null,
-    val type: String? = null,
-    val sections: List<Section> = emptyList(),
-    val cards: List<CardConfig> = emptyList(),
-    val badges: List<JsonObject> = emptyList(),
+  val title: String? = null,
+  val path: String? = null,
+  val icon: String? = null,
+  val theme: String? = null,
+  val type: String? = null,
+  val sections: List<Section> = emptyList(),
+  val cards: List<CardConfig> = emptyList(),
+  val badges: List<JsonObject> = emptyList(),
 )
 
 @Serializable
 data class Section(
-    val type: String? = null,
-    val title: String? = null,
-    val cards: List<CardConfig> = emptyList(),
+  val type: String? = null,
+  val title: String? = null,
+  val cards: List<CardConfig> = emptyList(),
 )
 
 /**
- * A Lovelace card config. Only `type` is guaranteed — everything else lives
- * in [raw] for per-card converters to interpret.
+ * A Lovelace card config. Only `type` is guaranteed — everything else lives in [raw] for per-card
+ * converters to interpret.
  */
-@Serializable
-data class CardConfig(
-    val type: String,
-    val raw: JsonObject = JsonObject(emptyMap()),
-)
+@Serializable data class CardConfig(val type: String, val raw: JsonObject = JsonObject(emptyMap()))

--- a/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/HaDomainState.kt
+++ b/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/HaDomainState.kt
@@ -1,205 +1,267 @@
 package ee.schimke.ha.model
 
 /**
- * Typed state hierarchies for the HA domains our converters care
- * about. Sealed over the known values (so `when` branches read as
- * symbolic names) but **not exhaustive on unknown values** — anything
- * we don't recognise is carried through as `Unknown(raw)` so a new
- * HA release or a custom integration won't crash the converter.
+ * Typed state hierarchies for the HA domains our converters care about. Sealed over the known
+ * values (so `when` branches read as symbolic names) but **not exhaustive on unknown values** —
+ * anything we don't recognise is carried through as `Unknown(raw)` so a new HA release or a custom
+ * integration won't crash the converter.
  *
- * State name reference:
- *   https://developers.home-assistant.io/docs/core/entity
+ * State name reference: https://developers.home-assistant.io/docs/core/entity
  */
-
 sealed interface OnOffState {
-    data object On : OnOffState
-    data object Off : OnOffState
-    data object Unavailable : OnOffState
-    data class Unknown(val raw: String) : OnOffState
+  data object On : OnOffState
 
-    companion object {
-        fun parse(raw: String): OnOffState = when (raw) {
-            "on" -> On
-            "off" -> Off
-            "unavailable" -> Unavailable
-            else -> Unknown(raw)
-        }
-    }
+  data object Off : OnOffState
+
+  data object Unavailable : OnOffState
+
+  data class Unknown(val raw: String) : OnOffState
+
+  companion object {
+    fun parse(raw: String): OnOffState =
+      when (raw) {
+        "on" -> On
+        "off" -> Off
+        "unavailable" -> Unavailable
+        else -> Unknown(raw)
+      }
+  }
 }
 
 sealed interface CoverState {
-    data object Closed : CoverState
-    data object Closing : CoverState
-    data object Opening : CoverState
-    data object Open : CoverState
-    data object Stopped : CoverState
-    data object Unavailable : CoverState
-    data class Unknown(val raw: String) : CoverState
+  data object Closed : CoverState
 
-    companion object {
-        fun parse(raw: String): CoverState = when (raw) {
-            "closed" -> Closed
-            "closing" -> Closing
-            "opening" -> Opening
-            "open" -> Open
-            "stopped" -> Stopped
-            "unavailable" -> Unavailable
-            else -> Unknown(raw)
-        }
-    }
+  data object Closing : CoverState
+
+  data object Opening : CoverState
+
+  data object Open : CoverState
+
+  data object Stopped : CoverState
+
+  data object Unavailable : CoverState
+
+  data class Unknown(val raw: String) : CoverState
+
+  companion object {
+    fun parse(raw: String): CoverState =
+      when (raw) {
+        "closed" -> Closed
+        "closing" -> Closing
+        "opening" -> Opening
+        "open" -> Open
+        "stopped" -> Stopped
+        "unavailable" -> Unavailable
+        else -> Unknown(raw)
+      }
+  }
 }
 
 sealed interface LockState {
-    data object Locked : LockState
-    data object Unlocked : LockState
-    data object Locking : LockState
-    data object Unlocking : LockState
-    data object Jammed : LockState
-    data object Open : LockState
-    data object Opening : LockState
-    data object Unavailable : LockState
-    data class Unknown(val raw: String) : LockState
+  data object Locked : LockState
 
-    companion object {
-        fun parse(raw: String): LockState = when (raw) {
-            "locked" -> Locked
-            "unlocked" -> Unlocked
-            "locking" -> Locking
-            "unlocking" -> Unlocking
-            "jammed" -> Jammed
-            "open" -> Open
-            "opening" -> Opening
-            "unavailable" -> Unavailable
-            else -> Unknown(raw)
-        }
-    }
+  data object Unlocked : LockState
+
+  data object Locking : LockState
+
+  data object Unlocking : LockState
+
+  data object Jammed : LockState
+
+  data object Open : LockState
+
+  data object Opening : LockState
+
+  data object Unavailable : LockState
+
+  data class Unknown(val raw: String) : LockState
+
+  companion object {
+    fun parse(raw: String): LockState =
+      when (raw) {
+        "locked" -> Locked
+        "unlocked" -> Unlocked
+        "locking" -> Locking
+        "unlocking" -> Unlocking
+        "jammed" -> Jammed
+        "open" -> Open
+        "opening" -> Opening
+        "unavailable" -> Unavailable
+        else -> Unknown(raw)
+      }
+  }
 }
 
 sealed interface MediaPlayerState {
-    data object Playing : MediaPlayerState
-    data object Paused : MediaPlayerState
-    data object Idle : MediaPlayerState
-    data object Off : MediaPlayerState
-    data object On : MediaPlayerState
-    data object Standby : MediaPlayerState
-    data object Buffering : MediaPlayerState
-    data object Unavailable : MediaPlayerState
-    data class Unknown(val raw: String) : MediaPlayerState
+  data object Playing : MediaPlayerState
 
-    companion object {
-        fun parse(raw: String): MediaPlayerState = when (raw) {
-            "playing" -> Playing
-            "paused" -> Paused
-            "idle" -> Idle
-            "off" -> Off
-            "on" -> On
-            "standby" -> Standby
-            "buffering" -> Buffering
-            "unavailable" -> Unavailable
-            else -> Unknown(raw)
-        }
-    }
+  data object Paused : MediaPlayerState
+
+  data object Idle : MediaPlayerState
+
+  data object Off : MediaPlayerState
+
+  data object On : MediaPlayerState
+
+  data object Standby : MediaPlayerState
+
+  data object Buffering : MediaPlayerState
+
+  data object Unavailable : MediaPlayerState
+
+  data class Unknown(val raw: String) : MediaPlayerState
+
+  companion object {
+    fun parse(raw: String): MediaPlayerState =
+      when (raw) {
+        "playing" -> Playing
+        "paused" -> Paused
+        "idle" -> Idle
+        "off" -> Off
+        "on" -> On
+        "standby" -> Standby
+        "buffering" -> Buffering
+        "unavailable" -> Unavailable
+        else -> Unknown(raw)
+      }
+  }
 }
 
 sealed interface ClimateMode {
-    data object Off : ClimateMode
-    data object Heat : ClimateMode
-    data object Cool : ClimateMode
-    data object HeatCool : ClimateMode
-    data object Auto : ClimateMode
-    data object Dry : ClimateMode
-    data object FanOnly : ClimateMode
-    data object Unavailable : ClimateMode
-    data class Unknown(val raw: String) : ClimateMode
+  data object Off : ClimateMode
 
-    companion object {
-        fun parse(raw: String): ClimateMode = when (raw) {
-            "off" -> Off
-            "heat" -> Heat
-            "cool" -> Cool
-            "heat_cool" -> HeatCool
-            "auto" -> Auto
-            "dry" -> Dry
-            "fan_only" -> FanOnly
-            "unavailable" -> Unavailable
-            else -> Unknown(raw)
-        }
-    }
+  data object Heat : ClimateMode
+
+  data object Cool : ClimateMode
+
+  data object HeatCool : ClimateMode
+
+  data object Auto : ClimateMode
+
+  data object Dry : ClimateMode
+
+  data object FanOnly : ClimateMode
+
+  data object Unavailable : ClimateMode
+
+  data class Unknown(val raw: String) : ClimateMode
+
+  companion object {
+    fun parse(raw: String): ClimateMode =
+      when (raw) {
+        "off" -> Off
+        "heat" -> Heat
+        "cool" -> Cool
+        "heat_cool" -> HeatCool
+        "auto" -> Auto
+        "dry" -> Dry
+        "fan_only" -> FanOnly
+        "unavailable" -> Unavailable
+        else -> Unknown(raw)
+      }
+  }
 }
 
 sealed interface AlarmState {
-    data object Disarmed : AlarmState
-    data object ArmedHome : AlarmState
-    data object ArmedAway : AlarmState
-    data object ArmedNight : AlarmState
-    data object ArmedVacation : AlarmState
-    data object ArmedCustomBypass : AlarmState
-    data object Triggered : AlarmState
-    data object Pending : AlarmState
-    data object Arming : AlarmState
-    data object Disarming : AlarmState
-    data object Unavailable : AlarmState
-    data class Unknown(val raw: String) : AlarmState
+  data object Disarmed : AlarmState
 
-    companion object {
-        fun parse(raw: String): AlarmState = when (raw) {
-            "disarmed" -> Disarmed
-            "armed_home" -> ArmedHome
-            "armed_away" -> ArmedAway
-            "armed_night" -> ArmedNight
-            "armed_vacation" -> ArmedVacation
-            "armed_custom_bypass" -> ArmedCustomBypass
-            "triggered" -> Triggered
-            "pending" -> Pending
-            "arming" -> Arming
-            "disarming" -> Disarming
-            "unavailable" -> Unavailable
-            else -> Unknown(raw)
-        }
-    }
+  data object ArmedHome : AlarmState
+
+  data object ArmedAway : AlarmState
+
+  data object ArmedNight : AlarmState
+
+  data object ArmedVacation : AlarmState
+
+  data object ArmedCustomBypass : AlarmState
+
+  data object Triggered : AlarmState
+
+  data object Pending : AlarmState
+
+  data object Arming : AlarmState
+
+  data object Disarming : AlarmState
+
+  data object Unavailable : AlarmState
+
+  data class Unknown(val raw: String) : AlarmState
+
+  companion object {
+    fun parse(raw: String): AlarmState =
+      when (raw) {
+        "disarmed" -> Disarmed
+        "armed_home" -> ArmedHome
+        "armed_away" -> ArmedAway
+        "armed_night" -> ArmedNight
+        "armed_vacation" -> ArmedVacation
+        "armed_custom_bypass" -> ArmedCustomBypass
+        "triggered" -> Triggered
+        "pending" -> Pending
+        "arming" -> Arming
+        "disarming" -> Disarming
+        "unavailable" -> Unavailable
+        else -> Unknown(raw)
+      }
+  }
 }
 
 val AlarmState.isArmed: Boolean
-    get() = this is AlarmState.ArmedHome || this is AlarmState.ArmedAway ||
-        this is AlarmState.ArmedNight || this is AlarmState.ArmedVacation ||
-        this is AlarmState.ArmedCustomBypass
+  get() =
+    this is AlarmState.ArmedHome ||
+      this is AlarmState.ArmedAway ||
+      this is AlarmState.ArmedNight ||
+      this is AlarmState.ArmedVacation ||
+      this is AlarmState.ArmedCustomBypass
 
 sealed interface VacuumState {
-    data object Cleaning : VacuumState
-    data object Docked : VacuumState
-    data object Idle : VacuumState
-    data object Paused : VacuumState
-    data object Returning : VacuumState
-    data object Error : VacuumState
-    data object Unavailable : VacuumState
-    data class Unknown(val raw: String) : VacuumState
+  data object Cleaning : VacuumState
 
-    companion object {
-        fun parse(raw: String): VacuumState = when (raw) {
-            "cleaning" -> Cleaning
-            "docked" -> Docked
-            "idle" -> Idle
-            "paused" -> Paused
-            "returning" -> Returning
-            "error" -> Error
-            "unavailable" -> Unavailable
-            else -> Unknown(raw)
-        }
-    }
+  data object Docked : VacuumState
+
+  data object Idle : VacuumState
+
+  data object Paused : VacuumState
+
+  data object Returning : VacuumState
+
+  data object Error : VacuumState
+
+  data object Unavailable : VacuumState
+
+  data class Unknown(val raw: String) : VacuumState
+
+  companion object {
+    fun parse(raw: String): VacuumState =
+      when (raw) {
+        "cleaning" -> Cleaning
+        "docked" -> Docked
+        "idle" -> Idle
+        "paused" -> Paused
+        "returning" -> Returning
+        "error" -> Error
+        "unavailable" -> Unavailable
+        else -> Unknown(raw)
+      }
+  }
 }
 
 sealed interface PersonState {
-    data object Home : PersonState
-    data object NotHome : PersonState
-    data object Unavailable : PersonState
-    data class Unknown(val raw: String) : PersonState
+  data object Home : PersonState
 
-    companion object {
-        fun parse(raw: String): PersonState = when (raw) {
-            "home" -> Home
-            "not_home" -> NotHome
-            "unavailable" -> Unavailable
-            else -> Unknown(raw)
-        }
-    }
+  data object NotHome : PersonState
+
+  data object Unavailable : PersonState
+
+  data class Unknown(val raw: String) : PersonState
+
+  companion object {
+    fun parse(raw: String): PersonState =
+      when (raw) {
+        "home" -> Home
+        "not_home" -> NotHome
+        "unavailable" -> Unavailable
+        else -> Unknown(raw)
+      }
+  }
 }

--- a/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/HaEntity.kt
+++ b/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/HaEntity.kt
@@ -6,142 +6,164 @@ import kotlinx.serialization.json.jsonPrimitive
  * Typed, parsed representation of an HA entity.
  *
  * Converters switch on this sealed hierarchy instead of matching
- * `(entity.entityId.substringBefore('.'), entity.state)` strings —
- * each subtype carries the domain-appropriate sealed state type.
- * Unknown raw values flow through as `<State>.Unknown(raw)` so a new
- * HA release never breaks the converter path.
+ * `(entity.entityId.substringBefore('.'), entity.state)` strings — each subtype carries the
+ * domain-appropriate sealed state type. Unknown raw values flow through as `<State>.Unknown(raw)`
+ * so a new HA release never breaks the converter path.
  *
- * Domains we don't model explicitly land in [Other] with the raw
- * [EntityState] still available for string-matching fallbacks.
+ * Domains we don't model explicitly land in [Other] with the raw [EntityState] still available for
+ * string-matching fallbacks.
  */
 sealed interface HaEntity {
-    val raw: EntityState
+  val raw: EntityState
 
-    val entityId: String get() = raw.entityId
-    val domain: String get() = entityId.substringBefore('.')
-    val deviceClass: String? get() = raw.attributes["device_class"]?.jsonPrimitive?.content
+  val entityId: String
+    get() = raw.entityId
 
-    /**
-     * "Is this entity in an active / on-like state?" Null means the
-     * domain doesn't have a binary active concept (pure sensors,
-     * weather, etc).
-     */
-    val isActive: Boolean?
+  val domain: String
+    get() = entityId.substringBefore('.')
 
-    data class Light(override val raw: EntityState, val state: OnOffState) : HaEntity {
-        override val isActive: Boolean get() = state is OnOffState.On
+  val deviceClass: String?
+    get() = raw.attributes["device_class"]?.jsonPrimitive?.content
+
+  /**
+   * "Is this entity in an active / on-like state?" Null means the domain doesn't have a binary
+   * active concept (pure sensors, weather, etc).
+   */
+  val isActive: Boolean?
+
+  data class Light(override val raw: EntityState, val state: OnOffState) : HaEntity {
+    override val isActive: Boolean
+      get() = state is OnOffState.On
+  }
+
+  data class Switch(override val raw: EntityState, val state: OnOffState) : HaEntity {
+    override val isActive: Boolean
+      get() = state is OnOffState.On
+  }
+
+  data class InputBoolean(override val raw: EntityState, val state: OnOffState) : HaEntity {
+    override val isActive: Boolean
+      get() = state is OnOffState.On
+  }
+
+  data class Fan(override val raw: EntityState, val state: OnOffState) : HaEntity {
+    override val isActive: Boolean
+      get() = state is OnOffState.On
+  }
+
+  data class Siren(override val raw: EntityState, val state: OnOffState) : HaEntity {
+    override val isActive: Boolean
+      get() = state is OnOffState.On
+  }
+
+  data class Humidifier(override val raw: EntityState, val state: OnOffState) : HaEntity {
+    override val isActive: Boolean
+      get() = state is OnOffState.On
+  }
+
+  data class Cover(override val raw: EntityState, val state: CoverState) : HaEntity {
+    override val isActive: Boolean
+      get() = state is CoverState.Open || state is CoverState.Opening || state is CoverState.Closing
+  }
+
+  /** "Active" means "locked" — the safe / typical resting state. */
+  data class Lock(override val raw: EntityState, val state: LockState) : HaEntity {
+    override val isActive: Boolean
+      get() = state is LockState.Locked
+  }
+
+  data class MediaPlayer(override val raw: EntityState, val state: MediaPlayerState) : HaEntity {
+    override val isActive: Boolean
+      get() =
+        state !is MediaPlayerState.Off &&
+          state !is MediaPlayerState.Idle &&
+          state !is MediaPlayerState.Standby &&
+          state !is MediaPlayerState.Paused &&
+          state !is MediaPlayerState.Unavailable &&
+          state !is MediaPlayerState.Unknown
+  }
+
+  data class Climate(override val raw: EntityState, val mode: ClimateMode) : HaEntity {
+    override val isActive: Boolean
+      get() =
+        mode is ClimateMode.Heat ||
+          mode is ClimateMode.Cool ||
+          mode is ClimateMode.HeatCool ||
+          mode is ClimateMode.Auto ||
+          mode is ClimateMode.Dry ||
+          mode is ClimateMode.FanOnly
+  }
+
+  data class AlarmControlPanel(override val raw: EntityState, val state: AlarmState) : HaEntity {
+    override val isActive: Boolean
+      get() =
+        state.isArmed ||
+          state is AlarmState.Triggered ||
+          state is AlarmState.Pending ||
+          state is AlarmState.Arming
+  }
+
+  data class Vacuum(override val raw: EntityState, val state: VacuumState) : HaEntity {
+    override val isActive: Boolean
+      get() = state is VacuumState.Cleaning || state is VacuumState.Returning
+  }
+
+  data class Sensor(override val raw: EntityState) : HaEntity {
+    override val isActive: Boolean?
+      get() = null
+  }
+
+  data class BinarySensor(override val raw: EntityState, val state: OnOffState) : HaEntity {
+    override val isActive: Boolean
+      get() = state is OnOffState.On
+  }
+
+  data class Person(override val raw: EntityState, val state: PersonState) : HaEntity {
+    override val isActive: Boolean
+      get() = state is PersonState.Home
+  }
+
+  data class DeviceTracker(override val raw: EntityState, val state: PersonState) : HaEntity {
+    override val isActive: Boolean
+      get() = state is PersonState.Home
+  }
+
+  data class Weather(override val raw: EntityState) : HaEntity {
+    override val isActive: Boolean?
+      get() = null
+  }
+
+  /** Catch-all for domains without a dedicated model. */
+  data class Other(override val raw: EntityState) : HaEntity {
+    override val isActive: Boolean?
+      get() = null
+  }
+
+  companion object {
+    fun parse(raw: EntityState): HaEntity {
+      val domain = raw.entityId.substringBefore('.')
+      return when (domain) {
+        "light" -> Light(raw, OnOffState.parse(raw.state))
+        "switch" -> Switch(raw, OnOffState.parse(raw.state))
+        "input_boolean" -> InputBoolean(raw, OnOffState.parse(raw.state))
+        "fan" -> Fan(raw, OnOffState.parse(raw.state))
+        "siren" -> Siren(raw, OnOffState.parse(raw.state))
+        "humidifier" -> Humidifier(raw, OnOffState.parse(raw.state))
+        "cover" -> Cover(raw, CoverState.parse(raw.state))
+        "lock" -> Lock(raw, LockState.parse(raw.state))
+        "media_player" -> MediaPlayer(raw, MediaPlayerState.parse(raw.state))
+        "climate" -> Climate(raw, ClimateMode.parse(raw.state))
+        "alarm_control_panel" -> AlarmControlPanel(raw, AlarmState.parse(raw.state))
+        "vacuum" -> Vacuum(raw, VacuumState.parse(raw.state))
+        "sensor" -> Sensor(raw)
+        "binary_sensor" -> BinarySensor(raw, OnOffState.parse(raw.state))
+        "person" -> Person(raw, PersonState.parse(raw.state))
+        "device_tracker" -> DeviceTracker(raw, PersonState.parse(raw.state))
+        "weather" -> Weather(raw)
+        else -> Other(raw)
+      }
     }
-
-    data class Switch(override val raw: EntityState, val state: OnOffState) : HaEntity {
-        override val isActive: Boolean get() = state is OnOffState.On
-    }
-
-    data class InputBoolean(override val raw: EntityState, val state: OnOffState) : HaEntity {
-        override val isActive: Boolean get() = state is OnOffState.On
-    }
-
-    data class Fan(override val raw: EntityState, val state: OnOffState) : HaEntity {
-        override val isActive: Boolean get() = state is OnOffState.On
-    }
-
-    data class Siren(override val raw: EntityState, val state: OnOffState) : HaEntity {
-        override val isActive: Boolean get() = state is OnOffState.On
-    }
-
-    data class Humidifier(override val raw: EntityState, val state: OnOffState) : HaEntity {
-        override val isActive: Boolean get() = state is OnOffState.On
-    }
-
-    data class Cover(override val raw: EntityState, val state: CoverState) : HaEntity {
-        override val isActive: Boolean
-            get() = state is CoverState.Open || state is CoverState.Opening || state is CoverState.Closing
-    }
-
-    /** "Active" means "locked" — the safe / typical resting state. */
-    data class Lock(override val raw: EntityState, val state: LockState) : HaEntity {
-        override val isActive: Boolean get() = state is LockState.Locked
-    }
-
-    data class MediaPlayer(override val raw: EntityState, val state: MediaPlayerState) : HaEntity {
-        override val isActive: Boolean
-            get() = state !is MediaPlayerState.Off &&
-                state !is MediaPlayerState.Idle &&
-                state !is MediaPlayerState.Standby &&
-                state !is MediaPlayerState.Paused &&
-                state !is MediaPlayerState.Unavailable &&
-                state !is MediaPlayerState.Unknown
-    }
-
-    data class Climate(override val raw: EntityState, val mode: ClimateMode) : HaEntity {
-        override val isActive: Boolean
-            get() = mode is ClimateMode.Heat || mode is ClimateMode.Cool ||
-                mode is ClimateMode.HeatCool || mode is ClimateMode.Auto ||
-                mode is ClimateMode.Dry || mode is ClimateMode.FanOnly
-    }
-
-    data class AlarmControlPanel(override val raw: EntityState, val state: AlarmState) : HaEntity {
-        override val isActive: Boolean
-            get() = state.isArmed ||
-                state is AlarmState.Triggered ||
-                state is AlarmState.Pending ||
-                state is AlarmState.Arming
-    }
-
-    data class Vacuum(override val raw: EntityState, val state: VacuumState) : HaEntity {
-        override val isActive: Boolean
-            get() = state is VacuumState.Cleaning || state is VacuumState.Returning
-    }
-
-    data class Sensor(override val raw: EntityState) : HaEntity {
-        override val isActive: Boolean? get() = null
-    }
-
-    data class BinarySensor(override val raw: EntityState, val state: OnOffState) : HaEntity {
-        override val isActive: Boolean get() = state is OnOffState.On
-    }
-
-    data class Person(override val raw: EntityState, val state: PersonState) : HaEntity {
-        override val isActive: Boolean get() = state is PersonState.Home
-    }
-
-    data class DeviceTracker(override val raw: EntityState, val state: PersonState) : HaEntity {
-        override val isActive: Boolean get() = state is PersonState.Home
-    }
-
-    data class Weather(override val raw: EntityState) : HaEntity {
-        override val isActive: Boolean? get() = null
-    }
-
-    /** Catch-all for domains without a dedicated model. */
-    data class Other(override val raw: EntityState) : HaEntity {
-        override val isActive: Boolean? get() = null
-    }
-
-    companion object {
-        fun parse(raw: EntityState): HaEntity {
-            val domain = raw.entityId.substringBefore('.')
-            return when (domain) {
-                "light" -> Light(raw, OnOffState.parse(raw.state))
-                "switch" -> Switch(raw, OnOffState.parse(raw.state))
-                "input_boolean" -> InputBoolean(raw, OnOffState.parse(raw.state))
-                "fan" -> Fan(raw, OnOffState.parse(raw.state))
-                "siren" -> Siren(raw, OnOffState.parse(raw.state))
-                "humidifier" -> Humidifier(raw, OnOffState.parse(raw.state))
-                "cover" -> Cover(raw, CoverState.parse(raw.state))
-                "lock" -> Lock(raw, LockState.parse(raw.state))
-                "media_player" -> MediaPlayer(raw, MediaPlayerState.parse(raw.state))
-                "climate" -> Climate(raw, ClimateMode.parse(raw.state))
-                "alarm_control_panel" -> AlarmControlPanel(raw, AlarmState.parse(raw.state))
-                "vacuum" -> Vacuum(raw, VacuumState.parse(raw.state))
-                "sensor" -> Sensor(raw)
-                "binary_sensor" -> BinarySensor(raw, OnOffState.parse(raw.state))
-                "person" -> Person(raw, PersonState.parse(raw.state))
-                "device_tracker" -> DeviceTracker(raw, PersonState.parse(raw.state))
-                "weather" -> Weather(raw)
-                else -> Other(raw)
-            }
-        }
-    }
+  }
 }
 
 fun EntityState.toTyped(): HaEntity = HaEntity.parse(this)

--- a/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/HaServer.kt
+++ b/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/HaServer.kt
@@ -3,25 +3,24 @@ package ee.schimke.ha.model
 import kotlinx.serialization.Serializable
 
 /**
- * One configured Home Assistant install the user has connected to. The
- * client may have several. Each becomes one HA WebSocket session at
- * runtime and one row in the (forthcoming) `ha_servers` Room table.
+ * One configured Home Assistant install the user has connected to. The client may have several.
+ * Each becomes one HA WebSocket session at runtime and one row in the (forthcoming) `ha_servers`
+ * Room table.
  *
- * `addonBaseUrl` is optional — if set, the runtime will try the add-on
- * for card rendering and fall back to local rendering on failure. The
- * add-on never serves dashboard structure or live state to the client;
- * those are read from HA Core directly.
+ * `addonBaseUrl` is optional — if set, the runtime will try the add-on for card rendering and fall
+ * back to local rendering on failure. The add-on never serves dashboard structure or live state to
+ * the client; those are read from HA Core directly.
  */
 @Serializable
 data class HaServer(
-    /** Stable UUID. Generated once on insert; never reused. */
-    val id: String,
-    /** User-visible name (e.g. "Home", "Cabin"). */
-    val label: String,
-    /** HA Core base URL, e.g. `http://homeassistant.local:8123`. */
-    val haBaseUrl: String,
-    /** HA long-lived access token. Stored encrypted on Android. */
-    val accessToken: String,
-    /** Optional add-on base URL, e.g. `http://homeassistant.local:8099`. */
-    val addonBaseUrl: String? = null,
+  /** Stable UUID. Generated once on insert; never reused. */
+  val id: String,
+  /** User-visible name (e.g. "Home", "Cabin"). */
+  val label: String,
+  /** HA Core base URL, e.g. `http://homeassistant.local:8123`. */
+  val haBaseUrl: String,
+  /** HA long-lived access token. Stored encrypted on Android. */
+  val accessToken: String,
+  /** Optional add-on base URL, e.g. `http://homeassistant.local:8099`. */
+  val addonBaseUrl: String? = null,
 )

--- a/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/HaState.kt
+++ b/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/HaState.kt
@@ -7,58 +7,53 @@ import kotlinx.serialization.json.JsonObject
 /**
  * Snapshot of Home Assistant state that a card converter may read.
  *
- * Cards in HA pull live data from a mutable `hass` object — state of every
- * entity plus service handles. A converter operating outside that runtime
- * needs a pre-resolved snapshot: the entities the card cares about, their
- * history/statistics/forecast payloads, and enough registry info to resolve
- * names and units.
+ * Cards in HA pull live data from a mutable `hass` object — state of every entity plus service
+ * handles. A converter operating outside that runtime needs a pre-resolved snapshot: the entities
+ * the card cares about, their history/statistics/forecast payloads, and enough registry info to
+ * resolve names and units.
  */
 @Serializable
 data class HaSnapshot(
-    val states: Map<String, EntityState> = emptyMap(),
-    val themes: ThemeSet = ThemeSet(),
-    val locale: Locale = Locale("en", "US"),
-    val history: Map<String, List<HistoryPoint>> = emptyMap(),
-    val statistics: Map<String, List<StatisticPoint>> = emptyMap(),
-    val forecasts: Map<String, JsonObject> = emptyMap(),
+  val states: Map<String, EntityState> = emptyMap(),
+  val themes: ThemeSet = ThemeSet(),
+  val locale: Locale = Locale("en", "US"),
+  val history: Map<String, List<HistoryPoint>> = emptyMap(),
+  val statistics: Map<String, List<StatisticPoint>> = emptyMap(),
+  val forecasts: Map<String, JsonObject> = emptyMap(),
 )
 
 @Serializable
 data class EntityState(
-    val entityId: String,
-    val state: String,
-    val attributes: JsonObject = JsonObject(emptyMap()),
-    val lastChanged: Instant? = null,
-    val lastUpdated: Instant? = null,
+  val entityId: String,
+  val state: String,
+  val attributes: JsonObject = JsonObject(emptyMap()),
+  val lastChanged: Instant? = null,
+  val lastUpdated: Instant? = null,
 )
 
 @Serializable
 data class HistoryPoint(
-    val ts: Instant,
-    val state: String,
-    val attributes: JsonObject = JsonObject(emptyMap()),
+  val ts: Instant,
+  val state: String,
+  val attributes: JsonObject = JsonObject(emptyMap()),
 )
 
 @Serializable
 data class StatisticPoint(
-    val start: Instant,
-    val mean: Double? = null,
-    val min: Double? = null,
-    val max: Double? = null,
-    val sum: Double? = null,
-    val state: Double? = null,
+  val start: Instant,
+  val mean: Double? = null,
+  val min: Double? = null,
+  val max: Double? = null,
+  val sum: Double? = null,
+  val state: Double? = null,
 )
 
 @Serializable
 data class ThemeSet(
-    val active: String? = null,
-    val dark: Boolean = false,
-    val tokens: Map<String, String> = emptyMap(),
+  val active: String? = null,
+  val dark: Boolean = false,
+  val tokens: Map<String, String> = emptyMap(),
 )
 
 @Serializable
-data class Locale(
-    val language: String,
-    val country: String,
-    val timeZone: String? = null,
-)
+data class Locale(val language: String, val country: String, val timeZone: String? = null)

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -1,29 +1,24 @@
-plugins {
-    alias(libs.plugins.kotlin.jvm)
-}
+plugins { alias(libs.plugins.kotlin.jvm) }
 
 kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
 
 dependencies {
-    testImplementation(libs.kotlin.test)
-    testImplementation(platform(libs.junit.jupiter.bom))
-    testImplementation(libs.junit.jupiter)
-    testRuntimeOnly(libs.junit.platform.launcher)
+  testImplementation(libs.kotlin.test)
+  testImplementation(platform(libs.junit.jupiter.bom))
+  testImplementation(libs.junit.jupiter)
+  testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 tasks.test {
-    useJUnitPlatform()
+  useJUnitPlatform()
 
-    // Our rendered PNGs come from `:previews:renderAllPreviews`. Wire it so
-    // `./gradlew :integration:test` is a single command.
-    dependsOn(":previews:renderAllPreviews")
+  // Our rendered PNGs come from `:previews:renderAllPreviews`. Wire it so
+  // `./gradlew :integration:test` is a single command.
+  dependsOn(":previews:renderAllPreviews")
 
-    systemProperty(
-        "ha.rendered.dir",
-        rootProject.file("previews/build/compose-previews/renders").absolutePath,
-    )
-    systemProperty(
-        "ha.references.dir",
-        rootProject.file("references").absolutePath,
-    )
+  systemProperty(
+    "ha.rendered.dir",
+    rootProject.file("previews/build/compose-previews/renders").absolutePath,
+  )
+  systemProperty("ha.references.dir", rootProject.file("references").absolutePath)
 }

--- a/integration/src/test/kotlin/ee/schimke/ha/integration/CardPixelDiffTest.kt
+++ b/integration/src/test/kotlin/ee/schimke/ha/integration/CardPixelDiffTest.kt
@@ -1,86 +1,95 @@
 package ee.schimke.ha.integration
 
+import java.io.File
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
-import java.io.File
 
 /**
- * Pixel-level regression tests for every HA-referenced card (not just
- * the 4 tile variants in [TileCardPixelDiffTest]). Each entry pairs an
- * RC preview's PNG filename pattern with a committed reference PNG.
+ * Pixel-level regression tests for every HA-referenced card (not just the 4 tile variants in
+ * [TileCardPixelDiffTest]). Each entry pairs an RC preview's PNG filename pattern with a committed
+ * reference PNG.
  *
- * Dynamic tests so a missing reference is a single skip, not a spray
- * of assumeTrue failures. A per-test threshold lets stacks / state
- * variants float higher than tile while we tune.
+ * Dynamic tests so a missing reference is a single skip, not a spray of assumeTrue failures. A
+ * per-test threshold lets stacks / state variants float higher than tile while we tune.
  */
 class CardPixelDiffTest {
 
-    private data class Case(
-        val previewPattern: String,
-        val referenceRel: String,
-        val maxPct: Double = 30.0,
+  private data class Case(
+    val previewPattern: String,
+    val referenceRel: String,
+    val maxPct: Double = 30.0,
+  )
+
+  private val cases =
+    listOf(
+      // tile — pinned functions
+      Case(
+        "Tile_TemperatureSensor_tile_sensor_temperature",
+        "tile/temperature_sensor_light.png",
+        25.0,
+      ),
+      Case(
+        "Tile_TemperatureSensor_Dark_tile_sensor_temperature_dark",
+        "tile/temperature_sensor_dark.png",
+        25.0,
+      ),
+      Case("Tile_LightOn_tile_light_on", "tile/light_on_light.png", 25.0),
+      Case("Tile_LightOn_Dark_tile_light_on_dark", "tile/light_on_dark.png", 25.0),
+
+      // tile state variants — light theme
+      Case("Tile_Light_States_tile_light_light_off", "tile/light_off_light.png", 30.0),
+      Case("Tile_Lock_States_tile_lock_light_locked", "tile/lock_locked_light.png", 30.0),
+      Case("Tile_Cover_States_tile_cover_light_closed", "tile/cover_light.png", 40.0),
+
+      // button
+      Case("Button_Light_button_light_on", "button/light_on_light.png", 45.0),
+      Case("Button_Light_button_light_off", "button/light_off_light.png", 45.0),
+      Case("Button_Dark_button_dark_on", "button/light_on_dark.png", 45.0),
+      Case("Button_Dark_button_dark_off", "button/light_off_dark.png", 45.0),
+
+      // entity — TODO: HA's `entity` card is multi-row (big state,
+      // small unit, icon top-right), not a single row. Our
+      // RemoteHaEntityRow is the wrong primitive for this card.
+      // Skip for now; see docs/followups/entity-card-redesign.md.
+      //   Case("Entity_Light_entity_light", "entity/temperature_sensor_light.png", 35.0),
+      //   Case("Entity_Dark_entity_dark", "entity/temperature_sensor_dark.png", 35.0),
+
+      // entities / glance / markdown
+      Case("Entities_Light_entities_light", "entities/living_room_light.png", 40.0),
+      Case("Entities_Dark_entities_dark", "entities/living_room_dark.png", 40.0),
+      Case("Glance_Light_glance_light", "glance/overview_light.png", 40.0),
+      Case("Glance_Dark_glance_dark", "glance/overview_dark.png", 40.0),
+      Case("Markdown_Light_markdown_light", "markdown/notes_light.png", 40.0),
+      Case("Markdown_Dark_markdown_dark", "markdown/notes_dark.png", 40.0),
     )
 
-    private val cases = listOf(
-        // tile — pinned functions
-        Case("Tile_TemperatureSensor_tile_sensor_temperature", "tile/temperature_sensor_light.png", 25.0),
-        Case("Tile_TemperatureSensor_Dark_tile_sensor_temperature_dark", "tile/temperature_sensor_dark.png", 25.0),
-        Case("Tile_LightOn_tile_light_on", "tile/light_on_light.png", 25.0),
-        Case("Tile_LightOn_Dark_tile_light_on_dark", "tile/light_on_dark.png", 25.0),
-
-        // tile state variants — light theme
-        Case("Tile_Light_States_tile_light_light_off", "tile/light_off_light.png", 30.0),
-        Case("Tile_Lock_States_tile_lock_light_locked", "tile/lock_locked_light.png", 30.0),
-        Case("Tile_Cover_States_tile_cover_light_closed", "tile/cover_light.png", 40.0),
-
-        // button
-        Case("Button_Light_button_light_on", "button/light_on_light.png", 45.0),
-        Case("Button_Light_button_light_off", "button/light_off_light.png", 45.0),
-        Case("Button_Dark_button_dark_on", "button/light_on_dark.png", 45.0),
-        Case("Button_Dark_button_dark_off", "button/light_off_dark.png", 45.0),
-
-        // entity — TODO: HA's `entity` card is multi-row (big state,
-        // small unit, icon top-right), not a single row. Our
-        // RemoteHaEntityRow is the wrong primitive for this card.
-        // Skip for now; see docs/followups/entity-card-redesign.md.
-        //   Case("Entity_Light_entity_light", "entity/temperature_sensor_light.png", 35.0),
-        //   Case("Entity_Dark_entity_dark", "entity/temperature_sensor_dark.png", 35.0),
-
-        // entities / glance / markdown
-        Case("Entities_Light_entities_light", "entities/living_room_light.png", 40.0),
-        Case("Entities_Dark_entities_dark", "entities/living_room_dark.png", 40.0),
-        Case("Glance_Light_glance_light", "glance/overview_light.png", 40.0),
-        Case("Glance_Dark_glance_dark", "glance/overview_dark.png", 40.0),
-        Case("Markdown_Light_markdown_light", "markdown/notes_light.png", 40.0),
-        Case("Markdown_Dark_markdown_dark", "markdown/notes_dark.png", 40.0),
-    )
-
-    @TestFactory
-    fun allCards(): List<DynamicTest> = cases.map { case ->
-        DynamicTest.dynamicTest("${case.referenceRel} <= ${case.maxPct}%") {
-            val rendered = locateRendered(case.previewPattern)
-            val reference = referenceFile(case.referenceRel)
-            assumeTrue(reference.exists(), "reference ${case.referenceRel} missing")
-            val report = ImageDiff.compare(rendered, reference)
-            println(report)
-            if (report.pctChanged > case.maxPct) {
-                error("pixel diff above threshold: ${report.pctChanged}% > ${case.maxPct}% — $report")
-            }
-        }
+  @TestFactory
+  fun allCards(): List<DynamicTest> = cases.map { case ->
+    DynamicTest.dynamicTest("${case.referenceRel} <= ${case.maxPct}%") {
+      val rendered = locateRendered(case.previewPattern)
+      val reference = referenceFile(case.referenceRel)
+      assumeTrue(reference.exists(), "reference ${case.referenceRel} missing")
+      val report = ImageDiff.compare(rendered, reference)
+      println(report)
+      if (report.pctChanged > case.maxPct) {
+        error("pixel diff above threshold: ${report.pctChanged}% > ${case.maxPct}% — $report")
+      }
     }
+  }
 
-    private fun locateRendered(previewName: String): File {
-        val dir = File(System.getProperty("ha.rendered.dir") ?: "previews/build/compose-previews/renders")
-        val exact = dir.listFiles { f -> f.name.contains(previewName) && f.extension == "png" }
-        require(!exact.isNullOrEmpty()) {
-            "No rendered PNG matching '$previewName' under $dir — run scripts/render-previews.sh"
-        }
-        return exact.first()
+  private fun locateRendered(previewName: String): File {
+    val dir =
+      File(System.getProperty("ha.rendered.dir") ?: "previews/build/compose-previews/renders")
+    val exact = dir.listFiles { f -> f.name.contains(previewName) && f.extension == "png" }
+    require(!exact.isNullOrEmpty()) {
+      "No rendered PNG matching '$previewName' under $dir — run scripts/render-previews.sh"
     }
+    return exact.first()
+  }
 
-    private fun referenceFile(rel: String): File {
-        val dir = File(System.getProperty("ha.references.dir") ?: "references")
-        return File(dir, rel)
-    }
+  private fun referenceFile(rel: String): File {
+    val dir = File(System.getProperty("ha.references.dir") ?: "references")
+    return File(dir, rel)
+  }
 }

--- a/integration/src/test/kotlin/ee/schimke/ha/integration/ImageDiff.kt
+++ b/integration/src/test/kotlin/ee/schimke/ha/integration/ImageDiff.kt
@@ -1,70 +1,81 @@
 package ee.schimke.ha.integration
 
-import java.awt.image.BufferedImage
 import java.io.File
 import javax.imageio.ImageIO
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
-import kotlin.math.roundToInt
-import kotlin.math.sqrt
 
 /**
  * Tiny per-pixel image comparator — no external deps, just `javax.imageio`.
  *
- * Trades precision for clarity: compares two RGB buffers at their
- * intersection (smaller of the two in each dimension), treats any pixel
- * whose max-channel delta exceeds `tolerance` as "changed", and reports
- * overall percent-changed.
+ * Trades precision for clarity: compares two RGB buffers at their intersection (smaller of the two
+ * in each dimension), treats any pixel whose max-channel delta exceeds `tolerance` as "changed",
+ * and reports overall percent-changed.
  */
 object ImageDiff {
-    data class Report(
-        val aPath: String,
-        val bPath: String,
-        val width: Int,
-        val height: Int,
-        val changed: Int,
-        val total: Int,
-        val maxDelta: Int,
-    ) {
-        val pctChanged: Double get() = if (total == 0) 0.0 else 100.0 * changed / total
-        override fun toString(): String =
-            "%dx%d  changed=%.2f%% (%d/%d)  maxDelta=%d  a=%s  b=%s".format(
-                width, height, pctChanged, changed, total, maxDelta,
-                File(aPath).name, File(bPath).name,
-            )
-    }
+  data class Report(
+    val aPath: String,
+    val bPath: String,
+    val width: Int,
+    val height: Int,
+    val changed: Int,
+    val total: Int,
+    val maxDelta: Int,
+  ) {
+    val pctChanged: Double
+      get() = if (total == 0) 0.0 else 100.0 * changed / total
 
-    fun compare(a: File, b: File, tolerance: Int = 8): Report {
-        val ia = ImageIO.read(a) ?: error("can't decode $a")
-        val ib = ImageIO.read(b) ?: error("can't decode $b")
-        val w = min(ia.width, ib.width)
-        val h = min(ia.height, ib.height)
-
-        var changed = 0
-        var maxDelta = 0
-        for (y in 0 until h) {
-            for (x in 0 until w) {
-                val pa = ia.getRGB(x, y)
-                val pb = ib.getRGB(x, y)
-                if (pa == pb) continue
-                val delta = maxChannelDelta(pa, pb)
-                if (delta > maxDelta) maxDelta = delta
-                if (delta > tolerance) changed++
-            }
-        }
-        return Report(
-            aPath = a.absolutePath,
-            bPath = b.absolutePath,
-            width = w, height = h,
-            changed = changed, total = w * h,
-            maxDelta = maxDelta,
+    override fun toString(): String =
+      "%dx%d  changed=%.2f%% (%d/%d)  maxDelta=%d  a=%s  b=%s"
+        .format(
+          width,
+          height,
+          pctChanged,
+          changed,
+          total,
+          maxDelta,
+          File(aPath).name,
+          File(bPath).name,
         )
-    }
+  }
 
-    private fun maxChannelDelta(a: Int, b: Int): Int {
-        val ar = (a shr 16) and 0xff; val ag = (a shr 8) and 0xff; val ab = a and 0xff
-        val br = (b shr 16) and 0xff; val bg = (b shr 8) and 0xff; val bb = b and 0xff
-        return max(abs(ar - br), max(abs(ag - bg), abs(ab - bb)))
+  fun compare(a: File, b: File, tolerance: Int = 8): Report {
+    val ia = ImageIO.read(a) ?: error("can't decode $a")
+    val ib = ImageIO.read(b) ?: error("can't decode $b")
+    val w = min(ia.width, ib.width)
+    val h = min(ia.height, ib.height)
+
+    var changed = 0
+    var maxDelta = 0
+    for (y in 0 until h) {
+      for (x in 0 until w) {
+        val pa = ia.getRGB(x, y)
+        val pb = ib.getRGB(x, y)
+        if (pa == pb) continue
+        val delta = maxChannelDelta(pa, pb)
+        if (delta > maxDelta) maxDelta = delta
+        if (delta > tolerance) changed++
+      }
     }
+    return Report(
+      aPath = a.absolutePath,
+      bPath = b.absolutePath,
+      width = w,
+      height = h,
+      changed = changed,
+      total = w * h,
+      maxDelta = maxDelta,
+    )
+  }
+
+  private fun maxChannelDelta(a: Int, b: Int): Int {
+    val ar = (a shr 16) and 0xff
+    val ag = (a shr 8) and 0xff
+    val ab = a and 0xff
+    val br = (b shr 16) and 0xff
+    val bg = (b shr 8) and 0xff
+    val bb = b and 0xff
+    return max(abs(ar - br), max(abs(ag - bg), abs(ab - bb)))
+  }
 }

--- a/integration/src/test/kotlin/ee/schimke/ha/integration/TileCardPixelDiffTest.kt
+++ b/integration/src/test/kotlin/ee/schimke/ha/integration/TileCardPixelDiffTest.kt
@@ -1,73 +1,78 @@
 package ee.schimke.ha.integration
 
-import org.junit.jupiter.api.Assumptions.assumeTrue
-import org.junit.jupiter.api.Test
 import java.io.File
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
 
 /**
  * Pixel-level regression tests for the `tile` converter.
  *
  * Inputs:
- *  - `:previews:renderAllPreviews` output (absolute path via sysprop
- *    `ha.rendered.dir`), naming `<classFqn>.<fun>_<previewName>.png`.
- *  - Committed reference PNGs under `references/<card-type>/<name>.png`
- *    (absolute path via sysprop `ha.references.dir`), captured by
- *    `integration/scripts/capture-references.sh` against a real HA demo.
+ * - `:previews:renderAllPreviews` output (absolute path via sysprop `ha.rendered.dir`), naming
+ *   `<classFqn>.<fun>_<previewName>.png`.
+ * - Committed reference PNGs under `references/<card-type>/<name>.png` (absolute path via sysprop
+ *   `ha.references.dir`), captured by `integration/scripts/capture-references.sh` against a real HA
+ *   demo.
  *
- * Thresholds are intentionally generous while we iterate on the
- * converter — the immediate signal we care about is "regression from our
- * own previous output," not exact HA parity. Tighten `maxPctChanged` as
- * specific cards approach pixel parity.
+ * Thresholds are intentionally generous while we iterate on the converter — the immediate signal we
+ * care about is "regression from our own previous output," not exact HA parity. Tighten
+ * `maxPctChanged` as specific cards approach pixel parity.
  */
 class TileCardPixelDiffTest {
 
-    @Test fun temperatureSensor_light_matchesReference() = diff(
-        previewName = "Tile_TemperatureSensor_tile_sensor_temperature",
-        referenceRelPath = "tile/temperature_sensor_light.png",
+  @Test
+  fun temperatureSensor_light_matchesReference() =
+    diff(
+      previewName = "Tile_TemperatureSensor_tile_sensor_temperature",
+      referenceRelPath = "tile/temperature_sensor_light.png",
     )
 
-    @Test fun lightOn_light_matchesReference() = diff(
-        previewName = "Tile_LightOn_tile_light_on",
-        referenceRelPath = "tile/light_on_light.png",
+  @Test
+  fun lightOn_light_matchesReference() =
+    diff(previewName = "Tile_LightOn_tile_light_on", referenceRelPath = "tile/light_on_light.png")
+
+  @Test
+  fun temperatureSensor_dark_matchesReference() =
+    diff(
+      previewName = "Tile_TemperatureSensor_Dark_tile_sensor_temperature_dark",
+      referenceRelPath = "tile/temperature_sensor_dark.png",
     )
 
-    @Test fun temperatureSensor_dark_matchesReference() = diff(
-        previewName = "Tile_TemperatureSensor_Dark_tile_sensor_temperature_dark",
-        referenceRelPath = "tile/temperature_sensor_dark.png",
+  @Test
+  fun lightOn_dark_matchesReference() =
+    diff(
+      previewName = "Tile_LightOn_Dark_tile_light_on_dark",
+      referenceRelPath = "tile/light_on_dark.png",
     )
 
-    @Test fun lightOn_dark_matchesReference() = diff(
-        previewName = "Tile_LightOn_Dark_tile_light_on_dark",
-        referenceRelPath = "tile/light_on_dark.png",
+  private fun diff(previewName: String, referenceRelPath: String, maxPctChanged: Double = 25.0) {
+    val rendered = locateRendered(previewName)
+    val reference = referenceFile(referenceRelPath)
+    assumeTrue(
+      reference.exists(),
+      "reference $referenceRelPath missing — run integration/scripts/capture-references.sh",
     )
+    val report = ImageDiff.compare(rendered, reference)
+    println(report)
+    assertTrue(
+      report.pctChanged <= maxPctChanged,
+      "pixel diff above threshold: ${report.pctChanged}% > $maxPctChanged% — $report",
+    )
+  }
 
-    private fun diff(previewName: String, referenceRelPath: String, maxPctChanged: Double = 25.0) {
-        val rendered = locateRendered(previewName)
-        val reference = referenceFile(referenceRelPath)
-        assumeTrue(
-            reference.exists(),
-            "reference $referenceRelPath missing — run integration/scripts/capture-references.sh",
-        )
-        val report = ImageDiff.compare(rendered, reference)
-        println(report)
-        assertTrue(
-            report.pctChanged <= maxPctChanged,
-            "pixel diff above threshold: ${report.pctChanged}% > $maxPctChanged% — $report",
-        )
+  private fun locateRendered(previewName: String): File {
+    val dir =
+      File(System.getProperty("ha.rendered.dir") ?: "previews/build/compose-previews/renders")
+    val exact = dir.listFiles { f -> f.name.contains(previewName) && f.extension == "png" }
+    require(!exact.isNullOrEmpty()) {
+      "No rendered PNG matching '$previewName' under $dir — run ./gradlew :previews:renderAllPreviews"
     }
+    return exact.first()
+  }
 
-    private fun locateRendered(previewName: String): File {
-        val dir = File(System.getProperty("ha.rendered.dir") ?: "previews/build/compose-previews/renders")
-        val exact = dir.listFiles { f -> f.name.contains(previewName) && f.extension == "png" }
-        require(!exact.isNullOrEmpty()) {
-            "No rendered PNG matching '$previewName' under $dir — run ./gradlew :previews:renderAllPreviews"
-        }
-        return exact.first()
-    }
-
-    private fun referenceFile(rel: String): File {
-        val dir = File(System.getProperty("ha.references.dir") ?: "references")
-        return File(dir, rel)
-    }
+  private fun referenceFile(rel: String): File {
+    val dir = File(System.getProperty("ha.references.dir") ?: "references")
+    return File(dir, rel)
+  }
 }

--- a/previews/build.gradle.kts
+++ b/previews/build.gradle.kts
@@ -1,47 +1,45 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.compose.preview)
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.compose.preview)
 }
 
 android {
-    namespace = "ee.schimke.ha.previews"
-    compileSdk = libs.versions.android.compileSdk.get().toInt()
-    defaultConfig {
-        minSdk = libs.versions.android.minSdk.get().toInt()
-    }
-    buildFeatures { compose = true }
-    compileOptions {
-        sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-        targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-    }
-    kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
+  namespace = "ee.schimke.ha.previews"
+  compileSdk = libs.versions.android.compileSdk.get().toInt()
+  defaultConfig { minSdk = libs.versions.android.minSdk.get().toInt() }
+  buildFeatures { compose = true }
+  compileOptions {
+    sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+    targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+  }
+  kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
 }
 
 composePreview {
-    variant.set("debug")
-    sdkVersion.set(35)
-    enabled.set(true)
+  variant.set("debug")
+  sdkVersion.set(35)
+  enabled.set(true)
 }
 
 dependencies {
-    implementation(project(":ha-model"))
-    implementation(project(":rc-converter"))
-    implementation(project(":rc-card-shutter"))
+  implementation(project(":ha-model"))
+  implementation(project(":rc-converter"))
+  implementation(project(":rc-card-shutter"))
 
-    implementation(platform(libs.compose.bom))
-    implementation(libs.compose.ui)
-    implementation(libs.compose.foundation)
-    implementation(libs.compose.material3)
-    implementation(libs.compose.ui.tooling.preview)
-    debugImplementation(libs.compose.ui.tooling)
+  implementation(platform(libs.compose.bom))
+  implementation(libs.compose.ui)
+  implementation(libs.compose.foundation)
+  implementation(libs.compose.material3)
+  implementation(libs.compose.ui.tooling.preview)
+  debugImplementation(libs.compose.ui.tooling)
 
-    implementation(libs.remote.creation.compose)
-    implementation(libs.remote.creation.android)
-    implementation(libs.remote.creation.core)
-    implementation(libs.remote.player.compose)
-    implementation(libs.remote.player.view)
-    implementation(libs.remote.tooling.preview)
+  implementation(libs.remote.creation.compose)
+  implementation(libs.remote.creation.android)
+  implementation(libs.remote.creation.core)
+  implementation(libs.remote.player.compose)
+  implementation(libs.remote.player.view)
+  implementation(libs.remote.tooling.preview)
 
-    implementation(libs.kotlinx.serialization.json)
+  implementation(libs.kotlinx.serialization.json)
 }

--- a/rc-card-shutter/build.gradle.kts
+++ b/rc-card-shutter/build.gradle.kts
@@ -1,41 +1,39 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.kotlin.serialization)
 }
 
 android {
-    namespace = "ee.schimke.ha.rc.cards.shutter"
-    compileSdk = libs.versions.android.compileSdk.get().toInt()
-    defaultConfig {
-        minSdk = libs.versions.android.minSdk.get().toInt()
-    }
-    buildFeatures { compose = true }
-    compileOptions {
-        sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-        targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-    }
-    kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
+  namespace = "ee.schimke.ha.rc.cards.shutter"
+  compileSdk = libs.versions.android.compileSdk.get().toInt()
+  defaultConfig { minSdk = libs.versions.android.minSdk.get().toInt() }
+  buildFeatures { compose = true }
+  compileOptions {
+    sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+    targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+  }
+  kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
 }
 
 dependencies {
-    api(project(":rc-converter"))
-    api(project(":rc-components"))
-    implementation(project(":ha-model"))
+  api(project(":rc-converter"))
+  api(project(":rc-components"))
+  implementation(project(":ha-model"))
 
-    implementation(platform(libs.compose.bom))
-    implementation(libs.compose.ui)
-    implementation(libs.compose.foundation)
-    implementation(libs.compose.material3)
-    implementation(libs.compose.material.icons.extended)
+  implementation(platform(libs.compose.bom))
+  implementation(libs.compose.ui)
+  implementation(libs.compose.foundation)
+  implementation(libs.compose.material3)
+  implementation(libs.compose.material.icons.extended)
 
-    implementation(libs.remote.creation.compose)
-    implementation(libs.remote.creation.android)
-    implementation(libs.remote.creation.core)
-    implementation(libs.remote.core)
-    implementation(libs.remote.material3)
+  implementation(libs.remote.creation.compose)
+  implementation(libs.remote.creation.android)
+  implementation(libs.remote.creation.core)
+  implementation(libs.remote.core)
+  implementation(libs.remote.material3)
 
-    implementation(libs.kotlinx.serialization.json)
+  implementation(libs.kotlinx.serialization.json)
 
-    testImplementation(libs.kotlin.test)
+  testImplementation(libs.kotlin.test)
 }

--- a/rc-components/build.gradle.kts
+++ b/rc-components/build.gradle.kts
@@ -1,39 +1,37 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.kotlin.serialization)
 }
 
 android {
-    namespace = "ee.schimke.ha.rc.components"
-    compileSdk = libs.versions.android.compileSdk.get().toInt()
-    defaultConfig {
-        minSdk = libs.versions.android.minSdk.get().toInt()
-    }
-    buildFeatures { compose = true }
-    compileOptions {
-        sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-        targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-    }
-    kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
+  namespace = "ee.schimke.ha.rc.components"
+  compileSdk = libs.versions.android.compileSdk.get().toInt()
+  defaultConfig { minSdk = libs.versions.android.minSdk.get().toInt() }
+  buildFeatures { compose = true }
+  compileOptions {
+    sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+    targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+  }
+  kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
 }
 
 dependencies {
-    implementation(platform(libs.compose.bom))
-    implementation(libs.compose.ui)
-    implementation(libs.compose.foundation)
-    implementation(libs.compose.material3)
-    implementation(libs.compose.material.icons.extended)
-    implementation(libs.compose.ui.text.google.fonts)
-    api(libs.materialkolor)
+  implementation(platform(libs.compose.bom))
+  implementation(libs.compose.ui)
+  implementation(libs.compose.foundation)
+  implementation(libs.compose.material3)
+  implementation(libs.compose.material.icons.extended)
+  implementation(libs.compose.ui.text.google.fonts)
+  api(libs.materialkolor)
 
-    implementation(libs.remote.creation.compose)
-    implementation(libs.remote.creation.android)
-    implementation(libs.remote.creation.core)
-    implementation(libs.remote.core)
-    implementation(libs.remote.material3)
+  implementation(libs.remote.creation.compose)
+  implementation(libs.remote.creation.android)
+  implementation(libs.remote.creation.core)
+  implementation(libs.remote.core)
+  implementation(libs.remote.material3)
 
-    implementation(libs.kotlinx.serialization.json)
+  implementation(libs.kotlinx.serialization.json)
 
-    testImplementation(libs.kotlin.test)
+  testImplementation(libs.kotlin.test)
 }

--- a/rc-converter/build.gradle.kts
+++ b/rc-converter/build.gradle.kts
@@ -1,42 +1,40 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.compose.compiler)
 }
 
 android {
-    namespace = "ee.schimke.ha.rc"
-    compileSdk = libs.versions.android.compileSdk.get().toInt()
-    defaultConfig {
-        minSdk = libs.versions.android.minSdk.get().toInt()
-    }
-    buildFeatures { compose = true }
-    compileOptions {
-        sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-        targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-    }
-    kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
+  namespace = "ee.schimke.ha.rc"
+  compileSdk = libs.versions.android.compileSdk.get().toInt()
+  defaultConfig { minSdk = libs.versions.android.minSdk.get().toInt() }
+  buildFeatures { compose = true }
+  compileOptions {
+    sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+    targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+  }
+  kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
 }
 
 dependencies {
-    api(project(":rc-components"))
-    implementation(project(":ha-model"))
-    implementation(project(":ha-client"))
+  api(project(":rc-components"))
+  implementation(project(":ha-model"))
+  implementation(project(":ha-client"))
 
-    implementation(platform(libs.compose.bom))
-    implementation(libs.compose.ui)
-    implementation(libs.compose.foundation)
-    implementation(libs.compose.material3)
-    implementation(libs.compose.material.icons.extended)
+  implementation(platform(libs.compose.bom))
+  implementation(libs.compose.ui)
+  implementation(libs.compose.foundation)
+  implementation(libs.compose.material3)
+  implementation(libs.compose.material.icons.extended)
 
-    // RemoteCompose authoring + playback
-    implementation(libs.remote.creation.compose)
-    implementation(libs.remote.creation.android)
-    implementation(libs.remote.creation.core)
-    implementation(libs.remote.core)
-    implementation(libs.remote.player.core)
-    implementation(libs.remote.player.compose)
-    implementation(libs.remote.player.view)
-    implementation(libs.remote.material3)
+  // RemoteCompose authoring + playback
+  implementation(libs.remote.creation.compose)
+  implementation(libs.remote.creation.android)
+  implementation(libs.remote.creation.core)
+  implementation(libs.remote.core)
+  implementation(libs.remote.player.core)
+  implementation(libs.remote.player.compose)
+  implementation(libs.remote.player.view)
+  implementation(libs.remote.material3)
 
-    testImplementation(libs.kotlin.test)
+  testImplementation(libs.kotlin.test)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,39 +1,39 @@
 pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        google {
-            content {
-                includeGroupByRegex("com\\.android.*")
-                includeGroupByRegex("com\\.google.*")
-                includeGroupByRegex("androidx.*")
-            }
-        }
-        mavenCentral()
+  repositories {
+    gradlePluginPortal()
+    google {
+      content {
+        includeGroupByRegex("com\\.android.*")
+        includeGroupByRegex("com\\.google.*")
+        includeGroupByRegex("androidx.*")
+      }
     }
+    mavenCentral()
+  }
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-        google()
-        mavenCentral()
-    }
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositories {
+    google()
+    mavenCentral()
+  }
 }
 
 rootProject.name = "homeassistant-remotecompose"
 
 include(
-    ":ha-model",
-    ":ha-client",
-    ":rc-components",
-    ":rc-converter",
-    ":rc-card-shutter",
-    ":previews",
-    ":demo-app",
-    ":terrazzo-core",
-    ":app",
-    ":wear",
-    ":tv",
-    ":integration",
-    ":addon-server",
+  ":ha-model",
+  ":ha-client",
+  ":rc-components",
+  ":rc-converter",
+  ":rc-card-shutter",
+  ":previews",
+  ":demo-app",
+  ":terrazzo-core",
+  ":app",
+  ":wear",
+  ":tv",
+  ":integration",
+  ":addon-server",
 )

--- a/terrazzo-core/build.gradle.kts
+++ b/terrazzo-core/build.gradle.kts
@@ -1,30 +1,30 @@
 plugins {
-    alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.android.kmp.library)
-    alias(libs.plugins.metro)
+  alias(libs.plugins.kotlin.multiplatform)
+  alias(libs.plugins.android.kmp.library)
+  alias(libs.plugins.metro)
 }
 
 kotlin {
-    jvmToolchain(libs.versions.java.get().toInt())
+  jvmToolchain(libs.versions.java.get().toInt())
 
-    androidLibrary {
-        namespace = "ee.schimke.terrazzo.core"
-        compileSdk = libs.versions.android.compileSdk.get().toInt()
-        // RemoteCompose widget needs API 35+; align with :app so Android
-        // sources can reference the same platform APIs.
-        minSdk = 35
-    }
+  androidLibrary {
+    namespace = "ee.schimke.terrazzo.core"
+    compileSdk = libs.versions.android.compileSdk.get().toInt()
+    // RemoteCompose widget needs API 35+; align with :app so Android
+    // sources can reference the same platform APIs.
+    minSdk = 35
+  }
 
-    sourceSets {
-        commonMain.dependencies {
-            implementation(project(":ha-model"))
-            implementation(project(":ha-client"))
-            implementation(libs.kotlinx.coroutines.core)
-            implementation(libs.kotlinx.serialization.json)
-        }
-        androidMain.dependencies {
-            implementation(libs.androidx.datastore.preferences)
-            implementation(libs.appauth)
-        }
+  sourceSets {
+    commonMain.dependencies {
+      implementation(project(":ha-model"))
+      implementation(project(":ha-client"))
+      implementation(libs.kotlinx.coroutines.core)
+      implementation(libs.kotlinx.serialization.json)
     }
+    androidMain.dependencies {
+      implementation(libs.androidx.datastore.preferences)
+      implementation(libs.appauth)
+    }
+  }
 }

--- a/terrazzo-core/src/commonMain/kotlin/ee/schimke/terrazzo/core/di/AppScope.kt
+++ b/terrazzo-core/src/commonMain/kotlin/ee/schimke/terrazzo/core/di/AppScope.kt
@@ -3,8 +3,7 @@ package ee.schimke.terrazzo.core.di
 import dev.zacsweers.metro.Scope
 
 /**
- * Process-wide scope. Graph bindings marked `@SingleIn(AppScope::class)`
- * get a single instance per graph (i.e. per `Application`).
+ * Process-wide scope. Graph bindings marked `@SingleIn(AppScope::class)` get a single instance per
+ * graph (i.e. per `Application`).
  */
-@Scope
-annotation class AppScope
+@Scope annotation class AppScope

--- a/tv/build.gradle.kts
+++ b/tv/build.gradle.kts
@@ -1,50 +1,50 @@
 plugins {
-    alias(libs.plugins.android.application)
-    alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.compose.preview)
+  alias(libs.plugins.android.application)
+  alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.compose.preview)
 }
 
 android {
-    namespace = "ee.schimke.terrazzo.tv"
-    compileSdk = libs.versions.android.compileSdk.get().toInt()
-    defaultConfig {
-        applicationId = "ee.schimke.terrazzo.tv"
-        // Match rc-components' minSdk (29). Android TV 10 (API 29) is
-        // a reasonable floor for HA dashboards; dropping lower would
-        // need a tools:overrideLibrary escape hatch.
-        minSdk = libs.versions.android.minSdk.get().toInt()
-        targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 1
-        versionName = "0.1.0"
-    }
-    buildFeatures { compose = true }
-    compileOptions {
-        sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-        targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-    }
-    kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
+  namespace = "ee.schimke.terrazzo.tv"
+  compileSdk = libs.versions.android.compileSdk.get().toInt()
+  defaultConfig {
+    applicationId = "ee.schimke.terrazzo.tv"
+    // Match rc-components' minSdk (29). Android TV 10 (API 29) is
+    // a reasonable floor for HA dashboards; dropping lower would
+    // need a tools:overrideLibrary escape hatch.
+    minSdk = libs.versions.android.minSdk.get().toInt()
+    targetSdk = libs.versions.android.targetSdk.get().toInt()
+    versionCode = 1
+    versionName = "0.1.0"
+  }
+  buildFeatures { compose = true }
+  compileOptions {
+    sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+    targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+  }
+  kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
 }
 
 composePreview {
-    variant.set("debug")
-    sdkVersion.set(34)
-    enabled.set(true)
+  variant.set("debug")
+  sdkVersion.set(34)
+  enabled.set(true)
 }
 
 dependencies {
-    implementation(project(":rc-components"))
+  implementation(project(":rc-components"))
 
-    implementation(platform(libs.compose.bom))
-    implementation(libs.compose.ui)
-    implementation(libs.compose.foundation)
-    implementation(libs.compose.material3)
-    implementation(libs.compose.ui.text.google.fonts)
-    implementation(libs.compose.ui.tooling.preview)
-    debugImplementation(libs.compose.ui.tooling)
-    implementation(libs.activity.compose)
+  implementation(platform(libs.compose.bom))
+  implementation(libs.compose.ui)
+  implementation(libs.compose.foundation)
+  implementation(libs.compose.material3)
+  implementation(libs.compose.ui.text.google.fonts)
+  implementation(libs.compose.ui.tooling.preview)
+  debugImplementation(libs.compose.ui.tooling)
+  implementation(libs.activity.compose)
 
-    implementation(libs.tv.material)
+  implementation(libs.tv.material)
 
-    implementation(libs.androidx.datastore.preferences)
-    implementation(libs.kotlinx.coroutines.core)
+  implementation(libs.androidx.datastore.preferences)
+  implementation(libs.kotlinx.coroutines.core)
 }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -1,66 +1,67 @@
 plugins {
-    alias(libs.plugins.android.application)
-    alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.compose.preview)
-    alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.android.application)
+  alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.compose.preview)
+  alias(libs.plugins.kotlin.serialization)
 }
 
 android {
-    namespace = "ee.schimke.terrazzo.wear"
-    compileSdk = libs.versions.android.compileSdk.get().toInt()
-    defaultConfig {
-        applicationId = "ee.schimke.terrazzo.wear"
-        minSdk = 30
-        targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 1
-        versionName = "0.1.0"
-    }
-    buildFeatures { compose = true }
-    compileOptions {
-        sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-        targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-    }
-    kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
+  namespace = "ee.schimke.terrazzo.wear"
+  compileSdk = libs.versions.android.compileSdk.get().toInt()
+  defaultConfig {
+    applicationId = "ee.schimke.terrazzo.wear"
+    minSdk = 30
+    targetSdk = libs.versions.android.targetSdk.get().toInt()
+    versionCode = 1
+    versionName = "0.1.0"
+  }
+  buildFeatures { compose = true }
+  compileOptions {
+    sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+    targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+  }
+  kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
 }
 
 composePreview {
-    variant.set("debug")
-    sdkVersion.set(34)
-    enabled.set(true)
+  variant.set("debug")
+  sdkVersion.set(34)
+  enabled.set(true)
 }
 
 dependencies {
-    implementation(project(":rc-components"))
-    implementation(project(":ha-model"))
+  implementation(project(":rc-components"))
+  implementation(project(":ha-model"))
 
-    implementation(platform(libs.compose.bom))
-    implementation(libs.compose.ui)
-    implementation(libs.compose.foundation)
-    // `rc-components` exposes terrazzoColorScheme returning an androidx.compose.material3 ColorScheme;
-    // we include material3 here only to unpack that for the Wear `ColorScheme.copy(...)` mapping.
-    implementation(libs.compose.material3)
-    implementation(libs.compose.ui.text.google.fonts)
-    implementation(libs.compose.ui.tooling.preview)
-    debugImplementation(libs.compose.ui.tooling)
-    implementation(libs.activity.compose)
+  implementation(platform(libs.compose.bom))
+  implementation(libs.compose.ui)
+  implementation(libs.compose.foundation)
+  // `rc-components` exposes terrazzoColorScheme returning an androidx.compose.material3
+  // ColorScheme;
+  // we include material3 here only to unpack that for the Wear `ColorScheme.copy(...)` mapping.
+  implementation(libs.compose.material3)
+  implementation(libs.compose.ui.text.google.fonts)
+  implementation(libs.compose.ui.tooling.preview)
+  debugImplementation(libs.compose.ui.tooling)
+  implementation(libs.activity.compose)
 
-    implementation(libs.wear.compose.material3)
-    implementation(libs.wear.compose.foundation)
+  implementation(libs.wear.compose.material3)
+  implementation(libs.wear.compose.foundation)
 
-    // Proto DataStore + Horologist data layer for sync with phone.
-    // Schema is documented in `src/main/proto/wear_sync.proto`; we
-    // encode @Serializable Kotlin data classes to the same proto wire
-    // format via kotlinx-serialization-protobuf. (TODO: switch to Wire
-    // once its Gradle plugin recognises AGP 9's built-in Kotlin.)
-    implementation(libs.androidx.datastore)
-    implementation(libs.androidx.datastore.preferences)
-    implementation(libs.kotlinx.serialization.protobuf)
-    implementation(libs.play.services.wearable)
-    implementation(libs.horologist.datalayer)
-    implementation(libs.horologist.datalayer.watch)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.lifecycle.process)
+  // Proto DataStore + Horologist data layer for sync with phone.
+  // Schema is documented in `src/main/proto/wear_sync.proto`; we
+  // encode @Serializable Kotlin data classes to the same proto wire
+  // format via kotlinx-serialization-protobuf. (TODO: switch to Wire
+  // once its Gradle plugin recognises AGP 9's built-in Kotlin.)
+  implementation(libs.androidx.datastore)
+  implementation(libs.androidx.datastore.preferences)
+  implementation(libs.kotlinx.serialization.protobuf)
+  implementation(libs.play.services.wearable)
+  implementation(libs.horologist.datalayer)
+  implementation(libs.horologist.datalayer.watch)
+  implementation(libs.androidx.lifecycle.runtime.ktx)
+  implementation(libs.androidx.lifecycle.process)
 
-    implementation(libs.kotlinx.coroutines.core)
-    implementation(libs.kotlinx.serialization.json)
+  implementation(libs.kotlinx.coroutines.core)
+  implementation(libs.kotlinx.serialization.json)
 }


### PR DESCRIPTION
## Summary

- Whole-tree result of `./gradlew ktfmtFormat` against the ktfmt setup landed in #28 (Google style, 2-space, 100-col).
- Pure whitespace / line-wrapping changes — no semantic edits.
- `./gradlew ktfmtCheck` is clean across all 20 source sets after this PR, so the `ktfmt` workflow added in #28 will go green.
- 42 files touched (mostly `*.gradle.kts` and a handful of `.kt` files in `addon-server`, `ha-client`, `ha-model`, `integration`, `terrazzo-core`).

Best reviewed with whitespace ignored: append `?w=1` to the diff URL or `git diff --ignore-all-space main...agent/ktfmt-reformat` locally.

## Test plan

- [ ] CI: the new `ktfmt` workflow goes green (it failed on `main` until this lands)
- [ ] CI: existing `CI` workflow (assemble, test, lint, instrumented) still green — ktfmt is AST-preserving so this should be a no-op for compilation
- [ ] Spot-check the rendered diff with whitespace ignored to confirm there are no semantic changes


---
_Generated by [Claude Code](https://claude.ai/code/session_014HpHfoA7MhRHBeYuiW7F2v)_