### PR TITLE
ci: bump compose-ai-tools to v0.8.6

### DIFF
--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -29,7 +29,7 @@ jobs:
           # credentials persisted here.
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.8.5
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.8.6
         with:
           cli-version: catalog
           catalog-key: compose-preview-plugin

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.8.5
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.8.6
         with:
           cli-version: catalog
           catalog-key: compose-preview-plugin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ junit-jupiter-bom = "6.0.3"
 mockserver = "5.15.0"
 
 # Preview tooling
-compose-preview-plugin = "0.8.5"
+compose-preview-plugin = "0.8.6"
 
 # Formatting
 ktfmt-gradle = "0.26.0"


### PR DESCRIPTION
## Summary
- Bump `compose-preview-plugin` (the `ee.schimke.composeai.preview` Gradle plugin) from 0.8.5 → 0.8.6 in `gradle/libs.versions.toml`.
- Bump the `yschimke/compose-ai-tools` composite actions used by `preview-baselines.yml` and `preview-comment.yml` from `@v0.8.5` → `@v0.8.6` to match.

## Test plan
- [ ] `preview-baselines` workflow runs green on this PR
- [ ] `preview-comment` workflow runs green on this PR
- [ ] CI build/test/lint passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01V3To2LmyhPB3crz6iZ4fJZ)_