### PR TITLE
feat: implement alarm-panel, media-control, and todo-list cards

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
@@ -616,41 +616,59 @@ private fun lightCardConfig() = card(
     """{"type":"light","entity":"light.kitchen"}""",
 )
 
-// ——— clock ———
+// ——— alarm-panel ———
 
-@Preview(name = "clock (light)", showBackground = false, widthDp = 200, heightDp = 100)
+@Preview(name = "alarm-panel (light)", showBackground = false, widthDp = 320, heightDp = 380)
 @Composable
-fun Clock_Light() = CardHost(HaTheme.Light) {
-    RenderChild(clockCard(), Fixtures.mixed, RemoteModifier.fillMaxWidth())
+fun AlarmPanel_Light() = CardHost(HaTheme.Light) {
+    RenderChild(alarmPanelCard(), Fixtures.alarmDisarmed, RemoteModifier.fillMaxWidth())
 }
 
-@Preview(name = "clock (dark)", showBackground = false, widthDp = 200, heightDp = 100)
+@Preview(name = "alarm-panel (dark)", showBackground = false, widthDp = 320, heightDp = 380)
 @Composable
-fun Clock_Dark() = CardHost(HaTheme.Dark) {
-    RenderChild(clockCard(), Fixtures.mixed, RemoteModifier.fillMaxWidth())
+fun AlarmPanel_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(alarmPanelCard(), Fixtures.alarmDisarmed, RemoteModifier.fillMaxWidth())
 }
 
-private fun clockCard() = card(
-    """{"type":"clock","clock_size":"medium","time_format":"24"}""",
+private fun alarmPanelCard() = card(
+    """{"type":"alarm-panel","entity":"alarm_control_panel.house",
+        "states":["arm_away","arm_home"]}""",
 )
 
-// ——— statistics-graph ———
+// ——— media-control ———
 
-@Preview(name = "statistics-graph (light)", showBackground = false, widthDp = 381, heightDp = 200)
+@Preview(name = "media-control (light)", showBackground = false, widthDp = 381, heightDp = 168)
 @Composable
-fun StatisticsGraph_Light() = CardHost(HaTheme.Light) {
-    RenderChild(statsGraphCard(), Fixtures.energyStatistics, RemoteModifier.fillMaxWidth())
+fun MediaControl_Light() = CardHost(HaTheme.Light) {
+    RenderChild(mediaControlCard(), Fixtures.mediaPlaying, RemoteModifier.fillMaxWidth())
 }
 
-@Preview(name = "statistics-graph (dark)", showBackground = false, widthDp = 381, heightDp = 200)
+@Preview(name = "media-control (dark)", showBackground = false, widthDp = 381, heightDp = 168)
 @Composable
-fun StatisticsGraph_Dark() = CardHost(HaTheme.Dark) {
-    RenderChild(statsGraphCard(), Fixtures.energyStatistics, RemoteModifier.fillMaxWidth())
+fun MediaControl_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(mediaControlCard(), Fixtures.mediaPlaying, RemoteModifier.fillMaxWidth())
 }
 
-private fun statsGraphCard() = card(
-    """{"type":"statistics-graph","title":"Power","period":"hour","stat_types":["mean"],
-        "entities":["sensor.house_power","sensor.solar_power"]}""",
+private fun mediaControlCard() = card(
+    """{"type":"media-control","entity":"media_player.office_speaker"}""",
+)
+
+// ——— todo-list ———
+
+@Preview(name = "todo-list (light)", showBackground = false, widthDp = 320, heightDp = 220)
+@Composable
+fun TodoList_Light() = CardHost(HaTheme.Light) {
+    RenderChild(todoListCard(), Fixtures.shoppingList, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "todo-list (dark)", showBackground = false, widthDp = 320, heightDp = 220)
+@Composable
+fun TodoList_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(todoListCard(), Fixtures.shoppingList, RemoteModifier.fillMaxWidth())
+}
+
+private fun todoListCard() = card(
+    """{"type":"todo-list","entity":"todo.shopping","title":"Shopping list"}""",
 )
 
 // ——— tile, state variants via PreviewParameter ———

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
@@ -176,6 +176,52 @@ object Fixtures {
         ),
     )
 
+    /** Alarm-panel disarmed. */
+    val alarmDisarmed = snapshot(
+        state("alarm_control_panel.house", "disarmed",
+            mapOf("friendly_name" to "House")),
+    )
+
+    /** Office speaker mid-track. */
+    val mediaPlaying = snapshot(
+        "media_player.office_speaker" to EntityState(
+            entityId = "media_player.office_speaker",
+            state = "playing",
+            attributes = JsonObject(mapOf(
+                "friendly_name" to JsonPrimitive("Office speaker"),
+                "media_title" to JsonPrimitive("The Anthem"),
+                "media_artist" to JsonPrimitive("Good Charlotte"),
+                "media_position" to JsonPrimitive(75.0),
+                "media_duration" to JsonPrimitive(176.0),
+            )),
+        ),
+    )
+
+    /** Shopping list with two active items + one completed. */
+    val shoppingList = snapshot(
+        "todo.shopping" to EntityState(
+            entityId = "todo.shopping",
+            state = "2",
+            attributes = JsonObject(mapOf(
+                "friendly_name" to JsonPrimitive("Shopping list"),
+                "items" to JsonArray(listOf(
+                    JsonObject(mapOf(
+                        "summary" to JsonPrimitive("Salt"),
+                        "status" to JsonPrimitive("needs_action"),
+                    )),
+                    JsonObject(mapOf(
+                        "summary" to JsonPrimitive("Butter"),
+                        "status" to JsonPrimitive("needs_action"),
+                    )),
+                    JsonObject(mapOf(
+                        "summary" to JsonPrimitive("Milk"),
+                        "status" to JsonPrimitive("completed"),
+                    )),
+                )),
+            )),
+        ),
+    )
+
     /** Light at 60% brightness. */
     val brightLight = snapshot(
         "light.kitchen" to EntityState(

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
@@ -290,3 +290,47 @@ data class HaStatisticsGraphData(
     val rows: List<HaHistoryGraphRow>,
     val chartType: String = "line",
 )
+
+/** `alarm-panel` card model — title, status badge, ARM AWAY/HOME
+ *  buttons (variants depend on `states:` config), code-input field +
+ *  numeric keypad. */
+data class HaAlarmPanelData(
+    val title: RemoteString,
+    val state: RemoteString,
+    val accent: Color,
+    val statusIcon: ImageVector,
+    val actions: List<HaAlarmAction>,
+    val showKeypad: Boolean,
+)
+
+/** One ARM button on the alarm panel — label + the call-service action
+ *  it fires (typically `alarm_control_panel.alarm_arm_*`). */
+data class HaAlarmAction(
+    val label: RemoteString,
+    val accent: Color,
+    val tapAction: HaAction,
+)
+
+/** `media-control` card model — name + title/artist + transport buttons
+ *  + position bar. Album-art is a placeholder swatch (alpha08 can't pull
+ *  arbitrary HTTP images into a .rc document). */
+data class HaMediaControlData(
+    val playerName: RemoteString,
+    val title: RemoteString,
+    val artist: RemoteString?,
+    val accent: Color,
+    val isPlaying: Boolean,
+    val positionFraction: Float,
+    val positionLabel: RemoteString?,
+    val durationLabel: RemoteString?,
+    val previousAction: HaAction,
+    val playPauseAction: HaAction,
+    val nextAction: HaAction,
+)
+
+/** `todo-list` card model — title + active/completed item rows. */
+data class HaTodoListData(
+    val title: RemoteString,
+    val activeItems: List<RemoteString>,
+    val completedItems: List<RemoteString>,
+)

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaAlarmPanel.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaAlarmPanel.kt
@@ -1,0 +1,172 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clickable
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.modifier.size
+import androidx.compose.remote.creation.compose.shapes.RemoteCircleShape
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rf
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.wear.compose.remote.material3.RemoteIcon
+
+/**
+ * `alarm-panel` card — title, status badge, ARM action buttons, and
+ * the static numeric keypad (matches HA's reference). The keypad is
+ * informational only at capture time (button-press dispatch through
+ * the .rc document into `alarm_control_panel.alarm_arm_*` would need
+ * a code-entry text-buffer that alpha08 doesn't model yet).
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaAlarmPanel(data: HaAlarmPanelData, modifier: RemoteModifier = RemoteModifier) {
+    val theme = haTheme()
+    RemoteBox(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(horizontal = 14.rdp, vertical = 12.rdp),
+    ) {
+        RemoteColumn(verticalArrangement = RemoteArrangement.spacedBy(10.rdp)) {
+            RemoteRow(
+                modifier = RemoteModifier.fillMaxWidth(),
+                verticalAlignment = RemoteAlignment.CenterVertically,
+                horizontalArrangement = RemoteArrangement.SpaceBetween,
+            ) {
+                RemoteColumn {
+                    RemoteText(
+                        text = data.title,
+                        color = theme.primaryText.rc,
+                        fontSize = 16.rsp,
+                        fontWeight = FontWeight.Medium,
+                        style = RemoteTextStyle.Default,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    RemoteText(
+                        text = data.state,
+                        color = data.accent.rc,
+                        fontSize = 12.rsp,
+                        style = RemoteTextStyle.Default,
+                        maxLines = 1,
+                    )
+                }
+                RemoteBox(
+                    modifier = RemoteModifier
+                        .size(40.rdp)
+                        .clip(RemoteCircleShape)
+                        .border(2.rdp, data.accent.rc, RemoteCircleShape),
+                    contentAlignment = RemoteAlignment.Center,
+                ) {
+                    RemoteIcon(
+                        imageVector = data.statusIcon,
+                        contentDescription = data.state,
+                        modifier = RemoteModifier.size(22.rdp),
+                        tint = data.accent.rc,
+                    )
+                }
+            }
+
+            // ARM AWAY / ARM HOME / DISARM buttons.
+            if (data.actions.isNotEmpty()) {
+                RemoteRow(
+                    modifier = RemoteModifier.fillMaxWidth(),
+                    horizontalArrangement = RemoteArrangement.spacedBy(8.rdp, RemoteAlignment.CenterHorizontally),
+                ) {
+                    data.actions.forEach { action ->
+                        ActionPill(action, theme)
+                    }
+                }
+            }
+
+            if (data.showKeypad) Keypad(data.accent, theme)
+        }
+    }
+}
+
+@Composable
+private fun ActionPill(action: HaAlarmAction, theme: HaTheme) {
+    val click = action.tapAction.toRemoteAction()
+        ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
+    val accent = action.accent.rc
+    RemoteBox(
+        modifier = RemoteModifier.then(click)
+            .clip(RemoteRoundedCornerShape(6.rdp))
+            .background(accent.copy(alpha = accent.alpha * 0.0f.rf))
+            .border(1.rdp, accent, RemoteRoundedCornerShape(6.rdp))
+            .padding(horizontal = 14.rdp, vertical = 8.rdp),
+        contentAlignment = RemoteAlignment.Center,
+    ) {
+        RemoteText(
+            text = action.label,
+            color = accent,
+            fontSize = 12.rsp,
+            fontWeight = FontWeight.Medium,
+            style = RemoteTextStyle.Default,
+            maxLines = 1,
+        )
+    }
+}
+
+@Composable
+private fun Keypad(accent: androidx.compose.ui.graphics.Color, theme: HaTheme) {
+    RemoteColumn(
+        modifier = RemoteModifier.fillMaxWidth().padding(top = 6.rdp),
+        verticalArrangement = RemoteArrangement.spacedBy(6.rdp),
+        horizontalAlignment = RemoteAlignment.CenterHorizontally,
+    ) {
+        listOf(listOf("1", "2", "3"), listOf("4", "5", "6"), listOf("7", "8", "9"))
+            .forEach { row ->
+                RemoteRow(horizontalArrangement = RemoteArrangement.spacedBy(8.rdp)) {
+                    row.forEach { KeypadKey(it, accent, theme) }
+                }
+            }
+        RemoteRow(horizontalArrangement = RemoteArrangement.spacedBy(8.rdp)) {
+            RemoteBox(modifier = RemoteModifier.size(48.rdp))
+            KeypadKey("0", accent, theme)
+            KeypadKey("⌫", accent, theme)
+        }
+    }
+}
+
+@Composable
+private fun KeypadKey(label: String, accent: androidx.compose.ui.graphics.Color, theme: HaTheme) {
+    RemoteBox(
+        modifier = RemoteModifier
+            .size(48.rdp)
+            .clip(RemoteRoundedCornerShape(6.rdp))
+            .border(1.rdp, accent.rc, RemoteRoundedCornerShape(6.rdp)),
+        contentAlignment = RemoteAlignment.Center,
+    ) {
+        RemoteText(
+            text = label.rs,
+            color = accent.rc,
+            fontSize = 16.rsp,
+            fontWeight = FontWeight.Medium,
+            style = RemoteTextStyle.Default,
+            maxLines = 1,
+        )
+    }
+}

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaMediaControl.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaMediaControl.kt
@@ -1,0 +1,190 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clickable
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.height
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.modifier.size
+import androidx.compose.remote.creation.compose.shapes.RemoteCircleShape
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rf
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.wear.compose.remote.material3.RemoteIcon
+
+/**
+ * `media-control` card — title/artist + transport buttons + a position
+ * bar. Album art renders as a tinted music-note placeholder; pulling
+ * arbitrary HTTP image entities into the .rc document needs a media
+ * channel alpha08 doesn't expose.
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaMediaControl(data: HaMediaControlData, modifier: RemoteModifier = RemoteModifier) {
+    val theme = haTheme()
+    RemoteBox(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(horizontal = 12.rdp, vertical = 12.rdp),
+    ) {
+        RemoteRow(
+            modifier = RemoteModifier.fillMaxWidth(),
+            verticalAlignment = RemoteAlignment.CenterVertically,
+        ) {
+            // Body
+            RemoteColumn(modifier = RemoteModifier.weight(1f).padding(end = 12.rdp)) {
+                RemoteText(
+                    text = data.playerName,
+                    color = data.accent.rc,
+                    fontSize = 11.rsp,
+                    fontWeight = FontWeight.Medium,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                RemoteText(
+                    text = data.title,
+                    color = theme.primaryText.rc,
+                    fontSize = 16.rsp,
+                    fontWeight = FontWeight.Medium,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (data.artist != null) {
+                    RemoteText(
+                        text = data.artist,
+                        color = theme.secondaryText.rc,
+                        fontSize = 12.rsp,
+                        style = RemoteTextStyle.Default,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                RemoteRow(
+                    modifier = RemoteModifier.padding(top = 6.rdp),
+                    horizontalArrangement = RemoteArrangement.spacedBy(4.rdp),
+                    verticalAlignment = RemoteAlignment.CenterVertically,
+                ) {
+                    TransportButton(Icons.Filled.SkipPrevious, data.previousAction, data.accent)
+                    TransportButton(
+                        if (data.isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                        data.playPauseAction,
+                        data.accent,
+                        big = true,
+                    )
+                    TransportButton(Icons.Filled.SkipNext, data.nextAction, data.accent)
+                }
+                ProgressBar(data.positionFraction, data.accent, theme)
+                if (data.positionLabel != null && data.durationLabel != null) {
+                    RemoteRow(
+                        modifier = RemoteModifier.fillMaxWidth(),
+                        horizontalArrangement = RemoteArrangement.SpaceBetween,
+                    ) {
+                        RemoteText(
+                            text = data.positionLabel,
+                            color = theme.secondaryText.rc,
+                            fontSize = 11.rsp,
+                            style = RemoteTextStyle.Default,
+                        )
+                        RemoteText(
+                            text = data.durationLabel,
+                            color = theme.secondaryText.rc,
+                            fontSize = 11.rsp,
+                            style = RemoteTextStyle.Default,
+                        )
+                    }
+                }
+            }
+            // Album-art placeholder
+            RemoteBox(
+                modifier = RemoteModifier
+                    .size(96.rdp)
+                    .clip(RemoteRoundedCornerShape(8.rdp))
+                    .background(data.accent.rc.copy(alpha = data.accent.rc.alpha * 0.15f.rf)),
+                contentAlignment = RemoteAlignment.Center,
+            ) {
+                RemoteIcon(
+                    imageVector = Icons.Filled.MusicNote,
+                    contentDescription = data.title,
+                    modifier = RemoteModifier.size(40.rdp),
+                    tint = data.accent.rc,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TransportButton(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    action: HaAction,
+    accent: androidx.compose.ui.graphics.Color,
+    big: Boolean = false,
+) {
+    val click = action.toRemoteAction()
+        ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
+    val size = if (big) 40.rdp else 32.rdp
+    val iconSize = if (big) 22.rdp else 18.rdp
+    RemoteBox(
+        modifier = RemoteModifier.then(click)
+            .size(size)
+            .clip(RemoteCircleShape),
+        contentAlignment = RemoteAlignment.Center,
+    ) {
+        RemoteIcon(
+            imageVector = icon,
+            contentDescription = "transport".rs,
+            modifier = RemoteModifier.size(iconSize),
+            tint = accent.rc,
+        )
+    }
+}
+
+@Composable
+private fun ProgressBar(fraction: Float, accent: androidx.compose.ui.graphics.Color, theme: HaTheme) {
+    val f = fraction.coerceIn(0f, 1f)
+    RemoteBox(
+        modifier = RemoteModifier
+            .fillMaxWidth()
+            .height(3.rdp)
+            .padding(top = 4.rdp)
+            .clip(RemoteRoundedCornerShape(1.rdp))
+            .background(theme.divider.rc),
+    ) {
+        RemoteBox(
+            modifier = RemoteModifier
+                .fillMaxWidth(f)
+                .height(3.rdp)
+                .background(accent.rc),
+        )
+    }
+}

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaTodoList.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaTodoList.kt
@@ -1,0 +1,117 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckBox
+import androidx.compose.material.icons.outlined.CheckBoxOutlineBlank
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.modifier.size
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.wear.compose.remote.material3.RemoteIcon
+
+/**
+ * `todo-list` card — title + active items section + completed items
+ * section. Items are rendered as static rows; toggling a checkbox
+ * inside the .rc document needs the todo-list service-call channel
+ * (alpha08-compatible follow-up).
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaTodoList(data: HaTodoListData, modifier: RemoteModifier = RemoteModifier) {
+    val theme = haTheme()
+    RemoteBox(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(horizontal = 14.rdp, vertical = 12.rdp),
+    ) {
+        RemoteColumn(verticalArrangement = RemoteArrangement.spacedBy(8.rdp)) {
+            RemoteText(
+                text = data.title,
+                color = theme.primaryText.rc,
+                fontSize = 16.rsp,
+                fontWeight = FontWeight.Medium,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+
+            if (data.activeItems.isNotEmpty()) {
+                Section("Active", theme)
+                data.activeItems.forEach { Row(it, completed = false, theme = theme) }
+            }
+            if (data.completedItems.isNotEmpty()) {
+                Section("Completed", theme)
+                data.completedItems.forEach { Row(it, completed = true, theme = theme) }
+            }
+            if (data.activeItems.isEmpty() && data.completedItems.isEmpty()) {
+                RemoteText(
+                    text = "No items".rs,
+                    color = theme.secondaryText.rc,
+                    fontSize = 12.rsp,
+                    style = RemoteTextStyle.Default,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun Section(label: String, theme: HaTheme) {
+    RemoteText(
+        text = label.rs,
+        color = theme.secondaryText.rc,
+        fontSize = 11.rsp,
+        fontWeight = FontWeight.Medium,
+        style = RemoteTextStyle.Default,
+    )
+}
+
+@Composable
+private fun Row(label: androidx.compose.remote.creation.compose.state.RemoteString, completed: Boolean, theme: HaTheme) {
+    RemoteRow(
+        modifier = RemoteModifier.fillMaxWidth().padding(vertical = 4.rdp),
+        verticalAlignment = RemoteAlignment.CenterVertically,
+    ) {
+        RemoteIcon(
+            imageVector = if (completed) Icons.Filled.CheckBox
+            else Icons.Outlined.CheckBoxOutlineBlank,
+            contentDescription = label,
+            modifier = RemoteModifier.size(18.rdp),
+            tint = if (completed) theme.placeholderAccent.rc else theme.secondaryText.rc,
+        )
+        RemoteBox(modifier = RemoteModifier.padding(start = 10.rdp)) {
+            RemoteText(
+                text = label,
+                color = if (completed) theme.secondaryText.rc else theme.primaryText.rc,
+                fontSize = 13.rsp,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/AlarmPanelCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/AlarmPanelCardConverter.kt
@@ -1,0 +1,105 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.LockOpen
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.components.HaAction
+import ee.schimke.ha.rc.components.HaAlarmAction
+import ee.schimke.ha.rc.components.HaAlarmPanelData
+import ee.schimke.ha.rc.components.RemoteHaAlarmPanel
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `alarm-panel` card. Maps `alarm_control_panel.*` entity state into a
+ * panel showing the disarmed/armed status, ARM action buttons (driven
+ * by `states:` config — defaults to away/home), and a static numeric
+ * keypad. Tapping an ARM action fires the corresponding service.
+ */
+class AlarmPanelCardConverter : CardConverter {
+    override val cardType: String = CardTypes.ALARM_PANEL
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 380
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val entityId = card.raw["entity"]?.jsonPrimitive?.content
+        val entity = entityId?.let { snapshot.states[it] }
+        val title = card.raw["name"]?.jsonPrimitive?.content
+            ?: entity?.attributes?.get("friendly_name")?.jsonPrimitive?.content
+            ?: entityId
+            ?: "Alarm"
+        val state = entity?.state ?: "unknown"
+        val statesArr = (card.raw["states"] as? JsonArray)
+            ?.mapNotNull { (it as? JsonPrimitive)?.content }
+            ?: listOf("arm_away", "arm_home")
+        val actions = entityId?.let { id ->
+            statesArr.map { suffix ->
+                val label = suffix.removePrefix("arm_").replace('_', ' ').uppercase()
+                HaAlarmAction(
+                    label = "ARM $label".rs,
+                    accent = armAccent(suffix),
+                    tapAction = HaAction.CallService(
+                        domain = "alarm_control_panel",
+                        service = "alarm_$suffix",
+                        entityId = id,
+                        serviceData = JsonObject(emptyMap()),
+                    ),
+                )
+            }
+        }.orEmpty()
+
+        RemoteHaAlarmPanel(
+            HaAlarmPanelData(
+                title = title.rs,
+                state = formatState(state).rs,
+                accent = stateAccent(state),
+                statusIcon = stateIcon(state),
+                actions = actions,
+                showKeypad = card.raw["show_keypad"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: true,
+            ),
+            modifier = modifier,
+        )
+    }
+}
+
+private fun stateAccent(state: String): Color = when (state) {
+    "armed_away", "armed_home", "armed_night", "armed_vacation", "armed_custom_bypass" ->
+        Color(0xFF43A047)
+    "disarmed" -> Color(0xFF43A047)
+    "pending", "arming" -> Color(0xFFFFA000)
+    "triggered" -> Color(0xFFE53935)
+    else -> Color(0xFF757575)
+}
+
+private fun armAccent(suffix: String): Color = when (suffix) {
+    "arm_away" -> Color(0xFF1565C0)
+    "arm_home" -> Color(0xFF00838F)
+    "arm_night" -> Color(0xFF6A1B9A)
+    "disarm" -> Color(0xFFE53935)
+    else -> Color(0xFF1565C0)
+}
+
+private fun stateIcon(state: String): ImageVector = when (state) {
+    "disarmed" -> Icons.Filled.LockOpen
+    "triggered" -> Icons.Filled.Warning
+    "armed_away", "armed_home", "armed_night", "armed_vacation", "armed_custom_bypass" -> Icons.Filled.Shield
+    else -> Icons.Filled.Lock
+}
+
+private fun formatState(s: String): String =
+    s.replace('_', ' ').replaceFirstChar { it.uppercaseChar() }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/DefaultConverters.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/DefaultConverters.kt
@@ -48,6 +48,9 @@ fun defaultConverters(): List<CardConverter> = buildList {
     add(LightCardConverter())
     add(ClockCardConverter())
     add(StatisticsGraphCardConverter())
+    add(AlarmPanelCardConverter())
+    add(MediaControlCardConverter())
+    add(TodoListCardConverter())
 
     add(BambuLabAmsCardConverter())
     add(BambuLabSpoolCardConverter())
@@ -64,11 +67,8 @@ fun defaultConverters(): List<CardConverter> = buildList {
 fun defaultRegistry(): CardRegistry = CardRegistry(defaultConverters())
 
 private val PLACEHOLDER_CARD_TYPES: List<String> = listOf(
-    CardTypes.MEDIA_CONTROL,
-    CardTypes.ALARM_PANEL,
     CardTypes.AREA,
     CardTypes.CALENDAR,
-    CardTypes.TODO_LIST,
     CardTypes.PICTURE,
     CardTypes.PICTURE_GLANCE,
     CardTypes.PICTURE_ELEMENTS,

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/MediaControlCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/MediaControlCardConverter.kt
@@ -1,0 +1,77 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.components.HaAction
+import ee.schimke.ha.rc.components.HaMediaControlData
+import ee.schimke.ha.rc.components.RemoteHaMediaControl
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `media-control` card. Reads `media_title`, `media_artist`, position +
+ * duration from the entity. Transport buttons fire
+ * `media_player.media_*`; Play/Pause auto-toggles based on the current
+ * play state.
+ */
+class MediaControlCardConverter : CardConverter {
+    override val cardType: String = CardTypes.MEDIA_CONTROL
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 168
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val entityId = card.raw["entity"]?.jsonPrimitive?.content
+        val entity = entityId?.let { snapshot.states[it] }
+        val attrs = entity?.attributes ?: JsonObject(emptyMap())
+        val playerName = attrs["friendly_name"]?.jsonPrimitive?.content ?: entityId ?: "Player"
+        val title = attrs["media_title"]?.jsonPrimitive?.content ?: "Idle"
+        val artist = attrs["media_artist"]?.jsonPrimitive?.content
+        val state = entity?.state ?: "off"
+        val isPlaying = state == "playing"
+        val pos = attrs["media_position"]?.jsonPrimitive?.content?.toFloatOrNull() ?: 0f
+        val dur = attrs["media_duration"]?.jsonPrimitive?.content?.toFloatOrNull() ?: 0f
+        val fraction = if (dur > 0f) (pos / dur).coerceIn(0f, 1f) else 0f
+        val accent = Color(0xFF673AB7)
+
+        fun svc(svcName: String): HaAction = entityId?.let { id ->
+            HaAction.CallService(
+                domain = "media_player",
+                service = svcName,
+                entityId = id,
+                serviceData = JsonObject(emptyMap()),
+            )
+        } ?: HaAction.None
+
+        RemoteHaMediaControl(
+            HaMediaControlData(
+                playerName = playerName.rs,
+                title = title.rs,
+                artist = artist?.rs,
+                accent = accent,
+                isPlaying = isPlaying,
+                positionFraction = fraction,
+                positionLabel = if (dur > 0f) formatHms(pos.toLong()).rs else null,
+                durationLabel = if (dur > 0f) formatHms(dur.toLong()).rs else null,
+                previousAction = svc("media_previous_track"),
+                playPauseAction = svc(if (isPlaying) "media_pause" else "media_play"),
+                nextAction = svc("media_next_track"),
+            ),
+            modifier = modifier,
+        )
+    }
+}
+
+private fun formatHms(totalSeconds: Long): String {
+    if (totalSeconds < 0) return "0:00"
+    val h = totalSeconds / 3600
+    val m = (totalSeconds / 60) % 60
+    val s = totalSeconds % 60
+    return if (h > 0) "$h:%02d:%02d".format(m, s) else "%d:%02d".format(m, s)
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/TodoListCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/TodoListCardConverter.kt
@@ -1,0 +1,62 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.components.HaTodoListData
+import ee.schimke.ha.rc.components.RemoteHaTodoList
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `todo-list` card. HA carries todo items in the entity's `items`
+ * attribute (each item: {summary, status: needs_action | completed}).
+ * The converter splits them into active and completed sections; mutating
+ * items via `todo.update_item` is a follow-up.
+ */
+class TodoListCardConverter : CardConverter {
+    override val cardType: String = CardTypes.TODO_LIST
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int {
+        val entityId = card.raw["entity"]?.jsonPrimitive?.content ?: return 120
+        val items = ((card.raw["entity"]?.jsonPrimitive?.content
+            ?.let { id -> emptyList<Any>() }) ?: emptyList<Any>())
+        // Without a snapshot at compute time we estimate generously.
+        return 200
+    }
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val entityId = card.raw["entity"]?.jsonPrimitive?.content
+        val entity = entityId?.let { snapshot.states[it] }
+        val title = card.raw["title"]?.jsonPrimitive?.content
+            ?: entity?.attributes?.get("friendly_name")?.jsonPrimitive?.content
+            ?: entityId
+            ?: "To-do list"
+
+        val items = entity?.attributes?.get("items") as? JsonArray ?: JsonArray(emptyList())
+        val active = mutableListOf<String>()
+        val completed = mutableListOf<String>()
+        items.forEach { el ->
+            val obj = el as? JsonObject ?: return@forEach
+            val summary = obj["summary"]?.jsonPrimitive?.content ?: return@forEach
+            val status = obj["status"]?.jsonPrimitive?.content
+            if (status == "completed") completed += summary else active += summary
+        }
+
+        RemoteHaTodoList(
+            HaTodoListData(
+                title = title.rs,
+                activeItems = active.map { it.rs },
+                completedItems = completed.map { it.rs },
+            ),
+            modifier = modifier,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Three layout-heavy card types out of `PLACEHOLDER_CARD_TYPES`.

- **alarm-panel** — title + status badge + ARM action buttons (driven by `states:` config) + the static numeric keypad (matches HA's web reference). Tap on an ARM button fires `alarm_control_panel.alarm_arm_<state>`; keypad keys are visual only — the .rc document doesn't carry a code-entry text buffer.
- **media-control** — title/artist + transport buttons (prev / play|pause / next) + a position progress bar + a music-note album-art placeholder (alpha08 has no media-image channel into the document). Play/Pause auto-toggles based on current state.
- **todo-list** — title + Active section + Completed section. HA's todo entity carries items in the `items` attribute; converter splits by status. Mutating items via `todo.update_item` is a follow-up.

## Previews

### Alarm panel — disarmed

| Light | Dark |
|---|---|
| ![alarm light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/4ed220e4138cc9a5714b3a1501475b8a64966c86/AlarmPanel_Light.png) | ![alarm dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/4ed220e4138cc9a5714b3a1501475b8a64966c86/AlarmPanel_Dark.png) |

### Media control — Office speaker mid-track

| Light | Dark |
|---|---|
| ![media light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/4ed220e4138cc9a5714b3a1501475b8a64966c86/MediaControl_Light.png) | ![media dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/4ed220e4138cc9a5714b3a1501475b8a64966c86/MediaControl_Dark.png) |

### Todo list — shopping (2 active + 1 completed)

| Light | Dark |
|---|---|
| ![todo light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/4ed220e4138cc9a5714b3a1501475b8a64966c86/TodoList_Light.png) | ![todo dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/4ed220e4138cc9a5714b3a1501475b8a64966c86/TodoList_Dark.png) |

## Test plan

- [x] `./gradlew :rc-components:compileDebugKotlin :rc-converter:compileDebugKotlin :previews:assembleDebug` — green
- [x] `compose-preview render --filter AlarmPanel/MediaControl/TodoList` — all 6 render real data (see images above)
- [x] No HA-derived data — synthetic fixtures
- [ ] Pixel-diff cases will follow once #78 lands