### PR TITLE
test(integration): wire pixel-diff cases for gauge/weather/picture-entity/logbook

### DIFF
--- a/integration/src/test/kotlin/ee/schimke/ha/integration/CardPixelDiffTest.kt
+++ b/integration/src/test/kotlin/ee/schimke/ha/integration/CardPixelDiffTest.kt
@@ -62,6 +62,29 @@ class CardPixelDiffTest {
       Case("Glance_Dark_glance_dark", "glance/overview_dark.png", 40.0),
       Case("Markdown_Light_markdown_light", "markdown/notes_light.png", 40.0),
       Case("Markdown_Dark_markdown_dark", "markdown/notes_dark.png", 40.0),
+
+      // gauge / weather-forecast / picture-entity / logbook —
+      // converters and previews exist (see CardPreviews.kt), but no HA
+      // reference captures yet. The cases below are wired so that once
+      // `integration/scripts/capture-references.sh` is run against the
+      // seeded HA the diff pops in automatically; until then each one
+      // skips via assumeTrue.
+      Case("Gauge_Light_gauge_light", "gauge/battery_light.png", 40.0),
+      Case("Gauge_Dark_gauge_dark", "gauge/battery_dark.png", 40.0),
+      Case(
+        "WeatherForecast_Light_weather-forecast_light",
+        "weather-forecast/forecast_home_light.png",
+        40.0,
+      ),
+      Case(
+        "WeatherForecast_Dark_weather-forecast_dark",
+        "weather-forecast/forecast_home_dark.png",
+        40.0,
+      ),
+      Case("PictureEntity_Light_picture-entity_light", "picture-entity/driveway_light.png", 50.0),
+      Case("PictureEntity_Dark_picture-entity_dark", "picture-entity/driveway_dark.png", 50.0),
+      Case("Logbook_Light_logbook_light", "logbook/recent_activity_light.png", 40.0),
+      Case("Logbook_Dark_logbook_dark", "logbook/recent_activity_dark.png", 40.0),
     )
 
   @TestFactory


### PR DESCRIPTION
## Summary

Follow-up to #77. The four new card types ship with @Preview coverage but no committed reference PNGs, so this PR just wires up the pixel-diff `Case()` rows. Each one skips cleanly via `assumeTrue(reference.exists())` until references land.

Picture-entity uses a 50 % threshold (vs 40 % for the others) because our renderer paints a tinted-icon placeholder rather than the live camera frame — the diff against HA's real image will always be high there. The number is a guess; tighten once we have actual captures.

No reference images are added in this PR — capturing them needs the seeded HA at `integration/compose.yaml` to be running with onboarding done. Plan is to run `integration/scripts/capture-references.sh` separately (against the seeded synthetic HA, not a live one) and commit the resulting PNGs in a follow-up.

## Test plan

- [x] `./gradlew :integration:compileTestKotlin` — green
- [x] `./gradlew :integration:test --tests CardPixelDiffTest` — 8 new dynamic tests appear, each skipped with `Assumption failed: reference …/…png missing`
- [ ] Capture references from the seeded HA in a follow-up PR