### PR TITLE
Try Compose 1.11 Grid for dashboard sections + wrap-mode card docs

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -388,6 +388,7 @@ private fun SettingsScreen(
     val widgetRefresh = remember(context) { WidgetRefreshScheduler(context.applicationContext) }
     val themePref by graph.preferencesStore.themeStyle.collectAsState(initial = ThemePref.TerrazzoHome)
     val darkPref by graph.preferencesStore.darkMode.collectAsState(initial = DarkModePref.Follow)
+    val gridLayoutEnabled by graph.preferencesStore.experimentalGridLayout.collectAsState(initial = false)
 
     Scaffold(
         topBar = {
@@ -453,6 +454,28 @@ private fun SettingsScreen(
                     }
                 },
             )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Experimental: Grid layout", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        "Use Compose 1.11's Grid API for the wide-screen side-by-side " +
+                            "section layout instead of the chunked Row path. Only takes " +
+                            "effect on tablets / unfolded foldables with ≥2 sections.",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                Switch(
+                    checked = gridLayoutEnabled,
+                    onCheckedChange = { enabled ->
+                        scope.launch { graph.preferencesStore.setExperimentalGridLayout(enabled) }
+                    },
+                )
+            }
 
             OutlinedButton(onClick = onSignOut) {
                 Text(if (isDemo) "Exit demo" else "Sign out")

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -5,6 +5,8 @@ package ee.schimke.terrazzo.dashboard
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalGridApi
+import androidx.compose.foundation.layout.Grid
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -19,6 +21,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -40,12 +43,13 @@ import ee.schimke.terrazzo.core.session.HaSession
 import ee.schimke.ha.rc.CardWidthClass
 import ee.schimke.ha.rc.ProvideCardRegistry
 import ee.schimke.ha.rc.RenderChild
-import ee.schimke.ha.rc.androidXExperimental
+import ee.schimke.ha.rc.androidXExperimentalWrap
 import ee.schimke.ha.rc.cardHeightDp
 import ee.schimke.ha.rc.cardWidthClass
 import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.components.ProvideHaTheme
 import ee.schimke.ha.rc.components.haThemeFor
+import ee.schimke.terrazzo.LocalTerrazzoGraph
 import ee.schimke.terrazzo.ui.LayoutConfig
 import ee.schimke.terrazzo.ui.LocalIsDarkTheme
 import ee.schimke.terrazzo.ui.LocalThemeStyle
@@ -143,6 +147,8 @@ private fun DashboardList(
     val registry = remember { defaultRegistry() }
     val layout = remember(dashboard) { buildDashboardLayout(dashboard) }
     val cfg = rememberLayoutConfig()
+    val useGridLayout by LocalTerrazzoGraph.current
+        .preferencesStore.experimentalGridLayout.collectAsState(initial = false)
 
     val sectionColumns = (cfg.maxSectionColumns).coerceAtMost(layout.sectionCount).coerceAtLeast(1)
     val sideBySide = sectionColumns >= 2
@@ -173,6 +179,7 @@ private fun DashboardList(
                     cfg = cfg,
                     sideBySide = sideBySide,
                     sectionColumns = sectionColumns,
+                    useGridLayout = useGridLayout,
                     onLongPress = onCardLongPress,
                 )
             }
@@ -183,9 +190,13 @@ private fun DashboardList(
 /**
  * Emit one view's blocks into the parent [LazyListScope]. Orphan
  * cards (legacy `view.cards`) come first as a single column;
- * sections follow, either stacked (single-column mode) or
- * chunked into rows of [sectionColumns] section-columns
- * (wide mode).
+ * sections follow, either stacked (single-column mode) or — in wide
+ * mode — packed across [sectionColumns] tracks. The wide path has
+ * two implementations selected by [useGridLayout]: the legacy
+ * `Row` + `chunked` path with manual weight padding, or a single
+ * Compose 1.11 `Grid` with one section per cell. Compact / Medium
+ * widths render the same either way (both fall through to the
+ * single-column branch).
  */
 private fun LazyListScope.renderView(
     viewIndex: Int,
@@ -195,6 +206,7 @@ private fun LazyListScope.renderView(
     cfg: LayoutConfig,
     sideBySide: Boolean,
     sectionColumns: Int,
+    useGridLayout: Boolean,
     onLongPress: (CardConfig) -> Unit,
 ) {
     val viewKey = "v$viewIndex"
@@ -228,6 +240,16 @@ private fun LazyListScope.renderView(
                 // pair up so a "lights" cluster stays usable on
                 // narrow screens.
                 compactPerRow = cfg.compactCardsPerRow,
+                onLongPress = onLongPress,
+            )
+        }
+    } else if (useGridLayout) {
+        item(key = "$viewKey-grid") {
+            SectionGrid(
+                sections = view.sections,
+                columns = sectionColumns,
+                snapshot = snapshot,
+                registry = registry,
                 onLongPress = onLongPress,
             )
         }
@@ -292,6 +314,47 @@ private fun SectionRow(
         // matches its sibling rows when sections.size % columns != 0.
         repeat(columns - sections.size) {
             Box(modifier = Modifier.weight(1f))
+        }
+    }
+}
+
+/**
+ * Experimental wide-mode layout: every section in a view is one cell
+ * in a Compose 1.11 [Grid] with [columns] equal-weight column tracks.
+ * Replaces the [SectionRow] + `view.sections.chunked(columns)` +
+ * `Spacer(weight)` ceremony with a single layout pass that auto-flows
+ * sections by row. Per-cell content is the same [SectionColumn]
+ * the legacy path uses, so visual parity is the goal: any difference
+ * is the Grid layout policy itself, not a different cell renderer.
+ *
+ * Implicit row tracks default to `GridTrackSize.Auto`, so each row
+ * sizes to its tallest section (cards inside still report fixed
+ * heights via `cardHeightDp`).
+ */
+@OptIn(ExperimentalGridApi::class)
+@Composable
+private fun SectionGrid(
+    sections: List<SectionLayout>,
+    columns: Int,
+    snapshot: HaSnapshot,
+    registry: ee.schimke.ha.rc.CardRegistry,
+    onLongPress: (CardConfig) -> Unit,
+) {
+    Grid(
+        modifier = Modifier.fillMaxWidth(),
+        config = {
+            repeat(columns) { column(1.fr) }
+            gap(row = 16.dp, column = 16.dp)
+        },
+    ) {
+        sections.forEach { section ->
+            SectionColumn(
+                section = section,
+                snapshot = snapshot,
+                registry = registry,
+                onLongPress = onLongPress,
+                modifier = Modifier.gridItem(),
+            )
         }
     }
 }
@@ -413,7 +476,7 @@ private fun CardSlot(
             // events on the Main pass for in-document click regions.
             .longPressBeforeChild { onLongPress(card) },
     ) {
-        RemotePreview(profile = androidXExperimental) {
+        RemotePreview(profile = androidXExperimentalWrap) {
             ProvideCardRegistry(registry) {
                 ProvideHaTheme(haTheme) {
                     RenderChild(card, snapshot, RemoteModifier.fillMaxWidth())

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WrapModeProfile.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WrapModeProfile.kt
@@ -5,53 +5,49 @@ package ee.schimke.ha.rc
 import androidx.compose.remote.core.CoreDocument
 import androidx.compose.remote.core.RcProfiles
 import androidx.compose.remote.core.operations.Header
-import androidx.compose.remote.creation.CreationDisplayInfo
+import androidx.compose.remote.creation.RemoteComposeWriter
 import androidx.compose.remote.creation.RemoteComposeWriterAndroid
 import androidx.compose.remote.creation.platform.AndroidxRcPlatformServices
 import androidx.compose.remote.creation.profile.Profile
 
 /**
- * Same as [androidXExperimental], but with `Header.FEATURE_PAINT_MEASURE = 0` baked into the
- * document. The default in alpha08 is `1` ("direct measure in paint, instead of wrap behavior"),
- * which makes [androidx.compose.remote.player.view.platform.RemoteComposeView.onMeasure] report the
- * document's declared `mWidth`/`mHeight` to its parent regardless of the root layout's intrinsic
- * size. With the feature off, the player runs a real measure pass against the parent's
- * `maxWidth`/`maxHeight` and reports `mRootLayoutComponent.getWidth()/getHeight()` — i.e. the
- * document's natural content size — back up the View hierarchy.
+ * AndroidX experimental profile (FlowLayout / grid-card ops enabled) that emits documents with
+ * `Header.FEATURE_PAINT_MEASURE = 0`.
  *
- * Visually this is a no-op when the host wraps the player in `Modifier.size(...)` /
- * `Modifier.fillMaxSize()` (the `EXACTLY` MeasureSpec ignores the intrinsic). It becomes useful
- * when the host wants to flow cards by their own content size — e.g. a flexbox-style dashboard
- * layout, or a wrap-content card slot — at which point the document needs to be authored with the
- * wrap-friendly measure path. We bake the bit in now so future host changes don't have to
- * re-encode every card.
+ * The default in alpha08 is `1` ("direct measure in paint, instead of wrap behavior"), which makes
+ * [androidx.compose.remote.player.view.platform.RemoteComposeView.onMeasure] report the document's
+ * declared `mWidth`/`mHeight` to its parent regardless of the root layout's intrinsic size. With
+ * the feature off, the player runs a real measure pass against the parent's `maxWidth`/`maxHeight`
+ * and reports `mRootLayoutComponent.getWidth()/getHeight()` — the document's natural content size
+ * — back up the View hierarchy.
  *
- * Multiple `HEADER` ops are legal in the wire format; [CoreDocument.initFromBuffer] walks all
- * operations in order and assigns `mHeader = header` for each, so the **last** Header wins. The
- * super constructor writes the four standard tags (DOC_WIDTH/HEIGHT/CONTENT_DESCRIPTION/PROFILES);
- * we append a second Header carrying `FEATURE_PAINT_MEASURE = 0` from the subclass `init`.
- */
-private class WrapModeWriter(
-    creationDisplayInfo: CreationDisplayInfo,
-    profile: Profile,
-    callback: Any?,
-) : RemoteComposeWriterAndroid(creationDisplayInfo, null, profile, callback) {
-    init {
-        // mBuffer is protected on RemoteComposeWriter — accessible from this subclass.
-        mBuffer.addHeader(shortArrayOf(Header.FEATURE_PAINT_MEASURE), arrayOf<Any>(0))
-    }
-}
-
-/**
- * AndroidX experimental profile (FlowLayout / grid-card ops enabled) emitting documents with
- * `FEATURE_PAINT_MEASURE = 0`. Drop-in for [androidXExperimental] at any capture site that wants
- * the document to participate in wrap-content measurement.
+ * Visually a no-op when the host wraps the player in `Modifier.size(...)` /
+ * `Modifier.fillMaxSize()` (the `EXACTLY` MeasureSpec ignores the intrinsic). Becomes useful when
+ * the host wants to flow cards by their own content size — flexbox-style dashboard, wrap-content
+ * card slot, `RemoteComposePlayerFlags.shouldPlayerWrapContentSize` — at which point the document
+ * needs to be authored with the wrap-friendly measure path. Bake the bit in now so future host
+ * changes don't have to re-encode every card.
+ *
+ * The flag has to land in the same single `HEADER` op that carries DOC_WIDTH / DOC_HEIGHT /
+ * DOC_CONTENT_DESCRIPTION / DOC_PROFILES, which means we go through the writer's varargs
+ * constructor at construction time rather than appending a second `HEADER` op afterwards. The
+ * tradeoff: this path doesn't carry the `writerCallback` (no public setter for `mWriterCallback`
+ * once the writer is built without it). The callback tracks PendingIntent-style side effects
+ * issued from the writer; cards in this project don't issue any, so dropping it is safe today —
+ * if/when widget-style PendingIntent actions get added the wrap profile will need to be revisited.
  */
 val androidXExperimentalWrap: Profile =
     Profile(
         CoreDocument.DOCUMENT_API_LEVEL,
         RcProfiles.PROFILE_ANDROIDX or RcProfiles.PROFILE_EXPERIMENTAL,
         AndroidxRcPlatformServices(),
-    ) { creationDisplayInfo, profile, callback ->
-        WrapModeWriter(creationDisplayInfo, profile, callback)
+    ) { creationDisplayInfo, profile, _ ->
+        RemoteComposeWriterAndroid(
+            profile,
+            RemoteComposeWriter.hTag(Header.DOC_WIDTH, creationDisplayInfo.width),
+            RemoteComposeWriter.hTag(Header.DOC_HEIGHT, creationDisplayInfo.height),
+            RemoteComposeWriter.hTag(Header.DOC_CONTENT_DESCRIPTION, ""),
+            RemoteComposeWriter.hTag(Header.DOC_PROFILES, profile.operationsProfiles),
+            RemoteComposeWriter.hTag(Header.FEATURE_PAINT_MEASURE, 0),
+        )
     }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WrapModeProfile.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WrapModeProfile.kt
@@ -1,0 +1,57 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc
+
+import androidx.compose.remote.core.CoreDocument
+import androidx.compose.remote.core.RcProfiles
+import androidx.compose.remote.core.operations.Header
+import androidx.compose.remote.creation.CreationDisplayInfo
+import androidx.compose.remote.creation.RemoteComposeWriterAndroid
+import androidx.compose.remote.creation.platform.AndroidxRcPlatformServices
+import androidx.compose.remote.creation.profile.Profile
+
+/**
+ * Same as [androidXExperimental], but with `Header.FEATURE_PAINT_MEASURE = 0` baked into the
+ * document. The default in alpha08 is `1` ("direct measure in paint, instead of wrap behavior"),
+ * which makes [androidx.compose.remote.player.view.platform.RemoteComposeView.onMeasure] report the
+ * document's declared `mWidth`/`mHeight` to its parent regardless of the root layout's intrinsic
+ * size. With the feature off, the player runs a real measure pass against the parent's
+ * `maxWidth`/`maxHeight` and reports `mRootLayoutComponent.getWidth()/getHeight()` — i.e. the
+ * document's natural content size — back up the View hierarchy.
+ *
+ * Visually this is a no-op when the host wraps the player in `Modifier.size(...)` /
+ * `Modifier.fillMaxSize()` (the `EXACTLY` MeasureSpec ignores the intrinsic). It becomes useful
+ * when the host wants to flow cards by their own content size — e.g. a flexbox-style dashboard
+ * layout, or a wrap-content card slot — at which point the document needs to be authored with the
+ * wrap-friendly measure path. We bake the bit in now so future host changes don't have to
+ * re-encode every card.
+ *
+ * Multiple `HEADER` ops are legal in the wire format; [CoreDocument.initFromBuffer] walks all
+ * operations in order and assigns `mHeader = header` for each, so the **last** Header wins. The
+ * super constructor writes the four standard tags (DOC_WIDTH/HEIGHT/CONTENT_DESCRIPTION/PROFILES);
+ * we append a second Header carrying `FEATURE_PAINT_MEASURE = 0` from the subclass `init`.
+ */
+private class WrapModeWriter(
+    creationDisplayInfo: CreationDisplayInfo,
+    profile: Profile,
+    callback: Any?,
+) : RemoteComposeWriterAndroid(creationDisplayInfo, null, profile, callback) {
+    init {
+        // mBuffer is protected on RemoteComposeWriter — accessible from this subclass.
+        mBuffer.addHeader(shortArrayOf(Header.FEATURE_PAINT_MEASURE), arrayOf<Any>(0))
+    }
+}
+
+/**
+ * AndroidX experimental profile (FlowLayout / grid-card ops enabled) emitting documents with
+ * `FEATURE_PAINT_MEASURE = 0`. Drop-in for [androidXExperimental] at any capture site that wants
+ * the document to participate in wrap-content measurement.
+ */
+val androidXExperimentalWrap: Profile =
+    Profile(
+        CoreDocument.DOCUMENT_API_LEVEL,
+        RcProfiles.PROFILE_ANDROIDX or RcProfiles.PROFILE_EXPERIMENTAL,
+        AndroidxRcPlatformServices(),
+    ) { creationDisplayInfo, profile, callback ->
+        WrapModeWriter(creationDisplayInfo, profile, callback)
+    }

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/prefs/PreferencesStore.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/prefs/PreferencesStore.kt
@@ -73,6 +73,21 @@ class PreferencesStore(private val context: Context) {
     }
 
     /**
+     * Opt-in to the experimental Compose 1.11 `Grid` API for the
+     * dashboard side-by-side section layout. Off by default so the
+     * stable `Row` + chunked path keeps shipping; flip from Settings
+     * to evaluate visual / behavioural parity against the legacy
+     * path. Compact / Medium widths render the same either way (the
+     * flag only takes effect in Expanded width with ≥2 sections).
+     */
+    val experimentalGridLayout: Flow<Boolean>
+        get() = context.store.data.map { it[GRID_LAYOUT_KEY] ?: false }
+
+    suspend fun setExperimentalGridLayout(enabled: Boolean) {
+        context.store.edit { it[GRID_LAYOUT_KEY] = enabled }
+    }
+
+    /**
      * The dashboard the user last opened. Drives auto-launch: on cold
      * start, [ee.schimke.terrazzo.MainActivity] reads this once and
      * seeds the dashboard nav-state, so a single-dashboard or 2-3
@@ -122,6 +137,7 @@ class PreferencesStore(private val context: Context) {
         private val THEME_KEY = stringPreferencesKey("theme_style")
         private val DARK_KEY = stringPreferencesKey("dark_mode")
         private val LAST_VIEWED_KEY = stringPreferencesKey("last_viewed_dashboard")
+        private val GRID_LAYOUT_KEY = booleanPreferencesKey("experimental_grid_layout")
 
         /** Stored value for HA's default (unnamed) dashboard. */
         const val DEFAULT_DASHBOARD_SENTINEL: String = "__default__"


### PR DESCRIPTION
## Summary

Two probes against the Compose 1.11 / RemoteCompose alpha08 surface, both fully reversible:

- **Experimental Grid layout for sections** — new `PreferencesStore` flag (Settings → "Experimental: Grid layout", off by default) switches the wide-mode side-by-side section path from the legacy `Row` + `view.sections.chunked(columns)` + `Spacer(weight)` padding to a single `Grid` with N equal-`fr` column tracks. Implicit row tracks default to `GridTrackSize.Auto` so each row sizes to its tallest section. Compact / Medium widths fall through to the single-column branch unchanged.

- **`androidXExperimentalWrap` profile** — bakes `Header.FEATURE_PAINT_MEASURE = 0` into every dashboard card document by appending a second `HEADER` op from a thin `RemoteComposeWriterAndroid` subclass. `CoreDocument.initFromBuffer` walks operations in order assigning `mHeader = header`, so the later `Header` wins. Visually a no-op today (`RemotePreview` wraps the player in `fillMaxSize` / `Modifier.size` with `EXACTLY` constraints) but unlocks intrinsic-size reporting for a future host that wants to flow cards by their own content size — e.g. a Flexbox-style dashboard, or `RemoteComposePlayerFlags.shouldPlayerWrapContentSize`.

Widgets / `CardCapture` keep using `androidXExperimental` (non-wrap): they have explicit dimensions and don't need the wrap-friendly measure path.

## Test plan

- [ ] Run on a phone (Compact width): no visible change — still single-column with compact-card packing.
- [ ] Run on a tablet / unfolded foldable (Expanded width, ≥2 sections), Grid switch OFF: legacy chunked Row layout, identical to main.
- [ ] Flip the Grid switch in Settings → side-by-side sections render via Compose `Grid`. Verify visual parity (column widths, gaps, row heights pin to tallest section in row).
- [ ] Verify a dashboard card still renders correctly under the wrap-mode profile (wire-format-level change, no on-screen difference expected).
- [ ] Widget pin / refresh path still works (uses non-wrap profile).
- [ ] `./gradlew ktfmtCheck :app:assembleDebug` clean.