### PR TITLE
chore(hooks): fix pre-commit and add conventional-commits commit-msg

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Enforce Conventional Commits on the first line. Bypass with `--no-verify`.
+set -euo pipefail
+
+msg_file="$1"
+first_line="$(sed -n '1p' "$msg_file")"
+
+# Allow merges, reverts, fixup/squash/amend trailers, and empty (aborted) messages.
+case "$first_line" in
+  ""|"Merge "*|"Revert "*|"fixup!"*|"squash!"*|"amend!"*) exit 0 ;;
+esac
+
+pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?!?: .+'
+if [[ ! "$first_line" =~ $pattern ]]; then
+  cat <<EOF
+Commit message does not follow Conventional Commits.
+
+  Got: $first_line
+
+  Expected: <type>(<scope>)?!?: <description>
+  Types:    build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test
+  Examples:
+    feat: add foo
+    fix(auth): handle empty token
+    refactor!: drop legacy API
+EOF
+  exit 1
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,21 +5,17 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
-staged="$(git diff --cached --name-only --diff-filter=ACMR -z \
-  | tr '\0' '\n' \
-  | grep -E '\.(kt|kts)$' || true)"
-
-if [ -z "$staged" ]; then
+if ! git diff --cached --name-only --diff-filter=ACMR -z \
+    | tr '\0' '\n' \
+    | grep -qE '\.(kt|kts)$'; then
   exit 0
 fi
 
-include_only="$(printf '%s' "$staged" | paste -sd: -)"
-
-echo "Running ktfmtCheck on staged Kotlin files..."
-if ! ./gradlew --quiet ktfmtCheck "--include-only=$include_only"; then
+echo "Running ktfmtCheck..."
+if ! ./gradlew --quiet ktfmtCheck; then
   echo
   echo "ktfmt check failed. Fix with:"
-  echo "  ./gradlew ktfmtFormat --include-only=$include_only"
+  echo "  ./gradlew ktfmtFormat"
   echo "Then re-stage and commit again."
   exit 1
 fi


### PR DESCRIPTION
## Summary
- Drop the `--include-only` flag from the existing `pre-commit` — ktfmt-gradle 0.26.0 doesn't recognise it, so the hook would fail any commit that touches Kotlin. Run `ktfmtCheck` project-wide instead; Gradle's incremental up-to-date checks keep no-op runs fast.
- Add `.githooks/commit-msg` enforcing Conventional Commits on the subject line, with carve-outs for `Merge`/`Revert`/`fixup!`/`squash!`/`amend!`.
- Bypass either with `git commit --no-verify`.

To activate locally: `./gradlew installGitHooks` (one-time, sets `core.hooksPath`).

## Test plan
- [x] `commit-msg` rejects `broken commit message`
- [x] `commit-msg` accepts `feat(scope): a thing`
- [x] `commit-msg` accepts `Merge branch foo`
- [ ] `pre-commit` no-ops when only non-Kotlin files are staged
- [ ] `pre-commit` aborts when a staged `.kt` has bad formatting