### PR TITLE
feat: implement picture, picture-glance, picture-elements cards

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
@@ -711,6 +711,69 @@ private fun areaCard() = card(
                     "cover.living_room_blinds"]}""",
 )
 
+// ——— picture ———
+
+@Preview(name = "picture (light)", showBackground = false, widthDp = 320, heightDp = 140)
+@Composable
+fun Picture_Light() = CardHost(HaTheme.Light) {
+    RenderChild(pictureCardConfig(), Fixtures.driveway, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "picture (dark)", showBackground = false, widthDp = 320, heightDp = 140)
+@Composable
+fun Picture_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(pictureCardConfig(), Fixtures.driveway, RemoteModifier.fillMaxWidth())
+}
+
+private fun pictureCardConfig() = card(
+    """{"type":"picture","image":"/local/floorplan.png","name":"Floor plan"}""",
+)
+
+// ——— picture-glance ———
+
+@Preview(name = "picture-glance (light)", showBackground = false, widthDp = 381, heightDp = 168)
+@Composable
+fun PictureGlance_Light() = CardHost(HaTheme.Light) {
+    RenderChild(pictureGlanceCardConfig(), Fixtures.livingRoomGlance, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "picture-glance (dark)", showBackground = false, widthDp = 381, heightDp = 168)
+@Composable
+fun PictureGlance_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(pictureGlanceCardConfig(), Fixtures.livingRoomGlance, RemoteModifier.fillMaxWidth())
+}
+
+private fun pictureGlanceCardConfig() = card(
+    """{"type":"picture-glance","title":"Living room","image":"/local/lr.png",
+        "entities":["light.living_room_lamp","light.kitchen_lights",
+                    "cover.living_room_blinds","switch.fan"]}""",
+)
+
+// ——— picture-elements ———
+
+@Preview(name = "picture-elements (light)", showBackground = false, widthDp = 381, heightDp = 180)
+@Composable
+fun PictureElements_Light() = CardHost(HaTheme.Light) {
+    RenderChild(pictureElementsCardConfig(), Fixtures.livingRoomGlance, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "picture-elements (dark)", showBackground = false, widthDp = 381, heightDp = 180)
+@Composable
+fun PictureElements_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(pictureElementsCardConfig(), Fixtures.livingRoomGlance, RemoteModifier.fillMaxWidth())
+}
+
+private fun pictureElementsCardConfig() = card(
+    """{"type":"picture-elements","image":"/local/floorplan.png",
+        "elements":[
+          {"type":"state-icon","entity":"light.living_room_lamp"},
+          {"type":"state-icon","entity":"cover.living_room_blinds"},
+          {"type":"state-label","entity":"light.living_room_lamp"},
+          {"type":"service-button","title":"All off",
+           "tap_action":{"action":"call-service","service":"light.turn_off","target":{"entity_id":"light.living_room_lamp"}}}
+        ]}""",
+)
+
 // ——— tile, state variants via PreviewParameter ———
 
 @Preview(name = "tile light (light)", showBackground = false, widthDp = 187, heightDp = 43)

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
@@ -142,6 +142,19 @@ object Fixtures {
             mapOf("friendly_name" to "Garage motion", "device_class" to "motion")),
     )
 
+    /** Picture-glance fixture: light + cover + switch entities for the
+     *  chip strip. */
+    val livingRoomGlance = snapshot(
+        state("light.living_room_lamp", "on",
+            mapOf("friendly_name" to "Lamp")),
+        state("light.kitchen_lights", "off",
+            mapOf("friendly_name" to "Kitchen")),
+        state("cover.living_room_blinds", "open",
+            mapOf("friendly_name" to "Blinds", "device_class" to "blind")),
+        state("switch.fan", "on",
+            mapOf("friendly_name" to "Fan")),
+    )
+
     /** Climate entity in heating mode at 21.4°C, target 22°C. */
     val thermostat = snapshot(
         "climate.living_room" to EntityState(

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
@@ -371,3 +371,60 @@ data class HaTodoListData(
     val activeItems: List<RemoteString>,
     val completedItems: List<RemoteString>,
 )
+
+/** `picture` card model — a static `image:` URL with an optional name
+ *  overlay and tap target. We can't pull arbitrary HTTP images into a
+ *  .rc document, so the renderer paints a tinted placeholder and shows
+ *  the configured image URL as a debug caption (so a host that wires
+ *  in an image-channel later doesn't need to change converters). */
+data class HaPictureCardData(
+    val name: RemoteString?,
+    val captionUrl: RemoteString?,
+    val placeholderIcon: ImageVector,
+    val tapAction: HaAction = HaAction.None,
+)
+
+/** `picture-glance` card model — image with a row of clickable entity
+ *  cells overlaid (typically lights / covers / switches). */
+data class HaPictureGlanceData(
+    val title: RemoteString?,
+    val captionUrl: RemoteString?,
+    val placeholderIcon: ImageVector,
+    val cells: List<HaPictureGlanceCell>,
+)
+
+data class HaPictureGlanceCell(
+    val icon: ImageVector,
+    val accent: Color,
+    val isActive: Boolean,
+    val label: RemoteString,
+    val tapAction: HaAction,
+)
+
+/** `picture-elements` card model — image with arbitrarily-positioned
+ *  elements. We don't render the precise positions yet; v1 emits the
+ *  elements as a strip below the image so all data shows. */
+data class HaPictureElementsData(
+    val captionUrl: RemoteString?,
+    val placeholderIcon: ImageVector,
+    val elements: List<HaPictureElement>,
+)
+
+sealed interface HaPictureElement {
+    data class StateIcon(
+        val icon: ImageVector,
+        val accent: Color,
+        val isActive: Boolean,
+        val tapAction: HaAction,
+    ) : HaPictureElement
+
+    data class StateLabel(
+        val text: RemoteString,
+    ) : HaPictureElement
+
+    data class ServiceButton(
+        val label: RemoteString,
+        val accent: Color,
+        val tapAction: HaAction,
+    ) : HaPictureElement
+}

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaPicture.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaPicture.kt
@@ -1,0 +1,290 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clickable
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.height
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.modifier.size
+import androidx.compose.remote.creation.compose.shapes.RemoteCircleShape
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rf
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.wear.compose.remote.material3.RemoteIcon
+
+/**
+ * `picture` card — a static image with optional name overlay. RC
+ * alpha08 has no channel for arbitrary HTTP images, so the renderer
+ * paints a tinted placeholder + caption. Hosts that wire an image
+ * channel later can replace the placeholder without changing the
+ * converter / model boundary.
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaPicture(data: HaPictureCardData, modifier: RemoteModifier = RemoteModifier) {
+    val theme = haTheme()
+    val click = data.tapAction.toRemoteAction()
+        ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
+    RemoteBox(
+        modifier = modifier
+            .then(click)
+            .fillMaxWidth()
+            .height(140.rdp)
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.divider.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp)),
+        contentAlignment = RemoteAlignment.Center,
+    ) {
+        RemoteIcon(
+            imageVector = data.placeholderIcon,
+            contentDescription = data.name ?: "image".rs,
+            modifier = RemoteModifier.size(48.rdp),
+            tint = theme.placeholderAccent.rc,
+        )
+        if (data.name != null) {
+            RemoteBox(
+                modifier = RemoteModifier
+                    .fillMaxWidth()
+                    .background(theme.cardBackground.rc.copy(alpha = theme.cardBackground.rc.alpha * 0.85f.rf))
+                    .padding(horizontal = 12.rdp, vertical = 6.rdp),
+            ) {
+                RemoteText(
+                    text = data.name,
+                    color = theme.primaryText.rc,
+                    fontSize = 13.rsp,
+                    fontWeight = FontWeight.Medium,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        if (data.captionUrl != null) {
+            RemoteBox(
+                modifier = RemoteModifier
+                    .padding(8.rdp)
+                    .clip(RemoteRoundedCornerShape(4.rdp))
+                    .background(theme.cardBackground.rc.copy(alpha = theme.cardBackground.rc.alpha * 0.7f.rf))
+                    .padding(horizontal = 6.rdp, vertical = 2.rdp),
+            ) {
+                RemoteText(
+                    text = data.captionUrl,
+                    color = theme.secondaryText.rc,
+                    fontSize = 9.rsp,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * `picture-glance` card — image with a strip of clickable entity cells
+ * across the bottom. Same image-channel limitation as [RemoteHaPicture].
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaPictureGlance(
+    data: HaPictureGlanceData,
+    modifier: RemoteModifier = RemoteModifier,
+) {
+    val theme = haTheme()
+    RemoteBox(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.divider.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp)),
+    ) {
+        RemoteColumn {
+            RemoteBox(
+                modifier = RemoteModifier
+                    .fillMaxWidth()
+                    .height(120.rdp)
+                    .background(theme.divider.rc),
+                contentAlignment = RemoteAlignment.Center,
+            ) {
+                RemoteIcon(
+                    imageVector = data.placeholderIcon,
+                    contentDescription = data.title ?: "image".rs,
+                    modifier = RemoteModifier.size(40.rdp),
+                    tint = theme.placeholderAccent.rc,
+                )
+            }
+            RemoteRow(
+                modifier = RemoteModifier
+                    .fillMaxWidth()
+                    .background(theme.cardBackground.rc)
+                    .padding(horizontal = 10.rdp, vertical = 8.rdp),
+                horizontalArrangement = RemoteArrangement.spacedBy(8.rdp),
+                verticalAlignment = RemoteAlignment.CenterVertically,
+            ) {
+                if (data.title != null) {
+                    RemoteText(
+                        text = data.title,
+                        color = theme.primaryText.rc,
+                        fontSize = 13.rsp,
+                        fontWeight = FontWeight.Medium,
+                        style = RemoteTextStyle.Default,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                data.cells.forEach { cell -> Cell(cell, theme) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Cell(cell: HaPictureGlanceCell, theme: HaTheme) {
+    val click = cell.tapAction.toRemoteAction()
+        ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
+    val accent = cell.accent.rc
+    RemoteBox(
+        modifier = RemoteModifier.then(click)
+            .size(32.rdp)
+            .clip(RemoteCircleShape)
+            .background(
+                if (cell.isActive) accent.copy(alpha = accent.alpha * 0.18f.rf)
+                else theme.divider.rc.copy(alpha = theme.divider.rc.alpha * 0.5f.rf),
+            ),
+        contentAlignment = RemoteAlignment.Center,
+    ) {
+        RemoteIcon(
+            imageVector = cell.icon,
+            contentDescription = cell.label,
+            modifier = RemoteModifier.size(18.rdp),
+            tint = if (cell.isActive) accent else theme.secondaryText.rc,
+        )
+    }
+}
+
+/**
+ * `picture-elements` card — image plus a list of elements. v1 lays the
+ * elements out as a chip strip below the image; precise XY positioning
+ * needs absolute placement that RC's RemoteBox parent doesn't expose
+ * cleanly (follow-up).
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaPictureElements(
+    data: HaPictureElementsData,
+    modifier: RemoteModifier = RemoteModifier,
+) {
+    val theme = haTheme()
+    RemoteBox(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp)),
+    ) {
+        RemoteColumn {
+            RemoteBox(
+                modifier = RemoteModifier
+                    .fillMaxWidth()
+                    .height(120.rdp)
+                    .background(theme.divider.rc),
+                contentAlignment = RemoteAlignment.Center,
+            ) {
+                RemoteIcon(
+                    imageVector = data.placeholderIcon,
+                    contentDescription = "elements".rs,
+                    modifier = RemoteModifier.size(40.rdp),
+                    tint = theme.placeholderAccent.rc,
+                )
+            }
+            if (data.elements.isNotEmpty()) {
+                RemoteRow(
+                    modifier = RemoteModifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 10.rdp, vertical = 8.rdp),
+                    horizontalArrangement = RemoteArrangement.spacedBy(8.rdp, RemoteAlignment.Start),
+                    verticalAlignment = RemoteAlignment.CenterVertically,
+                ) {
+                    data.elements.forEach { Element(it, theme) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Element(element: HaPictureElement, theme: HaTheme) {
+    when (element) {
+        is HaPictureElement.StateIcon -> {
+            val click = element.tapAction.toRemoteAction()
+                ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
+            val accent = element.accent.rc
+            RemoteBox(
+                modifier = RemoteModifier.then(click)
+                    .size(28.rdp)
+                    .clip(RemoteCircleShape)
+                    .background(
+                        if (element.isActive) accent.copy(alpha = accent.alpha * 0.18f.rf)
+                        else theme.divider.rc.copy(alpha = theme.divider.rc.alpha * 0.5f.rf),
+                    ),
+                contentAlignment = RemoteAlignment.Center,
+            ) {
+                RemoteIcon(
+                    imageVector = element.icon,
+                    contentDescription = "element".rs,
+                    modifier = RemoteModifier.size(16.rdp),
+                    tint = if (element.isActive) accent else theme.secondaryText.rc,
+                )
+            }
+        }
+        is HaPictureElement.StateLabel -> {
+            RemoteText(
+                text = element.text,
+                color = theme.primaryText.rc,
+                fontSize = 12.rsp,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        is HaPictureElement.ServiceButton -> {
+            val click = element.tapAction.toRemoteAction()
+                ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
+            val accent = element.accent.rc
+            RemoteBox(
+                modifier = RemoteModifier.then(click)
+                    .clip(RemoteRoundedCornerShape(6.rdp))
+                    .border(1.rdp, accent, RemoteRoundedCornerShape(6.rdp))
+                    .padding(horizontal = 10.rdp, vertical = 6.rdp),
+            ) {
+                RemoteText(
+                    text = element.label,
+                    color = accent,
+                    fontSize = 11.rsp,
+                    fontWeight = FontWeight.Medium,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                )
+            }
+        }
+    }
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/DefaultConverters.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/DefaultConverters.kt
@@ -53,6 +53,9 @@ fun defaultConverters(): List<CardConverter> = buildList {
     add(TodoListCardConverter())
     add(CalendarCardConverter())
     add(AreaCardConverter())
+    add(PictureCardConverter())
+    add(PictureGlanceCardConverter())
+    add(PictureElementsCardConverter())
 
     add(BambuLabAmsCardConverter())
     add(BambuLabSpoolCardConverter())
@@ -69,9 +72,6 @@ fun defaultConverters(): List<CardConverter> = buildList {
 fun defaultRegistry(): CardRegistry = CardRegistry(defaultConverters())
 
 private val PLACEHOLDER_CARD_TYPES: List<String> = listOf(
-    CardTypes.PICTURE,
-    CardTypes.PICTURE_GLANCE,
-    CardTypes.PICTURE_ELEMENTS,
     CardTypes.STATISTIC,
     CardTypes.SENSOR,
     CardTypes.ENTITY_FILTER,

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/PictureCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/PictureCardConverter.kt
@@ -1,0 +1,40 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.components.HaPictureCardData
+import ee.schimke.ha.rc.components.RemoteHaPicture
+import ee.schimke.ha.rc.parseHaAction
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/** `picture` card — static image URL. RC has no media-image channel
+ *  yet; renderer paints a placeholder + caption. */
+class PictureCardConverter : CardConverter {
+    override val cardType: String = CardTypes.PICTURE
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 140
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val image = card.raw["image"]?.jsonPrimitive?.content
+        val name = card.raw["name"]?.jsonPrimitive?.content
+        val tap = parseHaAction(card.raw["tap_action"]?.jsonObject, defaultEntityId = null)
+        RemoteHaPicture(
+            HaPictureCardData(
+                name = name?.rs,
+                captionUrl = image?.rs,
+                placeholderIcon = Icons.Filled.Image,
+                tapAction = tap,
+            ),
+            modifier = modifier,
+        )
+    }
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/PictureElementsCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/PictureElementsCardConverter.kt
@@ -1,0 +1,86 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.HaStateColor
+import ee.schimke.ha.rc.components.HaAction
+import ee.schimke.ha.rc.components.HaPictureElement
+import ee.schimke.ha.rc.components.HaPictureElementsData
+import ee.schimke.ha.rc.components.RemoteHaPictureElements
+import ee.schimke.ha.rc.defaultTapActionFor
+import ee.schimke.ha.rc.formatState
+import ee.schimke.ha.rc.icons.HaIconMap
+import ee.schimke.ha.rc.parseHaAction
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `picture-elements` card. Each element in the config has a `type:` —
+ * we map state-icon / state-label / service-button / icon into the
+ * corresponding [HaPictureElement] variant. Position metadata
+ * (`style.top`, `style.left`) is parsed but not rendered yet — v1 lays
+ * everything out as a chip strip below the image.
+ */
+class PictureElementsCardConverter : CardConverter {
+    override val cardType: String = CardTypes.PICTURE_ELEMENTS
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 180
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val image = card.raw["image"]?.jsonPrimitive?.content
+        val arr = card.raw["elements"] as? JsonArray ?: JsonArray(emptyList())
+        val elements = arr.mapNotNull { el ->
+            val obj = el as? JsonObject ?: return@mapNotNull null
+            mapElement(obj, snapshot)
+        }
+        RemoteHaPictureElements(
+            HaPictureElementsData(
+                captionUrl = image?.rs,
+                placeholderIcon = Icons.Filled.Image,
+                elements = elements,
+            ),
+            modifier = modifier,
+        )
+    }
+}
+
+private fun mapElement(obj: JsonObject, snapshot: HaSnapshot): HaPictureElement? {
+    val type = obj["type"]?.jsonPrimitive?.content ?: return null
+    val entityId = obj["entity"]?.jsonPrimitive?.content
+    val entity = entityId?.let { snapshot.states[it] }
+    return when (type) {
+        "state-icon", "icon" -> HaPictureElement.StateIcon(
+            icon = HaIconMap.resolve(obj["icon"]?.jsonPrimitive?.content, entity),
+            accent = HaStateColor.activeFor(entity),
+            isActive = entity?.state == "on" || entity?.state == "open",
+            tapAction = parseTap(obj, entityId),
+        )
+        "state-label" -> HaPictureElement.StateLabel(text = formatState(entity).rs)
+        "service-button" -> {
+            val title = obj["title"]?.jsonPrimitive?.content ?: "Action"
+            HaPictureElement.ServiceButton(
+                label = title.rs,
+                accent = androidx.compose.ui.graphics.Color(0xFF1565C0),
+                tapAction = parseTap(obj, entityId),
+            )
+        }
+        else -> null
+    }
+}
+
+private fun parseTap(obj: JsonObject, defaultEntity: String?): HaAction {
+    val tapCfg = obj["tap_action"]?.jsonObject
+    if (tapCfg != null) return parseHaAction(tapCfg, defaultEntity)
+    return defaultTapActionFor(defaultEntity)
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/PictureGlanceCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/PictureGlanceCardConverter.kt
@@ -1,0 +1,64 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.HaStateColor
+import ee.schimke.ha.rc.components.HaPictureGlanceCell
+import ee.schimke.ha.rc.components.HaPictureGlanceData
+import ee.schimke.ha.rc.components.RemoteHaPictureGlance
+import ee.schimke.ha.rc.defaultTapActionFor
+import ee.schimke.ha.rc.icons.HaIconMap
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+
+/** `picture-glance` card — image with a row of clickable entity cells. */
+class PictureGlanceCardConverter : CardConverter {
+    override val cardType: String = CardTypes.PICTURE_GLANCE
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 168
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val image = card.raw["image"]?.jsonPrimitive?.content
+        val title = card.raw["title"]?.jsonPrimitive?.content
+
+        val ids: List<String> = (card.raw["entities"] as? JsonArray)?.mapNotNull { el ->
+            when (el) {
+                is JsonObject -> el["entity"]?.jsonPrimitive?.content
+                else -> el.jsonPrimitive.content
+            }
+        }.orEmpty()
+
+        val cells = ids.map { id ->
+            val entity = snapshot.states[id]
+            val name = entity?.attributes?.get("friendly_name")?.jsonPrimitive?.content ?: id
+            val active = entity?.state == "on" || entity?.state == "open"
+            HaPictureGlanceCell(
+                icon = HaIconMap.resolve(null, entity),
+                accent = HaStateColor.activeFor(entity),
+                isActive = active,
+                label = name.rs,
+                tapAction = defaultTapActionFor(id),
+            )
+        }
+
+        RemoteHaPictureGlance(
+            HaPictureGlanceData(
+                title = title?.rs,
+                captionUrl = image?.rs,
+                placeholderIcon = Icons.Filled.Image,
+                cells = cells,
+            ),
+            modifier = modifier,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Three image-style card types out of `PLACEHOLDER_CARD_TYPES`. RC alpha08 has no media-image channel, so each one paints a tinted placeholder + the configured URL as a debug caption — hosts that wire an image channel later don't need to change converters.

- **picture** — static image card with an optional name overlay and tap target.
- **picture-glance** — image with a strip of clickable entity cells across the bottom (active/inactive accent matches the area card).
- **picture-elements** — image + a list of positioned elements. v1 lays them out as a chip strip below the image (state-icon / state-label / service-button); absolute XY positioning over the image is a follow-up.

## Previews

### Picture

| Light | Dark |
|---|---|
| ![picture light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/46bdfcdcd7e910b3c98d75fbc38eb9fb5c8d161b/Picture_Light.png) | ![picture dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/46bdfcdcd7e910b3c98d75fbc38eb9fb5c8d161b/Picture_Dark.png) |

### Picture glance

| Light | Dark |
|---|---|
| ![glance light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/46bdfcdcd7e910b3c98d75fbc38eb9fb5c8d161b/PictureGlance_Light.png) | ![glance dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/46bdfcdcd7e910b3c98d75fbc38eb9fb5c8d161b/PictureGlance_Dark.png) |

### Picture elements

| Light | Dark |
|---|---|
| ![elements light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/46bdfcdcd7e910b3c98d75fbc38eb9fb5c8d161b/PictureElements_Light.png) | ![elements dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/46bdfcdcd7e910b3c98d75fbc38eb9fb5c8d161b/PictureElements_Dark.png) |

## Test plan

- [x] `./gradlew :rc-components:compileDebugKotlin :rc-converter:compileDebugKotlin :previews:assembleDebug` — green
- [x] `compose-preview render --filter Picture_/PictureGlance_/PictureElements_` — all 6 render real data (see images above)
- [x] No HA-derived data — synthetic fixture entity ids
- [ ] Pixel-diff cases will follow once references are captured