### PR TITLE
Run Metro builds on JDK 21

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.compose.preview)
   alias(libs.plugins.metro)
+  alias(libs.plugins.tapmoc)
   alias(libs.plugins.kotlin.serialization)
   alias(libs.plugins.play.publisher)
 }
@@ -68,11 +69,12 @@ android {
     compose = true
     buildConfig = true
   }
-  compileOptions {
-    sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-    targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
-  }
   kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
+}
+
+tapmoc {
+  java(libs.versions.java.get().toInt())
+  kotlin(libs.versions.kotlin.get())
 }
 
 composePreview {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
   alias(libs.plugins.kotlin.jvm) apply false
   alias(libs.plugins.kotlin.serialization) apply false
   alias(libs.plugins.compose.compiler) apply false
+  alias(libs.plugins.tapmoc) apply false
   alias(libs.plugins.ktfmt) apply false
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,10 @@ org.gradle.configuration-cache=true
 
 kotlin.code.style=official
 kotlin.mpp.stability.nowarn=true
+# Metro RC4's compiler plugin is compiled for Java 21. Keep Kotlin compiler plugin loading inside
+# the Gradle daemon JVM selected by gradle/gradle-daemon-jvm.properties instead of a stale Java 17
+# Kotlin daemon.
+kotlin.compiler.execution.strategy=in-process
 
 android.useAndroidX=true
 android.nonTransitiveRClass=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ mockserver = "5.15.0"
 
 # Preview tooling
 compose-preview-plugin = "0.9.1"
+tapmoc = "0.4.2"
 
 # Formatting
 ktfmt-gradle = "0.26.0"
@@ -153,5 +154,6 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 compose-preview = { id = "ee.schimke.composeai.preview", version.ref = "compose-preview-plugin" }
 metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
+tapmoc = { id = "com.gradleup.tapmoc", version.ref = "tapmoc" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt-gradle" }
 play-publisher = { id = "com.github.triplet.play", version.ref = "play-publisher" }

--- a/terrazzo-core/build.gradle.kts
+++ b/terrazzo-core/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
   alias(libs.plugins.kotlin.multiplatform)
   alias(libs.plugins.android.kmp.library)
   alias(libs.plugins.metro)
+  alias(libs.plugins.tapmoc)
   alias(libs.plugins.kotlin.serialization)
 }
 
@@ -28,4 +29,9 @@ kotlin {
       implementation(libs.appauth)
     }
   }
+}
+
+tapmoc {
+  java(libs.versions.java.get().toInt())
+  kotlin(libs.versions.kotlin.get())
 }


### PR DESCRIPTION
## Summary
- Apply TapMoc to the Metro-bearing app and terrazzo-core modules.
- Configure TapMoc from the catalog Java/Kotlin versions and let it own Java compatibility for the app module.
- Keep Kotlin compiler execution in-process so Metro RC4's Java 21 compiler plugin is loaded by the Gradle daemon JVM selected by `gradle/gradle-daemon-jvm.properties`.

## Validation
- `./gradlew ktfmtCheck`
- `git diff --check`

## Not run
- `./gradlew :app:compileDebugKotlin --stacktrace` could not run in this checkout because no Android SDK is configured (`ANDROID_HOME`/`local.properties` missing).