### PR TITLE
ci: bump compose-ai-tools to v0.8.5

### DIFF
--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -29,7 +29,7 @@ jobs:
           # credentials persisted here.
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.8.4
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.8.5
         with:
           cli-version: catalog
           catalog-key: compose-preview-plugin

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.8.4
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.8.5
         with:
           cli-version: catalog
           catalog-key: compose-preview-plugin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ junit-jupiter-bom = "6.0.3"
 mockserver = "5.15.0"
 
 # Preview tooling
-compose-preview-plugin = "0.8.4"
+compose-preview-plugin = "0.8.5"
 
 # Formatting
 ktfmt-gradle = "0.26.0"


### PR DESCRIPTION
v0.8.5 fixes plugin detection for transitive @Preview deps in CMP-Android
layouts (compose-ai-tools#242), restoring `compose-preview show` for this
repo's `previews/` module — under v0.8.4 the CLI/doctor reported "no modules
with the compose-preview plugin applied" even though the plugin was applied.