### PR TITLE
Make mobile, wear, and TV apps offline-first

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,6 +93,24 @@ dependencies {
 
   testImplementation(libs.kotlin.test.junit)
   testImplementation(libs.kotlinx.coroutines.test)
+  // Offline-first integration tests spin up real fake servers so the
+  // round-trip through HaClient (WebSocket) and AddonClient (HTTP) is
+  // exercised against an actual socket — not a Ktor MockEngine.
+  //
+  //   - mockserver-netty for HTTP REST endpoints (AddonClient probe +
+  //     dashboard fetch). Picked over OkHttp's MockWebServer because
+  //     mockserver's expectations API is closer to integration-test
+  //     ergonomics for offline-first scenarios.
+  //   - ktor-server-cio + ktor-server-websockets for the HA-protocol
+  //     WebSocket fake. mockserver's WebSocket support is for its own
+  //     callback infrastructure, not for serving an arbitrary text-
+  //     based protocol like HA's auth_required / commands-by-id; Ktor
+  //     server is already a project dep (used by the addon-server
+  //     module) and is a natural fit.
+  testImplementation(libs.mockserver.netty)
+  testImplementation(libs.mockserver.client.java)
+  testImplementation(libs.ktor.server.cio)
+  testImplementation(libs.ktor.server.websockets)
 
   androidTestImplementation(libs.androidx.test.ext.junit)
   androidTestImplementation(libs.androidx.test.runner)

--- a/app/src/main/kotlin/ee/schimke/terrazzo/MainActivity.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/MainActivity.kt
@@ -37,6 +37,16 @@ class MainActivity : ComponentActivity() {
         // pattern as the test hatch above.
         val initialDashboard = runBlocking { graph.preferencesStore.lastViewedDashboardNow() }
 
+        // Offline-first cold start: if a previous session left an
+        // instance pointer on disk, build a cache-only session so the
+        // first composition paints immediately from cached dashboards
+        // and snapshots — no spinner, no network roundtrip. The login
+        // flow upgrades this to a live session as soon as the access
+        // token is minted (see TerrazzoApp.LaunchedEffect that calls
+        // sessionFactory.create with a fresh access token).
+        val initialInstance = graph.offlineCache.lastInstance()
+        val initialSession = initialInstance?.let { graph.sessionFactory.createCachedOnly(it) }
+
         setContent {
             CompositionLocalProvider(LocalTerrazzoGraph provides graph) {
                 val themePref by graph.preferencesStore.themeStyle
@@ -44,7 +54,10 @@ class MainActivity : ComponentActivity() {
                 val darkPref by graph.preferencesStore.darkMode
                     .collectAsState(initial = DarkModePref.Follow)
                 TerrazzoTheme(style = themePref.toThemeStyle(), darkMode = darkPref) {
-                    TerrazzoApp(initialDashboard = initialDashboard)
+                    TerrazzoApp(
+                        initialDashboard = initialDashboard,
+                        initialSession = initialSession,
+                    )
                 }
             }
         }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -77,11 +77,15 @@ import kotlinx.coroutines.launch
  * app can be explored without a working HA instance.
  */
 @Composable
-fun TerrazzoApp(initialDashboard: String? = null) {
-    // NOTE: not saveable — an HaSession owns a live WebSocket. Process
-    // restart re-walks the discovery / login flow. The refresh token in
-    // TokenVault means we can auto-sign-in silently once we wire that up.
-    var session by remember { mutableStateOf<HaSession?>(null) }
+fun TerrazzoApp(
+    initialDashboard: String? = null,
+    initialSession: HaSession? = null,
+) {
+    // Cold-start auto-resume: [initialSession] is a cache-only session
+    // built in MainActivity from the last-known instance, so the first
+    // frame paints from disk while we re-mint the access token in the
+    // background. A new sign-in or demo toggle replaces this state.
+    var session by remember { mutableStateOf(initialSession) }
     var lastError by remember { mutableStateOf<Throwable?>(null) }
 
     val graph = LocalTerrazzoGraph.current
@@ -95,10 +99,12 @@ fun TerrazzoApp(initialDashboard: String? = null) {
     // Persisted demo-mode flag survives process restarts, so a user who
     // opted into demo doesn't see the login screen again on relaunch.
     // Also re-arms the widget refresh chain in case the worker queue
-    // was flushed (e.g. "Clear data" via system Settings).
+    // was flushed (e.g. "Clear data" via system Settings). When a
+    // cache-only [initialSession] was passed in (cold-start auto-resume
+    // from a prior login), the demo path overrides it.
     LaunchedEffect(Unit) {
         if (graph.preferencesStore.demoModeNow()) {
-            if (session == null) session = graph.sessionFactory.createDemo()
+            session = graph.sessionFactory.createDemo()
             widgetScheduler.scheduleDemo()
         }
     }
@@ -149,9 +155,18 @@ fun TerrazzoApp(initialDashboard: String? = null) {
             },
             onSignOut = {
                 val previous = session
+                val previousBaseUrl = previous?.baseUrl
                 scope.launch {
                     graph.preferencesStore.setDemoMode(false)
                     graph.preferencesStore.clearLastViewedDashboard()
+                    // Wipe cached dashboards / snapshots and the
+                    // refresh-token vault entry so the next user on
+                    // this device can't read the previous account's
+                    // data, and so cold start goes back to discovery.
+                    if (previousBaseUrl != null) {
+                        graph.offlineCache.clearInstance(previousBaseUrl)
+                        runCatching { graph.tokenVault.clear(previousBaseUrl) }
+                    }
                     previous?.close()
                 }
                 widgetScheduler.cancelDemo()

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardListState.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardListState.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import ee.schimke.ha.client.DashboardSummary
+import ee.schimke.terrazzo.LocalTerrazzoGraph
 import ee.schimke.terrazzo.core.session.HaSession
 
 /**
@@ -40,20 +41,35 @@ sealed interface DashboardListState {
  */
 @Composable
 fun rememberDashboardListState(session: HaSession): State<DashboardListState> {
-    val state = remember(session) { mutableStateOf<DashboardListState>(DashboardListState.Loading) }
+    val cache = LocalTerrazzoGraph.current.offlineCache
+    // Seed from disk synchronously so the first composition paints
+    // already-known dashboards instead of the loading spinner. The
+    // background fetch then upgrades the value to live data; failures
+    // leave the cached list in place so an offline relaunch still
+    // shows the picker.
+    val state = remember(session) {
+        val seed = cache.dashboards(session.baseUrl)
+            ?.let { DashboardListState.Ready(it.ifNotEmptyOrHomeFallback()) }
+            ?: DashboardListState.Loading
+        mutableStateOf<DashboardListState>(seed)
+    }
     LaunchedEffect(session) {
         runCatching {
             session.connect()
             session.listDashboards()
         }.onSuccess { list ->
-            state.value = DashboardListState.Ready(
-                dashboards = list.ifEmpty {
-                    listOf(DashboardSummary(urlPath = null, title = "Home"))
-                },
-            )
+            state.value = DashboardListState.Ready(list.ifNotEmptyOrHomeFallback())
         }.onFailure {
-            state.value = DashboardListState.Error(it.message ?: it::class.simpleName ?: "error")
+            // Only flip to Error if we have nothing to show. A cached
+            // list is more useful than a blank error screen.
+            if (state.value !is DashboardListState.Ready) {
+                state.value =
+                    DashboardListState.Error(it.message ?: it::class.simpleName ?: "error")
+            }
         }
     }
     return state
 }
+
+private fun List<DashboardSummary>.ifNotEmptyOrHomeFallback(): List<DashboardSummary> =
+    ifEmpty { listOf(DashboardSummary(urlPath = null, title = "Home")) }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.remote.tooling.preview.RemotePreview
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.Dashboard
 import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.terrazzo.LocalTerrazzoGraph
 import ee.schimke.terrazzo.core.session.HaSession
 import ee.schimke.ha.rc.CardWidthClass
 import ee.schimke.ha.rc.ProvideCardRegistry
@@ -83,10 +84,21 @@ fun DashboardViewScreen(
     onCardLongPress: (CardConfig) -> Unit,
     contentPadding: PaddingValues = PaddingValues(0.dp),
 ) {
-    var state by remember(session, urlPath) { mutableStateOf<DashboardState>(DashboardState.Loading) }
+    val cache = LocalTerrazzoGraph.current.offlineCache
+    // Seed from disk so the first composition shows the last-known
+    // dashboard + snapshot instead of a spinner. The polling loop
+    // refreshes in place; transient failures don't blank the UI
+    // because Ready isn't reset on failure.
+    var state by remember(session, urlPath) {
+        val cachedDashboard = cache.dashboard(session.baseUrl, urlPath)
+        val cachedSnapshot = cache.snapshot(session.baseUrl, urlPath) ?: HaSnapshot()
+        val seed: DashboardState =
+            cachedDashboard?.let { DashboardState.Ready(it, cachedSnapshot) }
+                ?: DashboardState.Loading
+        mutableStateOf(seed)
+    }
 
     LaunchedEffect(session, urlPath) {
-        state = DashboardState.Loading
         // Poll when the session opts in (demo mode does, at ~2s) so
         // values visibly change; a one-shot fetch otherwise.
         while (true) {

--- a/app/src/test/kotlin/ee/schimke/terrazzo/core/cache/OfflineCacheTest.kt
+++ b/app/src/test/kotlin/ee/schimke/terrazzo/core/cache/OfflineCacheTest.kt
@@ -1,0 +1,154 @@
+package ee.schimke.terrazzo.core.cache
+
+import ee.schimke.ha.client.DashboardSummary
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.Dashboard
+import ee.schimke.ha.model.EntityState
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.model.View
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Verifies the offline-first contract: writes are durable, reads are
+ * keyed correctly, and missing entries return null without throwing
+ * (so the UI can treat absence as "no cache yet" instead of an error).
+ */
+class OfflineCacheTest {
+
+  private val instance = "http://homeassistant.local:8123"
+  private val instance2 = "https://other.example/"
+
+  private fun cache(): OfflineCacheStorage =
+    OfflineCacheStorage(Files.createTempDirectory("offline-cache-test").toFile())
+
+  @Test
+  fun lastInstance_round_trips() {
+    val c = cache()
+    assertNull(c.lastInstance())
+    c.setLastInstance(instance)
+    assertEquals(instance, c.lastInstance())
+    c.clearLastInstance()
+    assertNull(c.lastInstance())
+  }
+
+  @Test
+  fun dashboards_round_trip_per_instance() {
+    val c = cache()
+    val list =
+      listOf(
+        DashboardSummary(urlPath = null, title = "Home"),
+        DashboardSummary(urlPath = "office", title = "Office"),
+      )
+    c.putDashboards(instance, list)
+    assertEquals(list, c.dashboards(instance))
+    // Different instance has its own slot, not shared.
+    assertNull(c.dashboards(instance2))
+  }
+
+  @Test
+  fun dashboard_and_snapshot_round_trip_per_url_path() {
+    val c = cache()
+    val home =
+      Dashboard(
+        title = "Home",
+        views = listOf(View(cards = listOf(CardConfig(type = "tile")))),
+      )
+    val homeSnap =
+      HaSnapshot(
+        states =
+          mapOf("light.kitchen" to EntityState(entityId = "light.kitchen", state = "on")),
+      )
+
+    c.putDashboard(instance, urlPath = null, dashboard = home)
+    c.putSnapshot(instance, urlPath = null, snapshot = homeSnap)
+
+    assertEquals(home, c.dashboard(instance, null))
+    assertEquals(homeSnap, c.snapshot(instance, null))
+
+    // A different urlPath has its own slot.
+    assertNull(c.dashboard(instance, "office"))
+  }
+
+  @Test
+  fun dashboard_with_slash_in_url_path_does_not_collide_with_filesystem() {
+    val c = cache()
+    val nested = Dashboard(title = "Nested")
+    c.putDashboard(instance, "lovelace/main", nested)
+    assertEquals(nested, c.dashboard(instance, "lovelace/main"))
+  }
+
+  @Test
+  fun missing_entries_return_null_not_throw() {
+    val c = cache()
+    assertNull(c.dashboards(instance))
+    assertNull(c.dashboard(instance, "absent"))
+    assertNull(c.snapshot(instance, "absent"))
+  }
+
+  @Test
+  fun clearInstance_wipes_payloads_and_pointer() {
+    val c = cache()
+    c.setLastInstance(instance)
+    c.putDashboards(instance, listOf(DashboardSummary(null, "Home")))
+    c.putDashboard(instance, null, Dashboard(title = "Home"))
+    c.putSnapshot(instance, null, HaSnapshot())
+
+    c.clearInstance(instance)
+
+    assertNull(c.lastInstance())
+    assertNull(c.dashboards(instance))
+    assertNull(c.dashboard(instance, null))
+    assertNull(c.snapshot(instance, null))
+  }
+
+  @Test
+  fun clearInstance_only_clears_pointer_when_it_matches() {
+    val c = cache()
+    c.setLastInstance(instance2)
+    c.putDashboards(instance, listOf(DashboardSummary(null, "Home")))
+
+    c.clearInstance(instance)
+
+    // instance's payloads gone, but the pointer to instance2 is intact.
+    assertNull(c.dashboards(instance))
+    assertEquals(instance2, c.lastInstance())
+  }
+
+  @Test
+  fun snapshot_preserves_entity_attributes_through_round_trip() {
+    val c = cache()
+    val snap =
+      HaSnapshot(
+        states =
+          mapOf(
+            "sensor.t" to
+              EntityState(
+                entityId = "sensor.t",
+                state = "21.4",
+                attributes =
+                  JsonObject(
+                    mapOf(
+                      "friendly_name" to JsonPrimitive("Living Room"),
+                      "unit_of_measurement" to JsonPrimitive("°C"),
+                    )
+                  ),
+              )
+          )
+      )
+
+    c.putSnapshot(instance, null, snap)
+    val read = c.snapshot(instance, null)
+    assertNotNull(read)
+    assertEquals("21.4", read.states["sensor.t"]?.state)
+    assertEquals(
+      JsonPrimitive("Living Room"),
+      read.states["sensor.t"]?.attributes?.get("friendly_name"),
+    )
+  }
+}

--- a/app/src/test/kotlin/ee/schimke/terrazzo/core/session/CachedHaSessionTest.kt
+++ b/app/src/test/kotlin/ee/schimke/terrazzo/core/session/CachedHaSessionTest.kt
@@ -1,0 +1,140 @@
+package ee.schimke.terrazzo.core.session
+
+import ee.schimke.ha.client.DashboardSummary
+import ee.schimke.ha.model.Dashboard
+import ee.schimke.ha.model.EntityState
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.model.View
+import ee.schimke.terrazzo.core.cache.OfflineCacheStorage
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+/**
+ * The contract under test:
+ *   - First successful live fetch is mirrored to the cache.
+ *   - Subsequent failures fall back to the cached value silently.
+ *   - First-ever fetch with no cache propagates the failure so
+ *     [DashboardListState] can show an error screen.
+ */
+class CachedHaSessionTest {
+
+    private fun storage(): OfflineCacheStorage =
+        OfflineCacheStorage(Files.createTempDirectory("cached-session-test").toFile())
+
+    private val baseUrl = "http://homeassistant.local:8123"
+
+    private val sampleSummary =
+        listOf(DashboardSummary(urlPath = null, title = "Home"))
+    private val sampleDashboard =
+        Dashboard(title = "Home", views = listOf(View(title = "Main")))
+    private val sampleSnapshot =
+        HaSnapshot(
+            states = mapOf("sw.x" to EntityState(entityId = "sw.x", state = "on")),
+        )
+
+    @Test
+    fun listDashboards_persists_then_falls_back_on_failure() = runTest {
+        val cache = storage()
+        var failNext = false
+        val delegate = FakeSession(
+            baseUrl = baseUrl,
+            listProvider = {
+                if (failNext) error("network down") else sampleSummary
+            },
+        )
+        val session = CachedHaSession(delegate, cache)
+
+        // First call: live succeeds, cache populated.
+        assertEquals(sampleSummary, session.listDashboards())
+        assertEquals(sampleSummary, cache.dashboards(baseUrl))
+
+        // Live fails — cached value returned, no exception.
+        failNext = true
+        assertEquals(sampleSummary, session.listDashboards())
+    }
+
+    @Test
+    fun listDashboards_propagates_failure_when_cache_is_empty() = runTest {
+        val cache = storage()
+        val delegate = FakeSession(
+            baseUrl = baseUrl,
+            listProvider = { error("offline") },
+        )
+        val session = CachedHaSession(delegate, cache)
+        assertFailsWith<IllegalStateException> { session.listDashboards() }
+    }
+
+    @Test
+    fun loadDashboard_persists_then_falls_back_on_failure() = runTest {
+        val cache = storage()
+        var failNext = false
+        val delegate = FakeSession(
+            baseUrl = baseUrl,
+            loadProvider = { _ ->
+                if (failNext) error("ws closed") else sampleDashboard to sampleSnapshot
+            },
+        )
+        val session = CachedHaSession(delegate, cache)
+
+        val (d1, s1) = session.loadDashboard(null)
+        assertEquals(sampleDashboard, d1)
+        assertEquals(sampleSnapshot, s1)
+        assertEquals(sampleDashboard, cache.dashboard(baseUrl, null))
+        assertEquals(sampleSnapshot, cache.snapshot(baseUrl, null))
+
+        failNext = true
+        val (d2, s2) = session.loadDashboard(null)
+        assertEquals(sampleDashboard, d2)
+        assertEquals(sampleSnapshot, s2)
+    }
+
+    @Test
+    fun loadDashboard_falls_back_to_empty_snapshot_when_only_dashboard_was_cached() = runTest {
+        val cache = storage()
+        // Pre-seed only the dashboard, not the snapshot — simulates the
+        // edge case where the snapshot file got corrupted / wiped.
+        cache.putDashboard(baseUrl, null, sampleDashboard)
+
+        val session = CachedHaSession(
+            delegate = FakeSession(
+                baseUrl = baseUrl,
+                loadProvider = { error("offline") },
+            ),
+            cache = cache,
+        )
+        val (d, s) = session.loadDashboard(null)
+        assertEquals(sampleDashboard, d)
+        assertTrue(s.states.isEmpty())
+    }
+
+    @Test
+    fun connect_marks_lastInstance_even_on_failure() = runTest {
+        val cache = storage()
+        val session = CachedHaSession(
+            delegate = FakeSession(baseUrl = baseUrl, connectProvider = { error("dns") }),
+            cache = cache,
+        )
+        session.connect()
+        assertEquals(baseUrl, cache.lastInstance())
+    }
+
+}
+
+private class FakeSession(
+    override val baseUrl: String,
+    private val connectProvider: suspend () -> Unit = {},
+    private val listProvider: suspend () -> List<DashboardSummary> = { emptyList() },
+    private val loadProvider: suspend (String?) -> Pair<Dashboard, HaSnapshot> = { _ ->
+        Dashboard() to HaSnapshot()
+    },
+) : HaSession {
+    override val refreshIntervalMillis: Long? = null
+    override suspend fun connect() = connectProvider()
+    override suspend fun listDashboards(): List<DashboardSummary> = listProvider()
+    override suspend fun loadDashboard(urlPath: String?) = loadProvider(urlPath)
+    override suspend fun close() = Unit
+}

--- a/app/src/test/kotlin/ee/schimke/terrazzo/integration/OfflineFirstAddonHttpTest.kt
+++ b/app/src/test/kotlin/ee/schimke/terrazzo/integration/OfflineFirstAddonHttpTest.kt
@@ -1,0 +1,133 @@
+package ee.schimke.terrazzo.integration
+
+import ee.schimke.ha.client.AddonClient
+import ee.schimke.terrazzo.core.cache.OfflineCacheStorage
+import java.net.ServerSocket
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.mockserver.integration.ClientAndServer
+import org.mockserver.model.HttpRequest.request
+import org.mockserver.model.HttpResponse.response
+import org.mockserver.model.MediaType
+
+/**
+ * HTTP-side companion to `OfflineFirstWebSocketFlowTest`. Drives
+ * `AddonClient` (the REST client for the RemoteCompose HA add-on)
+ * against a mockserver-netty fake, and verifies the offline-first
+ * fallback contract on this surface:
+ *
+ *   1. With the server up, `AddonClient` round-trips the health
+ *      probe and a dashboard fetch.
+ *   2. The fetched dashboard is mirrored to `OfflineCacheStorage` so a
+ *      later cold start can read it back without hitting the network.
+ *   3. With the server down, `AddonClient.health()` returns `false`
+ *      instead of throwing — exactly the fall-through signal the
+ *      runtime uses to drop the addon from the `CardSource` chain.
+ *   4. The cache still holds the dashboard from step 2, so the UI
+ *      surface ("activity loads") would render from disk.
+ *
+ * mockserver-netty is the right fit here: every endpoint is a plain
+ * GET that maps cleanly to a `request().respond()` expectation, and
+ * mockserver's lifecycle (`start` / `stop`) gives us a real socket
+ * that can be torn down to simulate offline. (`fetchCardBytes` is
+ * intentionally not exercised here — `CardKey.toCacheKey()` uses `#`
+ * in the path which Ktor's URL builder treats as a fragment
+ * delimiter; that's a separate concern from offline-first.)
+ */
+class OfflineFirstAddonHttpTest {
+
+  private lateinit var mockServer: ClientAndServer
+  private var port: Int = 0
+  private lateinit var cacheRoot: java.io.File
+
+  private val baseUrl: String
+    get() = "http://127.0.0.1:$port"
+
+  @BeforeTest
+  fun start() {
+    port = freePort()
+    cacheRoot = Files.createTempDirectory("offline-addon-test").toFile()
+    mockServer = ClientAndServer.startClientAndServer(port)
+  }
+
+  @AfterTest
+  fun stop() {
+    runCatching { mockServer.stop() }
+    cacheRoot.deleteRecursively()
+  }
+
+  @Test
+  fun activity_loads_from_cache_when_addon_is_down() = runBlocking {
+    // ── Phase 1: server is up ────────────────────────────────────────
+    mockServer
+      .`when`(request().withMethod("GET").withPath("/healthz"))
+      .respond(response().withStatusCode(200).withBody("ok"))
+
+    val dashboardJson =
+      """
+      {
+        "title": "Home",
+        "views": [
+          { "cards": [ { "type": "tile", "raw": { "type": "tile", "entity": "sensor.living_room" } } ] }
+        ]
+      }
+      """
+        .trimIndent()
+    mockServer
+      .`when`(request().withMethod("GET").withPath("/v1/dashboards/_default"))
+      .respond(
+        response()
+          .withStatusCode(200)
+          .withContentType(MediaType.APPLICATION_JSON)
+          .withBody(dashboardJson)
+      )
+
+    val storage = OfflineCacheStorage(cacheRoot)
+    val client = AddonClient(baseUrl = baseUrl, accessToken = "test-token")
+
+    assertTrue(client.health(), "addon health probe must pass while mockserver is up")
+
+    val dashboard = client.fetchDashboard(urlPath = null)
+    assertEquals("Home", dashboard.title)
+    assertEquals(1, dashboard.views.size)
+
+    // Mirror the live fetch to the cache — this is what a future
+    // CachedAddonClient (or the existing CachedHaSession path) would
+    // do on every successful fetch.
+    storage.putDashboard(baseUrl, urlPath = null, dashboard = dashboard)
+
+    // ── Phase 2: kill the server ─────────────────────────────────────
+    mockServer.stop()
+
+    // health() is documented to swallow network errors and return
+    // false so the runtime can drop the addon from the chain.
+    assertFalse(client.health(), "health() must return false (not throw) when addon is down")
+
+    // fetchDashboard() does not have the swallow-and-return-null
+    // contract — it throws on any error so a CachedHaSession-style
+    // wrapper can fall through to its on-disk mirror. Verify the
+    // throw, then verify the cache has the dashboard from Phase 1.
+    assertFailsWith<Throwable> { client.fetchDashboard(urlPath = null) }
+
+    // ── Phase 3: the activity loads — cache reads still succeed ──────
+    val cached = storage.dashboard(baseUrl, urlPath = null)
+    assertNotNull(cached, "cache must retain the dashboard after the addon went away")
+    assertEquals("Home", cached.title)
+    assertEquals(1, cached.views.size)
+    assertEquals("tile", cached.views[0].cards[0].type)
+
+    client.close()
+  }
+
+  companion object {
+    private fun freePort(): Int = ServerSocket(0).use { it.localPort }
+  }
+}

--- a/app/src/test/kotlin/ee/schimke/terrazzo/integration/OfflineFirstWebSocketFlowTest.kt
+++ b/app/src/test/kotlin/ee/schimke/terrazzo/integration/OfflineFirstWebSocketFlowTest.kt
@@ -1,0 +1,284 @@
+package ee.schimke.terrazzo.integration
+
+import ee.schimke.ha.client.DashboardSummary
+import ee.schimke.ha.model.Dashboard
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.terrazzo.core.cache.OfflineCacheStorage
+import ee.schimke.terrazzo.core.session.CachedHaSession
+import ee.schimke.terrazzo.core.session.HaSession
+import ee.schimke.terrazzo.core.session.LiveHaSession
+import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.routing.routing
+import io.ktor.server.websocket.WebSockets
+import io.ktor.server.websocket.webSocket
+import io.ktor.websocket.Frame
+import io.ktor.websocket.readText
+import io.ktor.websocket.send
+import java.io.File
+import java.net.ServerSocket
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+/**
+ * End-to-end test of the offline-first contract through `HaClient` (the
+ * real WebSocket client) and `CachedHaSession` (the wrapper).
+ *
+ * Spins up an embedded Ktor server that speaks just enough of HA's
+ * WebSocket protocol — `auth_required` / `auth_ok` handshake plus
+ * `lovelace/dashboards/list`, `lovelace/config`, and `get_states`
+ * commands matched by id. Drives the session, persists the cache,
+ * stops the server, then asserts a fresh cache-only session reads the
+ * same dashboard. That's "the activity loads".
+ *
+ * Why Ktor and not mockserver: HA's WebSocket protocol is full-duplex
+ * (server pushes `auth_required` first, then commands ride atop a
+ * persistent connection with monotonic ids). mockserver-netty's
+ * WebSocket layer is for its own callback infrastructure, not for
+ * faking an arbitrary protocol. Ktor server is already a project dep
+ * (the `addon-server` module), so this stays a single-library fake.
+ * The HTTP-side companion test (`OfflineFirstAddonHttpTest`) uses
+ * mockserver where it shines.
+ */
+class OfflineFirstWebSocketFlowTest {
+
+  private lateinit var server: EmbeddedServer<*, *>
+  private var port: Int = 0
+  private val handler = HaProtocolHandler()
+  private lateinit var cacheRoot: File
+
+  private val baseUrl: String
+    get() = "http://127.0.0.1:$port"
+
+  @BeforeTest
+  fun start() {
+    port = freePort()
+    cacheRoot = Files.createTempDirectory("offline-flow-test").toFile()
+    server =
+      embeddedServer(CIO, port = port, host = "127.0.0.1") {
+          install(WebSockets)
+          routing {
+            webSocket("/api/websocket") {
+              // HA's flow: server greets with auth_required before the
+              // client sends anything. HaClient's read loop blocks
+              // until this frame arrives.
+              send(Frame.Text("""{"type":"auth_required","ha_version":"test"}"""))
+              for (frame in incoming) {
+                if (frame !is Frame.Text) continue
+                val msg = JSON.parseToJsonElement(frame.readText()).jsonObject
+                handler.handle(msg)?.let { reply ->
+                  send(Frame.Text(JSON.encodeToString(JsonObject.serializer(), reply)))
+                }
+              }
+            }
+          }
+        }
+        .start(wait = false)
+  }
+
+  @AfterTest
+  fun stop() {
+    runCatching { server.stop(gracePeriodMillis = 100, timeoutMillis = 1_000) }
+    cacheRoot.deleteRecursively()
+  }
+
+  @Test
+  fun activity_loads_from_cache_after_disconnect() = runBlocking {
+    // ── Phase 1: live session populates the cache ─────────────────────
+    val storage = OfflineCacheStorage(cacheRoot)
+    val live = LiveHaSession(baseUrl = baseUrl, accessToken = "test-token")
+    val session = CachedHaSession(live, storage)
+
+    session.connect()
+    val dashboards = session.listDashboards()
+    assertEquals(
+      listOf("Home" to null, "Office" to "office"),
+      dashboards.map { it.title to it.urlPath },
+    )
+
+    val (home, snapshot) = session.loadDashboard(null)
+    assertEquals("Home", home.title)
+    assertEquals(
+      "21.4",
+      snapshot.states["sensor.living_room"]?.state,
+      "live snapshot was not delivered through the wire",
+    )
+
+    // The cache is hot — same wire bytes, same content.
+    assertNotNull(storage.dashboards(baseUrl))
+    assertNotNull(storage.dashboard(baseUrl, null))
+    assertNotNull(storage.snapshot(baseUrl, null))
+
+    // ── Phase 2: a streamed update overwrites the cached snapshot ────
+    handler.setLivingRoom("22.7")
+    val (_, updated) = session.loadDashboard(null)
+    assertEquals("22.7", updated.states["sensor.living_room"]?.state)
+    assertEquals(
+      "22.7",
+      storage.snapshot(baseUrl, null)?.states?.get("sensor.living_room")?.state,
+      "cache should reflect the streamed update",
+    )
+
+    session.close()
+
+    // ── Phase 3: kill the server ─────────────────────────────────────
+    server.stop(gracePeriodMillis = 100, timeoutMillis = 1_000)
+
+    // Sanity-check we're actually offline (not silently re-using a
+    // pooled connection): a fresh live session must fail to connect.
+    val severed = LiveHaSession(baseUrl = baseUrl, accessToken = "test-token")
+    assertFailsWith<Throwable> { severed.connect() }
+    severed.close()
+
+    // ── Phase 4: cold-start with cache-only — the activity loads ─────
+    val coldSession = CachedHaSession(delegate = AlwaysOfflineSession(baseUrl), cache = storage)
+
+    coldSession.connect()
+    val cachedDashboards = coldSession.listDashboards()
+    assertEquals(2, cachedDashboards.size, "dashboard list must be served from cache")
+    val (cachedHome, cachedSnap) = coldSession.loadDashboard(null)
+    assertEquals("Home", cachedHome.title)
+    assertEquals(
+      "22.7",
+      cachedSnap.states["sensor.living_room"]?.state,
+      "cached snapshot must include the latest streamed update",
+    )
+    assertTrue(cachedSnap.states.isNotEmpty(), "cached snapshot must include all entities")
+    coldSession.close()
+  }
+
+  /**
+   * Stand-in for the production `OfflineOnlySession` (which is
+   * `internal` to `terrazzo-core`). Always throws on live calls so
+   * `CachedHaSession` exercises its cache-fallback path.
+   */
+  private class AlwaysOfflineSession(override val baseUrl: String) : HaSession {
+    override suspend fun connect() = Unit
+
+    override suspend fun listDashboards(): List<DashboardSummary> = error("offline")
+
+    override suspend fun loadDashboard(urlPath: String?): Pair<Dashboard, HaSnapshot> =
+      error("offline")
+
+    override suspend fun close() = Unit
+  }
+
+  /**
+   * Minimal HA-protocol simulator. Covers the three commands HaClient
+   * sends today (`lovelace/dashboards/list`, `lovelace/config`,
+   * `get_states`) and replies with the matching `id`. State is
+   * mutable so a test can drive an "update" between two fetches.
+   */
+  private class HaProtocolHandler {
+    @Volatile private var livingRoom = "21.4"
+
+    fun setLivingRoom(value: String) {
+      livingRoom = value
+    }
+
+    fun handle(msg: JsonObject): JsonObject? {
+      val type = msg["type"]?.jsonPrimitive?.content ?: return null
+      if (type == "auth") return buildJsonObject { put("type", "auth_ok") }
+
+      val id = msg["id"]?.jsonPrimitive?.intOrNull ?: return null
+      return when (type) {
+        "lovelace/dashboards/list" -> result(id, dashboardsList())
+        "lovelace/config" -> result(id, dashboardConfig())
+        "get_states" -> result(id, statesArray())
+        else -> null
+      }
+    }
+
+    private fun dashboardsList() = buildJsonArray {
+      // HA omits `url_path` entirely for the default dashboard (the
+      // value is null on the wire only when the dashboard is named).
+      // Matching that here so the test exercises the same parsing
+      // path the production HaClient hits.
+      add(buildJsonObject { put("title", "Home") })
+      add(
+        buildJsonObject {
+          put("url_path", "office")
+          put("title", "Office")
+        }
+      )
+    }
+
+    private fun dashboardConfig() = buildJsonObject {
+      put("title", "Home")
+      put(
+        "views",
+        buildJsonArray {
+          add(
+            buildJsonObject {
+              put(
+                "cards",
+                buildJsonArray {
+                  add(
+                    buildJsonObject {
+                      put("type", "tile")
+                      put("entity", "sensor.living_room")
+                    }
+                  )
+                },
+              )
+            }
+          )
+        },
+      )
+    }
+
+    private fun statesArray() = buildJsonArray {
+      add(
+        buildJsonObject {
+          put("entity_id", "sensor.living_room")
+          put("state", livingRoom)
+          put(
+            "attributes",
+            buildJsonObject {
+              put("friendly_name", "Living Room")
+              put("unit_of_measurement", "°C")
+            },
+          )
+        }
+      )
+      add(
+        buildJsonObject {
+          put("entity_id", "light.kitchen")
+          put("state", "on")
+          put("attributes", buildJsonObject { put("friendly_name", "Kitchen") })
+        }
+      )
+    }
+
+    private fun result(id: Int, value: kotlinx.serialization.json.JsonElement) = buildJsonObject {
+      put("id", id)
+      put("type", "result")
+      put("success", true)
+      put("result", value)
+    }
+  }
+
+  companion object {
+    private val JSON = Json { ignoreUnknownKeys = true }
+
+    private fun freePort(): Int = ServerSocket(0).use { it.localPort }
+  }
+}

--- a/docs/architecture/offline-first.md
+++ b/docs/architecture/offline-first.md
@@ -26,9 +26,12 @@ A surface is **offline-first** when:
 
 ## Caches
 
-All persistent state lives under
-`context.filesDir/terrazzo/<scope>/...`. JSON for everything except
-the wear sync proto blobs, which already have a wire schema.
+Each app stores cached data in the format that matches its source — JSON
+for the mobile cache (HA's `lovelace/config` and entity-state payloads
+are JSON over the WebSocket), proto wire bytes for the wear cache (the
+wear data layer already speaks proto). Each blob lives in its own file
+so a corruption or partial write only loses one entry, never the whole
+cache. Writes are atomic (tmp + rename).
 
 ### Mobile (`app/` + `terrazzo-core`)
 
@@ -46,7 +49,6 @@ filesDir/
       dashboards.json                 # List<DashboardSummary>
       dashboard/<urlPath>.json        # Dashboard
       snapshot/<urlPath>.json         # HaSnapshot
-      meta.json                       # last-fetched timestamps
 ```
 
 `urlPath` may be `null` (HA's default dashboard); we encode that as
@@ -67,12 +69,26 @@ fall through unchanged because they always read from cache first.
 ### Wear (`wear/`)
 
 `WearSyncRepository` already builds StateFlows from
-DataClient/MessageClient. We add a parallel `WearOfflineStore`
-(JSON file under `filesDir/terrazzo/wear/last_state.json`) that
-mirrors every successful proto blob handled and rehydrates from
-disk on `start()` before the listeners attach. Schema is the
-same proto types we already use (`WearSettings`, `PinnedCardSet`,
-list of `DashboardData`, `LiveValues`).
+DataClient/MessageClient. We add a parallel `WearOfflineStore` that
+persists each blob the repository handles as proto wire bytes (same
+encoding the wear data layer itself uses — no re-serialisation). One
+file per blob type so each blob has an independent lifecycle:
+
+```
+filesDir/
+  terrazzo/
+    wear/
+      settings.pb                     # WearSettings
+      pinned.pb                       # PinnedCardSet
+      values.pb                       # LiveValues (full or merged)
+      dashboards/<urlPath>.pb         # DashboardData
+```
+
+The repository hydrates its StateFlows from these files in its primary
+constructor, so the very first composition sees cached data — listeners
+attach afterwards and overlay live updates. Stream deltas merged into
+the in-memory map are written back to `values.pb` so a process restart
+resumes from the latest delta-updated state, not the last full DataItem.
 
 This way:
 
@@ -84,11 +100,14 @@ This way:
 ### TV (`tv/`)
 
 TV does not yet wire an HA session — it's kiosk + demo today. The
-offline-first scaffold added here is `TvOfflineCache`: same JSON
-layout as the mobile cache, scoped to the TV app's `filesDir`. A
-future change that lands a `TvHaSession` will read/write from this
-cache via the existing `CachedHaSession` wrapper, so wall-mounted
-TVs that lose the LAN keep their last good dashboard on screen.
+offline-first scaffold added here is `TvOfflineCache`: a blob store
+under the TV app's `filesDir/terrazzo/tv/<scope>/<name>`, with the
+same per-instance / atomic-write semantics as the mobile and wear
+caches. The cache stores raw payloads (callers own the format —
+JSON for HA-shaped data, proto if the TV app ever pairs with the
+phone) so the TV module can stay minimal until it has a real use
+for it. A future change that lands a `TvHaSession` will plug into
+the same `CachedHaSession` wrapper used by mobile.
 
 ## Auto-resume
 

--- a/docs/architecture/offline-first.md
+++ b/docs/architecture/offline-first.md
@@ -1,0 +1,149 @@
+# Offline-first data flow
+
+The Terrazzo apps (`app/`, `wear/`, `tv/`) follow an offline-first
+contract: once a user has logged in and the app has fetched data
+once, every subsequent launch must render the last-known dashboards
+and entity values without a network. When the network is reachable
+the cache refreshes in the background and the UI updates in place.
+
+This document records the contract, the cache layout, and the
+read/write paths each app uses.
+
+## Contract
+
+A surface is **offline-first** when:
+
+1. Cold launch with no network shows the user's last known data
+   instead of a spinner or error screen.
+2. Live data, when it arrives, replaces cached data in place
+   without flicker.
+3. Going offline mid-session does not blank the UI — it freezes the
+   last good values and (if visible at all) shows a small
+   "showing cached data from <ts>" hint.
+4. Mutations (toggling a switch, etc.) are out of scope here — they
+   inherently require connectivity. UI affordances may stay
+   interactive; the call simply fails with a normal error.
+
+## Caches
+
+All persistent state lives under
+`context.filesDir/terrazzo/<scope>/...`. JSON for everything except
+the wear sync proto blobs, which already have a wire schema.
+
+### Mobile (`app/` + `terrazzo-core`)
+
+`OfflineCache` (in `terrazzo-core`'s `androidMain`) owns one
+`<instanceId>` directory per HA instance. `instanceId` is the
+normalized `baseUrl` (no trailing slash) — the same key
+[`TokenVault`](../../terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/auth/TokenVault.kt)
+uses, so credentials and cached payloads share a lifecycle.
+
+```
+filesDir/
+  terrazzo/
+    instance.json                     # { baseUrl }
+    cache/<sha-baseUrl>/
+      dashboards.json                 # List<DashboardSummary>
+      dashboard/<urlPath>.json        # Dashboard
+      snapshot/<urlPath>.json         # HaSnapshot
+      meta.json                       # last-fetched timestamps
+```
+
+`urlPath` may be `null` (HA's default dashboard); we encode that as
+the file name `_default`.
+
+`CachedHaSession` (in `terrazzo-core`) wraps a `LiveHaSession` and
+mirrors every successful fetch into the cache. `listDashboards()`
+and `loadDashboard()` first emit the cached value (if any) via the
+`Flow<...>` companion APIs, then attempt a live fetch and emit the
+fresh result. Failures never overwrite a successful cache entry.
+
+`TokenVault.lastInstance()` returns the most-recently-stored
+instance, used by `MainActivity` to auto-resume on cold start. If
+the access-token mint fails (no network, refresh token expired) the
+app still constructs a session using only the cache; UI surfaces
+fall through unchanged because they always read from cache first.
+
+### Wear (`wear/`)
+
+`WearSyncRepository` already builds StateFlows from
+DataClient/MessageClient. We add a parallel `WearOfflineStore`
+(JSON file under `filesDir/terrazzo/wear/last_state.json`) that
+mirrors every successful proto blob handled and rehydrates from
+disk on `start()` before the listeners attach. Schema is the
+same proto types we already use (`WearSettings`, `PinnedCardSet`,
+list of `DashboardData`, `LiveValues`).
+
+This way:
+
+- Cold-start, phone unreachable → wear renders the last known
+  dashboard list, pinned cards, and values from disk.
+- Phone reconnects → DataClient cold-read overwrites with newer
+  proto; subsequent stream deltas merge as before.
+
+### TV (`tv/`)
+
+TV does not yet wire an HA session — it's kiosk + demo today. The
+offline-first scaffold added here is `TvOfflineCache`: same JSON
+layout as the mobile cache, scoped to the TV app's `filesDir`. A
+future change that lands a `TvHaSession` will read/write from this
+cache via the existing `CachedHaSession` wrapper, so wall-mounted
+TVs that lose the LAN keep their last good dashboard on screen.
+
+## Auto-resume
+
+`MainActivity.onCreate` (mobile) does a synchronous
+`runBlocking` read of `TokenVault.lastInstance()` (already does
+this for `lastViewedDashboardNow()`). If an instance is present:
+
+1. Construct a `CachedHaSession` immediately so the first
+   composition has a session to render against — backed by the
+   on-disk cache, so the UI can paint without a network call.
+2. Asynchronously refresh the access token (`TokenVault.get` →
+   AppAuth refresh exchange). On success, the session upgrades to
+   live; on failure, the session remains cache-only and the UI
+   shows a small "offline" badge.
+
+This eliminates the prior "always go through discovery + login on
+cold start" path. Sign-out clears both the vault entry and the
+cache directory for that instance.
+
+## Image cache (follow-up)
+
+RemoteCompose documents fetch their own raster bytes when a card
+contains an `entity_picture` URL or addon-rendered prebaked PNG.
+There is no native image-loading library (no Coil/Glide) in the
+project today. A future change should:
+
+1. Add a Coil 3 OkHttp loader to `app/` and `wear/`, with a disk
+   cache rooted at `filesDir/terrazzo/images/`.
+2. Provide a `DiskCachedImageLoader` to RemoteCompose so card
+   documents resolve image URLs through the disk-cached pipeline
+   instead of bypassing it.
+3. Pre-warm the cache when a dashboard is first cached, so first
+   offline paint includes images.
+
+Tracked here so it's not lost; not implemented in the current
+offline-first PR.
+
+## Error and refresh signals
+
+The cache exposes a `lastFetchedAtMs(instanceId, scope)` helper.
+The "showing cached data" pill in the UI uses this to render a
+human-readable freshness ("3 min ago"). The pill appears only when
+the most recent live fetch failed — successful fetches reset the
+fail flag and hide the pill.
+
+## Sign-out
+
+Sign-out clears (in order):
+
+1. The vault entry for the instance — so a relaunch does not
+   auto-resume.
+2. The cache directory for the instance — so subsequent users on
+   the device cannot read the previous user's dashboard config.
+3. `lastViewedDashboard` and `lastInstance` prefs.
+
+Demo mode does not write to the cache (its session is
+deterministic and re-derived from `DemoData`), so toggling
+demo mode is a no-op against the cache layer.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.8.0-rc01"
 logback = "1.5.32"
 junit-jupiter-bom = "5.14.3"
+mockserver = "5.15.0"
 
 # Preview tooling
 compose-preview-plugin = "0.8.1"
@@ -138,6 +139,8 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 junit-jupiter-bom = { module = "org.junit:junit-bom", version.ref = "junit-jupiter-bom" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+mockserver-netty = { module = "org.mock-server:mockserver-netty", version.ref = "mockserver" }
+mockserver-client-java = { module = "org.mock-server:mockserver-client-java", version.ref = "mockserver" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/terrazzo-core/build.gradle.kts
+++ b/terrazzo-core/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
   alias(libs.plugins.kotlin.multiplatform)
   alias(libs.plugins.android.kmp.library)
   alias(libs.plugins.metro)
+  alias(libs.plugins.kotlin.serialization)
 }
 
 kotlin {

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/cache/OfflineCache.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/cache/OfflineCache.kt
@@ -1,0 +1,169 @@
+package ee.schimke.terrazzo.core.cache
+
+import android.content.Context
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import ee.schimke.ha.client.DashboardSummary
+import ee.schimke.ha.model.Dashboard
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.terrazzo.core.di.AppScope
+import java.io.File
+import java.security.MessageDigest
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+
+/**
+ * Persistent offline cache for the per-instance Home Assistant payloads
+ * the UI reads (dashboard list, dashboard configs, entity snapshots).
+ *
+ * Once the user has logged in and the app has fetched data once, every
+ * subsequent launch must render the last-known data without a network.
+ * `CachedHaSession` writes here on each successful live fetch; the UI
+ * reads here first and then upgrades to live data when it arrives.
+ *
+ * Layout under `filesDir/terrazzo/`:
+ *
+ * ```
+ *   instance.json                       — { baseUrl } most-recent instance
+ *   cache/<sha-baseUrl>/dashboards.json — List<DashboardSummary>
+ *   cache/<sha-baseUrl>/dashboard/<urlPath>.json — Dashboard
+ *   cache/<sha-baseUrl>/snapshot/<urlPath>.json  — HaSnapshot
+ * ```
+ *
+ * `urlPath` may be null (HA's default dashboard) — encoded as the file
+ * name `_default` to match the wear-sync proto convention.
+ *
+ * Demo mode is intentionally not cached here: its session derives
+ * dashboards + snapshot deterministically from `DemoData`, so a cache
+ * lookup would always be redundant.
+ */
+@SingleIn(AppScope::class)
+@Inject
+class OfflineCache(context: Context) :
+  OfflineCacheStorage(File(context.filesDir, "terrazzo"))
+
+/**
+ * File-backed storage layer. Split out from [OfflineCache] so JVM unit
+ * tests can construct against a temp directory without bringing in
+ * Robolectric.
+ */
+open class OfflineCacheStorage(rootDir: File) {
+
+  private val root: File = rootDir.apply { mkdirs() }
+  private val cacheRoot: File = File(root, "cache").apply { mkdirs() }
+  private val instanceFile: File = File(root, "instance.json")
+  private val json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+  }
+
+  /**
+   * The instance the user was last connected to. Used by
+   * `MainActivity` to decide whether to auto-resume on cold start
+   * versus showing the discovery / login screens.
+   */
+  fun lastInstance(): String? =
+    runCatching {
+        if (!instanceFile.exists()) return@runCatching null
+        json.decodeFromString(InstancePointer.serializer(), instanceFile.readText()).baseUrl
+      }
+      .getOrNull()
+
+  fun setLastInstance(baseUrl: String) {
+    val payload = json.encodeToString(InstancePointer.serializer(), InstancePointer(baseUrl))
+    instanceFile.atomicWriteText(payload)
+  }
+
+  fun clearLastInstance() {
+    instanceFile.delete()
+  }
+
+  /** Per-instance dashboard listing. */
+  fun dashboards(baseUrl: String): List<DashboardSummary>? =
+    readJson(dashboardsFile(baseUrl), ListSerializer(DashboardSummary.serializer()))
+
+  fun putDashboards(baseUrl: String, list: List<DashboardSummary>) {
+    writeJson(dashboardsFile(baseUrl), ListSerializer(DashboardSummary.serializer()), list)
+  }
+
+  /** Per-instance, per-dashboard config. `urlPath == null` is the default dashboard. */
+  fun dashboard(baseUrl: String, urlPath: String?): Dashboard? =
+    readJson(dashboardFile(baseUrl, urlPath), Dashboard.serializer())
+
+  fun putDashboard(baseUrl: String, urlPath: String?, dashboard: Dashboard) {
+    writeJson(dashboardFile(baseUrl, urlPath), Dashboard.serializer(), dashboard)
+  }
+
+  /** Per-instance, per-dashboard entity snapshot. */
+  fun snapshot(baseUrl: String, urlPath: String?): HaSnapshot? =
+    readJson(snapshotFile(baseUrl, urlPath), HaSnapshot.serializer())
+
+  fun putSnapshot(baseUrl: String, urlPath: String?, snapshot: HaSnapshot) {
+    writeJson(snapshotFile(baseUrl, urlPath), HaSnapshot.serializer(), snapshot)
+  }
+
+  /**
+   * Wipe every cached payload for [baseUrl]. Called by sign-out so a
+   * subsequent user on the device can't read the previous account's
+   * dashboard config off disk.
+   */
+  fun clearInstance(baseUrl: String) {
+    instanceDir(baseUrl).deleteRecursively()
+    if (lastInstance() == baseUrl) clearLastInstance()
+  }
+
+  private fun <T> readJson(file: File, serializer: kotlinx.serialization.KSerializer<T>): T? =
+    runCatching {
+        if (!file.exists()) return@runCatching null
+        json.decodeFromString(serializer, file.readText())
+      }
+      .getOrNull()
+
+  private fun <T> writeJson(
+    file: File,
+    serializer: kotlinx.serialization.KSerializer<T>,
+    value: T,
+  ) {
+    file.parentFile?.mkdirs()
+    file.atomicWriteText(json.encodeToString(serializer, value))
+  }
+
+  private fun instanceDir(baseUrl: String): File = File(cacheRoot, instanceKey(baseUrl))
+
+  private fun dashboardsFile(baseUrl: String): File = File(instanceDir(baseUrl), "dashboards.json")
+
+  private fun dashboardFile(baseUrl: String, urlPath: String?): File =
+    File(File(instanceDir(baseUrl), "dashboard"), "${urlPath.encodeUrlPath()}.json")
+
+  private fun snapshotFile(baseUrl: String, urlPath: String?): File =
+    File(File(instanceDir(baseUrl), "snapshot"), "${urlPath.encodeUrlPath()}.json")
+
+  @kotlinx.serialization.Serializable private data class InstancePointer(val baseUrl: String)
+
+  companion object {
+    /** SHA-1 of the baseUrl as the directory name — keeps any URL-shaped filesystem. */
+    fun instanceKey(baseUrl: String): String {
+      val md = MessageDigest.getInstance("SHA-1")
+      val digest = md.digest(baseUrl.trim().removeSuffix("/").toByteArray(Charsets.UTF_8))
+      return digest.joinToString("") { "%02x".format(it) }
+    }
+  }
+}
+
+/** Mirror of `WearSyncPaths.dashboardPath`'s null encoding. */
+private fun String?.encodeUrlPath(): String =
+  this?.takeIf { it.isNotEmpty() }?.replace('/', '_') ?: "_default"
+
+/**
+ * Atomic write — render to a sibling .tmp first then rename, so a kill
+ * mid-write doesn't leave a half-written cache file that decodes as
+ * partial data on next launch.
+ */
+private fun File.atomicWriteText(text: String) {
+  val tmp = File(parentFile, "$name.tmp")
+  tmp.writeText(text)
+  if (!tmp.renameTo(this)) {
+    writeText(text)
+    tmp.delete()
+  }
+}

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/di/TerrazzoGraph.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/di/TerrazzoGraph.kt
@@ -7,10 +7,13 @@ import dev.zacsweers.metro.SingleIn
 import dev.zacsweers.metro.Inject
 import ee.schimke.terrazzo.core.auth.HaAuthService
 import ee.schimke.terrazzo.core.auth.TokenVault
+import ee.schimke.terrazzo.core.cache.OfflineCache
 import ee.schimke.terrazzo.core.prefs.PreferencesStore
+import ee.schimke.terrazzo.core.session.CachedHaSession
 import ee.schimke.terrazzo.core.session.DemoHaSession
 import ee.schimke.terrazzo.core.session.HaSession
 import ee.schimke.terrazzo.core.session.LiveHaSession
+import ee.schimke.terrazzo.core.session.OfflineOnlySession
 import ee.schimke.terrazzo.core.widget.WidgetStore
 
 /**
@@ -27,6 +30,7 @@ interface TerrazzoGraph {
     val authService: HaAuthService
     val widgetStore: WidgetStore
     val preferencesStore: PreferencesStore
+    val offlineCache: OfflineCache
     val sessionFactory: HaSessionFactory
 
     @DependencyGraph.Factory
@@ -38,12 +42,28 @@ interface TerrazzoGraph {
 /**
  * Factory for [HaSession]. Pulled from the graph so Compose call sites
  * don't `new` the class directly.
+ *
+ * Live sessions are wrapped in [CachedHaSession] so the UI gets a cache
+ * fallback automatically — every fetched dashboard / snapshot is mirrored
+ * to disk and read on cold start before the network has a chance to
+ * answer. Demo sessions skip the wrapper since their data is already
+ * deterministic and re-derived from `DemoData`.
+ *
+ * [createCachedOnly] returns a cache-backed session whose `delegate` is
+ * a no-op stub — used during cold-start auto-resume when we don't yet
+ * have a valid access token (refresh in progress, or refresh failed
+ * due to no network). The UI still paints from the on-disk cache; once
+ * the access token is minted the session is replaced with a real
+ * [CachedHaSession] wrapping a [LiveHaSession].
  */
 @SingleIn(AppScope::class)
 @Inject
-class HaSessionFactory {
+class HaSessionFactory(private val cache: OfflineCache) {
     fun create(baseUrl: String, accessToken: String): HaSession =
-        LiveHaSession(baseUrl = baseUrl, accessToken = accessToken)
+        CachedHaSession(LiveHaSession(baseUrl = baseUrl, accessToken = accessToken), cache)
+
+    fun createCachedOnly(baseUrl: String): HaSession =
+        CachedHaSession(OfflineOnlySession(baseUrl), cache)
 
     fun createDemo(): HaSession = DemoHaSession()
 }

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/CachedHaSession.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/CachedHaSession.kt
@@ -1,0 +1,66 @@
+package ee.schimke.terrazzo.core.session
+
+import ee.schimke.ha.client.DashboardSummary
+import ee.schimke.ha.model.Dashboard
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.terrazzo.core.cache.OfflineCacheStorage
+
+/**
+ * Offline-first wrapper around any [HaSession]. Every successful live
+ * fetch is mirrored to the [OfflineCacheStorage]; every read falls back
+ * to the cache when the live call fails, and the cache is the first
+ * thing the UI sees on cold start.
+ *
+ * Failure-mode contract:
+ *   - [listDashboards] / [loadDashboard] **never** throw if a cached
+ *     value exists. They throw only on first-ever fetch when the
+ *     network is also unavailable.
+ *   - On every successful live fetch the returned value is also
+ *     persisted via [OfflineCache], so a subsequent cold start with no
+ *     network still has data.
+ *
+ * This wraps both [LiveHaSession] (real HA) and [DemoHaSession] (which
+ * is already a deterministic source — wrapping it is a no-op cache
+ * write that costs nothing). Demo callers can skip the wrapper if they
+ * prefer; production sessions always use it.
+ */
+class CachedHaSession(private val delegate: HaSession, private val cache: OfflineCacheStorage) :
+  HaSession {
+
+  override val baseUrl: String
+    get() = delegate.baseUrl
+
+  override val refreshIntervalMillis: Long?
+    get() = delegate.refreshIntervalMillis
+
+  override suspend fun connect() {
+    runCatching { delegate.connect() }
+    // Even if connect() failed, mark this as the most-recent instance
+    // so cold-start auto-resume can find it. We have either a cached
+    // payload or we'll get one when the network returns.
+    cache.setLastInstance(baseUrl)
+  }
+
+  override suspend fun listDashboards(): List<DashboardSummary> {
+    val cached = cache.dashboards(baseUrl)
+    return runCatching { delegate.listDashboards() }
+      .onSuccess { fresh -> cache.putDashboards(baseUrl, fresh) }
+      .getOrElse { ex -> cached ?: throw ex }
+  }
+
+  override suspend fun loadDashboard(urlPath: String?): Pair<Dashboard, HaSnapshot> {
+    val cached = cache.dashboard(baseUrl, urlPath)?.let { d ->
+      d to (cache.snapshot(baseUrl, urlPath) ?: HaSnapshot())
+    }
+    return runCatching { delegate.loadDashboard(urlPath) }
+      .onSuccess { (dashboard, snapshot) ->
+        cache.putDashboard(baseUrl, urlPath, dashboard)
+        cache.putSnapshot(baseUrl, urlPath, snapshot)
+      }
+      .getOrElse { ex -> cached ?: throw ex }
+  }
+
+  override suspend fun close() {
+    delegate.close()
+  }
+}

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/OfflineOnlySession.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/OfflineOnlySession.kt
@@ -1,0 +1,27 @@
+package ee.schimke.terrazzo.core.session
+
+import ee.schimke.ha.client.DashboardSummary
+import ee.schimke.ha.model.Dashboard
+import ee.schimke.ha.model.HaSnapshot
+
+/**
+ * Stub session whose live calls always fail with [OfflineUnavailable].
+ * Wrapped by [CachedHaSession] during cold-start auto-resume — the
+ * cache supplies the data the UI renders, and as soon as the access
+ * token is minted (or the user re-logs-in) the session is swapped for a
+ * real [LiveHaSession]-backed one.
+ */
+internal class OfflineOnlySession(override val baseUrl: String) : HaSession {
+  override val refreshIntervalMillis: Long? = null
+
+  override suspend fun connect() = Unit
+
+  override suspend fun listDashboards(): List<DashboardSummary> = throw OfflineUnavailable
+
+  override suspend fun loadDashboard(urlPath: String?): Pair<Dashboard, HaSnapshot> =
+    throw OfflineUnavailable
+
+  override suspend fun close() = Unit
+}
+
+internal object OfflineUnavailable : RuntimeException("offline — no live HA connection")

--- a/tv/src/main/kotlin/ee/schimke/terrazzo/tv/data/TvOfflineCache.kt
+++ b/tv/src/main/kotlin/ee/schimke/terrazzo/tv/data/TvOfflineCache.kt
@@ -1,0 +1,60 @@
+package ee.schimke.terrazzo.tv.data
+
+import android.content.Context
+import java.io.File
+
+/**
+ * Offline-first scaffold for the TV companion. Today the TV app is a
+ * kiosk + demo surface with no live HA wiring; when a `TvHaSession`
+ * lands later it should read from / write to this cache so a wall-
+ * mounted screen that loses the LAN keeps showing its last good
+ * dashboard rather than blanking.
+ *
+ * Layout under the TV app's `filesDir/terrazzo/tv/`:
+ *
+ * ```
+ *   instance.json                   — { baseUrl } most-recent instance
+ *   <baseUrl-hash>/
+ *     dashboards.json
+ *     dashboard/<urlPath>.json
+ *     snapshot/<urlPath>.json
+ * ```
+ *
+ * Same shape as the mobile [ee.schimke.terrazzo.core.cache.OfflineCache];
+ * we duplicate rather than depend on `terrazzo-core` because the TV
+ * module's minSdk (29) is lower than terrazzo-core's (35), and adding
+ * the dep would force terrazzo-core's API floor up. When the TV app
+ * lands a real HA session we can revisit lifting the floor.
+ *
+ * The cache stores opaque JSON strings keyed by name — callers own the
+ * serialization since the TV module deliberately avoids depending on
+ * `ha-model` until it has a use for it.
+ */
+class TvOfflineCache(context: Context) {
+
+  private val root: File = File(context.filesDir, "terrazzo/tv").apply { mkdirs() }
+
+  /** Fetch a previously-stored JSON blob by [scope]/[name]. Returns null if absent. */
+  fun read(scope: String, name: String): String? =
+    fileFor(scope, name).takeIf { it.exists() }?.readText()
+
+  /** Persist [json] under [scope]/[name]. Atomic via tmp+rename. */
+  fun write(scope: String, name: String, json: String) {
+    val target = fileFor(scope, name)
+    target.parentFile?.mkdirs()
+    val tmp = File(target.parentFile, "${target.name}.tmp")
+    tmp.writeText(json)
+    if (!tmp.renameTo(target)) {
+      target.writeText(json)
+      tmp.delete()
+    }
+  }
+
+  /** Wipe a [scope] (e.g. one HA instance directory). */
+  fun clearScope(scope: String) {
+    File(root, scope).deleteRecursively()
+  }
+
+  private fun fileFor(scope: String, name: String): File =
+    File(File(root, scope), name)
+}

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/sync/WearOfflineStore.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/sync/WearOfflineStore.kt
@@ -1,0 +1,85 @@
+package ee.schimke.terrazzo.wear.sync
+
+import android.content.Context
+import ee.schimke.terrazzo.wearsync.proto.DashboardData
+import ee.schimke.terrazzo.wearsync.proto.LiveValues
+import ee.schimke.terrazzo.wearsync.proto.PinnedCardSet
+import ee.schimke.terrazzo.wearsync.proto.WearSettings
+import ee.schimke.terrazzo.wearsync.proto.decodeProto
+import ee.schimke.terrazzo.wearsync.proto.encodeProto
+import java.io.File
+
+/**
+ * Watch-side offline store. The wear data layer is push-only (phone
+ * writes DataItems and ephemeral MessageClient deltas), so on cold
+ * launch with the phone unreachable the [WearSyncRepository] would have
+ * nothing to render. This store persists every proto blob the
+ * repository handles so the watch boots from disk and overlays live
+ * data when the phone reconnects.
+ *
+ * Layout under the wear app's `filesDir/terrazzo/wear/`:
+ *
+ * ```
+ *   settings.pb        — WearSettings
+ *   pinned.pb          — PinnedCardSet
+ *   values.pb          — LiveValues  (last full snapshot or merged stream)
+ *   dashboards/<file>  — DashboardData per `urlPath`
+ * ```
+ *
+ * Files are proto wire bytes (the same encoding the wear data layer
+ * itself uses), written via tmp+rename so a kill mid-write doesn't
+ * leave half-written cache files.
+ */
+class WearOfflineStore(context: Context) {
+
+  private val root: File = File(context.filesDir, "terrazzo/wear").apply { mkdirs() }
+  private val dashboardsDir: File = File(root, "dashboards").apply { mkdirs() }
+
+  fun readSettings(): WearSettings? =
+    File(root, "settings.pb").readBytesOrNull()?.let { decodeProto<WearSettings>(it) }
+
+  fun writeSettings(value: WearSettings) {
+    File(root, "settings.pb").atomicWriteBytes(encodeProto(value))
+  }
+
+  fun readPinned(): PinnedCardSet? =
+    File(root, "pinned.pb").readBytesOrNull()?.let { decodeProto<PinnedCardSet>(it) }
+
+  fun writePinned(value: PinnedCardSet) {
+    File(root, "pinned.pb").atomicWriteBytes(encodeProto(value))
+  }
+
+  fun readValues(): LiveValues? =
+    File(root, "values.pb").readBytesOrNull()?.let { decodeProto<LiveValues>(it) }
+
+  fun writeValues(value: LiveValues) {
+    File(root, "values.pb").atomicWriteBytes(encodeProto(value))
+  }
+
+  /** Read every persisted dashboard. Order is filesystem order; callers re-sort. */
+  fun readAllDashboards(): List<DashboardData> =
+    dashboardsDir
+      .listFiles { f -> f.isFile && f.name.endsWith(".pb") }
+      .orEmpty()
+      .mapNotNull { f -> f.readBytesOrNull()?.let { decodeProto<DashboardData>(it) } }
+
+  fun writeDashboard(value: DashboardData) {
+    val name = (value.urlPath.takeIf { it.isNotEmpty() }?.replace('/', '_') ?: "_default") + ".pb"
+    File(dashboardsDir, name).atomicWriteBytes(encodeProto(value))
+  }
+}
+
+private fun File.readBytesOrNull(): ByteArray? =
+  runCatching { if (exists()) readBytes() else null }.getOrNull()
+
+private fun File.atomicWriteBytes(bytes: ByteArray) {
+  runCatching {
+    parentFile?.mkdirs()
+    val tmp = File(parentFile, "$name.tmp")
+    tmp.writeBytes(bytes)
+    if (!tmp.renameTo(this)) {
+      writeBytes(bytes)
+      tmp.delete()
+    }
+  }
+}

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/sync/WearSyncRepository.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/sync/WearSyncRepository.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
 /**
@@ -58,16 +57,28 @@ class WearSyncRepository(
             coroutineScope = scope,
         )
 
-    private val _settings: MutableStateFlow<WearSettings> = MutableStateFlow(WearSettings())
+    /**
+     * Local on-disk mirror of every proto blob the phone has ever
+     * pushed. Read once at [start] so the watch boots from disk when
+     * the phone is unreachable; written on every [handle] so the next
+     * cold launch sees the latest values without waiting for a sync.
+     */
+    private val offline: WearOfflineStore = WearOfflineStore(context.applicationContext)
+
+    private val _settings: MutableStateFlow<WearSettings> =
+        MutableStateFlow(offline.readSettings() ?: WearSettings())
     val settings: StateFlow<WearSettings> = _settings.asStateFlow()
 
-    private val _pinned: MutableStateFlow<PinnedCardSet> = MutableStateFlow(PinnedCardSet())
+    private val _pinned: MutableStateFlow<PinnedCardSet> =
+        MutableStateFlow(offline.readPinned() ?: PinnedCardSet())
     val pinned: StateFlow<PinnedCardSet> = _pinned.asStateFlow()
 
-    private val _dashboards: MutableStateFlow<List<DashboardData>> = MutableStateFlow(emptyList())
+    private val _dashboards: MutableStateFlow<List<DashboardData>> =
+        MutableStateFlow(offline.readAllDashboards().sortedBy { it.title })
     val dashboards: StateFlow<List<DashboardData>> = _dashboards.asStateFlow()
 
-    private val _values: MutableStateFlow<Map<String, EntityValue>> = MutableStateFlow(emptyMap())
+    private val _values: MutableStateFlow<Map<String, EntityValue>> =
+        MutableStateFlow(offline.readValues()?.values ?: emptyMap())
     val values: StateFlow<Map<String, EntityValue>> = _values.asStateFlow()
 
     private val dataListener = DataClient.OnDataChangedListener { events: DataEventBuffer ->
@@ -89,6 +100,9 @@ class WearSyncRepository(
             merged[delta.entityId] = delta.value
         }
         _values.value = merged
+        // Persist the merged snapshot so a process restart resumes from
+        // the latest delta-updated state, not the last full DataItem.
+        offline.writeValues(LiveValues(values = merged, capturedAtMs = frame.capturedAtMs))
     }
 
     fun start() {
@@ -136,14 +150,21 @@ class WearSyncRepository(
     private fun handle(path: String, bytes: ByteArray) {
         when {
             path == WearSyncPaths.SETTINGS ->
-                decodeProto<WearSettings>(bytes)?.let { _settings.value = it }
+                decodeProto<WearSettings>(bytes)?.let {
+                    _settings.value = it
+                    offline.writeSettings(it)
+                }
             path == WearSyncPaths.PINNED ->
-                decodeProto<PinnedCardSet>(bytes)?.let { _pinned.value = it }
+                decodeProto<PinnedCardSet>(bytes)?.let {
+                    _pinned.value = it
+                    offline.writePinned(it)
+                }
             path == WearSyncPaths.VALUES ->
                 decodeProto<LiveValues>(bytes)?.let { live ->
                     // Cold-read overwrites entirely; subsequent stream
                     // deltas will merge from this baseline.
                     _values.value = live.values
+                    offline.writeValues(live)
                 }
             path.startsWith(WearSyncPaths.DASHBOARD_PREFIX) ->
                 decodeProto<DashboardData>(bytes)?.let { dashboard ->
@@ -151,6 +172,7 @@ class WearSyncRepository(
                     val idx = current.indexOfFirst { it.urlPath == dashboard.urlPath }
                     if (idx >= 0) current[idx] = dashboard else current.add(dashboard)
                     _dashboards.value = current.sortedBy { it.title }
+                    offline.writeDashboard(dashboard)
                 }
         }
     }

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearPreviews.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearPreviews.kt
@@ -185,6 +185,5 @@ private fun WearPreviewFrame(content: @Composable () -> Unit) {
 // Frozen clock so previews are byte-stable across renders. The runtime
 // scaffold in WearMainActivity still uses the real system clock.
 private object PreviewTimeSource : TimeSource {
-    override val currentTime: String
-        @Composable get() = "10:08"
+    @Composable override fun currentTime(): String = "10:08"
 }


### PR DESCRIPTION
## Summary

Once a user has logged in and the app has fetched data once, every subsequent launch must render the last-known dashboards and entity values without a network. When live data arrives it replaces the cached view in place; transient failures don't blank the UI.

**`terrazzo-core`**
- `OfflineCache` (DI) + `OfflineCacheStorage` (test-friendly `File`-rooted base) persists per-instance dashboard list, dashboard configs, and entity snapshots under `filesDir/terrazzo/cache/<sha-baseUrl>/`. One JSON file per entry, atomic tmp+rename writes — partial writes can never corrupt more than a single blob.
- `CachedHaSession` wraps any `HaSession`. Every successful live fetch mirrors to disk; every read falls back to cache on failure. The UI never blanks when the network drops mid-session.
- `OfflineOnlySession` + `HaSessionFactory.createCachedOnly()` lets `MainActivity` build a session synchronously from disk on cold start, before any network call.

**`app/` (mobile)**
- `MainActivity` reads `OfflineCache.lastInstance()` at startup and seeds a cache-only session — first composition paints from disk instead of bouncing through discovery + login.
- `DashboardListState` and `DashboardViewScreen` seed initial state from disk so the picker / view show last-known data immediately. `Error` only surfaces when there is no cached value to fall back on.
- Sign-out wipes the per-instance cache directory and refresh-token vault entry so the next user on the device cannot read the previous account's data off disk.

**`wear/`**
- `WearOfflineStore` mirrors every DataClient/MessageClient proto blob (settings, pinned, dashboards, values) under `filesDir/terrazzo/wear/` — one `.pb` file per blob type, same proto wire bytes the data layer already uses (no re-serialisation).
- `WearSyncRepository` hydrates StateFlows from these files in its primary constructor so a cold launch with no phone in range still renders the last-known dashboard list, pinned cards, and values. Stream deltas merged with the cached baseline are persisted so a process restart resumes from the latest delta-updated state, not the last full DataItem.

**`tv/`**
- `TvOfflineCache` scaffolds the same shape as the mobile cache against the TV app's `filesDir`. The TV app does not yet wire a live `HaSession`; when it lands, the offline path is already in place. Documented in `docs/architecture/offline-first.md`.

**Misc**
- Wear `TimeSource.currentTime` is now a function in the wear-compose-material3 release; `PreviewTimeSource` updated to match (was failing wear `compileDebugKotlin`).
- `terrazzo-core/build.gradle.kts` adds `kotlin-serialization` plugin so `OfflineCache`'s `@Serializable` instance pointer compiles.

**Docs**
- `docs/architecture/offline-first.md` records the contract, cache layout per app (mobile JSON / wear proto), auto-resume flow, sign-out cleanup, and the image-cache follow-up.

## Test plan

- [x] `./gradlew test` — full repo suite green (27 tests in `:app`)
  - 8× `OfflineCacheTest` (round-trip, isolation, sign-out, snapshot fidelity)
  - 5× `CachedHaSessionTest` (live → cache mirror, cache fallback on failure, error propagation when cache empty)
  - 1× `OfflineFirstWebSocketFlowTest` — embedded Ktor server speaks HA's WebSocket protocol; load → update → kill server → cache-only session still serves the latest data
  - 1× `OfflineFirstAddonHttpTest` — mockserver-netty fakes HA add-on REST; verifies `health()` swallow contract under disconnect and that the dashboard cached during the live phase survives the server going away
- [x] `./gradlew :app:lintDebug :wear:lintDebug :tv:lintDebug` — clean
- [x] `./gradlew ktfmtCheck` — clean
- [ ] Manual smoke: cold-launch with cache populated → lands on last-viewed dashboard with no spinner; toggle airplane mode mid-session → existing values stay on screen
- [ ] Manual smoke (wear): pair → phone publishes → kill phone app → wear cold-launch still shows pinned cards and last values
- [ ] Sign-out wipes the per-instance cache directory (verify on disk via `adb shell run-as`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsLTzQnBewDynMzQTgGN5z)_