### PR TITLE
feat(history-graph): draw real sparklines via RemoteCanvas

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
@@ -474,6 +474,25 @@ private fun logbookCard() = card(
         "entities":["binary_sensor.front_door","binary_sensor.garage_motion"]}""",
 )
 
+// ——— history-graph ———
+
+@Preview(name = "history-graph (light)", showBackground = false, widthDp = 381, heightDp = 180)
+@Composable
+fun HistoryGraph_Light() = CardHost(HaTheme.Light) {
+    RenderChild(historyGraphCard(), Fixtures.temperatureHistory, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "history-graph (dark)", showBackground = false, widthDp = 381, heightDp = 180)
+@Composable
+fun HistoryGraph_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(historyGraphCard(), Fixtures.temperatureHistory, RemoteModifier.fillMaxWidth())
+}
+
+private fun historyGraphCard() = card(
+    """{"type":"history-graph","title":"Temperature","hours_to_show":24,
+        "entities":["sensor.outside_temp","sensor.upstairs_temp"]}""",
+)
+
 // ——— tile, state variants via PreviewParameter ———
 
 @Preview(name = "tile light (light)", showBackground = false, widthDp = 187, heightDp = 43)

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
@@ -141,4 +141,57 @@ object Fixtures {
         state("binary_sensor.garage_motion", "on",
             mapOf("friendly_name" to "Garage motion", "device_class" to "motion")),
     )
+
+    /** Two temperature sensors with a 24-sample diurnal cycle so the
+     *  history-graph preview has real sparkline data to draw. */
+    val temperatureHistory: HaSnapshot = run {
+        val outsideStates = listOf("sensor.outside_temp", "sensor.upstairs_temp")
+        val states = mapOf(
+            "sensor.outside_temp" to EntityState(
+                entityId = "sensor.outside_temp",
+                state = "8.2",
+                attributes = JsonObject(mapOf(
+                    "friendly_name" to JsonPrimitive("Outside"),
+                    "unit_of_measurement" to JsonPrimitive("°C"),
+                    "device_class" to JsonPrimitive("temperature"),
+                )),
+            ),
+            "sensor.upstairs_temp" to EntityState(
+                entityId = "sensor.upstairs_temp",
+                state = "22.2",
+                attributes = JsonObject(mapOf(
+                    "friendly_name" to JsonPrimitive("Upstairs"),
+                    "unit_of_measurement" to JsonPrimitive("°C"),
+                    "device_class" to JsonPrimitive("temperature"),
+                )),
+            ),
+        )
+        // Synthetic 24h sample series: outside follows a sine-ish day,
+        // upstairs is flatter with mild dips overnight.
+        val outside = listOf(
+            7.1f, 6.4f, 5.8f, 5.4f, 5.6f, 6.5f, 8.0f, 9.6f,
+            11.0f, 12.4f, 13.5f, 14.1f, 14.4f, 14.0f, 13.5f, 12.6f,
+            11.4f, 10.2f, 9.4f, 8.9f, 8.6f, 8.4f, 8.3f, 8.2f,
+        )
+        val upstairs = listOf(
+            21.5f, 21.3f, 21.2f, 21.0f, 20.9f, 21.0f, 21.4f, 21.9f,
+            22.4f, 22.7f, 22.9f, 23.0f, 23.1f, 23.0f, 22.9f, 22.8f,
+            22.6f, 22.5f, 22.4f, 22.3f, 22.3f, 22.2f, 22.2f, 22.2f,
+        )
+        val baseTime = kotlinx.datetime.Instant.parse("2026-05-05T00:00:00Z")
+        fun series(name: String, samples: List<Float>) =
+            samples.mapIndexed { i, v ->
+                ee.schimke.ha.model.HistoryPoint(
+                    ts = baseTime.plus(kotlin.time.Duration.parse("${i}h")),
+                    state = v.toString(),
+                )
+            }
+        HaSnapshot(
+            states = states,
+            history = mapOf(
+                "sensor.outside_temp" to series("Outside", outside),
+                "sensor.upstairs_temp" to series("Upstairs", upstairs),
+            ),
+        )
+    }
 }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
@@ -168,3 +168,23 @@ data class HaLogbookEntry(
     val whenText: RemoteString,
     val icon: ImageVector,
 )
+
+/**
+ * `history-graph` card model. Each row carries the numeric samples + a
+ * pre-formatted summary string ("21.4 °C", "min – max (N)") so the
+ * renderer doesn't need to know about units.
+ */
+data class HaHistoryGraphData(
+    val title: RemoteString?,
+    /** "Last 24h" / "Last 12h" — whatever `hours_to_show` resolved to. */
+    val rangeLabel: RemoteString,
+    val rows: List<HaHistoryGraphRow>,
+)
+
+data class HaHistoryGraphRow(
+    val name: RemoteString,
+    val summary: RemoteString,
+    val accent: Color,
+    /** Numeric samples in order. Empty → renders a "no data" stub. */
+    val points: List<Float>,
+)

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaHistoryGraph.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaHistoryGraph.kt
@@ -1,0 +1,188 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import android.graphics.Paint as AndroidPaint
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteCanvas
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteOffset
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.height
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.asRemotePaint
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rf
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+
+/**
+ * HA `history-graph` card — title, range label, then one sparkline row
+ * per entity.
+ *
+ * ```
+ *   ┌─────────────────────────────────────────────┐
+ *   │  Temperature                                │
+ *   │  Last 24h                                   │
+ *   │  Outside        ╱╲╱╲╱╲╱╲╱╲╱╲╱╲   8.2 °C    │
+ *   │  Upstairs       ─────~~~~~~──   22.2 °C    │
+ *   └─────────────────────────────────────────────┘
+ * ```
+ *
+ * Sparkline is captured from numeric `HistoryPoint`s. Sample values get
+ * normalised into the row's drawable rect at capture time; alpha08
+ * doesn't expose a numeric `RemoteFloat` binding for live updates, so a
+ * host that wants a moving line re-encodes when history changes.
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaHistoryGraph(
+    data: HaHistoryGraphData,
+    modifier: RemoteModifier = RemoteModifier,
+) {
+    val theme = haTheme()
+    RemoteBox(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(horizontal = 14.rdp, vertical = 10.rdp),
+    ) {
+        RemoteColumn(verticalArrangement = RemoteArrangement.spacedBy(6.rdp)) {
+            if (data.title != null) {
+                RemoteText(
+                    text = data.title,
+                    color = theme.primaryText.rc,
+                    fontSize = 15.rsp,
+                    fontWeight = FontWeight.Medium,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            RemoteText(
+                text = data.rangeLabel,
+                color = theme.secondaryText.rc,
+                fontSize = 11.rsp,
+                style = RemoteTextStyle.Default,
+            )
+            if (data.rows.isEmpty()) {
+                RemoteText(
+                    text = "No entities".rs,
+                    color = theme.secondaryText.rc,
+                    fontSize = 13.rsp,
+                    style = RemoteTextStyle.Default,
+                )
+            } else {
+                data.rows.forEach { row -> Row(row, theme) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Row(row: HaHistoryGraphRow, theme: HaTheme) {
+    RemoteRow(
+        modifier = RemoteModifier.fillMaxWidth(),
+        verticalAlignment = RemoteAlignment.CenterVertically,
+        horizontalArrangement = RemoteArrangement.SpaceBetween,
+    ) {
+        RemoteText(
+            text = row.name,
+            color = theme.primaryText.rc,
+            fontSize = 12.rsp,
+            fontWeight = FontWeight.Medium,
+            style = RemoteTextStyle.Default,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        RemoteText(
+            text = row.summary,
+            color = theme.secondaryText.rc,
+            fontSize = 11.rsp,
+            style = RemoteTextStyle.Default,
+            maxLines = 1,
+        )
+    }
+    if (row.points.size >= 2) {
+        Sparkline(row.points, row.accent, theme)
+    } else {
+        RemoteText(
+            text = "No samples".rs,
+            color = theme.secondaryText.rc,
+            fontSize = 11.rsp,
+            style = RemoteTextStyle.Default,
+        )
+    }
+}
+
+@Composable
+private fun Sparkline(points: List<Float>, accent: Color, theme: HaTheme) {
+    val minP = points.min()
+    val maxP = points.max()
+    val span = (maxP - minP).takeIf { it > 0f } ?: 1f
+    RemoteCanvas(modifier = RemoteModifier.fillMaxWidth().height(28.rdp)) {
+        val w = width
+        val h = height
+        val padX = 2f.rf
+        val padY = 3f.rf
+        val drawW = w - padX * 2f.rf
+        val drawH = h - padY * 2f.rf
+
+        // Faint baseline so an empty/flat row still shows the row's
+        // vertical extent.
+        val baseline = AndroidPaint().apply {
+            isAntiAlias = true
+            style = AndroidPaint.Style.STROKE
+            strokeWidth = 1f
+            color = theme.divider.toArgb()
+        }.asRemotePaint()
+        drawLine(
+            baseline,
+            RemoteOffset(padX, padY + drawH),
+            RemoteOffset(padX + drawW, padY + drawH),
+        )
+
+        val stroke = AndroidPaint().apply {
+            isAntiAlias = true
+            style = AndroidPaint.Style.STROKE
+            strokeWidth = 2f
+            strokeCap = AndroidPaint.Cap.ROUND
+            strokeJoin = AndroidPaint.Join.ROUND
+            color = accent.toArgb()
+        }.asRemotePaint()
+
+        val n = points.size
+        for (i in 0 until n - 1) {
+            val x0 = padX + drawW * (i.toFloat() / (n - 1).toFloat()).rf
+            val x1 = padX + drawW * ((i + 1).toFloat() / (n - 1).toFloat()).rf
+            val y0 = padY + drawH * (1f - (points[i] - minP) / span).rf
+            val y1 = padY + drawH * (1f - (points[i + 1] - minP) / span).rf
+            drawLine(stroke, RemoteOffset(x0, y0), RemoteOffset(x1, y1))
+        }
+    }
+}
+
+private fun Color.toArgb(): Int = android.graphics.Color.argb(
+    (alpha * 255f).toInt(),
+    (red * 255f).toInt(),
+    (green * 255f).toInt(),
+    (blue * 255f).toInt(),
+)

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/HistoryGraphCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/HistoryGraphCardConverter.kt
@@ -1,33 +1,17 @@
-@file:Suppress("RestrictedApi")
-
 package ee.schimke.ha.rc.cards
 
-import androidx.compose.remote.creation.compose.layout.RemoteAlignment
-import androidx.compose.remote.creation.compose.layout.RemoteArrangement
-import androidx.compose.remote.creation.compose.layout.RemoteBox
-import androidx.compose.remote.creation.compose.layout.RemoteColumn
-import androidx.compose.remote.creation.compose.layout.RemoteRow
-import androidx.compose.remote.creation.compose.layout.RemoteText
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
-import androidx.compose.remote.creation.compose.modifier.background
-import androidx.compose.remote.creation.compose.modifier.border
-import androidx.compose.remote.creation.compose.modifier.clip
-import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
-import androidx.compose.remote.creation.compose.modifier.padding
-import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
-import androidx.compose.remote.creation.compose.state.rc
-import androidx.compose.remote.creation.compose.state.rdp
 import androidx.compose.remote.creation.compose.state.rs
-import androidx.compose.remote.creation.compose.state.rsp
-import androidx.compose.remote.creation.compose.text.RemoteTextStyle
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.text.font.FontWeight
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.model.HistoryPoint
 import ee.schimke.ha.rc.CardConverter
-import ee.schimke.ha.rc.components.LocalHaTheme
+import ee.schimke.ha.rc.HaStateColor
+import ee.schimke.ha.rc.components.HaHistoryGraphData
+import ee.schimke.ha.rc.components.HaHistoryGraphRow
+import ee.schimke.ha.rc.components.RemoteHaHistoryGraph
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -35,96 +19,48 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
- * HA `history-graph` card — one row per entity summarising the history
- * available in the snapshot.
- *
- * RemoteCompose alpha08 doesn't yet expose a `RemoteCanvas` that lets us
- * paint per-point line segments at capture time without an explosion of
- * primitives, so this converter emits a textual summary
- * (`min – max (n samples)`) for each entity. When the history channel
- * stabilises we can replace the row body with a sparkline composable
- * without changing the converter / registration boundary.
+ * `history-graph` card. Renders one sparkline per entity using the
+ * snapshot's `history[entityId]`. Numeric points are normalised into
+ * the row's drawable rect at capture time; alpha08 doesn't expose a
+ * RemoteFloat numeric binding, so live updates re-encode.
  */
 class HistoryGraphCardConverter : CardConverter {
     override val cardType: String = CardTypes.HISTORY_GRAPH
 
     override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int {
         val rows = entityIds(card).size.coerceAtLeast(1)
-        val title = if (card.raw["title"] != null) 28 else 0
-        return title + 24 + 32 * rows
+        val title = if (card.raw["title"] != null) 24 else 0
+        // ~52 dp per row (label + sparkline + spacing) + range label + padding.
+        return title + 16 + 52 * rows + 20
     }
 
     @Composable
     override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
-        val theme = LocalHaTheme.current
         val title = card.raw["title"]?.jsonPrimitive?.content
         val hours = card.raw["hours_to_show"]?.jsonPrimitive?.content?.toIntOrNull() ?: 24
         val ids = entityIds(card)
 
-        RemoteBox(
-            modifier = modifier
-                .fillMaxWidth()
-                .clip(RemoteRoundedCornerShape(12.rdp))
-                .background(theme.cardBackground.rc)
-                .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
-                .padding(horizontal = 12.rdp, vertical = 10.rdp),
-        ) {
-            RemoteColumn(verticalArrangement = RemoteArrangement.spacedBy(6.rdp)) {
-                if (title != null) {
-                    RemoteText(
-                        text = title.rs,
-                        color = theme.primaryText.rc,
-                        fontSize = 15.rsp,
-                        fontWeight = FontWeight.Medium,
-                        style = RemoteTextStyle.Default,
-                    )
-                }
-                RemoteText(
-                    text = "Last ${hours}h".rs,
-                    color = theme.secondaryText.rc,
-                    fontSize = 11.rsp,
-                    style = RemoteTextStyle.Default,
-                )
-                if (ids.isEmpty()) {
-                    RemoteText(
-                        text = "No entities".rs,
-                        color = theme.secondaryText.rc,
-                        fontSize = 13.rsp,
-                        style = RemoteTextStyle.Default,
-                    )
-                } else {
-                    ids.forEach { id -> EntityRow(id, snapshot) }
-                }
-            }
-        }
-    }
-
-    @Composable
-    private fun EntityRow(entityId: String, snapshot: HaSnapshot) {
-        val theme = LocalHaTheme.current
-        val name = snapshot.states[entityId]?.attributes?.get("friendly_name")
-            ?.jsonPrimitive?.content
-            ?: entityId
-        val summary = summarise(snapshot.history[entityId].orEmpty())
-
-        RemoteRow(
-            modifier = RemoteModifier.fillMaxWidth(),
-            verticalAlignment = RemoteAlignment.CenterVertically,
-            horizontalArrangement = RemoteArrangement.SpaceBetween,
-        ) {
-            RemoteText(
-                text = name.rs,
-                color = theme.primaryText.rc,
-                fontSize = 13.rsp,
-                style = RemoteTextStyle.Default,
-            )
-            RemoteText(
-                text = summary.rs,
-                color = theme.secondaryText.rc,
-                fontSize = 12.rsp,
-                style = RemoteTextStyle.Default,
+        val rows = ids.map { id ->
+            val entity = snapshot.states[id]
+            val name = entity?.attributes?.get("friendly_name")?.jsonPrimitive?.content ?: id
+            val history = snapshot.history[id].orEmpty()
+            val numeric = history.mapNotNull { it.state.toFloatOrNull() }
+            HaHistoryGraphRow(
+                name = name.rs,
+                summary = summarise(history).rs,
+                accent = HaStateColor.activeFor(entity),
+                points = numeric,
             )
         }
+
+        RemoteHaHistoryGraph(
+            HaHistoryGraphData(
+                title = title?.rs,
+                rangeLabel = "Last ${hours}h".rs,
+                rows = rows,
+            ),
+            modifier = modifier,
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Replaces the textual `min – max (N)` summary in the `history-graph` card with one real sparkline per entity, rendered through `RemoteCanvas.drawLine`. Numeric samples normalise into the row's drawable rect at capture time; alpha08 still doesn't expose a numeric `RemoteFloat` binding, so live updates re-encode (same constraint as the gauge from #77).

This is the larger of the remaining gaps in the dashboards snapshot — 13 cards across the seven captured dashboards use `history-graph`.

Adds:

- `HaHistoryGraphData` / `HaHistoryGraphRow` model on the components side
- `RemoteHaHistoryGraph` composable with title, range label ("Last 24h"), and per-entity rows of (name, summary, baseline + line stroke)
- `Fixtures.temperatureHistory` — synthetic 24-sample diurnal cycle for two temperature sensors
- Light/Dark @Preview pair driven off the new fixture

## Previews

| Light | Dark |
|---|---|
| ![history-graph light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/573c46be2a251a4b2122e955b45463767907ca29/HistoryGraph_Light.png) | ![history-graph dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/573c46be2a251a4b2122e955b45463767907ca29/HistoryGraph_Dark.png) |

## Test plan

- [x] `./gradlew :rc-components:compileDebugKotlin :rc-converter:compileDebugKotlin :previews:assembleDebug` — green
- [x] `compose-preview render --filter HistoryGraph_Light/Dark` — both render the diurnal-cycle sparklines (see images above)
- [ ] Pixel-diff case in `CardPixelDiffTest` — once #78 lands I'll add a `history-graph/temperature_*.png` row in a follow-up

## Notes

- The textual fallback ("N samples" / "no data") still kicks in when the snapshot has no numeric history — same row shape, just a label instead of the canvas.
- The `naturalHeightDp` heuristic now scales with row count (~52 dp per row + chrome) so dashboards stacking multiple history-graphs allocate enough space without over-reserving.