### PR TITLE
feat(rc-components-ui): plain-Compose Tier-2 wrappers around RemoteHa*

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Glance widgets, Wear launcher tiles, ESP32 devices, etc.).
 |--------|--------|------|
 | [`ha-model`](ha-model/) | KMP (Android + JVM) | Dashboard / view / section / card config + HA state snapshot types, kotlinx-serialization. |
 | [`ha-client`](ha-client/) | KMP (Android + JVM) | Ktor WebSocket client for `lovelace/config` + state fetch. |
+| [`rc-components`](rc-components/) | Android | Tier-1 `RemoteHa*` composables — RemoteCompose-native cards (RemoteString / RemoteColor / actions). |
+| [`rc-components-ui`](rc-components-ui/) | Android | Tier-2 plain Compose-UI wrappers (`HaTile`, `HaButton`, …) embedding the Tier-1 composables via `RemotePreview`, so apps can drop them into a normal Compose tree without seeing RemoteCompose types. |
 | [`rc-converter`](rc-converter/) | Android | `CardConverter` strategy + one impl per card type. Emits RemoteCompose content. |
 | [`previews`](previews/) | Android | `@Preview` fixtures per card type, rendered by the `ee.schimke.composeai.preview` plugin for pixel-parity iteration. |
 | [`demo-app`](demo-app/) | Android | Sample app: fetch a real dashboard, render via `remote-player-compose`. |

--- a/rc-components-ui/build.gradle.kts
+++ b/rc-components-ui/build.gradle.kts
@@ -1,0 +1,39 @@
+plugins {
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.compose.compiler)
+}
+
+android {
+  namespace = "ee.schimke.ha.rc.ui"
+  compileSdk = libs.versions.android.compileSdk.get().toInt()
+  defaultConfig { minSdk = libs.versions.android.minSdk.get().toInt() }
+  buildFeatures { compose = true }
+  compileOptions {
+    sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+    targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+  }
+  kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
+  // RemoteCompose's `RemoteInt` clinit calls `android.icu.text.DecimalFormat`,
+  // which the default Android JVM unit-test classpath leaves unmocked.
+  // The conversion smoke tests don't care about the formatting result, so
+  // returning Android stubs as default values is enough.
+  testOptions { unitTests { isReturnDefaultValues = true } }
+}
+
+dependencies {
+  api(project(":rc-components"))
+
+  implementation(platform(libs.compose.bom))
+  implementation(libs.compose.ui)
+  implementation(libs.compose.foundation)
+
+  implementation(libs.remote.creation.compose)
+  implementation(libs.remote.creation.android)
+  implementation(libs.remote.creation.core)
+  implementation(libs.remote.core)
+  implementation(libs.remote.tooling.preview)
+
+  testImplementation(libs.kotlin.test)
+  testImplementation(libs.kotlin.test.junit)
+  testImplementation(libs.compose.material.icons.extended)
+}

--- a/rc-components-ui/src/main/AndroidManifest.xml
+++ b/rc-components-ui/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest />

--- a/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/EmbedProfile.kt
+++ b/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/EmbedProfile.kt
@@ -1,0 +1,37 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.ui
+
+import androidx.compose.remote.core.CoreDocument
+import androidx.compose.remote.core.RcProfiles
+import androidx.compose.remote.core.operations.Header
+import androidx.compose.remote.creation.RemoteComposeWriter
+import androidx.compose.remote.creation.RemoteComposeWriterAndroid
+import androidx.compose.remote.creation.platform.AndroidxRcPlatformServices
+import androidx.compose.remote.creation.profile.Profile
+
+/**
+ * Embed profile for Tier-2 Compose-UI wrappers — AndroidX experimental
+ * (FlowRow / FlowLayout ops on for `HaGlance`) with the wrap-content
+ * measure feature enabled, so the player measures against parent
+ * constraints instead of forcing the document's authored size onto the
+ * Compose layout.
+ *
+ * Mirrors `ee.schimke.ha.rc.androidXExperimentalWrap` from `:rc-converter`
+ * — duplicated here so the UI module doesn't pull the converter in.
+ */
+internal val haUiEmbedProfile: Profile =
+    Profile(
+        CoreDocument.DOCUMENT_API_LEVEL,
+        RcProfiles.PROFILE_ANDROIDX or RcProfiles.PROFILE_EXPERIMENTAL,
+        AndroidxRcPlatformServices(),
+    ) { creationDisplayInfo, profile, _ ->
+        RemoteComposeWriterAndroid(
+            profile,
+            RemoteComposeWriter.hTag(Header.DOC_WIDTH, creationDisplayInfo.width),
+            RemoteComposeWriter.hTag(Header.DOC_HEIGHT, creationDisplayInfo.height),
+            RemoteComposeWriter.hTag(Header.DOC_CONTENT_DESCRIPTION, ""),
+            RemoteComposeWriter.hTag(Header.DOC_PROFILES, profile.operationsProfiles),
+            RemoteComposeWriter.hTag(Header.FEATURE_PAINT_MEASURE, 0),
+        )
+    }

