### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,6 @@
 import com.github.triplet.gradle.androidpublisher.ReleaseStatus
 
-val appVersionName = "0.1.1" // x-release-please-version
+val appVersionName = "0.1.2" // x-release-please-version
 
 // Pack MAJOR.MINOR.PATCH into a monotonic int. Caps at major < 22.
 val appVersionCode: Int =


### PR DESCRIPTION
## Summary
Trivial bump so the Release workflow has a fresh tag/version to build. v0.1.1's workflow run failed against the pre-DRAFT-revert commit.

## Test plan
- [ ] Merge
- [ ] Tag v0.1.2 → CI builds + uploads AAB to Play Console internal track as Draft
- [ ] Promote in Play Console