### PR TITLE
feat: implement gauge, weather-forecast, picture-entity, logbook cards

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
@@ -396,7 +396,83 @@ fun Unsupported_Dark() = CardHost(HaTheme.Dark) {
     RenderChild(unsupportedCard(), Fixtures.mixed)
 }
 
-private fun unsupportedCard() = card("""{"type":"gauge","entity":"sensor.living_room"}""")
+private fun unsupportedCard() = card("""{"type":"thermostat","entity":"climate.living_room"}""")
+
+// ——— gauge ———
+
+@Preview(name = "gauge (light)", showBackground = false, widthDp = 187, heightDp = 150)
+@Composable
+fun Gauge_Light() = CardHost(HaTheme.Light) {
+    RenderChild(gaugeCard(), Fixtures.battery, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "gauge (dark)", showBackground = false, widthDp = 187, heightDp = 150)
+@Composable
+fun Gauge_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(gaugeCard(), Fixtures.battery, RemoteModifier.fillMaxWidth())
+}
+
+private fun gaugeCard() = card(
+    """{"type":"gauge","entity":"sensor.repeater_battery","name":"Battery %",
+        "min":0,"max":100,"needle":true,
+        "severity":{"green":60,"yellow":30,"red":0}}""",
+)
+
+// ——— picture-entity ———
+
+@Preview(name = "picture-entity (light)", showBackground = false, widthDp = 312, heightDp = 160)
+@Composable
+fun PictureEntity_Light() = CardHost(HaTheme.Light) {
+    RenderChild(pictureEntityCard(), Fixtures.driveway, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "picture-entity (dark)", showBackground = false, widthDp = 312, heightDp = 160)
+@Composable
+fun PictureEntity_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(pictureEntityCard(), Fixtures.driveway, RemoteModifier.fillMaxWidth())
+}
+
+private fun pictureEntityCard() = card(
+    """{"type":"picture-entity","entity":"camera.driveway","name":"Driveway","show_name":true}""",
+)
+
+// ——— weather-forecast ———
+
+@Preview(name = "weather-forecast (light)", showBackground = false, widthDp = 381, heightDp = 168)
+@Composable
+fun WeatherForecast_Light() = CardHost(HaTheme.Light) {
+    RenderChild(weatherForecastCard(), Fixtures.weather, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "weather-forecast (dark)", showBackground = false, widthDp = 381, heightDp = 168)
+@Composable
+fun WeatherForecast_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(weatherForecastCard(), Fixtures.weather, RemoteModifier.fillMaxWidth())
+}
+
+private fun weatherForecastCard() = card(
+    """{"type":"weather-forecast","entity":"weather.forecast_home",
+        "show_current":true,"show_forecast":true}""",
+)
+
+// ——— logbook ———
+
+@Preview(name = "logbook (light)", showBackground = false, widthDp = 381, heightDp = 150)
+@Composable
+fun Logbook_Light() = CardHost(HaTheme.Light) {
+    RenderChild(logbookCard(), Fixtures.activity, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "logbook (dark)", showBackground = false, widthDp = 381, heightDp = 150)
+@Composable
+fun Logbook_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(logbookCard(), Fixtures.activity, RemoteModifier.fillMaxWidth())
+}
+
+private fun logbookCard() = card(
+    """{"type":"logbook","title":"Recent activity","hours_to_show":24,
+        "entities":["binary_sensor.front_door","binary_sensor.garage_motion"]}""",
+)
 
 // ——— tile, state variants via PreviewParameter ———
 

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
@@ -4,7 +4,10 @@ import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.EntityState
 import ee.schimke.ha.model.HaSnapshot
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 
 private val json = Json { ignoreUnknownKeys = true; isLenient = true }