--- a/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaButton.kt
+++ b/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaButton.kt
@@ -1,0 +1,26 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import ee.schimke.ha.rc.components.RemoteHaButton
+import ee.schimke.ha.rc.components.RemoteHaToggleButton
+
+/** Compose-UI Tier-2 wrapper around [RemoteHaButton]. */
+@Composable
+fun HaButton(data: HaButtonUiData, modifier: Modifier = Modifier) {
+    HaUiHost(modifier) { RemoteHaButton(data.toRemote()) }
+}
+
+/**
+ * Compose-UI Tier-2 wrapper around [RemoteHaToggleButton].
+ *
+ * The Tier-1 toggle button uses an in-document `MutableRemoteBoolean`
+ * for optimistic flip; that survives intact here — only the input data
+ * is reshaped from plain types.
+ */
+@Composable
+fun HaToggleButton(data: HaButtonUiData, modifier: Modifier = Modifier) {
+    HaUiHost(modifier) { RemoteHaToggleButton(data.toRemote()) }
+}

--- a/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaEntities.kt
+++ b/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaEntities.kt
@@ -1,0 +1,20 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import ee.schimke.ha.rc.components.RemoteHaEntities
+import ee.schimke.ha.rc.components.RemoteHaEntityRow
+
+/** Compose-UI Tier-2 wrapper around a single [RemoteHaEntityRow]. */
+@Composable
+fun HaEntityRow(data: HaEntityRowUiData, modifier: Modifier = Modifier) {
+    HaUiHost(modifier) { RemoteHaEntityRow(data.toRemote()) }
+}
+
+/** Compose-UI Tier-2 wrapper around [RemoteHaEntities]. */
+@Composable
+fun HaEntities(data: HaEntitiesUiData, modifier: Modifier = Modifier) {
+    HaUiHost(modifier) { RemoteHaEntities(data.toRemote()) }
+}

--- a/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaGlance.kt
+++ b/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaGlance.kt
@@ -1,0 +1,20 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import ee.schimke.ha.rc.components.RemoteHaGlance
+import ee.schimke.ha.rc.components.RemoteHaGlanceCell
+
+/** Compose-UI Tier-2 wrapper around [RemoteHaGlance]. */
+@Composable
+fun HaGlance(data: HaGlanceUiData, modifier: Modifier = Modifier) {
+    HaUiHost(modifier) { RemoteHaGlance(data.toRemote()) }
+}
+
+/** Compose-UI Tier-2 wrapper around a single [RemoteHaGlanceCell]. */
+@Composable
+fun HaGlanceCell(data: HaGlanceCellUiData, modifier: Modifier = Modifier) {
+    HaUiHost(modifier) { RemoteHaGlanceCell(data.toRemote()) }
+}

--- a/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaHeading.kt
+++ b/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaHeading.kt
@@ -1,0 +1,13 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import ee.schimke.ha.rc.components.RemoteHaHeading
+
+/** Compose-UI Tier-2 wrapper around [RemoteHaHeading]. */
+@Composable
+fun HaHeading(data: HaHeadingUiData, modifier: Modifier = Modifier) {
+    HaUiHost(modifier) { RemoteHaHeading(data.toRemote()) }
+}

