### PR TITLE
feat: implement calendar and area cards

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
@@ -671,6 +671,46 @@ private fun todoListCard() = card(
     """{"type":"todo-list","entity":"todo.shopping","title":"Shopping list"}""",
 )
 
+// ——— calendar ———
+
+@Preview(name = "calendar (light)", showBackground = false, widthDp = 381, heightDp = 220)
+@Composable
+fun Calendar_Light() = CardHost(HaTheme.Light) {
+    RenderChild(calendarCard(), Fixtures.calendarEvents, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "calendar (dark)", showBackground = false, widthDp = 381, heightDp = 220)
+@Composable
+fun Calendar_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(calendarCard(), Fixtures.calendarEvents, RemoteModifier.fillMaxWidth())
+}
+
+private fun calendarCard() = card(
+    """{"type":"calendar","title":"Family calendar","initial_view":"listWeek",
+        "entities":["calendar.family"]}""",
+)
+
+// ——— area ———
+
+@Preview(name = "area (light)", showBackground = false, widthDp = 280, heightDp = 140)
+@Composable
+fun Area_Light() = CardHost(HaTheme.Light) {
+    RenderChild(areaCard(), Fixtures.livingRoomArea, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "area (dark)", showBackground = false, widthDp = 280, heightDp = 140)
+@Composable
+fun Area_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(areaCard(), Fixtures.livingRoomArea, RemoteModifier.fillMaxWidth())
+}
+
+private fun areaCard() = card(
+    """{"type":"area","name":"Living room",
+        "entities":["sensor.living_room_temp","sensor.living_room_humidity",
+                    "light.living_room_lamp","switch.living_room_speaker",
+                    "cover.living_room_blinds"]}""",
+)
+
 // ——— tile, state variants via PreviewParameter ———
 
 @Preview(name = "tile light (light)", showBackground = false, widthDp = 187, heightDp = 43)

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
@@ -222,6 +222,53 @@ object Fixtures {
         ),
     )
 
