### PR TITLE
feat: implement clock and statistics-graph cards

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
@@ -616,6 +616,43 @@ private fun lightCardConfig() = card(
     """{"type":"light","entity":"light.kitchen"}""",
 )
 
+// ——— clock ———
+
+@Preview(name = "clock (light)", showBackground = false, widthDp = 200, heightDp = 100)
+@Composable
+fun Clock_Light() = CardHost(HaTheme.Light) {
+    RenderChild(clockCard(), Fixtures.mixed, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "clock (dark)", showBackground = false, widthDp = 200, heightDp = 100)
+@Composable
+fun Clock_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(clockCard(), Fixtures.mixed, RemoteModifier.fillMaxWidth())
+}
+
+private fun clockCard() = card(
+    """{"type":"clock","clock_size":"medium","time_format":"24"}""",
+)
+
+// ——— statistics-graph ———
+
+@Preview(name = "statistics-graph (light)", showBackground = false, widthDp = 381, heightDp = 200)
+@Composable
+fun StatisticsGraph_Light() = CardHost(HaTheme.Light) {
+    RenderChild(statsGraphCard(), Fixtures.energyStatistics, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "statistics-graph (dark)", showBackground = false, widthDp = 381, heightDp = 200)
+@Composable
+fun StatisticsGraph_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(statsGraphCard(), Fixtures.energyStatistics, RemoteModifier.fillMaxWidth())
+}
+
+private fun statsGraphCard() = card(
+    """{"type":"statistics-graph","title":"Power","period":"hour","stat_types":["mean"],
+        "entities":["sensor.house_power","sensor.solar_power"]}""",
+)
+
 // ——— tile, state variants via PreviewParameter ———
 
 @Preview(name = "tile light (light)", showBackground = false, widthDp = 187, heightDp = 43)

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
@@ -322,4 +322,56 @@ object Fixtures {
             ),
         )
     }
+
+    /** Hourly statistics for an energy-consumption sensor — synthetic
+     *  series so the statistics-graph preview has data to plot. */
+    val energyStatistics: HaSnapshot = run {
+        val states = mapOf(
+            "sensor.house_power" to EntityState(
+                entityId = "sensor.house_power",
+                state = "1840",
+                attributes = JsonObject(mapOf(
+                    "friendly_name" to JsonPrimitive("House power"),
+                    "unit_of_measurement" to JsonPrimitive("W"),
+                    "device_class" to JsonPrimitive("power"),
+                )),
+            ),
+            "sensor.solar_power" to EntityState(
+                entityId = "sensor.solar_power",
+                state = "640",
+                attributes = JsonObject(mapOf(
+                    "friendly_name" to JsonPrimitive("Solar power"),
+                    "unit_of_measurement" to JsonPrimitive("W"),
+                    "device_class" to JsonPrimitive("power"),
+                )),
+            ),
+        )
+        val baseTime = kotlinx.datetime.Instant.parse("2026-05-05T00:00:00Z")
+        // Mean power consumption per hour — house draws are baseline
+        // ~600W, peaks during cooking + evening; solar follows midday.
+        val houseMeans = listOf(
+            520.0, 480.0, 460.0, 450.0, 470.0, 600.0, 1450.0, 2100.0,
+            1800.0, 1100.0, 950.0, 880.0, 1700.0, 1850.0, 1300.0, 1100.0,
+            980.0, 1450.0, 2200.0, 2800.0, 2400.0, 1700.0, 980.0, 720.0,
+        )
+        val solarMeans = listOf(
+            0.0, 0.0, 0.0, 0.0, 0.0, 30.0, 180.0, 480.0,
+            960.0, 1380.0, 1780.0, 2050.0, 2150.0, 2080.0, 1840.0, 1430.0,
+            930.0, 480.0, 160.0, 20.0, 0.0, 0.0, 0.0, 0.0,
+        )
+        fun statSeries(values: List<Double>) =
+            values.mapIndexed { i, v ->
+                ee.schimke.ha.model.StatisticPoint(
+                    start = baseTime.plus(kotlin.time.Duration.parse("${i}h")),
+                    mean = v,
+                )
+            }
+        HaSnapshot(
+            states = states,
+            statistics = mapOf(
+                "sensor.house_power" to statSeries(houseMeans),
+                "sensor.solar_power" to statSeries(solarMeans),
+            ),
+        )
+    }
 }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