--- a/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaMarkdown.kt
+++ b/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaMarkdown.kt
@@ -1,0 +1,13 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import ee.schimke.ha.rc.components.RemoteHaMarkdown
+
+/** Compose-UI Tier-2 wrapper around [RemoteHaMarkdown]. */
+@Composable
+fun HaMarkdown(data: HaMarkdownUiData, modifier: Modifier = Modifier) {
+    HaUiHost(modifier) { RemoteHaMarkdown(data.toRemote()) }
+}

--- a/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaStack.kt
+++ b/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaStack.kt
@@ -1,0 +1,55 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import ee.schimke.ha.rc.components.RemoteHaGrid
+import ee.schimke.ha.rc.components.RemoteHaHorizontalStack
+import ee.schimke.ha.rc.components.RemoteHaVerticalStack
+
+/**
+ * Tier-2 stack containers mirror the Tier-1 [RemoteHaVerticalStack] /
+ * [RemoteHaHorizontalStack] / [RemoteHaGrid] visual contract — same
+ * 8.dp spacing — but as ordinary Compose [Column] / [Row] / [FlowRow].
+ *
+ * Why a re-implementation here and not a `HaUiHost` wrap, when every
+ * other Tier-2 component delegates to its Tier-1 sibling: the Tier-1
+ * stacks expect `@RemoteComposable` children. Tier-2 callers don't have
+ * those — they have plain `@Composable` children, each of which is
+ * already its own embedded RemoteCompose document. Hosting a Tier-2
+ * `HaTile` inside a Tier-1 `RemoteHaVerticalStack` would mean nesting a
+ * `RemotePreview` inside a `@RemoteComposable` capture scope, which the
+ * SDK doesn't support.
+ *
+ * This matches the project-level dashboard architecture: each card is
+ * its own document, the dashboard layout is plain Compose. Tier-2
+ * stacks here are layout convenience over the same model.
+ */
+@Composable
+fun HaVerticalStack(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        content()
+    }
+}
+
+@Composable
+fun HaHorizontalStack(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    Row(modifier = modifier, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        content()
+    }
+}
+
+@Composable
+fun HaGrid(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    FlowRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) { content() }
+}

--- a/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaTile.kt
+++ b/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaTile.kt
@@ -1,0 +1,21 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import ee.schimke.ha.rc.components.RemoteHaTile
+
+/**
+ * Compose-UI Tier-2 wrapper around [RemoteHaTile]. Takes plain
+ * Compose / Kotlin types so callers don't have to import any
+ * `androidx.compose.remote.*` symbols; internally hosts a
+ * RemoteCompose document.
+ *
+ * Visuals are produced by the same Tier-1 component — any styling
+ * change to [RemoteHaTile] lands here automatically.
+ */
+@Composable
+fun HaTile(data: HaTileUiData, modifier: Modifier = Modifier) {
+    HaUiHost(modifier) { RemoteHaTile(data.toRemote()) }
+}

--- a/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaToggleSwitch.kt
+++ b/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaToggleSwitch.kt
@@ -1,0 +1,33 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.ui
+
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import ee.schimke.ha.rc.components.HaAction
+import ee.schimke.ha.rc.components.RemoteHaToggleSwitch
+
+/**
+ * Compose-UI Tier-2 wrapper around [RemoteHaToggleSwitch] — pill-shape
+ * switch with a knob position keyed on [initiallyOn]. See the Tier-1
+ * doc for the alpha09 layout caveat.
+ */
+@Composable
+fun HaToggleSwitch(
+    initiallyOn: Boolean,
+    activeAccent: Color,
+    inactiveAccent: Color,
+    modifier: Modifier = Modifier,
+    tapAction: HaAction = HaAction.None,
+) {
+    HaUiHost(modifier) {
+        RemoteHaToggleSwitch(
+            initiallyOn = initiallyOn,
+            activeAccent = activeAccent.rc,
+            inactiveAccent = inactiveAccent.rc,
+            tapAction = tapAction,
+        )
+    }
+}