+    /** Calendar entity with three upcoming events. */
+    val calendarEvents = snapshot(
+        "calendar.family" to EntityState(
+            entityId = "calendar.family",
+            state = "off",
+            attributes = JsonObject(mapOf(
+                "friendly_name" to JsonPrimitive("Family calendar"),
+                "events" to JsonArray(listOf(
+                    JsonObject(mapOf(
+                        "summary" to JsonPrimitive("Dentist appointment"),
+                        "start" to JsonPrimitive("2026-05-08T09:30:00+01:00"),
+                    )),
+                    JsonObject(mapOf(
+                        "summary" to JsonPrimitive("Trash day"),
+                        "start" to JsonPrimitive("2026-05-09"),
+                    )),
+                    JsonObject(mapOf(
+                        "summary" to JsonPrimitive("Anniversary"),
+                        "start" to JsonPrimitive("2026-05-12"),
+                    )),
+                )),
+            )),
+        ),
+    )
+
+    /** Area with two sensors + a light + a switch. */
+    val livingRoomArea = snapshot(
+        state("sensor.living_room_temp", "21.4",
+            mapOf(
+                "friendly_name" to "Temperature",
+                "unit_of_measurement" to "°C",
+                "device_class" to "temperature",
+            )),
+        state("sensor.living_room_humidity", "48",
+            mapOf(
+                "friendly_name" to "Humidity",
+                "unit_of_measurement" to "%",
+                "device_class" to "humidity",
+            )),
+        state("light.living_room_lamp", "on",
+            mapOf("friendly_name" to "Lamp")),
+        state("switch.living_room_speaker", "off",
+            mapOf("friendly_name" to "Speaker")),
+        state("cover.living_room_blinds", "open",
+            mapOf("friendly_name" to "Blinds", "device_class" to "blind")),
+    )
+
     /** Light at 60% brightness. */
     val brightLight = snapshot(
         "light.kitchen" to EntityState(

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
@@ -254,6 +254,43 @@ data class HaBambuSpoolSlot(
  *   - humidifier → same shape, value/target are humidity %, mode = "Humidifying"/"Drying"
  *   - light       → [valueFraction] = brightness, no target marker, mode = on/off label
  */
+/** `calendar` card model — title + chronological list of upcoming
+ *  events (HA's web calendar shows a month grid; we use a list because
+ *  it conveys the same information in less space and degrades better
+ *  on watch / phone widgets). */
+data class HaCalendarData(
+    val title: RemoteString,
+    val rangeLabel: RemoteString,
+    val events: List<HaCalendarEvent>,
+)
+
+data class HaCalendarEvent(
+    val whenLabel: RemoteString,
+    val summary: RemoteString,
+    val accent: Color,
+)
+
+/** `area` card model — area name + summary stats row + action chips
+ *  (typically light/cover/fan toggles). Camera/picture attachments are
+ *  the placeholder swatch (alpha08 has no area-image channel). */
+data class HaAreaCardData(
+    val name: RemoteString,
+    val stats: List<HaAreaStat>,
+    val actions: List<HaAreaAction>,
+)
+
+data class HaAreaStat(
+    val icon: ImageVector,
+    val label: RemoteString,
+)
+
+data class HaAreaAction(
+    val icon: ImageVector,
+    val accent: Color,
+    val isActive: Boolean,
+    val tapAction: HaAction,
+)
+
 data class HaArcDialData(
     val name: RemoteString,
     val valueFraction: Float,

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaArea.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaArea.kt
@@ -1,0 +1,124 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clickable
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.modifier.size
+import androidx.compose.remote.creation.compose.shapes.RemoteCircleShape
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rf
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.wear.compose.remote.material3.RemoteIcon
+
+/**
+ * `area` card — composite area tile with name, summary stat row, and
+ * action chips (toggleable lights/covers/fans). HA's web card also
+ * shows an optional area camera/picture; we don't render that yet
+ * (alpha08 has no media-image channel into the document).
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaArea(data: HaAreaCardData, modifier: RemoteModifier = RemoteModifier) {
+    val theme = haTheme()
+    RemoteBox(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(horizontal = 14.rdp, vertical = 12.rdp),
+    ) {
+        RemoteColumn(verticalArrangement = RemoteArrangement.spacedBy(8.rdp)) {
+            RemoteText(
+                text = data.name,
+                color = theme.primaryText.rc,
+                fontSize = 16.rsp,
+                fontWeight = FontWeight.Medium,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (data.stats.isNotEmpty()) {
+                RemoteRow(
+                    modifier = RemoteModifier.fillMaxWidth(),
+                    horizontalArrangement = RemoteArrangement.spacedBy(12.rdp),
+                    verticalAlignment = RemoteAlignment.CenterVertically,
+                ) {
+                    data.stats.forEach { Stat(it, theme) }
+                }
+            }
+            if (data.actions.isNotEmpty()) {
+                RemoteRow(
+                    modifier = RemoteModifier.fillMaxWidth().padding(top = 4.rdp),
+                    horizontalArrangement = RemoteArrangement.spacedBy(8.rdp),
+                ) {
+                    data.actions.forEach { ActionChip(it, theme) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Stat(stat: HaAreaStat, theme: HaTheme) {
+    RemoteRow(verticalAlignment = RemoteAlignment.CenterVertically) {
+        RemoteIcon(
+            imageVector = stat.icon,
+            contentDescription = stat.label,
+            modifier = RemoteModifier.size(16.rdp),
+            tint = theme.secondaryText.rc,
+        )
+        RemoteBox(modifier = RemoteModifier.padding(start = 6.rdp)) {
+            RemoteText(
+                text = stat.label,
+                color = theme.secondaryText.rc,
+                fontSize = 12.rsp,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ActionChip(action: HaAreaAction, theme: HaTheme) {
+    val click = action.tapAction.toRemoteAction()
+        ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
+    val accent = action.accent.rc
+    val bg = if (action.isActive) accent.copy(alpha = accent.alpha * 0.18f.rf)
+    else theme.divider.rc.copy(alpha = theme.divider.rc.alpha * 0.4f.rf)
+    RemoteBox(
+        modifier = RemoteModifier.then(click)
+            .size(40.rdp)
+            .clip(RemoteCircleShape)
+            .background(bg),
+        contentAlignment = RemoteAlignment.Center,
+    ) {
+        RemoteIcon(
+            imageVector = action.icon,
+            contentDescription = "action".rs,
+            modifier = RemoteModifier.size(20.rdp),
+            tint = if (action.isActive) accent else theme.secondaryText.rc,
+        )
+    }
+}

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaCalendar.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaCalendar.kt
@@ -1,0 +1,114 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.modifier.size
+import androidx.compose.remote.creation.compose.shapes.RemoteCircleShape
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+
+/**
+ * `calendar` card — title + chronological list of upcoming events.
+ * Rendered as a list rather than a month-grid because the list survives
+ * watch/phone-widget squeezes and conveys the same data in less space.
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaCalendar(data: HaCalendarData, modifier: RemoteModifier = RemoteModifier) {
+    val theme = haTheme()
+    RemoteBox(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(horizontal = 14.rdp, vertical = 12.rdp),
+    ) {
+        RemoteColumn(verticalArrangement = RemoteArrangement.spacedBy(8.rdp)) {
+            RemoteRow(
+                modifier = RemoteModifier.fillMaxWidth(),
+                horizontalArrangement = RemoteArrangement.SpaceBetween,
+                verticalAlignment = RemoteAlignment.CenterVertically,
+            ) {
+                RemoteText(
+                    text = data.title,
+                    color = theme.primaryText.rc,
+                    fontSize = 16.rsp,
+                    fontWeight = FontWeight.Medium,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                RemoteText(
+                    text = data.rangeLabel,
+                    color = theme.secondaryText.rc,
+                    fontSize = 11.rsp,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                )
+            }
+            if (data.events.isEmpty()) {
+                RemoteText(
+                    text = "No upcoming events".rs,
+                    color = theme.secondaryText.rc,
+                    fontSize = 12.rsp,
+                    style = RemoteTextStyle.Default,
+                )
+            } else {
+                data.events.forEach { Event(it, theme) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Event(event: HaCalendarEvent, theme: HaTheme) {
+    RemoteRow(
+        modifier = RemoteModifier.fillMaxWidth().padding(vertical = 2.rdp),
+        verticalAlignment = RemoteAlignment.CenterVertically,
+    ) {
+        RemoteBox(
+            modifier = RemoteModifier
+                .size(8.rdp)
+                .clip(RemoteCircleShape)
+                .background(event.accent.rc),
+        )
+        RemoteColumn(modifier = RemoteModifier.padding(start = 10.rdp)) {
+            RemoteText(
+                text = event.whenLabel,
+                color = theme.secondaryText.rc,
+                fontSize = 11.rsp,
+                style = RemoteTextStyle.Default,
+            )
+            RemoteText(
+                text = event.summary,
+                color = theme.primaryText.rc,
+                fontSize = 13.rsp,
+                fontWeight = FontWeight.Medium,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/AreaCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/AreaCardConverter.kt
@@ -1,0 +1,96 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Air
+import androidx.compose.material.icons.filled.Lightbulb
+import androidx.compose.material.icons.filled.PowerSettingsNew
+import androidx.compose.material.icons.filled.Thermostat
+import androidx.compose.material.icons.filled.WaterDrop
+import androidx.compose.material.icons.filled.Window
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.components.HaAction
+import ee.schimke.ha.rc.components.HaAreaAction
+import ee.schimke.ha.rc.components.HaAreaCardData
+import ee.schimke.ha.rc.components.HaAreaStat
+import ee.schimke.ha.rc.components.RemoteHaArea
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `area` card. The card config carries an `area:` id that we can't
+ * resolve without a registry channel. We accept an optional
+ * `entities:` list (HA also accepts that as an override) — temperature
+ * / humidity sensors light the stat row, light/cover/fan entities
+ * become action chips. Tap fires the entity's domain toggle.
+ */
+class AreaCardConverter : CardConverter {
+    override val cardType: String = CardTypes.AREA
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 140
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val name = card.raw["name"]?.jsonPrimitive?.content
+            ?: card.raw["area"]?.jsonPrimitive?.content
+                ?.replace('_', ' ')
+                ?.replaceFirstChar { it.uppercaseChar() }
+            ?: "Area"
+
+        val explicitEntities = card.raw["entities"] as? kotlinx.serialization.json.JsonArray
+        val entityIds = explicitEntities?.mapNotNull {
+            when (it) {
+                is kotlinx.serialization.json.JsonPrimitive -> it.content
+                is JsonObject -> it["entity"]?.jsonPrimitive?.content
+                else -> null
+            }
+        } ?: emptyList()
+
+        val stats = entityIds.mapNotNull { id ->
+            val entity = snapshot.states[id] ?: return@mapNotNull null
+            val deviceClass = entity.attributes["device_class"]?.jsonPrimitive?.content
+            val unit = entity.attributes["unit_of_measurement"]?.jsonPrimitive?.content
+            when (deviceClass) {
+                "temperature" -> HaAreaStat(Icons.Filled.Thermostat,
+                    "${entity.state}${unit ?: " °C"}".rs)
+                "humidity", "moisture" -> HaAreaStat(Icons.Filled.WaterDrop,
+                    "${entity.state}${unit ?: " %"}".rs)
+                else -> null
+            }
+        }
+
+        val actions = entityIds.mapNotNull { id ->
+            val entity = snapshot.states[id] ?: return@mapNotNull null
+            val domain = id.substringBefore('.')
+            val (icon, accent) = when (domain) {
+                "light" -> Icons.Filled.Lightbulb to Color(0xFFFFBE3E)
+                "switch", "input_boolean" -> Icons.Filled.PowerSettingsNew to Color(0xFF2196F3)
+                "cover" -> Icons.Filled.Window to Color(0xFF00897B)
+                "fan" -> Icons.Filled.Air to Color(0xFF00BFA5)
+                else -> return@mapNotNull null
+            }
+            HaAreaAction(
+                icon = icon as ImageVector,
+                accent = accent,
+                isActive = entity.state == "on" || entity.state == "open",
+                tapAction = HaAction.Toggle(id),
+            )
+        }
+
+        RemoteHaArea(
+            HaAreaCardData(
+                name = name.rs,
+                stats = stats,
+                actions = actions,
+            ),
+            modifier = modifier,
+        )
+    }
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/CalendarCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/CalendarCardConverter.kt
@@ -1,0 +1,105 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.components.HaCalendarData
+import ee.schimke.ha.rc.components.HaCalendarEvent
+import ee.schimke.ha.rc.components.RemoteHaCalendar
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `calendar` card. HA carries event data via the calendar API rather
+ * than entity attributes; the converter checks each calendar entity's
+ * `events` attribute (some integrations expose it) and otherwise falls
+ * back to a "no upcoming events" stub. Hosts that hydrate events at
+ * capture time can extend [HaSnapshot] later; the model accepts any
+ * pre-built event list so adapters can plug in.
+ */
+class CalendarCardConverter : CardConverter {
+    override val cardType: String = CardTypes.CALENDAR
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 220
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val ids = entityIds(card)
+        val title = card.raw["title"]?.jsonPrimitive?.content
+            ?: ids.firstOrNull()
+                ?.let { snapshot.states[it]?.attributes?.get("friendly_name")?.jsonPrimitive?.content }
+            ?: "Calendar"
+        val initialDays = card.raw["initial_view"]?.jsonPrimitive?.content?.let { view ->
+            when (view) {
+                "dayGridMonth" -> 28
+                "dayGridDay" -> 1
+                else -> 7
+            }
+        } ?: 7
+
+        val events = ids.flatMap { id ->
+            val arr = (snapshot.states[id]?.attributes?.get("events") as? JsonArray)
+                ?: JsonArray(emptyList())
+            arr.mapNotNull { el ->
+                val obj = el as? JsonObject ?: return@mapNotNull null
+                val summary = obj["summary"]?.jsonPrimitive?.content ?: return@mapNotNull null
+                val start = obj["start"]?.jsonPrimitive?.content ?: ""
+                HaCalendarEvent(
+                    whenLabel = formatStart(start).rs,
+                    summary = summary.rs,
+                    accent = calendarColor(id),
+                )
+            }
+        }.take(8)
+
+        RemoteHaCalendar(
+            HaCalendarData(
+                title = title.rs,
+                rangeLabel = "Next ${initialDays} days".rs,
+                events = events,
+            ),
+            modifier = modifier,
+        )
+    }
+}
+
+private fun entityIds(card: CardConfig): List<String> {
+    val arr: JsonArray = card.raw["entities"]?.jsonArray ?: return emptyList()
+    return arr.mapNotNull { el ->
+        when (el) {
+            is JsonPrimitive -> el.content
+            is JsonObject -> el["entity"]?.jsonPrimitive?.content
+            else -> null
+        }
+    }
+}
+
+/** Best-effort: take the date portion of an ISO datetime, optionally
+ *  appending the HH:mm if present. Robust to the all-day form which
+ *  emits just the date. */
+private fun formatStart(start: String): String {
+    if (start.isBlank()) return ""
+    val datePart = start.substringBefore('T')
+    val timePart = start.substringAfter('T', "").substringBefore(':')
+    val minuteOf = if (start.contains(':')) start.substringAfter(':', "").take(2) else ""
+    return if (timePart.isNotEmpty() && minuteOf.isNotEmpty()) "$datePart $timePart:$minuteOf"
+    else datePart
+}
+
+private fun calendarColor(entityId: String): Color {
+    // Stable colour per calendar so visually grouped events share a dot.
+    val hash = entityId.hashCode()
+    val palette = listOf(
+        Color(0xFF1565C0), Color(0xFF2E7D32), Color(0xFF6A1B9A),
+        Color(0xFFC62828), Color(0xFFE65100), Color(0xFF00838F),
+    )
+    return palette[((hash % palette.size) + palette.size) % palette.size]
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/DefaultConverters.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/DefaultConverters.kt
@@ -51,6 +51,8 @@ fun defaultConverters(): List<CardConverter> = buildList {
     add(AlarmPanelCardConverter())
     add(MediaControlCardConverter())
     add(TodoListCardConverter())
+    add(CalendarCardConverter())
+    add(AreaCardConverter())
 
     add(BambuLabAmsCardConverter())
     add(BambuLabSpoolCardConverter())
@@ -67,8 +69,6 @@ fun defaultConverters(): List<CardConverter> = buildList {
 fun defaultRegistry(): CardRegistry = CardRegistry(defaultConverters())
 
 private val PLACEHOLDER_CARD_TYPES: List<String> = listOf(
-    CardTypes.AREA,
-    CardTypes.CALENDAR,
     CardTypes.PICTURE,
     CardTypes.PICTURE_GLANCE,
     CardTypes.PICTURE_ELEMENTS,


### PR DESCRIPTION
## Summary

Last two card types from the dashboards backlog out of `PLACEHOLDER_CARD_TYPES`.

- **calendar** — title + chronological event list (coloured dot + when label + summary). Rendered as a list rather than HA's web month-grid because the list survives watch/phone-widget squeezes and conveys the same data in less space. Reads each calendar entity's `events` attribute (some integrations expose it); hosts that hydrate full calendars at capture time can plug in via the same model.
- **area** — composite area tile with name, summary stats row (temperature + humidity sensors) and action chips for light/cover/fan/switch entities. Active state lights up the chip's background; tap fires the entity's domain toggle.

## Previews

### Calendar — Family, next 7 days

| Light | Dark |
|---|---|
| ![calendar light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/603892f7db9f693b1d4be3462dea40d2adb26354/Calendar_Light.png) | ![calendar dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/603892f7db9f693b1d4be3462dea40d2adb26354/Calendar_Dark.png) |

### Area — Living room, lamp on / switch off / blinds open

| Light | Dark |
|---|---|
| ![area light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/603892f7db9f693b1d4be3462dea40d2adb26354/Area_Light.png) | ![area dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/603892f7db9f693b1d4be3462dea40d2adb26354/Area_Dark.png) |

## Test plan

- [x] `./gradlew :rc-components:compileDebugKotlin :rc-converter:compileDebugKotlin :previews:assembleDebug` — green
- [x] `compose-preview render --filter Calendar_/Area_` — both render real data (see images above)
- [x] No HA-derived data — synthetic fixtures
- [ ] Pixel-diff cases will follow once #78 lands

## Notes

This closes out the implementation backlog from the dashboards snapshot. Remaining `PLACEHOLDER_CARD_TYPES` after this lands: `picture`, `picture-glance`, `picture-elements`, `statistic`, `sensor`, `entity-filter`, `iframe` — all visual-light or special-purpose enough that the placeholder behaviour is acceptable.