### PR TITLE
chore: bump Kotlin toolchain from JDK 17 to 21

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,10 +1,7 @@
 name: 'Setup JDK + Gradle'
 description: >
-  Dual-JDK setup: Temurin 17 (Kotlin toolchain) + 21 (Gradle daemon, so the
-  Metro plugin loads — it requires JVM runtime 21+). Last entry in the
-  setup-java version list wins as JAVA_HOME, so daemon = 21 and Gradle's
-  toolchain discovery finds 17 via JAVA_HOME_17_X64 for the Kotlin
-  compiler. Matches the pattern already used in ci.yml.
+  Temurin 21 covers both the Kotlin toolchain and the Gradle daemon (the
+  Metro plugin's buildscript requires JVM runtime 21+).
 
 inputs:
   cache-read-only:
@@ -19,9 +16,7 @@ runs:
     - uses: actions/setup-java@v5
       with:
         distribution: temurin
-        java-version: |
-          17
-          21
+        java-version: 21
     - uses: gradle/actions/setup-gradle@v6
       with:
         cache-read-only: ${{ inputs.cache-read-only }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,16 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: gradle/actions/wrapper-validation@v6
-      # Gradle itself (and the Metro plugin's buildscript) need JVM 21+.
-      # The Kotlin toolchain stays pinned to 17 (libs.versions.toml), and
-      # setup-java installs both so Gradle's toolchain discovery finds 17
-      # via JAVA_HOME_17_X64 while the daemon runs on 21.
+      # Kotlin toolchain and Gradle daemon both run on JVM 21 (libs.versions.toml).
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: |
-            17
-            21
+          java-version: 21
       - uses: gradle/actions/setup-gradle@v6
       - run: ./gradlew assembleDebug --stacktrace
 
@@ -38,16 +33,11 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
-      # Gradle itself (and the Metro plugin's buildscript) need JVM 21+.
-      # The Kotlin toolchain stays pinned to 17 (libs.versions.toml), and
-      # setup-java installs both so Gradle's toolchain discovery finds 17
-      # via JAVA_HOME_17_X64 while the daemon runs on 21.
+      # Kotlin toolchain and Gradle daemon both run on JVM 21 (libs.versions.toml).
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: |
-            17
-            21
+          java-version: 21
       - uses: gradle/actions/setup-gradle@v6
       # `test` fans out to every module: Android library / app modules get
       # their `testDebugUnitTest`, JVM modules (`:integration`, KMP common)
@@ -71,16 +61,11 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
-      # Gradle itself (and the Metro plugin's buildscript) need JVM 21+.
-      # The Kotlin toolchain stays pinned to 17 (libs.versions.toml), and
-      # setup-java installs both so Gradle's toolchain discovery finds 17
-      # via JAVA_HOME_17_X64 while the daemon runs on 21.
+      # Kotlin toolchain and Gradle daemon both run on JVM 21 (libs.versions.toml).
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: |
-            17
-            21
+          java-version: 21
       - uses: gradle/actions/setup-gradle@v6
       # `lint` fans out across every Android module. Debug variant is
       # enough for CI; release-only rules (e.g. ObsoleteSdkInt on
@@ -113,16 +98,11 @@ jobs:
             | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-      # Gradle itself (and the Metro plugin's buildscript) need JVM 21+.
-      # The Kotlin toolchain stays pinned to 17 (libs.versions.toml), and
-      # setup-java installs both so Gradle's toolchain discovery finds 17
-      # via JAVA_HOME_17_X64 while the daemon runs on 21.
+      # Kotlin toolchain and Gradle daemon both run on JVM 21 (libs.versions.toml).
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: |
-            17
-            21
+          java-version: 21
       - uses: gradle/actions/setup-gradle@v6
 
       - name: AVD cache

--- a/.github/workflows/ktfmt.yml
+++ b/.github/workflows/ktfmt.yml
@@ -18,15 +18,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      # Gradle itself (and the Metro plugin's buildscript) need JVM 21+.
-      # The Kotlin toolchain stays pinned to 17 (libs.versions.toml), and
-      # setup-java installs both so Gradle's toolchain discovery finds 17
-      # via JAVA_HOME_17_X64 while the daemon runs on 21.
+      # Kotlin toolchain and Gradle daemon both run on JVM 21 (libs.versions.toml).
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: |
-            17
-            21
+          java-version: 21
       - uses: gradle/actions/setup-gradle@v6
       - run: ./gradlew ktfmtCheck --stacktrace

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ check) into your clone:
 ## Running the previews
 
 ```sh
-compose-preview doctor             # verifies Java 17 toolchain
+compose-preview doctor             # verifies Java 21 toolchain
 compose-preview list               # lists all @Preview entries
 compose-preview show --json        # renders and prints PNG paths
 compose-preview render --filter tile

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Toolchain
 kotlin = "2.3.21"
 agp = "9.2.0"
-java = "17"
+java = "21"
 play-publisher = "4.0.0"
 
 # Metro (DI) — requires Kotlin 2.2.20+.


### PR DESCRIPTION
## Summary

- Bumps `java = "17"` → `"21"` in `gradle/libs.versions.toml`. Every module's `compileOptions` and `kotlin { jvmToolchain(...) }` reads from there, so all modules move together.
- Drops the dual-JDK CI workaround. The Gradle daemon already had to run on 21 (Metro plugin needs JVM 21+); with the Kotlin toolchain also on 21 there is no second JDK to install, so `setup-java` collapses to `java-version: 21` and the explanatory comments go away.
- Updates the README's `compose-preview doctor` blurb to mention JDK 21.

## Test plan

- [x] `./gradlew :previews:assembleDebug` (under JDK 21) — clean.
- [x] `compose-preview list` enumerates all preview entries with the new toolchain.
- [ ] CI: `Assemble (debug)`, `Unit tests`, `Android lint`, `Instrumented tests`, `ktfmt check` pass on the PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YZDUgZ5tFnpTs2Y4uYvEeN)_