### PR TITLE
icon: rework adaptive-icon foreground in Italian-terracotta palette

### DIFF
--- a/demo-app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/demo-app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Adaptive-icon foreground: a house silhouette filled with scattered
-  terrazzo chips. The house path doubles as a clip mask, so chips drawn
-  inside the group are trimmed to the silhouette regardless of how far
-  they bleed. Sized inside the 72dp safe zone of the 108dp canvas.
+  Adaptive-icon foreground. Italian-terracotta palette: a terracotta-tile
+  roof sits on warm stucco walls. Each surface is broken up by angular
+  tile chips in tighter shades of its base, with the base colour acting
+  as the mortar between chips. Sized inside the 72dp safe zone of the
+  108dp canvas.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"
@@ -11,82 +12,76 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
 
+    <!-- Roof: terracotta base + tile fragments. Clipped to the roof triangle. -->
     <group>
-        <clip-path android:pathData="M54,32 L22,60 L28,60 L28,84 L80,84 L80,60 L86,60 Z" />
+        <clip-path android:pathData="M54,32 L22,60 L28,60 L86,60 Z" />
 
-        <!-- Mortar / cream base inside the house -->
+        <!-- Mortar / base tile colour -->
         <path
-            android:fillColor="#F5EFE0"
-            android:pathData="M54,32 L22,60 L28,60 L28,84 L80,84 L80,60 L86,60 Z" />
+            android:fillColor="#B5532E"
+            android:pathData="M54,32 L22,60 L28,60 L86,60 Z" />
 
-        <!-- Larger terrazzo chips -->
+        <!-- Darker tile fragments -->
         <path
-            android:fillColor="#E07A5F"
-            android:pathData="M32,50 a6,4 0 1,0 12,0 a6,4 0 1,0 -12,0" />
+            android:fillColor="#8C3A1C"
+            android:pathData="M30,58 L42,52 L48,58 L46,60 L30,60 Z" />
         <path
-            android:fillColor="#F2CC8F"
-            android:pathData="M63,44 a5,4 0 1,0 10,0 a5,4 0 1,0 -10,0" />
+            android:fillColor="#8C3A1C"
+            android:pathData="M58,44 L66,48 L62,56 L54,52 Z" />
         <path
-            android:fillColor="#81B29A"
-            android:pathData="M47,66 a7,5 0 1,0 14,0 a7,5 0 1,0 -14,0" />
-        <path
-            android:fillColor="#3D405B"
-            android:pathData="M29,72 a4,3 0 1,0 8,0 a4,3 0 1,0 -8,0" />
-        <path
-            android:fillColor="#C9ADA7"
-            android:pathData="M67,76 a5,4 0 1,0 10,0 a5,4 0 1,0 -10,0" />
-        <path
-            android:fillColor="#6B4F4F"
-            android:pathData="M55,52 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0" />
-        <path
-            android:fillColor="#4A6670"
-            android:pathData="M41,78 a3,2 0 1,0 6,0 a3,2 0 1,0 -6,0" />
-        <path
-            android:fillColor="#E07A5F"
-            android:pathData="M68,58 a4,3 0 1,0 8,0 a4,3 0 1,0 -8,0" />
-        <path
-            android:fillColor="#81B29A"
-            android:pathData="M45,42 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0" />
-        <path
-            android:fillColor="#F2CC8F"
-            android:pathData="M61,80 a3,2 0 1,0 6,0 a3,2 0 1,0 -6,0" />
-        <path
-            android:fillColor="#C9ADA7"
-            android:pathData="M39,58 a3,2 0 1,0 6,0 a3,2 0 1,0 -6,0" />
-        <path
-            android:fillColor="#3D405B"
-            android:pathData="M62,66 a4,3 0 1,0 8,0 a4,3 0 1,0 -8,0" />
+            android:fillColor="#8C3A1C"
+            android:pathData="M70,55 L80,58 L78,60 L66,60 Z" />
 
-        <!-- Smaller speckles -->
+        <!-- Lighter tile fragments -->
         <path
-            android:fillColor="#E07A5F"
-            android:pathData="M34,82 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
+            android:fillColor="#D67149"
+            android:pathData="M44,40 L52,38 L52,46 L44,48 Z" />
         <path
-            android:fillColor="#81B29A"
-            android:pathData="M74,70 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
+            android:fillColor="#D67149"
+            android:pathData="M50,52 L60,52 L62,60 L50,60 Z" />
         <path