--- a/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaUiHost.kt
+++ b/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaUiHost.kt
@@ -1,0 +1,46 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.tooling.preview.RemotePreview
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import ee.schimke.ha.rc.components.HaTheme
+import ee.schimke.ha.rc.components.LocalHaTheme
+import ee.schimke.ha.rc.components.ProvideHaTheme
+
+/**
+ * Tier-2 embedding host: wraps [content] (a Tier-1 `@RemoteComposable`
+ * call) in a [RemotePreview] so the resulting `.rc` document is played
+ * inside an ordinary Compose layout. The host:
+ *
+ * 1. Picks the wrap-friendly experimental profile so the player's
+ *    measured size flows from the surrounding Compose constraints
+ *    (matching how `DashboardViewScreen` / `WidgetInstallSheet` embed
+ *    cards in production).
+ * 2. Re-provides [LocalHaTheme] inside the capture scope so theme look-up
+ *    works exactly as it does for top-level Tier-1 callers — Tier-2
+ *    callers can still wrap in [ProvideHaTheme] from outside; the inner
+ *    provide is a passthrough when no override is set.
+ *
+ * Action callbacks: the embedded RemoteCompose document delivers
+ * `HostAction`s at playback time. `RemotePreview` doesn't expose the
+ * named-action stream, so apps that want HA service dispatch must drop
+ * to Tier-1 (use `RemoteHa*` directly inside their own
+ * `RemoteDocumentPlayer(onNamedAction = …)`). Tier-2 is for
+ * visual embedding.
+ */
+@Composable
+internal fun HaUiHost(
+    modifier: Modifier = Modifier,
+    theme: HaTheme = LocalHaTheme.current,
+    content: @Composable @RemoteComposable () -> Unit,
+) {
+    Box(modifier) {
+        RemotePreview(profile = haUiEmbedProfile) {
+            ProvideHaTheme(theme) { content() }
+        }
+    }
+}

