### PR TITLE
feat(bambu): real renderings for ams, spool, print_control cards

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
@@ -512,6 +512,60 @@ private fun bambuPrintStatusCard() = card(
         "printer":"<device-id-placeholder>","style":"full"}""",
 )
 
+// ——— bambu print-control ———
+
+@Preview(name = "bambu print-control (light)", showBackground = false, widthDp = 381, heightDp = 124)
+@Composable
+fun BambuPrintControl_Light() = CardHost(HaTheme.Light) {
+    RenderChild(bambuPrintControlCard(), Fixtures.bambuPrintControl, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "bambu print-control (dark)", showBackground = false, widthDp = 381, heightDp = 124)
+@Composable
+fun BambuPrintControl_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(bambuPrintControlCard(), Fixtures.bambuPrintControl, RemoteModifier.fillMaxWidth())
+}
+
+private fun bambuPrintControlCard() = card(
+    """{"type":"custom:ha-bambulab-print_control-card","printer":"<device-id-placeholder>"}""",
+)
+
+// ——— bambu ams ———
+
+@Preview(name = "bambu ams (light)", showBackground = false, widthDp = 381, heightDp = 130)
+@Composable
+fun BambuAms_Light() = CardHost(HaTheme.Light) {
+    RenderChild(bambuAmsCard(), Fixtures.bambuAms, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "bambu ams (dark)", showBackground = false, widthDp = 381, heightDp = 130)
+@Composable
+fun BambuAms_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(bambuAmsCard(), Fixtures.bambuAms, RemoteModifier.fillMaxWidth())
+}
+
+private fun bambuAmsCard() = card(
+    """{"type":"custom:ha-bambulab-ams-card","ams":"<device-id-placeholder>","style":"full"}""",
+)
+
+// ——— bambu spool ———
+
+@Preview(name = "bambu spool (light)", showBackground = false, widthDp = 381, heightDp = 96)
+@Composable
+fun BambuSpool_Light() = CardHost(HaTheme.Light) {
+    RenderChild(bambuSpoolCard(), Fixtures.bambuSpool, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "bambu spool (dark)", showBackground = false, widthDp = 381, heightDp = 96)
+@Composable
+fun BambuSpool_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(bambuSpoolCard(), Fixtures.bambuSpool, RemoteModifier.fillMaxWidth())
+}
+
+private fun bambuSpoolCard() = card(
+    """{"type":"custom:ha-bambulab-spool-card","spool":"<spool-id-placeholder>"}""",
+)
+
 // ——— tile, state variants via PreviewParameter ———
 
 @Preview(name = "tile light (light)", showBackground = false, widthDp = 187, heightDp = 43)

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
@@ -142,6 +142,58 @@ object Fixtures {
             mapOf("friendly_name" to "Garage motion", "device_class" to "motion")),
     )
 
+    /** Helper for AMS tray entities — the converter reads `color`, `remain`,
+     *  `remain_enabled`, and `active` off attributes; tray state is the
+     *  filament name (e.g. "Generic PLA"). */
+    private fun trayState(
+        entityId: String,
+        material: String,
+        color: String,
+        remain: Int,
+        active: Boolean = false,
+    ): Pair<String, EntityState> = entityId to EntityState(
+        entityId = entityId,
+        state = material,
+        attributes = JsonObject(mapOf(
+            "friendly_name" to JsonPrimitive("$entityId tray"),
+            "color" to JsonPrimitive(color),
+            "remain" to JsonPrimitive(remain),
+            "remain_enabled" to JsonPrimitive(true),
+            "active" to JsonPrimitive(active),
+            "type" to JsonPrimitive(material.substringAfterLast(' ')),
+        )),
+    )
+
+    /** Bambu Lab AMS with four loaded spools, one of which is active. */
+    val bambuAms = snapshot(
+        trayState("sensor.p2s_printing_ams_1_tray_1", "Generic PLA", "#000000FF", 100, active = false),
+        trayState("sensor.p2s_printing_ams_1_tray_2", "Generic PETG", "#FF6600FF", 87, active = true),
+        trayState("sensor.p2s_printing_ams_1_tray_3", "Generic ASA", "#1E88E5FF", 43),
+        trayState("sensor.p2s_printing_ams_1_tray_4", "Generic TPU", "#43A047FF", 70),
+    )
+
+    /** Single spool — uses the same tray entities as bambuAms; the spool
+     *  card surfaces the active tray (slot 2 here). */
+    val bambuSpool = bambuAms
+
+    /** Pause / Resume / Stop button entities for the print-control card.
+     *  Same prefix as bambuPrinting so prefix-discovery picks it up; we
+     *  also include the print_progress sensor so the converter has a
+     *  printer-name source. */
+    val bambuPrintControl = snapshot(
+        state("sensor.p2s_printing_print_progress", "34",
+            mapOf(
+                "friendly_name" to "P2S Print progress",
+                "unit_of_measurement" to "%",
+            )),
+        state("button.p2s_printing_pause_printing", "unknown",
+            mapOf("friendly_name" to "P2S Pause printing")),
+        state("button.p2s_printing_resume_printing", "unknown",
+            mapOf("friendly_name" to "P2S Resume printing")),
+        state("button.p2s_printing_stop_printing", "unknown",
+            mapOf("friendly_name" to "P2S Stop printing")),
+    )
+
     /** Bambu Lab printer mid-print: progress, layer counts, time
      *  remaining, plus nozzle/bed temperatures. The entity prefix
      *  matches HA's `bambulab` integration scheme so the converter's

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
@@ -206,3 +206,40 @@ data class HaBambuPrintStatusData(
     val nozzleLine: RemoteString?,
     val bedLine: RemoteString?,
 )
+
+/** `custom:ha-bambulab-print_control-card` — pause / resume / stop pad. */
+data class HaBambuPrintControlData(
+    val printerName: RemoteString,
+    val pause: HaBambuControlButton?,
+    val resume: HaBambuControlButton?,
+    val stop: HaBambuControlButton?,
+)
+
+data class HaBambuControlButton(
+    val label: RemoteString,
+    val icon: ImageVector,
+    val accent: Color,
+    val tapAction: HaAction = HaAction.None,
+)
+
+/** `custom:ha-bambulab-ams-card` — grid of up to four filament slots. */
+data class HaBambuAmsData(
+    val title: RemoteString,
+    val slots: List<HaBambuSpoolSlot>,
+)
+
+/** `custom:ha-bambulab-spool-card` — single filament slot, larger. */
+data class HaBambuSpoolDetail(
+    val slot: HaBambuSpoolSlot,
+)
+
+/** One filament tray. [color] is the spool's swatch (state.attributes.color
+ *  parsed from `#RRGGBBAA`); [remainPercent] is 0..100 (or null when the
+ *  HA "remain_enabled" flag is off and the integration reports nothing). */
+data class HaBambuSpoolSlot(
+    val slotLabel: RemoteString,
+    val material: RemoteString,
+    val color: Color,
+    val remainPercent: Int?,
+    val active: Boolean,
+)

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaBambuAms.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaBambuAms.kt
@@ -1,0 +1,168 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.modifier.size
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+
+/**
+ * `custom:ha-bambulab-ams-card` — grid of up to four filament slots.
+ *
+ * ```
+ *   ┌──────────────────────────────────────────────┐
+ *   │  AMS                                         │
+ *   │  ●  PLA       ○  PETG     ●  ASA   ●  TPU    │
+ *   │     100%         87%        43%        70%   │
+ *   └──────────────────────────────────────────────┘
+ * ```
+ *
+ * Active slot gets a coloured outline; empty slots collapse to a
+ * dotted-style placeholder.
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaBambuAms(data: HaBambuAmsData, modifier: RemoteModifier = RemoteModifier) {
+    val theme = haTheme()
+    RemoteBox(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(horizontal = 14.rdp, vertical = 12.rdp),
+    ) {
+        RemoteColumn(verticalArrangement = RemoteArrangement.spacedBy(8.rdp)) {
+            RemoteText(
+                text = data.title,
+                color = theme.primaryText.rc,
+                fontSize = 14.rsp,
+                fontWeight = FontWeight.Medium,
+                style = RemoteTextStyle.Default,
+            )
+            RemoteRow(
+                modifier = RemoteModifier.fillMaxWidth(),
+                horizontalArrangement = RemoteArrangement.SpaceBetween,
+                verticalAlignment = RemoteAlignment.Top,
+            ) {
+                data.slots.forEach { slot ->
+                    SpoolSlot(slot, theme, big = false)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * `custom:ha-bambulab-spool-card` — single slot, larger swatch.
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaBambuSpool(data: HaBambuSpoolDetail, modifier: RemoteModifier = RemoteModifier) {
+    val theme = haTheme()
+    RemoteBox(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(horizontal = 14.rdp, vertical = 12.rdp),
+    ) {
+        RemoteRow(verticalAlignment = RemoteAlignment.CenterVertically) {
+            SpoolSwatch(data.slot, big = true, theme = theme)
+            RemoteColumn(modifier = RemoteModifier.padding(start = 14.rdp)) {
+                RemoteText(
+                    text = data.slot.slotLabel,
+                    color = theme.secondaryText.rc,
+                    fontSize = 11.rsp,
+                    style = RemoteTextStyle.Default,
+                )
+                RemoteText(
+                    text = data.slot.material,
+                    color = theme.primaryText.rc,
+                    fontSize = 16.rsp,
+                    fontWeight = FontWeight.Medium,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                RemoteText(
+                    text = (data.slot.remainPercent?.let { "$it %" } ?: "—").rs,
+                    color = theme.secondaryText.rc,
+                    fontSize = 13.rsp,
+                    style = RemoteTextStyle.Default,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SpoolSlot(slot: HaBambuSpoolSlot, theme: HaTheme, big: Boolean) {
+    RemoteColumn(horizontalAlignment = RemoteAlignment.CenterHorizontally) {
+        SpoolSwatch(slot, big = big, theme = theme)
+        RemoteBox(modifier = RemoteModifier.padding(top = 6.rdp)) {
+            RemoteText(
+                text = slot.material,
+                color = theme.primaryText.rc,
+                fontSize = 11.rsp,
+                fontWeight = FontWeight.Medium,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        RemoteText(
+            text = (slot.remainPercent?.let { "$it %" } ?: "—").rs,
+            color = theme.secondaryText.rc,
+            fontSize = 11.rsp,
+            style = RemoteTextStyle.Default,
+        )
+    }
+}
+
+@Composable
+private fun SpoolSwatch(slot: HaBambuSpoolSlot, big: Boolean, theme: HaTheme) {
+    val outerSize = if (big) 56.rdp else 36.rdp
+    val innerSize = if (big) 44.rdp else 28.rdp
+    val outline = if (slot.active) slot.color else theme.divider
+    RemoteBox(
+        modifier = RemoteModifier
+            .size(outerSize)
+            .clip(RemoteRoundedCornerShape(if (big) 16.rdp else 10.rdp))
+            .background(theme.cardBackground.rc)
+            .border(
+                if (slot.active) 2.rdp else 1.rdp,
+                outline.rc,
+                RemoteRoundedCornerShape(if (big) 16.rdp else 10.rdp),
+            ),
+        contentAlignment = RemoteAlignment.Center,
+    ) {
+        RemoteBox(
+            modifier = RemoteModifier
+                .size(innerSize)
+                .clip(RemoteRoundedCornerShape(if (big) 12.rdp else 8.rdp))
+                .background(slot.color.rc),
+        )
+    }
+}

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaBambuPrintControl.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaBambuPrintControl.kt
@@ -1,0 +1,103 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clickable
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.modifier.size
+import androidx.compose.remote.creation.compose.shapes.RemoteCircleShape
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rf
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.wear.compose.remote.material3.RemoteIcon
+
+/**
+ * `custom:ha-bambulab-print_control-card` — three-button pad that maps
+ * to the printer's pause / resume / stop button entities.
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaBambuPrintControl(
+    data: HaBambuPrintControlData,
+    modifier: RemoteModifier = RemoteModifier,
+) {
+    val theme = haTheme()
+    RemoteBox(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(horizontal = 14.rdp, vertical = 12.rdp),
+    ) {
+        RemoteColumn(verticalArrangement = RemoteArrangement.spacedBy(8.rdp)) {
+            RemoteText(
+                text = data.printerName,
+                color = theme.secondaryText.rc,
+                fontSize = 11.rsp,
+                style = RemoteTextStyle.Default,
+            )
+            RemoteRow(
+                modifier = RemoteModifier.fillMaxWidth(),
+                horizontalArrangement = RemoteArrangement.SpaceEvenly,
+                verticalAlignment = RemoteAlignment.CenterVertically,
+            ) {
+                listOfNotNull(data.pause, data.resume, data.stop).forEach { btn ->
+                    Button(btn, theme)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Button(button: HaBambuControlButton, theme: HaTheme) {
+    val click = button.tapAction.toRemoteAction()
+        ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
+    RemoteColumn(
+        modifier = RemoteModifier.then(click),
+        horizontalAlignment = RemoteAlignment.CenterHorizontally,
+    ) {
+        val accent = button.accent.rc
+        RemoteBox(
+            modifier = RemoteModifier
+                .size(48.rdp)
+                .clip(RemoteCircleShape)
+                .background(accent.copy(alpha = accent.alpha * 0.18f.rf)),
+            contentAlignment = RemoteAlignment.Center,
+        ) {
+            RemoteIcon(
+                imageVector = button.icon,
+                contentDescription = button.label,
+                modifier = RemoteModifier.size(24.rdp),
+                tint = accent,
+            )
+        }
+        RemoteBox(modifier = RemoteModifier.padding(top = 6.rdp)) {
+            RemoteText(
+                text = button.label,
+                color = theme.primaryText.rc,
+                fontSize = 12.rsp,
+                fontWeight = FontWeight.Medium,
+                style = RemoteTextStyle.Default,
+            )
+        }
+    }
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/BambuLabCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/BambuLabCardConverter.kt
@@ -20,6 +20,10 @@ import androidx.compose.remote.creation.compose.state.rdp
 import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.remote.creation.compose.state.rsp
 import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Stop
 import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.font.FontWeight
@@ -113,17 +117,116 @@ open class BambuLabCardConverter(
     }
 }
 
-/** AMS spool grid. */
+/** AMS spool grid. Discovers tray entities `sensor.<prefix>_ams_<n>_tray_<m>`
+ *  where n defaults to 1; the card config's `ams:` device id isn't
+ *  resolvable without a registry channel, so we use the first AMS that
+ *  matches and rely on `entity_prefix:` for disambiguation. */
 class BambuLabAmsCardConverter : BambuLabCardConverter(
     cardType = "custom:ha-bambulab-ams-card",
     variantLabel = "AMS",
-)
+) {
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val prefix = resolvePrinterPrefix(card, snapshot)
+        if (prefix == null) {
+            super.Render(card, snapshot, modifier)
+            return
+        }
+        val slots = readSpoolSlots(prefix, snapshot, amsIndex = 1)
+        if (slots.isEmpty()) {
+            super.Render(card, snapshot, modifier)
+            return
+        }
+        ee.schimke.ha.rc.components.RemoteHaBambuAms(
+            ee.schimke.ha.rc.components.HaBambuAmsData(
+                title = "AMS".rs,
+                slots = slots,
+            ),
+            modifier,
+        )
+    }
+}
 
-/** Single-spool detail. */
+/** Single-spool detail. The card config has `spool:<id>`; we don't have
+ *  a spool↔entity map, so we surface the active tray (or tray 1 if
+ *  none active). The fixture path is the most reliable; live HA users
+ *  can override with `entity_prefix:` + `slot:` to pin a specific tray. */
 class BambuLabSpoolCardConverter : BambuLabCardConverter(
     cardType = "custom:ha-bambulab-spool-card",
     variantLabel = "Spool",
-)
+) {
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val prefix = resolvePrinterPrefix(card, snapshot)
+        if (prefix == null) {
+            super.Render(card, snapshot, modifier)
+            return
+        }
+        val slots = readSpoolSlots(prefix, snapshot, amsIndex = 1)
+        val pinnedSlot = card.raw["slot"]?.jsonPrimitive?.content?.toIntOrNull()
+        val slot = pinnedSlot?.let { idx -> slots.getOrNull(idx - 1) }
+            ?: slots.firstOrNull { it.active }
+            ?: slots.firstOrNull()
+        if (slot == null) {
+            super.Render(card, snapshot, modifier)
+            return
+        }
+        ee.schimke.ha.rc.components.RemoteHaBambuSpool(
+            ee.schimke.ha.rc.components.HaBambuSpoolDetail(slot = slot),
+            modifier,
+        )
+    }
+}
+
+private fun readSpoolSlots(
+    prefix: String,
+    snapshot: HaSnapshot,
+    amsIndex: Int,
+): List<ee.schimke.ha.rc.components.HaBambuSpoolSlot> {
+    val s = snapshot.states
+    return (1..4).mapNotNull { trayIdx ->
+        val key = "sensor.${prefix}_ams_${amsIndex}_tray_$trayIdx"
+        val entity = s[key] ?: return@mapNotNull null
+        val attrs = entity.attributes
+        val material = entity.state.takeUnless { it == "unknown" || it == "unavailable" }
+            ?: "Empty"
+        val color = parseHexArgb(attrs["color"]?.jsonPrimitive?.content)
+        val remain = (attrs["remain"]?.jsonPrimitive?.content?.toIntOrNull())
+            ?.takeIf { attrs["remain_enabled"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() != false }
+        val active = attrs["active"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() == true
+        ee.schimke.ha.rc.components.HaBambuSpoolSlot(
+            slotLabel = "Slot $trayIdx".rs,
+            material = material.rs,
+            color = color,
+            remainPercent = remain,
+            active = active,
+        )
+    }
+}
+
+/** Parse `#RRGGBB` / `#RRGGBBAA` into a Compose [androidx.compose.ui.graphics.Color].
+ *  Returns mid-grey for null / unparseable input — callers paint the swatch
+ *  with this so an absent attribute still produces a recognisable slot. */
+private fun parseHexArgb(hex: String?): androidx.compose.ui.graphics.Color {
+    val fallback = androidx.compose.ui.graphics.Color(0xFF9E9E9E)
+    val raw = hex?.trim()?.removePrefix("#") ?: return fallback
+    return when (raw.length) {
+        6 -> {
+            val r = raw.substring(0, 2).toIntOrNull(16) ?: return fallback
+            val g = raw.substring(2, 4).toIntOrNull(16) ?: return fallback
+            val b = raw.substring(4, 6).toIntOrNull(16) ?: return fallback
+            androidx.compose.ui.graphics.Color(r, g, b)
+        }
+        8 -> {
+            val r = raw.substring(0, 2).toIntOrNull(16) ?: return fallback
+            val g = raw.substring(2, 4).toIntOrNull(16) ?: return fallback
+            val b = raw.substring(4, 6).toIntOrNull(16) ?: return fallback
+            val a = raw.substring(6, 8).toIntOrNull(16) ?: 0xFF
+            androidx.compose.ui.graphics.Color(r, g, b, a)
+        }
+        else -> fallback
+    }
+}
 
 /** Current print job + progress.
  *
@@ -156,10 +259,25 @@ class BambuLabPrintStatusCardConverter : BambuLabCardConverter(
 internal fun resolvePrinterPrefix(card: CardConfig, snapshot: HaSnapshot): String? {
     val explicit = card.raw["entity_prefix"]?.jsonPrimitive?.content
     if (!explicit.isNullOrEmpty()) return explicit
-    return snapshot.states.keys
-        .firstOrNull { it.startsWith("sensor.") && it.endsWith("_print_progress") }
-        ?.removePrefix("sensor.")
-        ?.removeSuffix("_print_progress")
+    // Try the most discriminating sensors first; fall through so an
+    // AMS- or controls-only snapshot still resolves.
+    val sensorSuffixes = listOf("_print_progress", "_print_status", "_current_stage")
+    for (suffix in sensorSuffixes) {
+        val hit = snapshot.states.keys
+            .firstOrNull { it.startsWith("sensor.") && it.endsWith(suffix) }
+        if (hit != null) return hit.removePrefix("sensor.").removeSuffix(suffix)
+    }
+    // AMS tray sensors look like sensor.<prefix>_ams_<n>_tray_<m>.
+    val tray = snapshot.states.keys
+        .firstOrNull { it.startsWith("sensor.") && Regex(".*_ams_\\d+_tray_\\d+$").matches(it) }
+    if (tray != null) {
+        return tray.removePrefix("sensor.").substringBeforeLast("_ams_")
+    }
+    // Print-control buttons.
+    val btn = snapshot.states.keys
+        .firstOrNull { it.startsWith("button.") && it.endsWith("_pause_printing") }
+    if (btn != null) return btn.removePrefix("button.").removeSuffix("_pause_printing")
+    return null
 }
 
 private fun buildPrintStatusData(
@@ -220,14 +338,92 @@ private fun buildPrintStatusData(
 private fun formatTemp(value: Float): String =
     if (value == value.toInt().toFloat()) value.toInt().toString() else "%.1f".format(value)
 
-/** Pause / resume / cancel pad. */
+/** Pause / resume / cancel pad. Wires the printer's three button
+ *  entities into a 3-button row; tap fires `button.press` on the
+ *  matching entity. Falls back to chrome-only when the snapshot has no
+ *  Bambu-shaped buttons. */
 class BambuLabPrintControlCardConverter : BambuLabCardConverter(
     cardType = "custom:ha-bambulab-print_control-card",
     variantLabel = "Print control",
-)
+) {
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val data = buildPrintControlData(card, snapshot)
+        if (data == null) {
+            super.Render(card, snapshot, modifier)
+            return
+        }
+        ee.schimke.ha.rc.components.RemoteHaBambuPrintControl(data, modifier)
+    }
+}
 
 /** Legacy alias of print_control card from earlier versions. */
 class BambuLabSkipObjectCardConverter : BambuLabCardConverter(
     cardType = "custom:ha-bambulab-skipobject-card",
     variantLabel = "Print control",
-)
+) {
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val data = buildPrintControlData(card, snapshot)
+        if (data == null) {
+            super.Render(card, snapshot, modifier)
+            return
+        }
+        ee.schimke.ha.rc.components.RemoteHaBambuPrintControl(data, modifier)
+    }
+}
+
+private fun buildPrintControlData(
+    card: CardConfig,
+    snapshot: HaSnapshot,
+): ee.schimke.ha.rc.components.HaBambuPrintControlData? {
+    val prefix = resolvePrinterPrefix(card, snapshot) ?: return null
+    val s = snapshot.states
+    fun btn(suffix: String) = s["button.${prefix}_$suffix"]?.entityId
+
+    val pause = btn("pause_printing")?.let {
+        ee.schimke.ha.rc.components.HaBambuControlButton(
+            label = "Pause".rs,
+            icon = Icons.Filled.Pause,
+            accent = androidx.compose.ui.graphics.Color(0xFFFFA000),
+            tapAction = ee.schimke.ha.rc.components.HaAction.CallService(
+                domain = "button", service = "press", entityId = it,
+                serviceData = kotlinx.serialization.json.JsonObject(emptyMap()),
+            ),
+        )
+    }
+    val resume = btn("resume_printing")?.let {
+        ee.schimke.ha.rc.components.HaBambuControlButton(
+            label = "Resume".rs,
+            icon = Icons.Filled.PlayArrow,
+            accent = androidx.compose.ui.graphics.Color(0xFF43A047),
+            tapAction = ee.schimke.ha.rc.components.HaAction.CallService(
+                domain = "button", service = "press", entityId = it,
+                serviceData = kotlinx.serialization.json.JsonObject(emptyMap()),
+            ),
+        )
+    }
+    val stop = btn("stop_printing")?.let {
+        ee.schimke.ha.rc.components.HaBambuControlButton(
+            label = "Stop".rs,
+            icon = Icons.Filled.Stop,
+            accent = androidx.compose.ui.graphics.Color(0xFFE53935),
+            tapAction = ee.schimke.ha.rc.components.HaAction.CallService(
+                domain = "button", service = "press", entityId = it,
+                serviceData = kotlinx.serialization.json.JsonObject(emptyMap()),
+            ),
+        )
+    }
+    if (pause == null && resume == null && stop == null) return null
+
+    val printerName = (s["sensor.${prefix}_print_progress"] ?: s["sensor.${prefix}_print_status"])
+        ?.attributes?.get("friendly_name")?.jsonPrimitive?.content
+        ?.substringBeforeLast(' ')
+        ?: prefix.uppercase()
+    return ee.schimke.ha.rc.components.HaBambuPrintControlData(
+        printerName = printerName.rs,
+        pause = pause,
+        resume = resume,
+        stop = stop,
+    )
+}


### PR DESCRIPTION
## Summary

Follow-ups to #80 — promotes the remaining three Bambu Lab card variants from chrome-only to real renderings. Same prefix-discovery escape hatch (the card config's device id isn't resolvable without a registry channel, so the converter scans the snapshot for Bambu-shaped entities, override via `entity_prefix:`).

- **print_control** — 3-button pad (pause / resume / stop) wired to the matching `button.<prefix>_*_printing` entities. Each tap fires `button.press`; the chrome-only fallback kicks in when no button entities are present.
- **ams** — 4-slot color swatch grid with material name + remaining %. Active slot gets a coloured outline (matches HA's web bambu card). Parses `#RRGGBBAA` color attributes into Compose colours.
- **spool** — single-slot detail view; surfaces the `slot:` config index, or the active tray, or slot 1 (in that order).

`resolvePrinterPrefix()` now scans `_print_progress` → `_print_status` → `_current_stage` → `_ams_<n>_tray_<m>` → `_pause_printing` so an AMS- or controls-only snapshot still resolves a prefix.

## Previews

### Print control

| Light | Dark |
|---|---|
| ![print-control light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/30fcdebcf05edcf3112e9637e3d88a1ba66dfa60/BambuPrintControl_Light.png) | ![print-control dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/30fcdebcf05edcf3112e9637e3d88a1ba66dfa60/BambuPrintControl_Dark.png) |

### AMS

| Light | Dark |
|---|---|
| ![ams light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/30fcdebcf05edcf3112e9637e3d88a1ba66dfa60/BambuAms_Light.png) | ![ams dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/30fcdebcf05edcf3112e9637e3d88a1ba66dfa60/BambuAms_Dark.png) |

### Spool

| Light | Dark |
|---|---|
| ![spool light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/30fcdebcf05edcf3112e9637e3d88a1ba66dfa60/BambuSpool_Light.png) | ![spool dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/30fcdebcf05edcf3112e9637e3d88a1ba66dfa60/BambuSpool_Dark.png) |

## Test plan

- [x] `./gradlew :rc-components:compileDebugKotlin :rc-converter:compileDebugKotlin :previews:assembleDebug` — green
- [x] `compose-preview render --filter Bambu*Light/Dark` — all three render real data (see images above)
- [x] No HA-derived data committed — fixture entity ids and friendly names are synthetic; device-id placeholders in card configs are literal strings the converter doesn't read
- [ ] Pixel-diff cases will follow once #78 lands

## Notes

- The `legacy skipobject-card` alias (`custom:ha-bambulab-skipobject-card`) shares the print-control implementation since they're the same UI.
- Color swatches: `#000000FF` (PLA black), `#FF6600FF` (PETG orange — active), `#1E88E5FF` (ASA blue), `#43A047FF` (TPU green).
- Slot active highlight is a 2-dp outline in the slot's own colour rather than a separate accent — keeps the swatch readable in both themes.