### PR TITLE
feat: thermostat, humidifier, and light cards via shared arc dial

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
@@ -396,7 +396,7 @@ fun Unsupported_Dark() = CardHost(HaTheme.Dark) {
     RenderChild(unsupportedCard(), Fixtures.mixed)
 }
 
-private fun unsupportedCard() = card("""{"type":"thermostat","entity":"climate.living_room"}""")
+private fun unsupportedCard() = card("""{"type":"iframe","url":"https://example.com"}""")
 
 // ——— gauge ———
 
@@ -564,6 +564,56 @@ fun BambuSpool_Dark() = CardHost(HaTheme.Dark) {
 
 private fun bambuSpoolCard() = card(
     """{"type":"custom:ha-bambulab-spool-card","spool":"<spool-id-placeholder>"}""",
+)
+
+// ——— thermostat / humidifier / light arc dials ———
+
+@Preview(name = "thermostat (light)", showBackground = false, widthDp = 240, heightDp = 290)
+@Composable
+fun Thermostat_Light() = CardHost(HaTheme.Light) {
+    RenderChild(thermostatCard(), Fixtures.thermostat, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "thermostat (dark)", showBackground = false, widthDp = 240, heightDp = 290)
+@Composable
+fun Thermostat_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(thermostatCard(), Fixtures.thermostat, RemoteModifier.fillMaxWidth())
+}
+
+private fun thermostatCard() = card(
+    """{"type":"thermostat","entity":"climate.living_room"}""",
+)
+
+@Preview(name = "humidifier (light)", showBackground = false, widthDp = 240, heightDp = 290)
+@Composable
+fun Humidifier_Light() = CardHost(HaTheme.Light) {
+    RenderChild(humidifierCard(), Fixtures.humidifier, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "humidifier (dark)", showBackground = false, widthDp = 240, heightDp = 290)
+@Composable
+fun Humidifier_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(humidifierCard(), Fixtures.humidifier, RemoteModifier.fillMaxWidth())
+}
+
+private fun humidifierCard() = card(
+    """{"type":"humidifier","entity":"humidifier.bedroom"}""",
+)
+
+@Preview(name = "light card (light)", showBackground = false, widthDp = 240, heightDp = 250)
+@Composable
+fun LightCard_Light() = CardHost(HaTheme.Light) {
+    RenderChild(lightCardConfig(), Fixtures.brightLight, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "light card (dark)", showBackground = false, widthDp = 240, heightDp = 250)
+@Composable
+fun LightCard_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(lightCardConfig(), Fixtures.brightLight, RemoteModifier.fillMaxWidth())
+}
+
+private fun lightCardConfig() = card(
+    """{"type":"light","entity":"light.kitchen"}""",
 )
 
 // ——— tile, state variants via PreviewParameter ———

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
@@ -142,6 +142,52 @@ object Fixtures {
             mapOf("friendly_name" to "Garage motion", "device_class" to "motion")),
     )
 
+    /** Climate entity in heating mode at 21.4°C, target 22°C. */
+    val thermostat = snapshot(
+        "climate.living_room" to EntityState(
+            entityId = "climate.living_room",
+            state = "heat",
+            attributes = JsonObject(mapOf(
+                "friendly_name" to JsonPrimitive("Living Room"),
+                "current_temperature" to JsonPrimitive(21.4),
+                "temperature" to JsonPrimitive(22.0),
+                "min_temp" to JsonPrimitive(7.0),
+                "max_temp" to JsonPrimitive(35.0),
+                "temperature_unit" to JsonPrimitive("°C"),
+                "hvac_action" to JsonPrimitive("heating"),
+                "target_temp_step" to JsonPrimitive(0.5),
+            )),
+        ),
+    )
+
+    /** Humidifier at 45% current, target 55%. */
+    val humidifier = snapshot(
+        "humidifier.bedroom" to EntityState(
+            entityId = "humidifier.bedroom",
+            state = "on",
+            attributes = JsonObject(mapOf(
+                "friendly_name" to JsonPrimitive("Bedroom"),
+                "current_humidity" to JsonPrimitive(45),
+                "humidity" to JsonPrimitive(55),
+                "min_humidity" to JsonPrimitive(20),
+                "max_humidity" to JsonPrimitive(80),
+                "action" to JsonPrimitive("humidifying"),
+            )),
+        ),
+    )
+
+    /** Light at 60% brightness. */
+    val brightLight = snapshot(
+        "light.kitchen" to EntityState(
+            entityId = "light.kitchen",
+            state = "on",
+            attributes = JsonObject(mapOf(
+                "friendly_name" to JsonPrimitive("Kitchen"),
+                "brightness" to JsonPrimitive(153),  // 60% of 255
+            )),
+        ),
+    )
+
     /** Helper for AMS tray entities — the converter reads `color`, `remain`,
      *  `remain_enabled`, and `active` off attributes; tray state is the
      *  filament name (e.g. "Generic PLA"). */

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
@@ -243,3 +243,29 @@ data class HaBambuSpoolSlot(
     val remainPercent: Int?,
     val active: Boolean,
 )