@@ -26,6 +29,38 @@ fun state(
 
 fun snapshot(vararg states: Pair<String, EntityState>): HaSnapshot =
     HaSnapshot(states = states.toMap())
+
+/** Build a `weather.*` entity carrying a `forecast` JSON array — needed for
+ *  weather-forecast previews because the basic [state] helper only accepts
+ *  `Map<String, String>` attributes. */
+private fun weatherStateWithForecast(
+    entityId: String,
+    condition: String,
+    attrs: Map<String, String>,
+    forecast: List<JsonObject>,
+): Pair<String, EntityState> {
+    val merged: Map<String, JsonElement> =
+        attrs.mapValues { JsonPrimitive(it.value) } + ("forecast" to JsonArray(forecast))
+    return entityId to EntityState(
+        entityId = entityId,
+        state = condition,
+        attributes = JsonObject(merged),
+    )
+}
+
+private fun forecastDay(
+    datetime: String,
+    condition: String,
+    high: Double,
+    low: Double,
+): JsonObject = JsonObject(
+    mapOf(
+        "datetime" to JsonPrimitive(datetime),
+        "condition" to JsonPrimitive(condition),
+        "temperature" to JsonPrimitive(high),
+        "templow" to JsonPrimitive(low),
+    ),
+)
 
 /** Fixture snapshots used across previews. Mirrors HA's ui-lovelace.yaml
  * so RC renderings can be diffed apples-to-apples against the committed
@@ -65,5 +100,45 @@ object Fixtures {
             mapOf("friendly_name" to "Front door")),
         state("cover.living_room_window", "open",
             mapOf("friendly_name" to "Living Room Window", "device_class" to "window")),
+    )
+
+    val battery = snapshot(
+        state("sensor.repeater_battery", "62",
+            mapOf(
+                "friendly_name" to "Repeater battery",
+                "unit_of_measurement" to "%",
+                "device_class" to "battery",
+            )),
+    )
+
+    val weather = snapshot(
+        weatherStateWithForecast(
+            entityId = "weather.forecast_home",
+            condition = "partlycloudy",
+            attrs = mapOf(
+                "friendly_name" to "Forecast Home",
+                "temperature" to "11.2",
+                "temperature_unit" to "°C",
+            ),
+            forecast = listOf(
+                forecastDay("2026-05-07", "partlycloudy", high = 13.4, low = 7.5),
+                forecastDay("2026-05-08", "rainy",        high = 11.9, low = 6.8),
+                forecastDay("2026-05-09", "cloudy",       high = 12.2, low = 8.1),
+                forecastDay("2026-05-10", "sunny",        high = 16.7, low = 9.0),
+                forecastDay("2026-05-11", "lightning-rainy", high = 14.0, low = 7.3),
+            ),
+        ),
+    )
+
+    val driveway = snapshot(
+        state("camera.driveway", "streaming",
+            mapOf("friendly_name" to "Driveway")),
+    )
+
+    val activity = snapshot(
+        state("binary_sensor.front_door", "off",
+            mapOf("friendly_name" to "Front door", "device_class" to "door")),
+        state("binary_sensor.garage_motion", "on",
+            mapOf("friendly_name" to "Garage motion", "device_class" to "motion")),
     )
 }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
@@ -99,3 +99,72 @@ data class HaHeadingData(
 data class HaUnsupportedData(
     val cardType: RemoteString,
 )
+
+/**
+ * `picture-entity` card model. We can't pull the live camera frame /
+ * image entity into a `.rc` document, so the renderer emits a tinted
+ * placeholder area with a domain-appropriate icon and the entity name
+ * + state at the bottom — matching the visual slot the dashboard
+ * expects.
+ */
+data class HaPictureEntityData(
+    val name: RemoteString,
+    val state: RemoteString,
+    val icon: ImageVector,
+    val accent: HaToggleAccent,
+    val showName: Boolean = true,
+    val showState: Boolean = true,
+    val tapAction: HaAction = HaAction.None,
+)
+
+/** `gauge` card model. Half-circle dial with current value + name + range. */
+data class HaGaugeData(
+    val name: RemoteString,
+    val valueText: RemoteString,
+    val unit: String?,
+    /** Current value in the gauge's [min..max] range; clamped at render time. */
+    val value: Double,
+    val min: Double,
+    val max: Double,
+    /** Severity bands sampled at the value position: green / yellow / red. */
+    val severity: HaGaugeSeverity = HaGaugeSeverity.None,
+    val tapAction: HaAction = HaAction.None,
+)
+
+enum class HaGaugeSeverity { None, Normal, Warning, Critical }
+
+/** `weather-forecast` card model. */
+data class HaWeatherForecastData(
+    val name: RemoteString,
+    val condition: RemoteString,
+    /** Current temperature display, including unit. */
+    val temperature: RemoteString,
+    /** Optional secondary line — feels like, low/high, or extra detail. */
+    val supportingLine: RemoteString?,
+    val icon: ImageVector,
+    val days: List<HaWeatherDay> = emptyList(),
+)
+
+/** One column in a weather forecast strip. */
+data class HaWeatherDay(
+    val label: RemoteString,
+    val high: RemoteString,
+    val low: RemoteString,
+    val icon: ImageVector,
+)
+
+/**
+ * `logbook` card model. Each entry is one row: name, what changed, and
+ * a short "when" suffix (relative time).
+ */
+data class HaLogbookData(
+    val title: RemoteString?,
+    val entries: List<HaLogbookEntry>,
+)
+
+data class HaLogbookEntry(
+    val name: RemoteString,
+    val message: RemoteString,
+    val whenText: RemoteString,
+    val icon: ImageVector,
+)

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaGauge.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaGauge.kt
@@ -1,0 +1,160 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import android.graphics.Paint as AndroidPaint
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteCanvas
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteOffset
+import androidx.compose.remote.creation.compose.layout.RemoteSize
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clickable
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.height
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.asRemotePaint
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rf
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+
+/**
+ * HA `gauge` card — half-circle dial.
+ *
+ * ```
+ *      ╱──────────╲
+ *     │   45 °C    │   ← arc (grey track + severity overlay) + value text
+ *      ╲──────────╱
+ *        Coolant
+ *      0       100
+ * ```
+ *
+ * The arc sweep representing `(value - min) / (max - min)` is computed
+ * at capture time; the host re-encodes when the underlying entity
+ * changes. Severity bands tint the value arc green / yellow / red
+ * (matching HA's `gauge.severity` config). Alpha08 doesn't expose a
+ * RemoteFloat numeric binding to animate the sweep without re-encode.
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaGauge(
+    data: HaGaugeData,
+    modifier: RemoteModifier = RemoteModifier,
+) {
+    val theme = haTheme()
+    val clickable = data.tapAction.toRemoteAction()
+        ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
+
+    val span = (data.max - data.min).coerceAtLeast(0.0001)
+    val fraction = ((data.value - data.min) / span).coerceIn(0.0, 1.0).toFloat()
+    val sweep = (180f * fraction)
+
+    val severityColor = when (data.severity) {
+        HaGaugeSeverity.None -> Color(0xFF03A9F4)
+        HaGaugeSeverity.Normal -> Color(0xFF43A047)
+        HaGaugeSeverity.Warning -> Color(0xFFFFA000)
+        HaGaugeSeverity.Critical -> Color(0xFFE53935)
+    }
+
+    RemoteBox(
+        modifier = modifier
+            .then(clickable)
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(horizontal = 14.rdp, vertical = 12.rdp),
+    ) {
+        RemoteColumn(
+            modifier = RemoteModifier.fillMaxWidth(),
+            verticalArrangement = RemoteArrangement.spacedBy(4.rdp),
+            horizontalAlignment = RemoteAlignment.CenterHorizontally,
+        ) {
+            RemoteCanvas(
+                modifier = RemoteModifier.fillMaxWidth().height(72.rdp),
+            ) {
+                val w = width
+                val h = height
+                val stroke = 10f.rf
+                val pad = (stroke / 2f.rf) + 2f.rf
+                val arcW = w - pad * 2f.rf
+                val arcH = (h - pad) * 2f.rf
+                val topLeft = RemoteOffset(pad, pad)
+                val arcSize = RemoteSize(arcW, arcH)
+
+                val track = AndroidPaint().apply {
+                    isAntiAlias = true
+                    style = AndroidPaint.Style.STROKE
+                    strokeWidth = 10f
+                    strokeCap = AndroidPaint.Cap.ROUND
+                    color = theme.divider.toArgb()
+                }.asRemotePaint()
+                drawArc(track, 180f.rf, 180f.rf, false, topLeft, arcSize)
+
+                if (sweep > 0.5f) {
+                    val value = AndroidPaint().apply {
+                        isAntiAlias = true
+                        style = AndroidPaint.Style.STROKE
+                        strokeWidth = 10f
+                        strokeCap = AndroidPaint.Cap.ROUND
+                        color = severityColor.toArgb()
+                    }.asRemotePaint()
+                    drawArc(value, 180f.rf, sweep.rf, false, topLeft, arcSize)
+                }
+            }
+
+            RemoteText(
+                text = data.valueText,
+                color = theme.primaryText.rc,
+                fontSize = 22.rsp,
+                fontWeight = FontWeight.SemiBold,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            RemoteText(
+                text = data.name,
+                color = theme.secondaryText.rc,
+                fontSize = 13.rsp,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (data.unit != null) {
+                RemoteText(
+                    text = "${formatRange(data.min)} – ${formatRange(data.max)} ${data.unit}".rs,
+                    color = theme.secondaryText.rc,
+                    fontSize = 11.rsp,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+private fun formatRange(d: Double): String =
+    if (d == d.toLong().toDouble()) d.toLong().toString() else "%.1f".format(d)
+
+private fun Color.toArgb(): Int = android.graphics.Color.argb(
+    (alpha * 255f).toInt(),
+    (red * 255f).toInt(),
+    (green * 255f).toInt(),
+    (blue * 255f).toInt(),
+)

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaLogbook.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaLogbook.kt
@@ -1,0 +1,121 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.modifier.size
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.wear.compose.remote.material3.RemoteIcon
+
+/**
+ * HA `logbook` card — list of recent state-change entries.
+ *
+ * ```
+ *   ┌──────────────────────────────────────────────┐
+ *   │  Title                                       │
+ *   │  ●  Front door  unlocked        2 min ago    │
+ *   │  ●  Kitchen     turned on       4 min ago    │
+ *   │  ●  Garage      opened          8 min ago    │
+ *   └──────────────────────────────────────────────┘
+ * ```
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaLogbook(data: HaLogbookData, modifier: RemoteModifier = RemoteModifier) {
+    val theme = haTheme()
+    RemoteBox(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(horizontal = 14.rdp, vertical = 12.rdp),
+    ) {
+        RemoteColumn(verticalArrangement = RemoteArrangement.spacedBy(8.rdp)) {
+            if (data.title != null) {
+                RemoteText(
+                    text = data.title,
+                    color = theme.primaryText.rc,
+                    fontSize = 15.rsp,
+                    fontWeight = FontWeight.Medium,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            if (data.entries.isEmpty()) {
+                RemoteText(
+                    text = "No recent activity".rs,
+                    color = theme.secondaryText.rc,
+                    fontSize = 12.rsp,
+                    style = RemoteTextStyle.Default,
+                )
+            } else {
+                data.entries.forEach { entry -> Entry(entry, theme) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Entry(entry: HaLogbookEntry, theme: HaTheme) {
+    RemoteRow(
+        modifier = RemoteModifier.fillMaxWidth(),
+        verticalAlignment = RemoteAlignment.CenterVertically,
+    ) {
+        RemoteIcon(
+            imageVector = entry.icon,
+            contentDescription = entry.name,
+            modifier = RemoteModifier.size(16.rdp),
+            tint = theme.secondaryText.rc,
+        )
+        RemoteColumn(
+            modifier = RemoteModifier.weight(1f).padding(start = 10.rdp),
+        ) {
+            RemoteText(
+                text = entry.name,
+                color = theme.primaryText.rc,
+                fontSize = 13.rsp,
+                fontWeight = FontWeight.Medium,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            RemoteText(
+                text = entry.message,
+                color = theme.secondaryText.rc,
+                fontSize = 12.rsp,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        RemoteText(
+            text = entry.whenText,
+            color = theme.secondaryText.rc,
+            fontSize = 11.rsp,
+            style = RemoteTextStyle.Default,
+            maxLines = 1,
+        )
+    }
+}

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaPictureEntity.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaPictureEntity.kt
@@ -1,0 +1,123 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clickable
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxSize
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.height
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.modifier.size
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rf
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.wear.compose.remote.material3.RemoteIcon
+
+/**
+ * HA `picture-entity` card — modern image-with-overlay tile
+ * (`hui-picture-entity-card.ts`).
+ *
+ * ```
+ *   ┌──────────────────────────────────┐
+ *   │                                  │
+ *   │              [icon]              │   ← image stub area
+ *   │                                  │
+ *   │  Name                  State     │   ← bottom translucent bar
+ *   └──────────────────────────────────┘
+ * ```
+ *
+ * RemoteCompose alpha08 doesn't accept arbitrary HTTP image references
+ * at capture time, so the image area renders a flat tinted placeholder
+ * with a domain-appropriate icon. The bottom bar matches HA's standard
+ * `hui-image-overlay`.
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaPictureEntity(
+    data: HaPictureEntityData,
+    modifier: RemoteModifier = RemoteModifier,
+) {
+    val theme = haTheme()
+    val accent = data.accent.isOn
+        ?.select(data.accent.activeAccent, data.accent.inactiveAccent)
+        ?: data.accent.activeAccent
+    val clickable = data.tapAction.toRemoteAction()
+        ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
+    val showStrip = data.showName || data.showState
+
+    RemoteBox(
+        modifier = modifier
+            .then(clickable)
+            .fillMaxWidth()
+            .height(160.rdp)
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.divider.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp)),
+    ) {
+        RemoteColumn(modifier = RemoteModifier.fillMaxSize()) {
+            RemoteBox(
+                modifier = RemoteModifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .background(accent.copy(alpha = accent.alpha * 0.10f.rf)),
+                contentAlignment = RemoteAlignment.Center,
+            ) {
+                RemoteIcon(
+                    imageVector = data.icon,
+                    contentDescription = data.name,
+                    modifier = RemoteModifier.size(40.rdp),
+                    tint = accent.copy(alpha = accent.alpha * 0.55f.rf),
+                )
+            }
+            if (showStrip) {
+                val barBg = theme.cardBackground.rc
+                RemoteRow(
+                    modifier = RemoteModifier
+                        .fillMaxWidth()
+                        .background(barBg.copy(alpha = barBg.alpha * 0.85f.rf))
+                        .padding(horizontal = 12.rdp, vertical = 8.rdp),
+                    verticalAlignment = RemoteAlignment.CenterVertically,
+                    horizontalArrangement = RemoteArrangement.SpaceBetween,
+                ) {
+                    RemoteText(
+                        text = if (data.showName) data.name else "".rs,
+                        color = theme.primaryText.rc,
+                        fontSize = 13.rsp,
+                        fontWeight = FontWeight.Medium,
+                        style = RemoteTextStyle.Default,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    if (data.showState) {
+                        RemoteText(
+                            text = data.state,
+                            color = theme.secondaryText.rc,
+                            fontSize = 12.rsp,
+                            style = RemoteTextStyle.Default,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaWeatherForecast.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaWeatherForecast.kt
@@ -1,0 +1,169 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.modifier.size
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.wear.compose.remote.material3.RemoteIcon
+
+/**
+ * HA `weather-forecast` card. Top row shows the current condition icon
+ * + summary + headline temperature; an optional strip of forecast days
+ * follows below.
+ *
+ * ```
+ *   ┌───────────────────────────────────────────────┐
+ *   │  ☀  Partly cloudy                  21°       │
+ *   │     Feels like 19°                            │
+ *   │  ─────────────────────────────────────────    │
+ *   │   Mon   Tue   Wed   Thu   Fri                 │
+ *   │   ☀    ⛅    ☁    🌧    ⛈                     │
+ *   │  21/12 19/11 17/10 14/9  13/8                 │
+ *   └───────────────────────────────────────────────┘
+ * ```
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaWeatherForecast(
+    data: HaWeatherForecastData,
+    modifier: RemoteModifier = RemoteModifier,
+) {
+    val theme = haTheme()
+    RemoteBox(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(horizontal = 14.rdp, vertical = 12.rdp),
+    ) {
+        RemoteColumn(verticalArrangement = RemoteArrangement.spacedBy(10.rdp)) {
+            CurrentRow(data, theme)
+            if (data.days.isNotEmpty()) {
+                ForecastStrip(data.days, theme)
+            }
+        }
+    }
+}
+
+@Composable
+private fun CurrentRow(data: HaWeatherForecastData, theme: HaTheme) {
+    RemoteRow(
+        modifier = RemoteModifier.fillMaxWidth(),
+        verticalAlignment = RemoteAlignment.CenterVertically,
+        horizontalArrangement = RemoteArrangement.SpaceBetween,
+    ) {
+        RemoteRow(verticalAlignment = RemoteAlignment.CenterVertically) {
+            RemoteIcon(
+                imageVector = data.icon,
+                contentDescription = data.condition,
+                modifier = RemoteModifier.size(36.rdp),
+                tint = theme.primaryText.rc,
+            )
+            RemoteColumn(modifier = RemoteModifier.padding(start = 10.rdp)) {
+                RemoteText(
+                    text = data.condition,
+                    color = theme.primaryText.rc,
+                    fontSize = 16.rsp,
+                    fontWeight = FontWeight.Medium,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (data.supportingLine != null) {
+                    RemoteText(
+                        text = data.supportingLine,
+                        color = theme.secondaryText.rc,
+                        fontSize = 12.rsp,
+                        style = RemoteTextStyle.Default,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                } else {
+                    RemoteText(
+                        text = data.name,
+                        color = theme.secondaryText.rc,
+                        fontSize = 12.rsp,
+                        style = RemoteTextStyle.Default,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+        RemoteText(
+            text = data.temperature,
+            color = theme.primaryText.rc,
+            fontSize = 28.rsp,
+            fontWeight = FontWeight.Light,
+            style = RemoteTextStyle.Default,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+@Composable
+private fun ForecastStrip(days: List<HaWeatherDay>, theme: HaTheme) {
+    RemoteRow(
+        modifier = RemoteModifier.fillMaxWidth(),
+        horizontalArrangement = RemoteArrangement.SpaceBetween,
+    ) {
+        days.forEach { day ->
+            RemoteColumn(
+                modifier = RemoteModifier.weight(1f),
+                horizontalAlignment = RemoteAlignment.CenterHorizontally,
+                verticalArrangement = RemoteArrangement.spacedBy(2.rdp),
+            ) {
+                RemoteText(
+                    text = day.label,
+                    color = theme.secondaryText.rc,
+                    fontSize = 11.rsp,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                )
+                RemoteIcon(
+                    imageVector = day.icon,
+                    contentDescription = day.label,
+                    modifier = RemoteModifier.size(20.rdp),
+                    tint = theme.primaryText.rc,
+                )
+                RemoteText(
+                    text = day.high,
+                    color = theme.primaryText.rc,
+                    fontSize = 12.rsp,
+                    fontWeight = FontWeight.Medium,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                )
+                RemoteText(
+                    text = day.low,
+                    color = theme.secondaryText.rc,
+                    fontSize = 11.rsp,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                )
+            }
+        }
+    }
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/DefaultConverters.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/DefaultConverters.kt
@@ -9,7 +9,8 @@ import ee.schimke.ha.rc.CardRegistry
  *
  * **Fully implemented** (produce visually-correct output):
  *   tile, button, entity, entities, glance, heading, markdown,
- *   vertical-stack, horizontal-stack, grid, conditional.
+ *   vertical-stack, horizontal-stack, grid, conditional, gauge,
+ *   weather-forecast, picture-entity, logbook.
  *
  * **Summary chrome** (registered with a real converter that renders
  * a card chrome but skips the rich visualisation — replace with the
@@ -19,9 +20,9 @@ import ee.schimke.ha.rc.CardRegistry
  * **Placeholder-only** (registered so the dashboard renders, but with a
  * "not yet supported" badge — extend by writing a `RemoteHa…` composable
  * + converter shim):
- *   gauge, thermostat, humidifier, light, media-control, alarm-panel,
- *   weather-forecast, clock, area, calendar, logbook, todo-list,
- *   picture, picture-entity, picture-glance, picture-elements,
+ *   thermostat, humidifier, light, media-control, alarm-panel,
+ *   clock, area, calendar, todo-list,
+ *   picture, picture-glance, picture-elements,
  *   statistics-graph, statistic, sensor, entity-filter, iframe.
  */
 fun defaultConverters(): List<CardConverter> = buildList {
@@ -38,6 +39,10 @@ fun defaultConverters(): List<CardConverter> = buildList {
     add(ConditionalCardConverter())
     add(MapCardConverter())
     add(HistoryGraphCardConverter())
+    add(GaugeCardConverter())
+    add(PictureEntityCardConverter())
+    add(WeatherForecastCardConverter())
+    add(LogbookCardConverter())
 
     add(BambuLabAmsCardConverter())
     add(BambuLabSpoolCardConverter())
@@ -54,20 +59,16 @@ fun defaultConverters(): List<CardConverter> = buildList {
 fun defaultRegistry(): CardRegistry = CardRegistry(defaultConverters())
 
 private val PLACEHOLDER_CARD_TYPES: List<String> = listOf(
-    CardTypes.GAUGE,
     CardTypes.THERMOSTAT,
     CardTypes.HUMIDIFIER,
     CardTypes.LIGHT,
     CardTypes.MEDIA_CONTROL,
     CardTypes.ALARM_PANEL,
-    CardTypes.WEATHER_FORECAST,
     CardTypes.CLOCK,
     CardTypes.AREA,
     CardTypes.CALENDAR,
-    CardTypes.LOGBOOK,
     CardTypes.TODO_LIST,
     CardTypes.PICTURE,
-    CardTypes.PICTURE_ENTITY,
     CardTypes.PICTURE_GLANCE,
     CardTypes.PICTURE_ELEMENTS,
     CardTypes.STATISTICS_GRAPH,

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/GaugeCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/GaugeCardConverter.kt
@@ -1,0 +1,86 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.LiveBindings
+import ee.schimke.ha.rc.components.HaGaugeData
+import ee.schimke.ha.rc.components.HaGaugeSeverity
+import ee.schimke.ha.rc.components.RemoteHaGauge
+import ee.schimke.ha.rc.defaultTapActionFor
+import ee.schimke.ha.rc.formatState
+import ee.schimke.ha.rc.parseHaAction
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `gauge` card. Maps the entity's numeric state into a half-circle dial
+ * with HA's severity bands (`severity.green`/`yellow`/`red` thresholds).
+ * Sweep is captured statically — alpha08 doesn't expose a `RemoteFloat`
+ * binding, so live updates re-encode.
+ */
+class GaugeCardConverter : CardConverter {
+    override val cardType: String = CardTypes.GAUGE
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 150
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val entityId = card.raw["entity"]?.jsonPrimitive?.content
+        val entity = entityId?.let { snapshot.states[it] }
+        val name = card.raw["name"]?.jsonPrimitive?.content
+            ?: entity?.attributes?.get("friendly_name")?.jsonPrimitive?.content
+            ?: entityId
+            ?: "(no entity)"
+        val unit = card.raw["unit"]?.jsonPrimitive?.content
+            ?: entity?.attributes?.get("unit_of_measurement")?.jsonPrimitive?.content
+        val min = card.raw["min"]?.jsonPrimitive?.content?.toDoubleOrNull() ?: 0.0
+        val max = card.raw["max"]?.jsonPrimitive?.content?.toDoubleOrNull() ?: 100.0
+        val value = entity?.state?.toDoubleOrNull() ?: min
+        val severity = parseSeverity(card.raw["severity"] as? JsonObject, value)
+        val tapCfg = card.raw["tap_action"]?.jsonObject
+        val tapAction = if (tapCfg != null) parseHaAction(tapCfg, entityId)
+        else defaultTapActionFor(entityId)
+
+        RemoteHaGauge(
+            HaGaugeData(
+                name = name.rs,
+                valueText = LiveBindings.state(entity, formatState(entity)),
+                unit = unit,
+                value = value,
+                min = min,
+                max = max,
+                severity = severity,
+                tapAction = tapAction,
+            ),
+            modifier = modifier,
+        )
+    }
+}
+
+/**
+ * HA's severity config is a map of `green` / `yellow` / `red` to numeric
+ * thresholds. The active band is the highest threshold the value
+ * crosses, regardless of the threshold ordering (HA accepts both
+ * "green=60, yellow=30, red=0" descending and "red=50, yellow=10, green=0"
+ * ascending — see the meshcore dashboard for examples).
+ */
+private fun parseSeverity(cfg: JsonObject?, value: Double): HaGaugeSeverity {
+    if (cfg == null) return HaGaugeSeverity.None
+    val green = cfg["green"]?.jsonPrimitive?.content?.toDoubleOrNull()
+    val yellow = cfg["yellow"]?.jsonPrimitive?.content?.toDoubleOrNull()
+    val red = cfg["red"]?.jsonPrimitive?.content?.toDoubleOrNull()
+    val bands = listOfNotNull(
+        green?.let { HaGaugeSeverity.Normal to it },
+        yellow?.let { HaGaugeSeverity.Warning to it },
+        red?.let { HaGaugeSeverity.Critical to it },
+    )
+    if (bands.isEmpty()) return HaGaugeSeverity.None
+    val ascending = bands.sortedBy { it.second }
+    return ascending.lastOrNull { value >= it.second }?.first ?: HaGaugeSeverity.None
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/LogbookCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/LogbookCardConverter.kt
@@ -1,0 +1,77 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.History
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.components.HaLogbookData
+import ee.schimke.ha.rc.components.HaLogbookEntry
+import ee.schimke.ha.rc.components.RemoteHaLogbook
+import ee.schimke.ha.rc.formatState
+import ee.schimke.ha.rc.icons.HaIconMap
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `logbook` card. The dashboard JSON only carries the entity ids — real
+ * logbook data lives behind the `/api/logbook` REST endpoint, which the
+ * `.rc` document can't fetch at playback. We render one entry per
+ * configured entity using its current state as the most-recent
+ * "message" line, with the entity's last-changed timestamp where
+ * available. Hosts that hydrate logbook history at capture time can
+ * extend [HaSnapshot] later; for now this gives a representative slot.
+ */
+class LogbookCardConverter : CardConverter {
+    override val cardType: String = CardTypes.LOGBOOK
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int {
+        val rows = entityIds(card).size.coerceAtLeast(1)
+        val title = if (card.raw["title"] != null) 28 else 0
+        return title + 24 + 36 * rows
+    }
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val title = card.raw["title"]?.jsonPrimitive?.content
+        val entries = entityIds(card).map { entityId ->
+            val entity = snapshot.states[entityId]
+            val name = entity?.attributes?.get("friendly_name")?.jsonPrimitive?.content
+                ?: entityId
+            HaLogbookEntry(
+                name = name.rs,
+                message = formatState(entity).rs,
+                whenText = formatRelative(entity?.lastChanged).rs,
+                icon = HaIconMap.resolve(null, entity),
+            )
+        }
+        RemoteHaLogbook(
+            HaLogbookData(
+                title = title?.rs,
+                entries = entries,
+            ),
+            modifier = modifier,
+        )
+    }
+}
+
+private fun entityIds(card: CardConfig): List<String> {
+    val arr: JsonArray = card.raw["entities"]?.jsonArray ?: return emptyList()
+    return arr.mapNotNull { el ->
+        when (el) {
+            is JsonObject -> el["entity"]?.jsonPrimitive?.content
+            else -> el.jsonPrimitive.content
+        }
+    }
+}
+
+private fun formatRelative(instant: kotlinx.datetime.Instant?): String {
+    if (instant == null) return ""
+    return instant.toString().substringBefore('T')
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/PictureEntityCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/PictureEntityCardConverter.kt
@@ -1,0 +1,65 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.HaStateColor
+import ee.schimke.ha.rc.LiveBindings
+import ee.schimke.ha.rc.components.HaPictureEntityData
+import ee.schimke.ha.rc.components.HaToggleAccent
+import ee.schimke.ha.rc.components.RemoteHaPictureEntity
+import ee.schimke.ha.rc.defaultTapActionFor
+import ee.schimke.ha.rc.formatState
+import ee.schimke.ha.rc.icons.HaIconMap
+import ee.schimke.ha.rc.parseHaAction
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `picture-entity` card. RemoteCompose alpha08 can't pull a live camera
+ * stream into a `.rc` document, so the renderer paints a tinted
+ * placeholder area + name/state bottom bar; tap forwards to the entity's
+ * default action (more-info / toggle).
+ */
+class PictureEntityCardConverter : CardConverter {
+    override val cardType: String = CardTypes.PICTURE_ENTITY
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 160
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val entityId = card.raw["entity"]?.jsonPrimitive?.content
+        val entity = entityId?.let { snapshot.states[it] }
+        val name = card.raw["name"]?.jsonPrimitive?.content
+            ?: entity?.attributes?.get("friendly_name")?.jsonPrimitive?.content
+            ?: entityId
+            ?: "(no entity)"
+        val showName = card.raw["show_name"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: true
+        val showState = card.raw["show_state"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: true
+        val tapCfg = card.raw["tap_action"]?.jsonObject
+        val tapAction = if (tapCfg != null) parseHaAction(tapCfg, entityId)
+        else defaultTapActionFor(entityId)
+
+        RemoteHaPictureEntity(
+            HaPictureEntityData(
+                name = name.rs,
+                state = LiveBindings.state(entity, formatState(entity)),
+                icon = HaIconMap.resolve(card.raw["icon"]?.jsonPrimitive?.content, entity),
+                accent = HaToggleAccent(
+                    activeAccent = HaStateColor.activeFor(entity).rc,
+                    inactiveAccent = HaStateColor.inactiveFor(entity).rc,
+                    isOn = LiveBindings.isOn(entity),
+                ),
+                showName = showName,
+                showState = showState,
+                tapAction = tapAction,
+            ),
+            modifier = modifier,
+        )
+    }
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/WeatherForecastCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/WeatherForecastCardConverter.kt
@@ -1,0 +1,126 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AcUnit
+import androidx.compose.material.icons.filled.Air
+import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.Thunderstorm
+import androidx.compose.material.icons.filled.Umbrella
+import androidx.compose.material.icons.filled.WbCloudy
+import androidx.compose.material.icons.filled.WbSunny
+import androidx.compose.material.icons.outlined.Cloud
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.components.HaWeatherDay
+import ee.schimke.ha.rc.components.HaWeatherForecastData
+import ee.schimke.ha.rc.components.RemoteHaWeatherForecast
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `weather-forecast` card. Reads the weather entity's
+ * `temperature` / `forecast` attributes from the snapshot, renders the
+ * current condition + an optional daily forecast strip. The forecast
+ * array isn't part of the standard state attributes — we look for it
+ * under `forecast` (legacy) or `forecast.daily` (post-2024 weather
+ * service); if neither is present we skip the strip.
+ */
+class WeatherForecastCardConverter : CardConverter {
+    override val cardType: String = CardTypes.WEATHER_FORECAST
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 168
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val entityId = card.raw["entity"]?.jsonPrimitive?.content
+        val entity = entityId?.let { snapshot.states[it] }
+        val attrs = entity?.attributes ?: emptyMap<String, kotlinx.serialization.json.JsonElement>()
+        val name = card.raw["name"]?.jsonPrimitive?.content
+            ?: attrs["friendly_name"]?.jsonPrimitive?.content
+            ?: entityId
+            ?: "Weather"
+        val condition = entity?.state ?: "unknown"
+        val tempUnit = attrs["temperature_unit"]?.jsonPrimitive?.content ?: "°"
+        val temp = attrs["temperature"]?.jsonPrimitive?.content
+        val temperature = if (temp != null) "$temp$tempUnit" else "—"
+        val showForecast = card.raw["show_forecast"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: true
+
+        val forecast = (attrs["forecast"] as? JsonArray)
+            ?: ((attrs["forecast"] as? JsonObject)?.get("daily") as? JsonArray)
+            ?: JsonArray(emptyList())
+        val days = if (showForecast) forecast.take(5).mapNotNull { day ->
+            val obj = day as? JsonObject ?: return@mapNotNull null
+            val cond = obj["condition"]?.jsonPrimitive?.content
+            val high = obj["temperature"]?.jsonPrimitive?.content
+            val low = obj["templow"]?.jsonPrimitive?.content
+            val dt = obj["datetime"]?.jsonPrimitive?.content
+            HaWeatherDay(
+                label = (formatDayLabel(dt) ?: "").rs,
+                high = (high?.let { "$it$tempUnit" } ?: "—").rs,
+                low = (low?.let { "$it$tempUnit" } ?: "—").rs,
+                icon = weatherIcon(cond),
+            )
+        } else emptyList()
+
+        RemoteHaWeatherForecast(
+            HaWeatherForecastData(
+                name = name.rs,
+                condition = formatCondition(condition).rs,
+                temperature = temperature.rs,
+                supportingLine = null,
+                icon = weatherIcon(condition),
+                days = days,
+            ),
+            modifier = modifier,
+        )
+    }
+}
+
+private fun weatherIcon(condition: String?): ImageVector = when (condition) {
+    "sunny", "clear-night" -> Icons.Filled.WbSunny
+    "partlycloudy" -> Icons.Filled.WbCloudy
+    "cloudy" -> Icons.Filled.Cloud
+    "fog" -> Icons.Outlined.Cloud
+    "rainy", "pouring" -> Icons.Filled.Umbrella
+    "lightning", "lightning-rainy" -> Icons.Filled.Thunderstorm
+    "snowy", "snowy-rainy", "hail" -> Icons.Filled.AcUnit
+    "windy", "windy-variant" -> Icons.Filled.Air
+    else -> Icons.Filled.Cloud
+}
+
+private fun formatCondition(state: String): String =
+    state.replace('-', ' ').replace('_', ' ').replaceFirstChar { it.uppercaseChar() }
+
+/** Best-effort short weekday label from an ISO-8601 datetime — we don't
+ *  parse the zone, just take the date part and convert. Returns null
+ *  if the input doesn't look parseable. */
+private fun formatDayLabel(datetime: String?): String? {
+    if (datetime.isNullOrEmpty()) return null
+    val datePart = datetime.substringBefore('T')
+    val parts = datePart.split('-')
+    if (parts.size != 3) return null
+    val (y, m, d) = parts
+    val year = y.toIntOrNull() ?: return null
+    val month = m.toIntOrNull() ?: return null
+    val day = d.toIntOrNull() ?: return null
+    // Zeller's-ish — day-of-week from the proleptic Gregorian calendar.
+    val q = day
+    val mAdj = if (month < 3) month + 12 else month
+    val yAdj = if (month < 3) year - 1 else year
+    val k = yAdj % 100
+    val j = yAdj / 100
+    val h = (q + 13 * (mAdj + 1) / 5 + k + k / 4 + j / 4 + 5 * j) % 7
+    return when (h) {
+        0 -> "Sat"; 1 -> "Sun"; 2 -> "Mon"; 3 -> "Tue"
+        4 -> "Wed"; 5 -> "Thu"; 6 -> "Fri"
+        else -> null
+    }
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/icons/HaIconMap.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/icons/HaIconMap.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.filled.Speaker
 import androidx.compose.material.icons.filled.Thermostat
 import androidx.compose.material.icons.filled.Tv
 import androidx.compose.material.icons.filled.Umbrella
+import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material.icons.filled.WaterDrop
 import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.material.icons.filled.Window
@@ -53,7 +54,16 @@ object HaIconMap {
         iconOverride?.let { mdi(it)?.let { v -> return v } }
         entity?.attributes?.get("icon")?.jsonPrimitive?.content
             ?.let { mdi(it)?.let { v -> return v } }
-        return entity?.toTyped()?.defaultIcon() ?: Icons.Filled.Help
+        val typed = entity?.toTyped() ?: return Icons.Filled.Help
+        if (typed is HaEntity.Other) byDomain(entity.entityId)?.let { return it }
+        return typed.defaultIcon()
+    }
+
+    /** Domain-only fallback for entity classes the typed hierarchy doesn't model
+     *  (camera, scene, script, …). Keeps `mdi:` overrides authoritative. */
+    private fun byDomain(entityId: String): ImageVector? = when (entityId.substringBefore('.')) {
+        "camera" -> Icons.Filled.Videocam
+        else -> null
     }
 
     private fun HaEntity.defaultIcon(): ImageVector = when (this) {


### PR DESCRIPTION
## Summary

Promotes four Lovelace card types from `PLACEHOLDER_CARD_TYPES` to fully-implemented converters with matching `RemoteHa*` composables:

- **gauge** — half-circle dial via `RemoteCanvas.drawArc` with severity bands (green / yellow / red) sampled at the value position from HA's `severity` config; sweep is captured statically (alpha08 has no `RemoteFloat` numeric binding, so live updates re-encode).
- **weather-forecast** — current condition row + optional 5-day strip, parses both legacy `forecast: [...]` and post-2024 `forecast.daily` shapes.
- **picture-entity** — tinted placeholder + name/state bottom bar; live camera frames can't ride in a `.rc` document, so the renderer paints a domain-icon stub. Adds a domain-prefix fallback in `HaIconMap` so `camera.*` resolves to `Videocam` instead of `?`.
- **logbook** — title + per-entity state rows. Full logbook history needs the REST `/api/logbook` endpoint that the document can't fetch at playback; renders one row per configured entity with its current state and last-changed date as a representative slot.

Wires all four into `defaultConverters()`, removes them from `PLACEHOLDER_CARD_TYPES`, and adds Light/Dark `@Preview` pairs in the previews module with matching fixtures (battery sensor, weather-with-forecast, driveway camera, activity log).

## Previews

### Gauge — `sensor.repeater_battery` at 62 % (green band)

| Light | Dark |
|---|---|
| ![gauge light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/d663117b17c58f24f744d18507e021e7b2bc24c2/Gauge_Light.png) | ![gauge dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/d663117b17c58f24f744d18507e021e7b2bc24c2/Gauge_Dark.png) |

### Weather forecast — current row + 5-day strip

| Light | Dark |
|---|---|
| ![weather light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/d663117b17c58f24f744d18507e021e7b2bc24c2/WeatherForecast_Light.png) | ![weather dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/d663117b17c58f24f744d18507e021e7b2bc24c2/WeatherForecast_Dark.png) |

### Picture-entity — `camera.driveway`

| Light | Dark |
|---|---|
| ![picture-entity light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/d663117b17c58f24f744d18507e021e7b2bc24c2/PictureEntity_Light.png) | ![picture-entity dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/d663117b17c58f24f744d18507e021e7b2bc24c2/PictureEntity_Dark.png) |

### Logbook — recent activity

| Light | Dark |
|---|---|
| ![logbook light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/d663117b17c58f24f744d18507e021e7b2bc24c2/Logbook_Light.png) | ![logbook dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/d663117b17c58f24f744d18507e021e7b2bc24c2/Logbook_Dark.png) |

## Test plan

- [x] `./gradlew :rc-components:compileDebugKotlin :rc-converter:compileDebugKotlin :previews:assembleDebug` — green
- [x] `compose-preview render` against all 8 new previews — all 4 card types render in both themes (see images above)
- [ ] Pixel-diff cases in `CardPixelDiffTest` (no committed reference PNGs for these card types yet)
- [ ] Interaction recording via `compose-preview-mcp` — blocked by yschimke/compose-ai-tools#834 (daemon classpath/manifest doesn't refresh after build)