### PR TITLE
[codex] Update compose-preview to 0.9.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ junit-jupiter-bom = "6.0.3"
 mockserver = "5.15.0"
 
 # Preview tooling
-compose-preview-plugin = "0.8.10"
+compose-preview-plugin = "0.9.1"
 
 # Formatting
 ktfmt-gradle = "0.26.0"


### PR DESCRIPTION
## Goal
Update compose-preview to the 0.9.1 release so local MCP setup can use the latest Antigravity-aware install behavior.

## What changed
- Bumped the compose-preview Gradle plugin version to `0.9.1`.

## Verification
- `git diff --check`