### PR TITLE
build: wire signing + Play Publisher; rename applicationId to ee.schimke.harc

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,12 @@
+import com.github.triplet.gradle.androidpublisher.ReleaseStatus
+
 plugins {
   alias(libs.plugins.android.application)
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.compose.preview)
   alias(libs.plugins.metro)
   alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.play.publisher)
 }
 
 android {
@@ -63,6 +66,14 @@ composePreview {
   variant.set("debug")
   sdkVersion.set(35)
   enabled.set(true)
+}
+
+play {
+  track.set("internal")
+  defaultToAppBundles.set(true)
+  releaseStatus.set(ReleaseStatus.DRAFT)
+  // Skip API calls in CI runs that build but don't publish (e.g. PRs).
+  enabled.set(System.getenv("ANDROID_PUBLISHER_CREDENTIALS") != null)
 }
 
 dependencies {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,7 @@ android {
   namespace = "ee.schimke.terrazzo"
   compileSdk = libs.versions.android.compileSdk.get().toInt()
   defaultConfig {
-    applicationId = "ee.schimke.terrazzo"
+    applicationId = "ee.schimke.harc"
     // Widget playback via RemoteViews.DrawInstructions needs API 35+
     // (VANILLA_ICE_CREAM). We still compile / target the newest
     // available SDK via `compileSdk` / `targetSdk`. Keeping minSdk
@@ -27,6 +27,26 @@ android {
     manifestPlaceholders["appAuthRedirectScheme"] = "rcha"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+  }
+  val releaseKeystorePath = System.getenv("HARC_KEYSTORE_PATH")
+  signingConfigs {
+    if (releaseKeystorePath != null) {
+      create("release") {
+        storeFile = file(releaseKeystorePath)
+        storePassword = System.getenv("HARC_KEYSTORE_PASSWORD")
+        keyAlias = System.getenv("HARC_KEY_ALIAS")
+        keyPassword = System.getenv("HARC_KEY_PASSWORD")
+      }
+    }
+  }
+  buildTypes {
+    getByName("release") {
+      isMinifyEnabled = true
+      isShrinkResources = true
+      if (releaseKeystorePath != null) {
+        signingConfig = signingConfigs.getByName("release")
+      }
+    }
   }
   buildFeatures {
     compose = true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@
 kotlin = "2.3.21"
 agp = "9.2.0"
 java = "17"
+play-publisher = "4.0.0"
 
 # Metro (DI) — requires Kotlin 2.2.20+.
 metro = "1.0.0-RC4"
@@ -153,3 +154,4 @@ compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "
 compose-preview = { id = "ee.schimke.composeai.preview", version.ref = "compose-preview-plugin" }
 metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt-gradle" }
+play-publisher = { id = "com.github.triplet.play", version.ref = "play-publisher" }


### PR DESCRIPTION
## Summary
- Adds env-var-driven `signingConfigs.release` keyed off `HARC_KEYSTORE_PATH` / `_PASSWORD` / `_ALIAS` / `HARC_KEY_PASSWORD`. When the env var is unset the release build remains unsigned, mirroring the opt-in pattern from cadence and meshcore-mobile.
- Renames the phone applicationId from `ee.schimke.terrazzo` to `ee.schimke.harc` so the Play Store identifier reflects the project name. Internal Kotlin package and `namespace` stay as `ee.schimke.terrazzo` to avoid a wide source rename.
- Applies the `com.github.triplet.play` plugin (4.0.0) and configures `play{}` to upload App Bundles to the internal track as DRAFT, gated on `ANDROID_PUBLISHER_CREDENTIALS` so PRs and local builds skip the Play API.

## Test plan
- [ ] First AAB uploaded manually to Play Console internal track (`ee.schimke.harc`)
- [ ] Repo secrets populated: `SIGNING_KEYSTORE`, `HARC_KEYSTORE_PASSWORD`, `HARC_KEY_ALIAS`, `HARC_KEY_PASSWORD`, `PLAY_SERVICE_ACCOUNT_JSON`
- [ ] Tag a release and watch the existing release-build.yml workflow sign the AAB and publish to internal track as DRAFT
- [ ] Promote DRAFT to internal in Play Console