### PR TITLE
build: publish releases directly to internal track at v0.1.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,10 @@
 # Agent notes
 
 - Do not exceed 1800px in any dimension when capturing or generating images (screenshots, previews, diffs). Downscale before returning or attaching them.
+- Use `agent/...` for branch names, never `claude/...` or `copilot/...`
+  (enforced by `.github/workflows/no-ai-coauthors.yml`).
+- Strip any `Co-authored-by` trailers, AI bot emails, and "Generated with"
+  lines from commits and PR bodies before pushing.
+- Keep PR titles in conventional-commits form
+  (`feat:`, `fix:`, `chore:`, `build:`, `ci:`, `docs:`, …); enforced
+  by `.github/workflows/pr-title.yml` and consumed by release-please.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,18 @@
 import com.github.triplet.gradle.androidpublisher.ReleaseStatus
 
+val appVersionName = "0.1.1" // x-release-please-version
+
+// Pack MAJOR.MINOR.PATCH into a monotonic int. Caps at major < 22.
+val appVersionCode: Int =
+  run {
+      val parts = appVersionName.split(".", "-").mapNotNull { it.toIntOrNull() }
+      val major = parts.getOrNull(0) ?: 0
+      val minor = parts.getOrNull(1) ?: 0
+      val patch = parts.getOrNull(2) ?: 0
+      major * 10_000 + minor * 100 + patch
+    }
+    .coerceAtLeast(1)
+
 plugins {
   alias(libs.plugins.android.application)
   alias(libs.plugins.compose.compiler)
@@ -22,8 +35,8 @@ android {
     // apk-for-local-test during renderPreviews.
     minSdk = 35
     targetSdk = libs.versions.android.targetSdk.get().toInt()
-    versionCode = 1
-    versionName = "0.1.0"
+    versionCode = appVersionCode
+    versionName = appVersionName
 
     // Exposed to AndroidManifest via placeholders so the IndieAuth
     // redirect scheme is declared in one place.
@@ -71,7 +84,7 @@ composePreview {
 play {
   track.set("internal")
   defaultToAppBundles.set(true)
-  releaseStatus.set(ReleaseStatus.DRAFT)
+  releaseStatus.set(ReleaseStatus.COMPLETED)
   // Skip API calls in CI runs that build but don't publish (e.g. PRs).
   enabled.set(System.getenv("ANDROID_PUBLISHER_CREDENTIALS") != null)
 }


### PR DESCRIPTION
## Summary
- Switches `releaseStatus` from DRAFT to COMPLETED so AABs uploaded by the release workflow go live on the internal track without manual rollout.
- Replaces hardcoded `versionCode = 1` with the cadence-style packed formula (`major*10_000 + minor*100 + patch`), derived from a single `appVersionName` marked with `x-release-please-version` so release-please bumps both on each release.
- Sets the new `appVersionName` to `0.1.1` to clear the versionCode reserved by the AAB uploaded manually to Play Console.
- Adds AGENTS.md notes for the `agent/*` branch convention, Co-authored-by stripping, and the conventional-commit PR-title rule.

## Test plan
- [ ] Merge, then push tag `v0.1.1`
- [ ] Watch the Release workflow build & sign an AAB and call `publishBundle`
- [ ] Confirm the AAB (`ee.schimke.harc`) appears in Play Console internal track as Released (not Draft)