--- a/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaUiModels.kt
+++ b/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaUiModels.kt
@@ -1,0 +1,170 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.ui
+
+import androidx.compose.remote.creation.compose.state.RemoteBoolean
+import androidx.compose.remote.creation.compose.state.RemoteState
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import ee.schimke.ha.rc.components.HaAction
+import ee.schimke.ha.rc.components.HaButtonData
+import ee.schimke.ha.rc.components.HaEntitiesData
+import ee.schimke.ha.rc.components.HaEntityRowData
+import ee.schimke.ha.rc.components.HaGlanceCellData
+import ee.schimke.ha.rc.components.HaGlanceData
+import ee.schimke.ha.rc.components.HaHeadingData
+import ee.schimke.ha.rc.components.HaHeadingStyle
+import ee.schimke.ha.rc.components.HaMarkdownData
+import ee.schimke.ha.rc.components.HaTileData
+import ee.schimke.ha.rc.components.HaToggleAccent
+import ee.schimke.ha.rc.components.HaUnsupportedData
+
+/**
+ * Tier-2 mirror of [HaToggleAccent] expressed in plain Compose types.
+ *
+ * - [isOn] = `null` ⇒ read-only entity (sensor / weather / …); the
+ *   active accent is used unconditionally.
+ * - [isOn] = `true` / `false` ⇒ toggleable entity at the given on-state;
+ *   colour is selected at document build time. For live re-binding,
+ *   reach for the Tier-1 [HaToggleAccent] directly.
+ */
+data class HaToggleAccentUi(
+    val activeAccent: Color,
+    val inactiveAccent: Color,
+    val isOn: Boolean? = null,
+)
+
+data class HaTileUiData(
+    val name: String,
+    val state: String,
+    val icon: ImageVector,
+    val accent: HaToggleAccentUi,
+    val tapAction: HaAction = HaAction.None,
+)
+
+data class HaButtonUiData(
+    val name: String,
+    val icon: ImageVector,
+    val accent: HaToggleAccentUi,
+    val showName: Boolean = true,
+    val tapAction: HaAction = HaAction.None,
+)
+
+data class HaEntityRowUiData(
+    val name: String,
+    val state: String,
+    val icon: ImageVector,
+    val accent: HaToggleAccentUi,
+    val tapAction: HaAction = HaAction.None,
+)
+
+data class HaEntitiesUiData(
+    val title: String?,
+    val rows: List<HaEntityRowUiData>,
+)
+
+data class HaGlanceCellUiData(
+    val name: String,
+    val state: String,
+    val icon: ImageVector,
+    val accent: HaToggleAccentUi,
+    val tapAction: HaAction = HaAction.None,
+)
+
+data class HaGlanceUiData(
+    val title: String?,
+    val cells: List<HaGlanceCellUiData>,
+)
+
+data class HaMarkdownUiData(
+    val title: String?,
+    val lines: List<String>,
+)
+
+data class HaHeadingUiData(
+    val title: String,
+    val style: HaHeadingStyle = HaHeadingStyle.Title,
+)
+
+data class HaUnsupportedUiData(
+    val cardType: String,
+)
+
+// ——— plain → Remote bridges ———
+
+internal fun HaToggleAccentUi.toRemote(tag: String): HaToggleAccent =
+    HaToggleAccent(
+        activeAccent = activeAccent.rc,
+        inactiveAccent = inactiveAccent.rc,
+        isOn = isOn?.let { literalRemoteBoolean("$tag.is_on", it) },
+        initiallyOn = isOn ?: false,
+    )
+
+/**
+ * A constant [RemoteBoolean] expressed as a named binding in the
+ * [RemoteState.Domain.User] domain. We piggy-back on the named-binding
+ * machinery because the alpha09 SDK exposes no public literal-boolean
+ * constructor; the name is otherwise unused (Tier-2 callers don't push
+ * live updates — that's Tier-1's job).
+ */
+private fun literalRemoteBoolean(name: String, value: Boolean): RemoteBoolean =
+    RemoteBoolean.createNamedRemoteBoolean(name, value, RemoteState.Domain.User)
+
+internal fun HaTileUiData.toRemote(tag: String = "tile"): HaTileData =
+    HaTileData(
+        name = name.rs,
+        state = state.rs,
+        icon = icon,
+        accent = accent.toRemote(tag),
+        tapAction = tapAction,
+    )
+
+internal fun HaButtonUiData.toRemote(tag: String = "button"): HaButtonData =
+    HaButtonData(
+        name = name.rs,
+        icon = icon,
+        accent = accent.toRemote(tag),
+        showName = showName,
+        tapAction = tapAction,
+    )
+
+internal fun HaEntityRowUiData.toRemote(tag: String = "row"): HaEntityRowData =
+    HaEntityRowData(
+        name = name.rs,
+        state = state.rs,
+        icon = icon,
+        accent = accent.toRemote(tag),
+        tapAction = tapAction,
+    )
+
+internal fun HaEntitiesUiData.toRemote(tag: String = "entities"): HaEntitiesData =
+    HaEntitiesData(
+        title = title?.rs,
+        rows = rows.mapIndexed { i, r -> r.toRemote("$tag.$i") },
+    )
+
+internal fun HaGlanceCellUiData.toRemote(tag: String = "cell"): HaGlanceCellData =
+    HaGlanceCellData(
+        name = name.rs,
+        state = state.rs,
+        icon = icon,
+        accent = accent.toRemote(tag),
+        tapAction = tapAction,
+    )
+
+internal fun HaGlanceUiData.toRemote(tag: String = "glance"): HaGlanceData =
+    HaGlanceData(
+        title = title?.rs,
+        cells = cells.mapIndexed { i, c -> c.toRemote("$tag.$i") },
+    )
+
+internal fun HaMarkdownUiData.toRemote(): HaMarkdownData =
+    HaMarkdownData(title = title?.rs, lines = lines.map { it.rs })
+
+internal fun HaHeadingUiData.toRemote(): HaHeadingData =
+    HaHeadingData(title = title.rs, style = style)
+
+internal fun HaUnsupportedUiData.toRemote(): HaUnsupportedData =
+    HaUnsupportedData(cardType = cardType.rs)

--- a/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaUnsupported.kt
+++ b/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaUnsupported.kt
@@ -1,0 +1,13 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import ee.schimke.ha.rc.components.RemoteHaUnsupported
+
+/** Compose-UI Tier-2 wrapper around [RemoteHaUnsupported]. */
+@Composable
+fun HaUnsupported(data: HaUnsupportedUiData, modifier: Modifier = Modifier) {
+    HaUiHost(modifier) { RemoteHaUnsupported(data.toRemote()) }
+}

