### PR TITLE
build: unify hamcrest 1.3 split jars on 2.2 globally

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,24 +81,6 @@ composePreview {
   enabled.set(true)
 }
 
-// Espresso 3.5.0 still ships split hamcrest 1.3 jars
-// (`hamcrest-library`, `hamcrest-integration`) that contain references to
-// the 2-arg `AllOf.allOf(Matcher, Matcher)` overload removed in
-// hamcrest-core 2.x. Robolectric's compose-test idling strategy
-// touches Espresso during preview rendering, so the split jars trip a
-// `NoSuchMethodError`. Substitute them with the unified
-// `org.hamcrest:hamcrest` jar that contains the modern API.
-configurations.all {
-  resolutionStrategy.dependencySubstitution {
-    substitute(module("org.hamcrest:hamcrest-library"))
-      .using(module("org.hamcrest:hamcrest:2.2"))
-      .because("hamcrest 1.3 split jars are incompatible with hamcrest-core 2.x")
-    substitute(module("org.hamcrest:hamcrest-integration"))
-      .using(module("org.hamcrest:hamcrest:2.2"))
-      .because("hamcrest 1.3 split jars are incompatible with hamcrest-core 2.x")
-  }
-}
-
 play {
   track.set("internal")
   defaultToAppBundles.set(true)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,20 @@ plugins {
 allprojects {
   apply(plugin = "com.ncorti.ktfmt.gradle")
   extensions.configure<KtfmtExtension> { googleStyle() }
+
+  // Unify every `org.hamcrest:*` coord on the 2.x unified jar. JUnit 4 and
+  // Espresso still pull `hamcrest-core:1.3` (and the split `-library` /
+  // `-integration` jars) transitively; their classes overlap with the
+  // unified `org.hamcrest:hamcrest:2.2` that newer test deps resolve to,
+  // tripping a duplicate-class check at android-test build time.
+  configurations.all {
+    resolutionStrategy.eachDependency {
+      if (requested.group == "org.hamcrest") {
+        useTarget("org.hamcrest:hamcrest:2.2")
+        because("Unify hamcrest split 1.3 jars with the 2.x unified jar")
+      }
+    }
+  }
 }
 
 // Wires .githooks/ as the repository's hooks directory, so the pre-commit


### PR DESCRIPTION
## Summary

- Replaces the per-module substitute block in `app/build.gradle.kts` with a single `allprojects` rule in the root `build.gradle.kts` that retargets every `org.hamcrest:*` coord to `org.hamcrest:hamcrest:2.2`.
- The previous app-only block covered `hamcrest-library` and `hamcrest-integration` but missed `hamcrest-core:1.3`, which JUnit 4 / Espresso still pull transitively. Once the split jars were substituted with the unified 2.2 jar, its `org.hamcrest.core.*` classes overlapped with `hamcrest-core:1.3`, failing the duplicate-class check at android-test build time (CI run [25092535047](https://github.com/yschimke/homeassistant-remotecompose/actions/runs/25092535047)).
- `eachDependency` catches every split coord (current and future) in one place, and applies project-wide so other modules don't re-trip the same problem.

## Test plan

- [x] `./gradlew :app:assembleDebugAndroidTest` builds cleanly locally.
- [x] `./gradlew :app:dependencies --configuration debugAndroidTestRuntimeClasspath` confirms `hamcrest-core:1.3`, `hamcrest-library:1.3`, and `hamcrest-integration:1.3` all resolve to `org.hamcrest:hamcrest:2.2`.
- [ ] CI Instrumented tests job goes green.