-            android:fillColor="#3D405B"
-            android:pathData="M48,58 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
-        <path
-            android:fillColor="#F2CC8F"
-            android:pathData="M38,64 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
-        <path
-            android:fillColor="#4A6670"
-            android:pathData="M66,82 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
-        <path
-            android:fillColor="#C9ADA7"
-            android:pathData="M58,40 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
-
-        <!-- Door, anchored to the floor of the body -->
-        <path
-            android:fillColor="#3D405B"
-            android:pathData="M49,71 L59,71 L59,84 L49,84 Z" />
+            android:fillColor="#D67149"
+            android:pathData="M62,55 L72,56 L72,60 L60,60 Z" />
     </group>
+
+    <!-- Walls: warm stucco base + chunkier tile chips. Clipped to the wall body. -->
+    <group>
+        <clip-path android:pathData="M28,60 L80,60 L80,84 L28,84 Z" />
+
+        <!-- Mortar / base wall colour -->
+        <path
+            android:fillColor="#E8CFA6"
+            android:pathData="M28,60 L80,60 L80,84 L28,84 Z" />
+
+        <!-- Umber chips -->
+        <path
+            android:fillColor="#A88456"
+            android:pathData="M30,63 L46,64 L44,71 L30,70 Z" />
+        <path
+            android:fillColor="#A88456"
+            android:pathData="M62,73 L78,72 L78,82 L62,82 Z" />
+        <path
+            android:fillColor="#A88456"
+            android:pathData="M30,73 L46,74 L46,82 L30,82 Z" />
+
+        <!-- Cream highlight chips -->
+        <path
+            android:fillColor="#F4E4C4"
+            android:pathData="M62,63 L78,63 L78,70 L62,70 Z" />
+        <path
+            android:fillColor="#F4E4C4"
+            android:pathData="M48,63 L60,64 L60,69 L48,68 Z" />
+    </group>
+
+    <!-- Door, anchored to the floor of the body -->
+    <path
+        android:fillColor="#3A1E12"
+        android:pathData="M49,71 L59,71 L59,84 L49,84 Z" />
 
     <!-- House outline for definition at small sizes -->
     <path
         android:pathData="M54,32 L22,60 L28,60 L28,84 L80,84 L80,60 L86,60 Z"
-        android:strokeColor="#2A2A2E"
+        android:strokeColor="#3A1E12"
         android:strokeWidth="1.6"
         android:strokeLineJoin="round" />
 </vector>

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/AppIconPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/AppIconPreviews.kt
@@ -1,0 +1,81 @@
+package ee.schimke.ha.previews
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import ee.schimke.ha.rc.components.R as ComponentsR
+
+@Preview(name = "app-icon (light)", widthDp = 360, heightDp = 200, showBackground = true, backgroundColor = 0xFFF5F1E6)
+@Composable
+fun AppIcon_Light() = AppIconShowcase(darkTheme = false)
+
+@Preview(name = "app-icon (dark)", widthDp = 360, heightDp = 200, showBackground = true, backgroundColor = 0xFF1C1C1E, uiMode = 0x21)
+@Composable
+fun AppIcon_Dark() = AppIconShowcase(darkTheme = true)
+
+@Composable
+private fun AppIconShowcase(darkTheme: Boolean) {
+    Surface(color = Color.Transparent) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = if (darkTheme) "Adaptive icon · dark" else "Adaptive icon · light",
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                AdaptiveIcon(shape = CircleShape, label = "circle")
+                AdaptiveIcon(shape = RoundedCornerShape(24.dp), label = "squircle")
+                AdaptiveIcon(shape = RoundedCornerShape(8.dp), label = "rounded")
+                AdaptiveIcon(shape = RoundedCornerShape(0.dp), label = "square")
+            }
+        }
+    }
+}
+
+@Composable
+private fun AdaptiveIcon(shape: Shape, label: String) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(72.dp)
+                .clip(shape)
+                .background(colorResource(ComponentsR.color.ic_launcher_background)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Image(
+                painter = painterResource(ComponentsR.drawable.ic_launcher_foreground),
+                contentDescription = null,
+                modifier = Modifier.size(72.dp),
+            )
+        }
+        Text(label, style = MaterialTheme.typography.labelSmall)
+    }
+}

