### PR TITLE
docs: restore terrazzo-auth IndieAuth client_id page

### DIFF
--- a/docs/terrazzo-auth/index.html
+++ b/docs/terrazzo-auth/index.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Terrazzo — Home Assistant client</title>
+  <!--
+    IndieAuth redirect URI declaration. Home Assistant's OAuth server
+    uses IndieAuth discovery: when a client_id URL is presented, HA
+    fetches this page and checks that the requested redirect_uri is
+    either same-origin or listed here.
+
+    This page serves as the `client_id` for the Terrazzo Android app.
+    The app declares redirect_uri=rcha://auth-callback, which isn't
+    same-origin with this URL (HTTPS vs custom scheme), so it has to
+    be whitelisted here.
+
+    Spec: https://indieauth.spec.indieweb.org/#redirect-url
+    HA auth docs: https://developers.home-assistant.io/docs/auth_api/
+  -->
+  <link rel="redirect_uri" href="rcha://auth-callback" />
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 32rem;
+      margin: 3rem auto;
+      padding: 0 1rem;
+      color: #1a1a1a;
+      line-height: 1.5;
+    }
+    code { background: #f3f3f3; padding: 0.1em 0.3em; border-radius: 0.25em; }
+    a { color: #1565c0; }
+  </style>
+</head>
+<body>
+  <h1>Terrazzo</h1>
+  <p>
+    A small Android app that talks to a user's own Home Assistant instance.
+    It scans the LAN for HA, asks you to sign in via the normal HA web
+    flow, picks up your dashboards, and lets you install up to five HA
+    cards as live-updating Android widgets.
+  </p>
+  <p>
+    This page exists as the app's IndieAuth <code>client_id</code>.
+    See <a href="https://github.com/yschimke/homeassistant-remotecompose">
+    github.com/yschimke/homeassistant-remotecompose</a>.
+  </p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Pages source switched from `gh-pages` → `main /docs` (in #52). The legacy `gh-pages` branch hosted just one file: `terrazzo-auth/index.html` — the IndieAuth client_id page that the Android app's OAuth flow points at.
- Restoring it under `docs/terrazzo-auth/` so the URL `https://yschimke.github.io/homeassistant-remotecompose/terrazzo-auth/` resolves identically.

## Test plan
- [ ] Merge, wait for Pages deploy
- [ ] Visit `https://yschimke.github.io/homeassistant-remotecompose/terrazzo-auth/` and confirm it renders the same HTML as before
- [ ] Verify HA login flow on a debug install still completes