### PR TITLE
Fix LongPressInstallTest after offline-first refactor

### DIFF
--- a/app/src/androidTest/kotlin/ee/schimke/terrazzo/dashboard/LongPressInstallTest.kt
+++ b/app/src/androidTest/kotlin/ee/schimke/terrazzo/dashboard/LongPressInstallTest.kt
@@ -52,11 +52,16 @@ class LongPressInstallTest {
             .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
             .putExtra(MainActivity.EXTRA_TEST_DEMO_MODE, true)
         context.startActivity(launch)
-        // Wait for the navigation suite to render (Dashboards is the
-        // default destination after demo-mode short-circuits auth).
+        // Wait for the dashboard picker. The shell is now a Scaffold +
+        // TopAppBar (the old NavigationSuiteScaffold is gone), so the
+        // first stable user-visible string after demo-mode short-
+        // circuits auth is the picker's TopAppBar title. Demo-mode
+        // also clears the last-viewed-dashboard pref so we always
+        // land on the picker, never auto-resumed onto a dashboard
+        // from a previous test run.
         assertTrue(
-            "navigation suite did not surface within 15s",
-            device.wait(Until.hasObject(By.text("Dashboards")), 15_000),
+            "dashboard picker did not surface within 15s",
+            device.wait(Until.hasObject(By.text("Pick a dashboard")), 15_000),
         )
     }
 

--- a/app/src/main/kotlin/ee/schimke/terrazzo/MainActivity.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/MainActivity.kt
@@ -26,8 +26,17 @@ class MainActivity : ComponentActivity() {
         // uiautomator test can land directly on the dashboard. Gated
         // on BuildConfig.DEBUG so production builds don't expose
         // the bypass even if the extra is present.
+        //
+        // Also clears the offline-cache instance pointer and the
+        // last-viewed-dashboard pref so the test starts on the
+        // dashboard picker every time, not auto-resumed onto a
+        // previous run's cached dashboard.
         if (BuildConfig.DEBUG && intent?.getBooleanExtra(EXTRA_TEST_DEMO_MODE, false) == true) {
-            runBlocking { graph.preferencesStore.setDemoMode(true) }
+            runBlocking {
+                graph.preferencesStore.setDemoMode(true)
+                graph.preferencesStore.clearLastViewedDashboard()
+            }
+            graph.offlineCache.clearLastInstance()
         }
 
         // Read the auto-launch dashboard pref synchronously so the


### PR DESCRIPTION
## Summary

The offline-first PR (#31) replaced the `NavigationSuiteScaffold` with a `Scaffold + TopAppBar` shell, which removed the user-visible `"Dashboards"` chip the instrumented test waited on. CI's `connectedDebugAndroidTest` job has been failing because of this stale wait.

- Update `LongPressInstallTest.launchAppInDemoMode` to wait on the new picker's stable string — the TopAppBar title `"Pick a dashboard"`. The body of the test (find `"Home"`, click, find `dashboard-card:*`, long-click, expect `"Add to Home Screen"` sheet) is unchanged.
- Harden the `EXTRA_TEST_DEMO_MODE` test hatch in `MainActivity` so it also clears the offline-cache instance pointer and the last-viewed-dashboard pref. Otherwise a previous run could leave state on disk that the offline-first auto-resume picks up, dropping the user straight onto a cached dashboard and skipping the picker entirely — which would silently invalidate the test premise.

## Test plan

- [x] `./gradlew :app:compileDebugAndroidTestKotlin` — clean
- [x] `./gradlew :app:testDebugUnitTest` — clean (auto-resume guards still intact)
- [x] `./gradlew :app:lintDebug` — clean
- [x] `./gradlew ktfmtCheck` — clean
- [ ] CI: `connectedDebugAndroidTest` on the API 36 emulator should now pass `LongPressInstallTest.longPressOnDashboardCard_opensInstallSheet` again

---
_Generated by [Claude Code](https://claude.ai/code/session_01NsLTzQnBewDynMzQTgGN5z)_