### PR TITLE
Update Compose AI Tools to 0.9.0

### DIFF
--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -11,14 +11,14 @@ permissions:
 concurrency:
   group: preview-baselines
   # Don't cancel in-flight runs: the job ends with a `git push` to the
-  # shared `preview_main` branch, and cancellation between commit-tree
+  # shared `compose-preview/main` branch, and cancellation between commit-tree
   # and push can leave the remote in a half-advanced / non-fast-forward
   # state. Queue subsequent runs instead.
   cancel-in-progress: false
 
 jobs:
   update:
-    name: Update preview_main
+    name: Update compose-preview/main
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -29,7 +29,7 @@ jobs:
           # credentials persisted here.
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.8.10
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.9.0
         with:
           cli-version: catalog
           catalog-key: compose-preview-plugin

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       # preview-comment composite action appends a commit to the shared
-      # preview_pr branch and upserts a PR comment with before/after images.
+      # compose-preview/pr branch and upserts a PR comment with before/after images.
       contents: write
       pull-requests: write
     steps:
@@ -29,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.8.10
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.9.0
         with:
           cli-version: catalog
           catalog-key: compose-preview-plugin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ junit-jupiter-bom = "6.0.3"
 mockserver = "5.15.0"
 
 # Preview tooling
-compose-preview-plugin = "0.8.10"
+compose-preview-plugin = "0.9.0"
 
 # Formatting
 ktfmt-gradle = "0.26.0"


### PR DESCRIPTION
## Summary
- bump the Compose AI Tools Gradle plugin catalog entry to 0.9.0
- update preview baseline/comment workflows to use the v0.9.0 shared actions
- update workflow comments/names for the new `compose-preview/main` and `compose-preview/pr` branches

Cleanup issue for old branches: #66.

## Validation so far
- `./gradlew help`
- `git diff --check`

Additional CLI/MCP validation is being run after opening this PR.