--- a/rc-components/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/rc-components/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Adaptive-icon foreground: a house silhouette filled with scattered
-  terrazzo chips. The house path doubles as a clip mask, so chips drawn
-  inside the group are trimmed to the silhouette regardless of how far
-  they bleed. Sized inside the 72dp safe zone of the 108dp canvas.
+  Adaptive-icon foreground. Italian-terracotta palette: a terracotta-tile
+  roof sits on warm stucco walls. Each surface is broken up by angular
+  tile chips in tighter shades of its base, with the base colour acting
+  as the mortar between chips. Sized inside the 72dp safe zone of the
+  108dp canvas.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"
@@ -11,82 +12,76 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
 
+    <!-- Roof: terracotta base + tile fragments. Clipped to the roof triangle. -->
     <group>
-        <clip-path android:pathData="M54,32 L22,60 L28,60 L28,84 L80,84 L80,60 L86,60 Z" />
+        <clip-path android:pathData="M54,32 L22,60 L28,60 L86,60 Z" />
 
-        <!-- Mortar / cream base inside the house -->
+        <!-- Mortar / base tile colour -->
         <path
-            android:fillColor="#F5EFE0"
-            android:pathData="M54,32 L22,60 L28,60 L28,84 L80,84 L80,60 L86,60 Z" />
+            android:fillColor="#B5532E"
+            android:pathData="M54,32 L22,60 L28,60 L86,60 Z" />
 
-        <!-- Larger terrazzo chips -->
+        <!-- Darker tile fragments -->
         <path
-            android:fillColor="#E07A5F"
-            android:pathData="M32,50 a6,4 0 1,0 12,0 a6,4 0 1,0 -12,0" />
+            android:fillColor="#8C3A1C"
+            android:pathData="M30,58 L42,52 L48,58 L46,60 L30,60 Z" />
         <path
-            android:fillColor="#F2CC8F"
-            android:pathData="M63,44 a5,4 0 1,0 10,0 a5,4 0 1,0 -10,0" />
+            android:fillColor="#8C3A1C"
+            android:pathData="M58,44 L66,48 L62,56 L54,52 Z" />
         <path
-            android:fillColor="#81B29A"
-            android:pathData="M47,66 a7,5 0 1,0 14,0 a7,5 0 1,0 -14,0" />
-        <path
-            android:fillColor="#3D405B"
-            android:pathData="M29,72 a4,3 0 1,0 8,0 a4,3 0 1,0 -8,0" />
-        <path
-            android:fillColor="#C9ADA7"
-            android:pathData="M67,76 a5,4 0 1,0 10,0 a5,4 0 1,0 -10,0" />
-        <path
-            android:fillColor="#6B4F4F"
-            android:pathData="M55,52 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0" />
-        <path
-            android:fillColor="#4A6670"
-            android:pathData="M41,78 a3,2 0 1,0 6,0 a3,2 0 1,0 -6,0" />
-        <path
-            android:fillColor="#E07A5F"
-            android:pathData="M68,58 a4,3 0 1,0 8,0 a4,3 0 1,0 -8,0" />
-        <path
-            android:fillColor="#81B29A"
-            android:pathData="M45,42 a3,3 0 1,0 6,0 a3,3 0 1,0 -6,0" />
-        <path
-            android:fillColor="#F2CC8F"
-            android:pathData="M61,80 a3,2 0 1,0 6,0 a3,2 0 1,0 -6,0" />
-        <path
-            android:fillColor="#C9ADA7"
-            android:pathData="M39,58 a3,2 0 1,0 6,0 a3,2 0 1,0 -6,0" />
-        <path
-            android:fillColor="#3D405B"
-            android:pathData="M62,66 a4,3 0 1,0 8,0 a4,3 0 1,0 -8,0" />
+            android:fillColor="#8C3A1C"
+            android:pathData="M70,55 L80,58 L78,60 L66,60 Z" />
 
-        <!-- Smaller speckles -->
+        <!-- Lighter tile fragments -->
         <path
-            android:fillColor="#E07A5F"
-            android:pathData="M34,82 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
+            android:fillColor="#D67149"
+            android:pathData="M44,40 L52,38 L52,46 L44,48 Z" />
         <path
-            android:fillColor="#81B29A"
-            android:pathData="M74,70 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
+            android:fillColor="#D67149"
+            android:pathData="M50,52 L60,52 L62,60 L50,60 Z" />
         <path