+
+/**
+ * Thermostat / humidifier / light arc-gauge model — 270° dial with a
+ * filled portion up to [valueFraction], an optional target marker at
+ * [targetFraction], a centred value label, and HA's mode chip.
+ *
+ * Used by:
+ *   - thermostat → [valueFraction] = current temp normalised, [targetFraction] = setpoint, mode = "Heating"/"Cooling"/...
+ *   - humidifier → same shape, value/target are humidity %, mode = "Humidifying"/"Drying"
+ *   - light       → [valueFraction] = brightness, no target marker, mode = on/off label
+ */
+data class HaArcDialData(
+    val name: RemoteString,
+    val valueFraction: Float,
+    val targetFraction: Float?,
+    val centerLabel: RemoteString,
+    /** Smaller secondary readout under the centre label (e.g. "↑ 22 °C"). */
+    val supportingLabel: RemoteString?,
+    val modeChip: RemoteString?,
+    val accent: Color,
+    val showSteppers: Boolean,
+    val centerIcon: ImageVector?,
+    val tapAction: HaAction = HaAction.None,
+    val incrementAction: HaAction = HaAction.None,
+    val decrementAction: HaAction = HaAction.None,
+)

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaArcDial.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaArcDial.kt
@@ -1,0 +1,232 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import android.graphics.Paint as AndroidPaint
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteCanvas
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteOffset
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteSize
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clickable
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.modifier.size
+import androidx.compose.remote.creation.compose.shapes.RemoteCircleShape
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.asRemotePaint
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rf
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.wear.compose.remote.material3.RemoteIcon
+
+/**
+ * 270° arc dial used by thermostat / humidifier / light cards.
+ *
+ * ```
+ *      ╱──────────╲
+ *     │  Heating   │
+ *     │  27.5 °C   │   ← centre label (or icon for light)
+ *     │  ↑ 25 °C   │   ← supporting label (target / brightness)
+ *      ╲──────────╱
+ *         (-)(+)
+ * ```
+ *
+ * The arc starts at 135° (top-left), sweeps clockwise 270° to 45°
+ * (top-right). The fill represents [HaArcDialData.valueFraction]; the
+ * target appears as text in [HaArcDialData.supportingLabel] (drawing a
+ * marker dot at an arbitrary angle requires scalar trig that
+ * RemoteFloat doesn't expose at capture time — follow-up).
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaArcDial(
+    data: HaArcDialData,
+    modifier: RemoteModifier = RemoteModifier,
+) {
+    val theme = haTheme()
+    val click = data.tapAction.toRemoteAction()
+        ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
+
+    RemoteBox(
+        modifier = modifier
+            .then(click)
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(horizontal = 14.rdp, vertical = 12.rdp),
+    ) {
+        RemoteColumn(
+            modifier = RemoteModifier.fillMaxWidth(),
+            horizontalAlignment = RemoteAlignment.CenterHorizontally,
+            verticalArrangement = RemoteArrangement.spacedBy(4.rdp),
+        ) {
+            RemoteText(
+                text = data.name,
+                color = theme.primaryText.rc,
+                fontSize = 14.rsp,
+                fontWeight = FontWeight.Medium,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            DialBody(data, theme)
+            if (data.showSteppers) {
+                Steppers(data.accent, data.incrementAction, data.decrementAction, theme)
+            }
+        }
+    }
+}
+
+@Composable
+private fun DialBody(data: HaArcDialData, theme: HaTheme) {
+    RemoteBox(
+        modifier = RemoteModifier.size(180.rdp),
+        contentAlignment = RemoteAlignment.Center,
+    ) {
+        ArcCanvas(data, theme)
+        RemoteColumn(
+            horizontalAlignment = RemoteAlignment.CenterHorizontally,
+            verticalArrangement = RemoteArrangement.spacedBy(2.rdp),
+        ) {
+            if (data.centerIcon != null) {
+                RemoteIcon(
+                    imageVector = data.centerIcon,
+                    contentDescription = data.name,
+                    modifier = RemoteModifier.size(40.rdp),
+                    tint = data.accent.rc,
+                )
+            }
+            if (data.modeChip != null) {
+                RemoteText(
+                    text = data.modeChip,
+                    color = data.accent.rc,
+                    fontSize = 12.rsp,
+                    fontWeight = FontWeight.Medium,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                )
+            }
+            RemoteText(
+                text = data.centerLabel,
+                color = theme.primaryText.rc,
+                fontSize = 26.rsp,
+                fontWeight = FontWeight.SemiBold,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (data.supportingLabel != null) {
+                RemoteText(
+                    text = data.supportingLabel,
+                    color = data.accent.rc,
+                    fontSize = 12.rsp,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ArcCanvas(data: HaArcDialData, theme: HaTheme) {
+    val v = data.valueFraction.coerceIn(0f, 1f)
+    val sweep = 270f * v
+    RemoteCanvas(modifier = RemoteModifier.size(180.rdp)) {
+        val w = width
+        val h = height
+        val stroke = 12f.rf
+        val pad = stroke / 2f.rf + 4f.rf
+        val topLeft = RemoteOffset(pad, pad)
+        val arcSize = RemoteSize(w - pad * 2f.rf, h - pad * 2f.rf)
+
+        val track = AndroidPaint().apply {
+            isAntiAlias = true
+            style = AndroidPaint.Style.STROKE
+            strokeWidth = 12f
+            strokeCap = AndroidPaint.Cap.ROUND
+            color = theme.divider.toArgb()
+        }.asRemotePaint()
+        drawArc(track, 135f.rf, 270f.rf, false, topLeft, arcSize)
+
+        if (sweep > 0.5f) {
+            val fill = AndroidPaint().apply {
+                isAntiAlias = true
+                style = AndroidPaint.Style.STROKE
+                strokeWidth = 12f
+                strokeCap = AndroidPaint.Cap.ROUND
+                color = data.accent.toArgb()
+            }.asRemotePaint()
+            drawArc(fill, 135f.rf, sweep.rf, false, topLeft, arcSize)
+        }
+    }
+}
+
+@Composable
+private fun Steppers(
+    accent: Color,
+    incrementAction: HaAction,
+    decrementAction: HaAction,
+    theme: HaTheme,
+) {
+    RemoteRow(
+        modifier = RemoteModifier.fillMaxWidth().padding(top = 6.rdp),
+        horizontalArrangement = RemoteArrangement.spacedBy(24.rdp, RemoteAlignment.CenterHorizontally),
+    ) {
+        StepperButton(Icons.Filled.Remove, decrementAction, accent, theme)
+        StepperButton(Icons.Filled.Add, incrementAction, accent, theme)
+    }
+}
+
+@Composable
+private fun StepperButton(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    action: HaAction,
+    accent: Color,
+    theme: HaTheme,
+) {
+    val click = action.toRemoteAction()
+        ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
+    RemoteBox(
+        modifier = RemoteModifier.then(click)
+            .size(36.rdp)
+            .clip(RemoteCircleShape)
+            .border(1.rdp, theme.divider.rc, RemoteCircleShape),
+        contentAlignment = RemoteAlignment.Center,
+    ) {
+        RemoteIcon(
+            imageVector = icon,
+            contentDescription = "stepper".rs,
+            modifier = RemoteModifier.size(20.rdp),
+            tint = accent.rc,
+        )
+    }
+}
+
+private fun Color.toArgb(): Int = android.graphics.Color.argb(
+    (alpha * 255f).toInt(),
+    (red * 255f).toInt(),
+    (green * 255f).toInt(),
+    (blue * 255f).toInt(),
+)

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/DefaultConverters.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/DefaultConverters.kt
@@ -43,6 +43,9 @@ fun defaultConverters(): List<CardConverter> = buildList {
     add(PictureEntityCardConverter())
     add(WeatherForecastCardConverter())
     add(LogbookCardConverter())
+    add(ThermostatCardConverter())
+    add(HumidifierCardConverter())
+    add(LightCardConverter())
 
     add(BambuLabAmsCardConverter())
     add(BambuLabSpoolCardConverter())
@@ -59,9 +62,6 @@ fun defaultConverters(): List<CardConverter> = buildList {
 fun defaultRegistry(): CardRegistry = CardRegistry(defaultConverters())
 
 private val PLACEHOLDER_CARD_TYPES: List<String> = listOf(
-    CardTypes.THERMOSTAT,
-    CardTypes.HUMIDIFIER,
-    CardTypes.LIGHT,
     CardTypes.MEDIA_CONTROL,
     CardTypes.ALARM_PANEL,
     CardTypes.CLOCK,

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/HumidifierCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/HumidifierCardConverter.kt
@@ -1,0 +1,103 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.components.HaAction
+import ee.schimke.ha.rc.components.HaArcDialData
+import ee.schimke.ha.rc.components.RemoteHaArcDial
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `humidifier` card — humidifier entity as a 270° arc dial.
+ *
+ * Same shape as the thermostat card but the arc fills with the current
+ * humidity %, the target humidity is the supportingLabel, and the
+ * mode chip reads "Humidifying" / "Drying" / "Off".
+ */
+class HumidifierCardConverter : CardConverter {
+    override val cardType: String = CardTypes.HUMIDIFIER
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 290
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val entityId = card.raw["entity"]?.jsonPrimitive?.content
+        val entity = entityId?.let { snapshot.states[it] }
+        val attrs = entity?.attributes ?: JsonObject(emptyMap())
+        val name = card.raw["name"]?.jsonPrimitive?.content
+            ?: attrs["friendly_name"]?.jsonPrimitive?.content
+            ?: entityId
+            ?: "Humidifier"
+        val current = attrs["current_humidity"]?.jsonPrimitive?.content?.toFloatOrNull()
+        val target = attrs["humidity"]?.jsonPrimitive?.content?.toFloatOrNull()
+        val min = attrs["min_humidity"]?.jsonPrimitive?.content?.toFloatOrNull() ?: 0f
+        val max = attrs["max_humidity"]?.jsonPrimitive?.content?.toFloatOrNull() ?: 100f
+        val state = entity?.state ?: "off"
+        val action = attrs["action"]?.jsonPrimitive?.content
+        val modeChip = when {
+            state == "off" -> "Off"
+            action == "humidifying" -> "Humidifying"
+            action == "drying" -> "Drying"
+            action == "idle" -> "Idle"
+            else -> state.replace('_', ' ').replaceFirstChar { it.uppercaseChar() }
+        }
+
+        val span = (max - min).coerceAtLeast(0.0001f)
+        val valueFraction = ((current ?: target ?: min) - min) / span
+        val targetFraction = target?.let { (it - min) / span }
+
+        val centerLabel = (current ?: target)?.let { "${it.toInt()}%" } ?: "—"
+        val supportingLabel = target?.let { "↑ ${it.toInt()}%" }
+
+        val (incAction, decAction) = stepperActions(entity?.entityId, target, 5f)
+
+        RemoteHaArcDial(
+            HaArcDialData(
+                name = name.rs,
+                valueFraction = valueFraction.coerceIn(0f, 1f),
+                targetFraction = targetFraction?.coerceIn(0f, 1f),
+                centerLabel = centerLabel.rs,
+                supportingLabel = supportingLabel?.rs,
+                modeChip = modeChip.rs,
+                accent = Color(0xFF00ACC1),
+                showSteppers = target != null,
+                centerIcon = null,
+                incrementAction = incAction,
+                decrementAction = decAction,
+            ),
+            modifier = modifier,
+        )
+    }
+}
+
+private fun stepperActions(
+    entityId: String?,
+    target: Float?,
+    step: Float,
+): Pair<HaAction, HaAction> {
+    if (entityId == null || target == null) return HaAction.None to HaAction.None
+    val up = HaAction.CallService(
+        domain = "humidifier",
+        service = "set_humidity",
+        entityId = entityId,
+        serviceData = kotlinx.serialization.json.JsonObject(mapOf(
+            "humidity" to kotlinx.serialization.json.JsonPrimitive((target + step).coerceAtMost(100f)),
+        )),
+    )
+    val down = HaAction.CallService(
+        domain = "humidifier",
+        service = "set_humidity",
+        entityId = entityId,
+        serviceData = kotlinx.serialization.json.JsonObject(mapOf(
+            "humidity" to kotlinx.serialization.json.JsonPrimitive((target - step).coerceAtLeast(0f)),
+        )),
+    )
+    return up to down
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/LightCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/LightCardConverter.kt
@@ -1,0 +1,95 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lightbulb
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.components.HaAction
+import ee.schimke.ha.rc.components.HaArcDialData
+import ee.schimke.ha.rc.components.RemoteHaArcDial
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `light` card — brightness ring around a bulb icon.
+ *
+ * Reads `brightness` (0..255) for the arc fill and uses on/off state
+ * to choose accent. Centre icon is a bulb so the card reads visually as
+ * a light at a glance. Tap toggles the light; the +/- steppers fire
+ * `light.turn_on` with `brightness_step` of 25 (~10%).
+ */
+class LightCardConverter : CardConverter {
+    override val cardType: String = CardTypes.LIGHT
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 250
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val entityId = card.raw["entity"]?.jsonPrimitive?.content
+        val entity = entityId?.let { snapshot.states[it] }
+        val attrs = entity?.attributes ?: JsonObject(emptyMap())
+        val name = card.raw["name"]?.jsonPrimitive?.content
+            ?: attrs["friendly_name"]?.jsonPrimitive?.content
+            ?: entityId
+            ?: "Light"
+        val isOn = entity?.state == "on"
+        val brightness = attrs["brightness"]?.jsonPrimitive?.content?.toFloatOrNull()
+        val fraction = if (isOn) (brightness ?: 255f) / 255f else 0f
+        val accent = if (isOn) Color(0xFFFFBE3E) else Color(0xFFB0B0B0)
+        val centerLabel = if (isOn) "${(fraction * 100f).toInt()}%" else "Off"
+
+        val tap = entityId?.let { HaAction.Toggle(it) } ?: HaAction.None
+        val (inc, dec) = brightnessSteppers(entityId, isOn, brightness)
+
+        RemoteHaArcDial(
+            HaArcDialData(
+                name = name.rs,
+                valueFraction = fraction,
+                targetFraction = null,
+                centerLabel = centerLabel.rs,
+                supportingLabel = null,
+                modeChip = (if (isOn) "On" else "Off").rs,
+                accent = accent,
+                showSteppers = isOn,
+                centerIcon = Icons.Filled.Lightbulb,
+                tapAction = tap,
+                incrementAction = inc,
+                decrementAction = dec,
+            ),
+            modifier = modifier,
+        )
+    }
+}
+
+private fun brightnessSteppers(
+    entityId: String?,
+    isOn: Boolean,
+    brightness: Float?,
+): Pair<HaAction, HaAction> {
+    if (entityId == null || !isOn) return HaAction.None to HaAction.None
+    val current = brightness ?: 255f
+    val step = 25f
+    val up = HaAction.CallService(
+        domain = "light",
+        service = "turn_on",
+        entityId = entityId,
+        serviceData = kotlinx.serialization.json.JsonObject(mapOf(
+            "brightness" to kotlinx.serialization.json.JsonPrimitive((current + step).coerceAtMost(255f).toInt()),
+        )),
+    )
+    val down = HaAction.CallService(
+        domain = "light",
+        service = "turn_on",
+        entityId = entityId,
+        serviceData = kotlinx.serialization.json.JsonObject(mapOf(
+            "brightness" to kotlinx.serialization.json.JsonPrimitive((current - step).coerceAtLeast(0f).toInt()),
+        )),
+    )
+    return up to down
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ThermostatCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ThermostatCardConverter.kt
@@ -1,0 +1,125 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.EntityState
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.components.HaAction
+import ee.schimke.ha.rc.components.HaArcDialData
+import ee.schimke.ha.rc.components.RemoteHaArcDial
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `thermostat` card — climate entity as a 270° arc dial.
+ *
+ * Reads `temperature` (target), `current_temperature`, `hvac_action`,
+ * `hvac_mode`, plus `min_temp`/`max_temp` for the arc range. Tapping
+ * the +/- steppers fires `climate.set_temperature` with `temperature`
+ * adjusted by `target_temp_step` (default 0.5°). The arc fill tracks
+ * the *current* temperature; the target is shown as a textual
+ * supporting line.
+ */
+class ThermostatCardConverter : CardConverter {
+    override val cardType: String = CardTypes.THERMOSTAT
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 290
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val entityId = card.raw["entity"]?.jsonPrimitive?.content
+        val entity = entityId?.let { snapshot.states[it] }
+        val attrs = entity?.attributes ?: JsonObject(emptyMap())
+        val name = card.raw["name"]?.jsonPrimitive?.content
+            ?: attrs["friendly_name"]?.jsonPrimitive?.content
+            ?: entityId
+            ?: "Thermostat"
+        val unit = attrs["temperature_unit"]?.jsonPrimitive?.content ?: "°C"
+        val current = attrs["current_temperature"]?.jsonPrimitive?.content?.toFloatOrNull()
+        val target = attrs["temperature"]?.jsonPrimitive?.content?.toFloatOrNull()
+        val min = attrs["min_temp"]?.jsonPrimitive?.content?.toFloatOrNull() ?: 7f
+        val max = attrs["max_temp"]?.jsonPrimitive?.content?.toFloatOrNull() ?: 35f
+        val step = attrs["target_temp_step"]?.jsonPrimitive?.content?.toFloatOrNull() ?: 0.5f
+        val mode = entity?.state ?: "off"
+        val hvacAction = attrs["hvac_action"]?.jsonPrimitive?.content
+        val modeChip = when (hvacAction) {
+            "heating" -> "Heating"
+            "cooling" -> "Cooling"
+            "drying" -> "Drying"
+            "fan" -> "Fan"
+            "idle" -> "Idle"
+            else -> mode.replace('_', ' ').replaceFirstChar { it.uppercaseChar() }
+        }
+        val accent = climateAccent(mode, hvacAction)
+        val span = (max - min).coerceAtLeast(0.0001f)
+        val valueFraction = ((current ?: target ?: min) - min) / span
+        val targetFraction = target?.let { (it - min) / span }
+
+        val centerLabel = current?.let { "${formatTemp(it)}$unit" }
+            ?: target?.let { "${formatTemp(it)}$unit" }
+            ?: "—"
+        val supportingLabel = target?.let { t -> "↑ ${formatTemp(t)}$unit" }
+
+        val (incAction, decAction) = stepperActions(entity, target, step) ?: (HaAction.None to HaAction.None)
+
+        RemoteHaArcDial(
+            HaArcDialData(
+                name = name.rs,
+                valueFraction = valueFraction.coerceIn(0f, 1f),
+                targetFraction = targetFraction?.coerceIn(0f, 1f),
+                centerLabel = centerLabel.rs,
+                supportingLabel = supportingLabel?.rs,
+                modeChip = modeChip.rs,
+                accent = accent,
+                showSteppers = target != null,
+                centerIcon = null,
+                incrementAction = incAction,
+                decrementAction = decAction,
+            ),
+            modifier = modifier,
+        )
+    }
+}
+
+private fun stepperActions(
+    entity: EntityState?,
+    target: Float?,
+    step: Float,
+): Pair<HaAction, HaAction>? {
+    val id = entity?.entityId ?: return null
+    val current = target ?: return null
+    val up = HaAction.CallService(
+        domain = "climate",
+        service = "set_temperature",
+        entityId = id,
+        serviceData = kotlinx.serialization.json.JsonObject(mapOf(
+            "temperature" to kotlinx.serialization.json.JsonPrimitive(current + step),
+        )),
+    )
+    val down = HaAction.CallService(
+        domain = "climate",
+        service = "set_temperature",
+        entityId = id,
+        serviceData = kotlinx.serialization.json.JsonObject(mapOf(
+            "temperature" to kotlinx.serialization.json.JsonPrimitive(current - step),
+        )),
+    )
+    return up to down
+}
+
+private fun climateAccent(mode: String, hvacAction: String?): Color = when {
+    hvacAction == "heating" || mode == "heat" -> Color(0xFFE65100)
+    hvacAction == "cooling" || mode == "cool" -> Color(0xFF2196F3)
+    hvacAction == "drying" || mode == "dry" -> Color(0xFFFDD835)
+    hvacAction == "fan" || mode == "fan_only" -> Color(0xFF00BFA5)
+    mode == "auto" || mode == "heat_cool" -> Color(0xFF546E7A)
+    else -> Color(0xFF9E9E9E)
+}
+
+private fun formatTemp(v: Float): String =
+    if (v == v.toInt().toFloat()) v.toInt().toString() else "%.1f".format(v)