@@ -269,3 +269,24 @@ data class HaArcDialData(
     val incrementAction: HaAction = HaAction.None,
     val decrementAction: HaAction = HaAction.None,
 )
+
+/** `clock` card model. The string is captured at capture time —
+ *  alpha08 has a `RemoteAccess.getTime()` API but emitting a Compose
+ *  text node bound to it requires canvas drawText; deferring live
+ *  ticking to a follow-up. The host re-encodes once a minute / hour. */
+data class HaClockData(
+    val title: RemoteString?,
+    val timeLabel: RemoteString,
+    val secondaryLabel: RemoteString?,
+    val isLarge: Boolean,
+)
+
+/** `statistics-graph` card model — mirrors history-graph, just with
+ *  pre-aggregated mean values from HA's `recorder.statistics_during_period`.
+ *  [chartType] defaults to "line"; bar mode is a follow-up. */
+data class HaStatisticsGraphData(
+    val title: RemoteString?,
+    val rangeLabel: RemoteString,
+    val rows: List<HaHistoryGraphRow>,
+    val chartType: String = "line",
+)

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaClock.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaClock.kt
@@ -1,0 +1,81 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+
+/**
+ * `clock` card — local time as a static text label captured at
+ * encode time. The host re-encodes once a minute (or whatever cadence
+ * the player uses); a future revision can swap this for a
+ * `RemoteCanvas.drawText` bound to `RemoteAccess.getTime()` for
+ * live-ticking without re-encode.
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaClock(data: HaClockData, modifier: RemoteModifier = RemoteModifier) {
+    val theme = haTheme()
+    val timeSize = if (data.isLarge) 64 else 36
+    RemoteBox(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(horizontal = 14.rdp, vertical = 12.rdp),
+        contentAlignment = RemoteAlignment.Center,
+    ) {
+        RemoteColumn(
+            horizontalAlignment = RemoteAlignment.CenterHorizontally,
+            verticalArrangement = RemoteArrangement.spacedBy(2.rdp),
+        ) {
+            if (data.title != null) {
+                RemoteText(
+                    text = data.title,
+                    color = theme.secondaryText.rc,
+                    fontSize = 12.rsp,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            RemoteText(
+                text = data.timeLabel,
+                color = theme.primaryText.rc,
+                fontSize = timeSize.rsp,
+                fontWeight = FontWeight.Light,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+            )
+            if (data.secondaryLabel != null) {
+                RemoteText(
+                    text = data.secondaryLabel,
+                    color = theme.secondaryText.rc,
+                    fontSize = 12.rsp,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaStatisticsGraph.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaStatisticsGraph.kt
@@ -1,0 +1,30 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.runtime.Composable
+
+/**
+ * `statistics-graph` card — same visual shape as the history-graph
+ * sparkline (one row per entity, chrome + range label + small line
+ * graph). Implemented as a thin shim over [RemoteHaHistoryGraph]; if
+ * the visual diverges later (axes, multi-series fill, bar mode) split
+ * into its own canvas pass.
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaStatisticsGraph(
+    data: HaStatisticsGraphData,
+    modifier: RemoteModifier = RemoteModifier,
+) {
+    RemoteHaHistoryGraph(
+        HaHistoryGraphData(
+            title = data.title,
+            rangeLabel = data.rangeLabel,
+            rows = data.rows,
+        ),
+        modifier = modifier,
+    )
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ClockCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ClockCardConverter.kt
@@ -1,0 +1,66 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.components.HaClockData
+import ee.schimke.ha.rc.components.RemoteHaClock
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `clock` card — local time text. Captured at capture time using the
+ * snapshot's [HaSnapshot.locale] when available; the host re-encodes
+ * to keep the label current. A future revision can wire
+ * `RemoteAccess.getTime()` into a canvas drawText for live ticking
+ * without re-encode.
+ */
+class ClockCardConverter : CardConverter {
+    override val cardType: String = CardTypes.CLOCK
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int {
+        val size = card.raw["clock_size"]?.jsonPrimitive?.content
+        return when (size) {
+            "large" -> 140
+            "medium" -> 100
+            else -> 70
+        }
+    }
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val title = card.raw["title"]?.jsonPrimitive?.content
+        val tz = card.raw["time_zone"]?.jsonPrimitive?.content
+            ?.let { runCatching { ZoneId.of(it) }.getOrNull() }
+            ?: ZoneId.systemDefault()
+        val showSeconds = card.raw["show_seconds"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: false
+        val timeFmt = card.raw["time_format"]?.jsonPrimitive?.content
+        val pattern = when {
+            timeFmt == "12" -> if (showSeconds) "h:mm:ss a" else "h:mm a"
+            else -> if (showSeconds) "HH:mm:ss" else "HH:mm"
+        }
+        val now = java.time.ZonedDateTime.now(tz)
+        val timeLabel = now.format(DateTimeFormatter.ofPattern(pattern))
+        val display = card.raw["display"]?.jsonPrimitive?.content ?: "primary"
+        val secondaryLabel = if (display == "primary" || display == null) {
+            now.format(DateTimeFormatter.ofPattern("EEE d MMM"))
+        } else null
+        val size = card.raw["clock_size"]?.jsonPrimitive?.content
+        val isLarge = size == "large" || size == "medium"
+
+        RemoteHaClock(
+            HaClockData(
+                title = title?.rs,
+                timeLabel = timeLabel.rs,
+                secondaryLabel = secondaryLabel?.rs,
+                isLarge = isLarge,
+            ),
+            modifier = modifier,
+        )
+    }
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/DefaultConverters.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/DefaultConverters.kt
@@ -46,6 +46,8 @@ fun defaultConverters(): List<CardConverter> = buildList {
     add(ThermostatCardConverter())
     add(HumidifierCardConverter())
     add(LightCardConverter())
+    add(ClockCardConverter())
+    add(StatisticsGraphCardConverter())
 
     add(BambuLabAmsCardConverter())
     add(BambuLabSpoolCardConverter())
@@ -64,14 +66,12 @@ fun defaultRegistry(): CardRegistry = CardRegistry(defaultConverters())
 private val PLACEHOLDER_CARD_TYPES: List<String> = listOf(
     CardTypes.MEDIA_CONTROL,
     CardTypes.ALARM_PANEL,
-    CardTypes.CLOCK,
     CardTypes.AREA,
     CardTypes.CALENDAR,
     CardTypes.TODO_LIST,
     CardTypes.PICTURE,
     CardTypes.PICTURE_GLANCE,
     CardTypes.PICTURE_ELEMENTS,
-    CardTypes.STATISTICS_GRAPH,
     CardTypes.STATISTIC,
     CardTypes.SENSOR,
     CardTypes.ENTITY_FILTER,

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/StatisticsGraphCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/StatisticsGraphCardConverter.kt
@@ -1,0 +1,90 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.model.StatisticPoint
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.HaStateColor
+import ee.schimke.ha.rc.components.HaHistoryGraphRow
+import ee.schimke.ha.rc.components.HaStatisticsGraphData
+import ee.schimke.ha.rc.components.RemoteHaStatisticsGraph
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `statistics-graph` card — same visual as history-graph but reads
+ * pre-aggregated `mean` values from `HaSnapshot.statistics`. HA's
+ * `chart_type: bar` and `stat_types` fan-out aren't visualised yet
+ * (would need a per-bucket rect pass); the textual summary still
+ * conveys range and sample count.
+ */
+class StatisticsGraphCardConverter : CardConverter {
+    override val cardType: String = CardTypes.STATISTICS_GRAPH
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int {
+        val rows = entityIds(card).size.coerceAtLeast(1)
+        val title = if (card.raw["title"] != null) 24 else 0
+        return title + 16 + 52 * rows + 20
+    }
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val title = card.raw["title"]?.jsonPrimitive?.content
+        val period = card.raw["period"]?.jsonPrimitive?.content ?: "hour"
+        val ids = entityIds(card)
+        val chartType = card.raw["chart_type"]?.jsonPrimitive?.content ?: "line"
+
+        val rows = ids.map { id ->
+            val entity = snapshot.states[id]
+            val name = entity?.attributes?.get("friendly_name")?.jsonPrimitive?.content ?: id
+            val statistics = snapshot.statistics[id].orEmpty()
+            val numeric = statistics.mapNotNull { it.mean?.toFloat() ?: it.state?.toFloat() }
+            HaHistoryGraphRow(
+                name = name.rs,
+                summary = summariseStatistics(statistics).rs,
+                accent = HaStateColor.activeFor(entity),
+                points = numeric,
+            )
+        }
+
+        RemoteHaStatisticsGraph(
+            HaStatisticsGraphData(
+                title = title?.rs,
+                rangeLabel = "Period: $period".rs,
+                rows = rows,
+                chartType = chartType,
+            ),
+            modifier = modifier,
+        )
+    }
+}
+
+private fun summariseStatistics(points: List<StatisticPoint>): String {
+    if (points.isEmpty()) return "no data"
+    val numeric = points.mapNotNull { it.mean ?: it.state }
+    if (numeric.isEmpty()) return "${points.size} buckets"
+    val min = numeric.min()
+    val max = numeric.max()
+    val fmt: (Double) -> String = { d ->
+        if (d == d.toLong().toDouble()) d.toLong().toString() else "%.1f".format(d)
+    }
+    return "${fmt(min)} – ${fmt(max)} (${points.size})"
+}
+
+private fun entityIds(card: CardConfig): List<String> {
+    val arr: JsonArray = card.raw["entities"]?.jsonArray ?: return emptyList()
+    return arr.mapNotNull { el ->
+        when (el) {
+            is JsonPrimitive -> el.content
+            is JsonObject -> el["entity"]?.jsonPrimitive?.content
+            else -> null
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two more out of `PLACEHOLDER_CARD_TYPES`.

- **clock** — simple text label with optional title + secondary date line. Time captured at encode time, formatted using the card's `time_format` / `show_seconds` / `time_zone` config; the host re-encodes to refresh. Live ticking via `RemoteAccess.getTime()` (the alpha08 RemoteFloat-bound time API) is a follow-up; doing it now would need `RemoteCanvas.drawText` rather than a Compose text node.
- **statistics-graph** — a thin shim over `RemoteHaHistoryGraph` that reads pre-aggregated `mean` values from `snapshot.statistics.<entity>`. Supports the most common shape (line + mean); `chart_type: bar` and per-stat-type fan-out are deferred — would need a per-bucket `drawRect` pass.

Adds `Fixtures.energyStatistics` with a synthetic 24-hour means series for house + solar power so the preview shows real shape (twin-peak consumption + midday solar bell).

## Previews

### Clock

| Light | Dark |
|---|---|
| ![clock light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/063f16c8ed796a5a43e5d5c22aafa2d0b2e4e362/Clock_Light.png) | ![clock dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/063f16c8ed796a5a43e5d5c22aafa2d0b2e4e362/Clock_Dark.png) |

### Statistics graph

| Light | Dark |
|---|---|
| ![stats light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/063f16c8ed796a5a43e5d5c22aafa2d0b2e4e362/StatisticsGraph_Light.png) | ![stats dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/063f16c8ed796a5a43e5d5c22aafa2d0b2e4e362/StatisticsGraph_Dark.png) |

## Test plan

- [x] `./gradlew :rc-components:compileDebugKotlin :rc-converter:compileDebugKotlin :previews:assembleDebug` — green
- [x] `compose-preview render --filter Clock_/StatisticsGraph_` — both render real data (see images above)
- [x] No HA-derived data — both fixtures are synthetic
- [ ] Pixel-diff cases will follow once #78 lands