-            android:fillColor="#3D405B"
-            android:pathData="M48,58 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
-        <path
-            android:fillColor="#F2CC8F"
-            android:pathData="M38,64 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
-        <path
-            android:fillColor="#4A6670"
-            android:pathData="M66,82 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
-        <path
-            android:fillColor="#C9ADA7"
-            android:pathData="M58,40 a2,2 0 1,0 4,0 a2,2 0 1,0 -4,0" />
-
-        <!-- Door, anchored to the floor of the body -->
-        <path
-            android:fillColor="#3D405B"
-            android:pathData="M49,71 L59,71 L59,84 L49,84 Z" />
+            android:fillColor="#D67149"
+            android:pathData="M62,55 L72,56 L72,60 L60,60 Z" />
     </group>
+
+    <!-- Walls: warm stucco base + chunkier tile chips. Clipped to the wall body. -->
+    <group>
+        <clip-path android:pathData="M28,60 L80,60 L80,84 L28,84 Z" />
+
+        <!-- Mortar / base wall colour -->
+        <path
+            android:fillColor="#E8CFA6"
+            android:pathData="M28,60 L80,60 L80,84 L28,84 Z" />
+
+        <!-- Umber chips -->
+        <path
+            android:fillColor="#A88456"
+            android:pathData="M30,63 L46,64 L44,71 L30,70 Z" />
+        <path
+            android:fillColor="#A88456"
+            android:pathData="M62,73 L78,72 L78,82 L62,82 Z" />
+        <path
+            android:fillColor="#A88456"
+            android:pathData="M30,73 L46,74 L46,82 L30,82 Z" />
+
+        <!-- Cream highlight chips -->
+        <path
+            android:fillColor="#F4E4C4"
+            android:pathData="M62,63 L78,63 L78,70 L62,70 Z" />
+        <path
+            android:fillColor="#F4E4C4"
+            android:pathData="M48,63 L60,64 L60,69 L48,68 Z" />
+    </group>
+
+    <!-- Door, anchored to the floor of the body -->
+    <path
+        android:fillColor="#3A1E12"
+        android:pathData="M49,71 L59,71 L59,84 L49,84 Z" />
 
     <!-- House outline for definition at small sizes -->
     <path
         android:pathData="M54,32 L22,60 L28,60 L28,84 L80,84 L80,60 L86,60 Z"
-        android:strokeColor="#2A2A2E"
+        android:strokeColor="#3A1E12"
         android:strokeWidth="1.6"
         android:strokeLineJoin="round" />
 </vector>


### PR DESCRIPTION
## Summary

- Reworks `ic_launcher_foreground.xml` (mirrored across `rc-components/` and `demo-app/`) into an Italian-terracotta house: terracotta-tile roof on warm-stucco walls, with each surface broken up by a handful of angular polygonal chips in tighter shades of its base.
- Drops the round terrazzo speckles (which read as polka-dots at thumbnail scale) for irregular tile fragments, and replaces the cool 7-colour palette (slate, sage, salmon, gold, plum, brown, blue) with a focused warm 7-colour palette (3 roof tones, 3 wall tones, 1 outline/door brown).
- Switches the silhouette outline + door from cool slate `#2A2A2E` / `#3D405B` to warm deep-brown `#3A1E12`, which holds up against both `#FAF6EC` and `#1C1C1E` launcher backgrounds (the previous slate outline disappeared into the dark background).
- Adds `AppIconPreviews.kt` under `:previews` so the icon can be re-rendered and reviewed via `compose-preview` at the four common launcher mask shapes (circle / squircle / rounded / square), in both light and dark.

## Notes

- Pre-commit hook (`.githooks/pre-commit`) was bypassed for this commit because it invokes `ktfmtCheck --include-only=...`, an option that does not exist in ktfmt-gradle 0.26.0 (the version pinned in `libs.versions.toml`). Running `:previews:ktfmtCheck` without that flag is clean. Worth a separate small PR to either bump ktfmt-gradle or drop `--include-only` from the hook.
- Themed (monochrome) icon and the launcher background colours are unchanged — this PR is foreground-only.

## Test plan

- [x] `compose-preview render --filter app-icon --module previews` produces both light + dark renders.
- [x] Visual review of all four mask shapes in both modes.
- [ ] Install on device and verify the launcher icon at real sizes.
- [ ] CI: `Assemble (debug)`, `Unit tests`, `Android lint`, `ktfmt check` pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YZDUgZ5tFnpTs2Y4uYvEeN)_