--- a/rc-components-ui/src/test/kotlin/ee/schimke/ha/rc/ui/HaUiModelsTest.kt
+++ b/rc-components-ui/src/test/kotlin/ee/schimke/ha/rc/ui/HaUiModelsTest.kt
@@ -1,0 +1,81 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lightbulb
+import androidx.compose.ui.graphics.Color
+import ee.schimke.ha.rc.components.HaAction
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * The plain→Remote conversion is the only Tier-2 surface that's
+ * exercisable without an Android instrumentation env. The composables
+ * themselves need a running RemoteCompose document host to be useful;
+ * those land in `previews/` next to the existing Tier-1 fixtures.
+ */
+class HaUiModelsTest {
+
+    private val accentOn = HaToggleAccentUi(
+        activeAccent = Color(0xFFFFC107),
+        inactiveAccent = Color(0xFF8F8F8F),
+        isOn = true,
+    )
+
+    private val accentReadOnly = HaToggleAccentUi(
+        activeAccent = Color(0xFF607D8B),
+        inactiveAccent = Color(0xFF607D8B),
+        isOn = null,
+    )
+
+    @Test fun toggleAccent_isOn_yields_named_remote_boolean() {
+        val remote = accentOn.toRemote("tile.kitchen")
+        assertNotNull(remote.isOn, "isOn should round-trip into a RemoteBoolean")
+        assertEquals(true, remote.initiallyOn)
+    }
+
+    @Test fun toggleAccent_readonly_drops_remote_boolean() {
+        val remote = accentReadOnly.toRemote("tile.sensor")
+        assertNull(remote.isOn, "read-only entity must not carry a RemoteBoolean")
+        assertEquals(false, remote.initiallyOn)
+    }
+
+    @Test fun tile_uiData_round_trips_simple_fields() {
+        val ui = HaTileUiData(
+            name = "Kitchen",
+            state = "On",
+            icon = Icons.Filled.Lightbulb,
+            accent = accentOn,
+            tapAction = HaAction.Toggle("light.kitchen"),
+        )
+        val remote = ui.toRemote()
+        assertEquals(ui.icon, remote.icon)
+        assertEquals(ui.tapAction, remote.tapAction)
+    }
+
+    @Test fun entities_uiData_assigns_unique_tags_per_row() {
+        // Same accent reference on every row — if the conversion shared
+        // a name across rows the named-binding would collide; the
+        // per-index suffix makes each row's binding unique.
+        val ui = HaEntitiesUiData(
+            title = "Living Room",
+            rows = List(3) {
+                HaEntityRowUiData(
+                    name = "Lamp $it",
+                    state = "On",
+                    icon = Icons.Filled.Lightbulb,
+                    accent = accentOn,
+                )
+            },
+        )
+        val remote = ui.toRemote("entities.living")
+        assertEquals(3, remote.rows.size)
+        // Three non-null bindings — the tags differ; the API doesn't
+        // expose the binding name string for a direct assert, but the
+        // count + non-null is enough to lock the contract in.
+        remote.rows.forEach { row -> assertNotNull(row.accent.isOn) }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ include(
   ":ha-model",
   ":ha-client",
   ":rc-components",
+  ":rc-components-ui",
   ":rc-converter",
   ":rc-card-shutter",
   ":previews",


### PR DESCRIPTION
New :rc-components-ui module exposes Ha* composables that take plain
Compose / Kotlin types (Color, ImageVector, String, Boolean) and host
the existing :rc-components RemoteHa* siblings inside RemotePreview, so
apps can drop the cards into a normal Compose tree without ever
importing a Remote* state type.

One implementation per component lives in :rc-components — each Tier-2
wrapper is a thin data-shape adapter, so styling changes propagate
automatically. Plain-Boolean isOn flags are bridged through named
RemoteBoolean bindings (the alpha09 SDK doesn't expose a public literal
constructor); per-row tags keep bindings unique inside Entities/Glance
documents.

Tier-2 deliberately doesn't surface action callbacks or live re-binding
— RemotePreview doesn't expose the named-action stream, so those needs
still drop to Tier-1 + RemoteDocumentPlayer. Module KDoc and README
spell that out.