### PR DESCRIPTION
## Summary

Three more card types out of `PLACEHOLDER_CARD_TYPES`. All share a new `RemoteHaArcDial` composable — a 270° arc (135° → 405°) sweep — so each card converter just maps its entity attributes into `HaArcDialData` (valueFraction, modeChip, centerLabel, supportingLabel, optional centerIcon).

- **thermostat** — arc fills with `current_temperature` within `min_temp..max_temp`; target appears as the supporting line (\"↑ 22 °C\"); accent picks up `hvac_action` (heating = orange, cooling = blue, etc). Steppers fire `climate.set_temperature` with `target_temp_step`.
- **humidifier** — same shape, `current_humidity` drives the arc; target humidity is the supporting line. Steppers fire `humidifier.set_humidity`.
- **light** — brightness ring around a centred bulb icon, arc fills the 0..255 range as %. Tap toggles, steppers fire `light.turn_on` with a 25-unit (\~10 %) step.

The target-position marker dot on the arc is deferred — `RemoteFloat` at capture time doesn't expose scalar literals for trig math without a custom canvas helper, so for now the textual target line covers the same data. Will pick up in a follow-up.

## Previews

### Thermostat — heating to 22 °C, current 21.4 °C

| Light | Dark |
|---|---|
| ![thermostat light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/8dab633918e7e09f87152c5341f256a98a1b62cb/Thermostat_Light.png) | ![thermostat dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/8dab633918e7e09f87152c5341f256a98a1b62cb/Thermostat_Dark.png) |

### Humidifier — target 55 %, current 45 %

| Light | Dark |
|---|---|
| ![humidifier light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/8dab633918e7e09f87152c5341f256a98a1b62cb/Humidifier_Light.png) | ![humidifier dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/8dab633918e7e09f87152c5341f256a98a1b62cb/Humidifier_Dark.png) |

### Light — Kitchen at 60 % brightness

| Light | Dark |
|---|---|
| ![light light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/8dab633918e7e09f87152c5341f256a98a1b62cb/LightCard_Light.png) | ![light dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/8dab633918e7e09f87152c5341f256a98a1b62cb/LightCard_Dark.png) |

## Test plan

- [x] `./gradlew :rc-components:compileDebugKotlin :rc-converter:compileDebugKotlin :previews:assembleDebug` — green
- [x] `compose-preview render --filter Thermostat/Humidifier/LightCard` — all 6 render real data (see images above)
- [x] No HA-derived data committed — all three fixtures are synthetic
- [ ] Pixel-diff cases will follow once #78 lands

## Notes

- The unsupported-card preview previously pointed at `thermostat` (now real); switched it to `iframe` which is still placeholder.
- `HaArcDialData.targetFraction` exists in the model so the marker-on-arc visual can land later without changing converters.