### PR TITLE
feat(bambu): real progress ring + sensor readouts in print_status card

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
@@ -493,6 +493,25 @@ private fun historyGraphCard() = card(
         "entities":["sensor.outside_temp","sensor.upstairs_temp"]}""",
 )
 
+// ——— bambu print-status ———
+
+@Preview(name = "bambu print-status (light)", showBackground = false, widthDp = 381, heightDp = 168)
+@Composable
+fun BambuPrintStatus_Light() = CardHost(HaTheme.Light) {
+    RenderChild(bambuPrintStatusCard(), Fixtures.bambuPrinting, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "bambu print-status (dark)", showBackground = false, widthDp = 381, heightDp = 168)
+@Composable
+fun BambuPrintStatus_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(bambuPrintStatusCard(), Fixtures.bambuPrinting, RemoteModifier.fillMaxWidth())
+}
+
+private fun bambuPrintStatusCard() = card(
+    """{"type":"custom:ha-bambulab-print_status-card",
+        "printer":"<device-id-placeholder>","style":"full"}""",
+)
+
 // ——— tile, state variants via PreviewParameter ———
 
 @Preview(name = "tile light (light)", showBackground = false, widthDp = 187, heightDp = 43)

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
@@ -142,6 +142,36 @@ object Fixtures {
             mapOf("friendly_name" to "Garage motion", "device_class" to "motion")),
     )
 
+    /** Bambu Lab printer mid-print: progress, layer counts, time
+     *  remaining, plus nozzle/bed temperatures. The entity prefix
+     *  matches HA's `bambulab` integration scheme so the converter's
+     *  prefix-discovery picks it up automatically. */
+    val bambuPrinting = snapshot(
+        state("sensor.p2s_printing_print_progress", "34",
+            mapOf(
+                "friendly_name" to "P2S Print progress",
+                "unit_of_measurement" to "%",
+            )),
+        state("sensor.p2s_printing_current_stage", "inspecting_first_layer",
+            mapOf("friendly_name" to "P2S Current stage")),
+        state("sensor.p2s_printing_print_status", "printing",
+            mapOf("friendly_name" to "P2S Print status")),
+        state("sensor.p2s_printing_current_layer", "12",
+            mapOf("friendly_name" to "P2S Current layer")),
+        state("sensor.p2s_printing_total_layer_count", "240",
+            mapOf("friendly_name" to "P2S Total layer count")),
+        state("sensor.p2s_printing_remaining_time", "82",
+            mapOf("friendly_name" to "P2S Remaining time", "unit_of_measurement" to "min")),
+        state("sensor.p2s_printing_nozzle_temperature", "218.4",
+            mapOf("friendly_name" to "P2S Nozzle temperature", "unit_of_measurement" to "°C")),
+        state("sensor.p2s_printing_target_nozzle_temperature", "220",
+            mapOf("friendly_name" to "P2S Target nozzle temperature", "unit_of_measurement" to "°C")),
+        state("sensor.p2s_printing_bed_temperature", "60",
+            mapOf("friendly_name" to "P2S Bed temperature", "unit_of_measurement" to "°C")),
+        state("sensor.p2s_printing_target_bed_temperature", "60",
+            mapOf("friendly_name" to "P2S Target bed temperature", "unit_of_measurement" to "°C")),
+    )
+
     /** Two temperature sensors with a 24-sample diurnal cycle so the
      *  history-graph preview has real sparkline data to draw. */
     val temperatureHistory: HaSnapshot = run {

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
@@ -188,3 +188,21 @@ data class HaHistoryGraphRow(
     /** Numeric samples in order. Empty → renders a "no data" stub. */
     val points: List<Float>,
 )
+
+/**
+ * `custom:ha-bambulab-print_status-card` model — current print job hero
+ * tile. The progress ring is keyed off [progressFraction] (0f…1f);
+ * ancillary fields can each be null when the snapshot doesn't have the
+ * corresponding entity (the row collapses).
+ */
+data class HaBambuPrintStatusData(
+    val printerName: RemoteString,
+    val stage: RemoteString,
+    val progressLabel: RemoteString,
+    val progressFraction: Float,
+    val accent: Color,
+    val layerLine: RemoteString?,
+    val remainingLine: RemoteString?,
+    val nozzleLine: RemoteString?,
+    val bedLine: RemoteString?,
+)

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaBambuPrintStatus.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaBambuPrintStatus.kt
@@ -1,0 +1,194 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import android.graphics.Paint as AndroidPaint
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteCanvas
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteOffset
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteSize
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.height
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.modifier.size
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.asRemotePaint
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rf
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+
+/**
+ * `custom:ha-bambulab-print_status-card` — printer hero tile with a
+ * progress ring + the key sensor readouts (stage, layer, remaining,
+ * temperatures).
+ *
+ * ```
+ *   ┌─────────────────────────────────────────────┐
+ *   │  P2S                                        │
+ *   │   ╭──╮   34 %                               │
+ *   │   │  │   inspecting first layer             │
+ *   │   ╰──╯   Layer 12 / 240    1 h 22 m left    │
+ *   │          Nozzle 220 °C    Bed 60 °C         │
+ *   └─────────────────────────────────────────────┘
+ * ```
+ *
+ * Progress ring is captured statically at the supplied fraction; alpha08
+ * doesn't expose a numeric `RemoteFloat` binding, so live updates
+ * re-encode (same constraint as gauge / history-graph).
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaBambuPrintStatus(
+    data: HaBambuPrintStatusData,
+    modifier: RemoteModifier = RemoteModifier,
+) {
+    val theme = haTheme()
+    RemoteBox(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(horizontal = 14.rdp, vertical = 12.rdp),
+    ) {
+        RemoteColumn(verticalArrangement = RemoteArrangement.spacedBy(8.rdp)) {
+            RemoteText(
+                text = data.printerName,
+                color = theme.secondaryText.rc,
+                fontSize = 11.rsp,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            RemoteRow(
+                modifier = RemoteModifier.fillMaxWidth(),
+                verticalAlignment = RemoteAlignment.CenterVertically,
+            ) {
+                ProgressRing(data.progressFraction, data.accent, theme)
+                RemoteColumn(
+                    modifier = RemoteModifier.padding(start = 14.rdp),
+                    verticalArrangement = RemoteArrangement.spacedBy(2.rdp),
+                ) {
+                    RemoteText(
+                        text = data.progressLabel,
+                        color = theme.primaryText.rc,
+                        fontSize = 22.rsp,
+                        fontWeight = FontWeight.SemiBold,
+                        style = RemoteTextStyle.Default,
+                        maxLines = 1,
+                    )
+                    RemoteText(
+                        text = data.stage,
+                        color = theme.secondaryText.rc,
+                        fontSize = 13.rsp,
+                        style = RemoteTextStyle.Default,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+            data.layerLine?.let {
+                RemoteText(
+                    text = it,
+                    color = theme.secondaryText.rc,
+                    fontSize = 12.rsp,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                )
+            }
+            data.remainingLine?.let {
+                RemoteText(
+                    text = it,
+                    color = theme.secondaryText.rc,
+                    fontSize = 12.rsp,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                )
+            }
+            if (data.nozzleLine != null || data.bedLine != null) {
+                RemoteRow(
+                    modifier = RemoteModifier.fillMaxWidth(),
+                    horizontalArrangement = RemoteArrangement.spacedBy(16.rdp),
+                ) {
+                    data.nozzleLine?.let {
+                        RemoteText(
+                            text = it,
+                            color = theme.secondaryText.rc,
+                            fontSize = 12.rsp,
+                            style = RemoteTextStyle.Default,
+                            maxLines = 1,
+                        )
+                    }
+                    data.bedLine?.let {
+                        RemoteText(
+                            text = it,
+                            color = theme.secondaryText.rc,
+                            fontSize = 12.rsp,
+                            style = RemoteTextStyle.Default,
+                            maxLines = 1,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProgressRing(fraction: Float, accent: Color, theme: HaTheme) {
+    val sweep = (fraction.coerceIn(0f, 1f) * 360f)
+    RemoteBox(modifier = RemoteModifier.size(64.rdp)) {
+        RemoteCanvas(modifier = RemoteModifier.size(64.rdp)) {
+            val w = width
+            val h = height
+            val stroke = 8f.rf
+            val pad = stroke / 2f.rf + 1f.rf
+            val topLeft = RemoteOffset(pad, pad)
+            val arcSize = RemoteSize(w - pad * 2f.rf, h - pad * 2f.rf)
+
+            val track = AndroidPaint().apply {
+                isAntiAlias = true
+                style = AndroidPaint.Style.STROKE
+                strokeWidth = 8f
+                strokeCap = AndroidPaint.Cap.ROUND
+                color = theme.divider.toArgb()
+            }.asRemotePaint()
+            drawArc(track, 0f.rf, 360f.rf, false, topLeft, arcSize)
+
+            if (sweep > 0.5f) {
+                val progress = AndroidPaint().apply {
+                    isAntiAlias = true
+                    style = AndroidPaint.Style.STROKE
+                    strokeWidth = 8f
+                    strokeCap = AndroidPaint.Cap.ROUND
+                    color = accent.toArgb()
+                }.asRemotePaint()
+                // Start at 12 o'clock (Android draws 0° at 3 o'clock).
+                drawArc(progress, (-90f).rf, sweep.rf, false, topLeft, arcSize)
+            }
+        }
+    }
+}
+
+private fun Color.toArgb(): Int = android.graphics.Color.argb(
+    (alpha * 255f).toInt(),
+    (red * 255f).toInt(),
+    (green * 255f).toInt(),
+    (blue * 255f).toInt(),
+)

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/BambuLabCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/BambuLabCardConverter.kt
@@ -20,6 +20,7 @@ import androidx.compose.remote.creation.compose.state.rdp
 import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.remote.creation.compose.state.rsp
 import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.font.FontWeight
 import ee.schimke.ha.model.CardConfig
@@ -124,11 +125,100 @@ class BambuLabSpoolCardConverter : BambuLabCardConverter(
     variantLabel = "Spool",
 )
 
-/** Current print job + progress. */
+/** Current print job + progress.
+ *
+ *  HA's bambulab integration exposes a flock of `sensor.<prefix>_*`
+ *  entities per printer; the card config references a device id that we
+ *  can't resolve without a device-registry channel. We discover the
+ *  prefix by scanning the snapshot for the first `sensor.*_print_progress`
+ *  and pull related sensors by suffix. Configurations with multiple
+ *  printers can override via an `entity_prefix:` config field. */
 class BambuLabPrintStatusCardConverter : BambuLabCardConverter(
     cardType = "custom:ha-bambulab-print_status-card",
     variantLabel = "Print status",
-)
+) {
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val prefix = resolvePrinterPrefix(card, snapshot)
+        if (prefix == null) {
+            super.Render(card, snapshot, modifier)
+            return
+        }
+        val data = buildPrintStatusData(prefix, snapshot)
+        ee.schimke.ha.rc.components.RemoteHaBambuPrintStatus(data, modifier)
+    }
+}
+
+/** Best-effort discovery: explicit `entity_prefix` wins; otherwise the
+ *  first `sensor.*_print_progress` entity's prefix. Returns null when
+ *  the snapshot has no Bambu-shaped entities, in which case the caller
+ *  falls back to the chrome-only renderer. */
+internal fun resolvePrinterPrefix(card: CardConfig, snapshot: HaSnapshot): String? {
+    val explicit = card.raw["entity_prefix"]?.jsonPrimitive?.content
+    if (!explicit.isNullOrEmpty()) return explicit
+    return snapshot.states.keys
+        .firstOrNull { it.startsWith("sensor.") && it.endsWith("_print_progress") }
+        ?.removePrefix("sensor.")
+        ?.removeSuffix("_print_progress")
+}
+
+private fun buildPrintStatusData(
+    prefix: String,
+    snapshot: HaSnapshot,
+): ee.schimke.ha.rc.components.HaBambuPrintStatusData {
+    val s = snapshot.states
+    fun sensor(suffix: String) = s["sensor.${prefix}_$suffix"]
+
+    val progress = sensor("print_progress")?.state?.toFloatOrNull() ?: 0f
+    val stageRaw = sensor("current_stage")?.state ?: sensor("print_status")?.state ?: "idle"
+    val stage = stageRaw.replace('_', ' ').replaceFirstChar { it.uppercaseChar() }
+
+    val printerEntity = sensor("print_progress") ?: sensor("print_status")
+    val printerName = printerEntity?.attributes?.get("friendly_name")
+        ?.jsonPrimitive?.content
+        ?.substringBeforeLast(' ')
+        ?: prefix.uppercase()
+
+    val current = sensor("current_layer")?.state?.toIntOrNull()
+    val total = sensor("total_layer_count")?.state?.toIntOrNull()
+    val layerLine = if (current != null && total != null) "Layer $current / $total" else null
+
+    val remaining = sensor("remaining_time")?.state?.toIntOrNull()
+    val remainingLine = remaining?.let { mins ->
+        val h = mins / 60
+        val m = mins % 60
+        if (h > 0) "${h}h ${m}m left" else "${m}m left"
+    }
+
+    val nozzle = sensor("nozzle_temperature")?.state?.toFloatOrNull()
+    val nozzleTarget = sensor("target_nozzle_temperature")?.state?.toFloatOrNull()
+    val nozzleLine = nozzle?.let {
+        val tgt = nozzleTarget?.let { t -> if (t > 0f) " → ${formatTemp(t)}°C" else "" } ?: ""
+        "Nozzle ${formatTemp(it)}°C$tgt"
+    }
+
+    val bed = sensor("bed_temperature")?.state?.toFloatOrNull()
+    val bedTarget = sensor("target_bed_temperature")?.state?.toFloatOrNull()
+    val bedLine = bed?.let {
+        val tgt = bedTarget?.let { t -> if (t > 0f) " → ${formatTemp(t)}°C" else "" } ?: ""
+        "Bed ${formatTemp(it)}°C$tgt"
+    }
+
+    return ee.schimke.ha.rc.components.HaBambuPrintStatusData(
+        printerName = printerName.rs,
+        stage = stage.rs,
+        progressLabel = "${progress.toInt()} %".rs,
+        progressFraction = (progress / 100f).coerceIn(0f, 1f),
+        accent = androidx.compose.ui.graphics.Color(0xFFFF8F00),
+        layerLine = layerLine?.rs,
+        remainingLine = remainingLine?.rs,
+        nozzleLine = nozzleLine?.rs,
+        bedLine = bedLine?.rs,
+    )
+}
+
+private fun formatTemp(value: Float): String =
+    if (value == value.toInt().toFloat()) value.toInt().toString() else "%.1f".format(value)
 
 /** Pause / resume / cancel pad. */
 class BambuLabPrintControlCardConverter : BambuLabCardConverter(


### PR DESCRIPTION
## Summary

Replaces the chrome-only render of `custom:ha-bambulab-print_status-card` with a hero tile: 64-dp progress ring (`RemoteCanvas.drawArc`), big % + stage label, layer count, time remaining, and nozzle/bed temperature lines. Sweep is captured statically — alpha08 has no `RemoteFloat` numeric binding for live updates (same constraint as gauge / history-graph).

The card config references a device id that we can't resolve without a device-registry channel, so the converter discovers the printer's entity prefix by scanning the snapshot for the first `sensor.*_print_progress` entity. Configs with multiple printers can override via an `entity_prefix:` field. When no Bambu-shaped entities are present in the snapshot, the converter falls through to the existing chrome-only renderer.

This is the highest-impact card in the bambu set — 2 uses on the captured 3D-printing dashboard, both as the hero of their printer section. Other variants (`ams-card`, `spool-card`, `print_control-card`) still render the chrome and can be upgraded similarly in follow-ups.

## Previews

| Light | Dark |
|---|---|
| ![bambu print-status light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/c35a255f323e4418f51bacd4f4375ac413166cbe/BambuPrintStatus_Light.png) | ![bambu print-status dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/c35a255f323e4418f51bacd4f4375ac413166cbe/BambuPrintStatus_Dark.png) |

## Test plan

- [x] `./gradlew :rc-components:compileDebugKotlin :rc-converter:compileDebugKotlin :previews:assembleDebug` — green
- [x] `compose-preview render --filter BambuPrintStatus_Light/Dark` — both render the progress ring + sensor readouts (see images above)
- [x] No HA-derived data committed — fixture entity ids and friendly names are synthetic; the device-id placeholder in the preview card config is a literal string the converter doesn't read
- [ ] Pixel-diff case in `CardPixelDiffTest` — once #78 lands I'll add a follow-up row

## Notes

- The progress arc starts at 12 o'clock and sweeps clockwise, mirroring the bambu integration's web card.
- Temperature lines collapse cleanly when target == current (just shows current); shown as `current → target` when targeting differs.
- Stage strings get the `replace('_', ' ').capitalize()` treatment so HA enum values like `inspecting_first_layer` read as `Inspecting first layer`.