### PR TITLE
feat: implement statistic, sensor, entity-filter cards

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
@@ -774,6 +774,62 @@ private fun pictureElementsCardConfig() = card(
         ]}""",
 )
 
+// ——— statistic ———
+
+@Preview(name = "statistic (light)", showBackground = false, widthDp = 240, heightDp = 110)
+@Composable
+fun Statistic_Light() = CardHost(HaTheme.Light) {
+    RenderChild(statisticCardConfig(), Fixtures.energyStatistics, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "statistic (dark)", showBackground = false, widthDp = 240, heightDp = 110)
+@Composable
+fun Statistic_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(statisticCardConfig(), Fixtures.energyStatistics, RemoteModifier.fillMaxWidth())
+}
+
+private fun statisticCardConfig() = card(
+    """{"type":"statistic","entity":"sensor.house_power","stat_type":"mean","period":"day"}""",
+)
+
+// ——— sensor ———
+
+@Preview(name = "sensor (light)", showBackground = false, widthDp = 320, heightDp = 130)
+@Composable
+fun Sensor_Light() = CardHost(HaTheme.Light) {
+    RenderChild(sensorCardConfig(), Fixtures.temperatureHistory, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "sensor (dark)", showBackground = false, widthDp = 320, heightDp = 130)
+@Composable
+fun Sensor_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(sensorCardConfig(), Fixtures.temperatureHistory, RemoteModifier.fillMaxWidth())
+}
+
+private fun sensorCardConfig() = card(
+    """{"type":"sensor","entity":"sensor.outside_temp","hours_to_show":24}""",
+)
+
+// ——— entity-filter ———
+
+@Preview(name = "entity-filter (light)", showBackground = false, widthDp = 381, heightDp = 149)
+@Composable
+fun EntityFilter_Light() = CardHost(HaTheme.Light) {
+    RenderChild(entityFilterCardConfig(), Fixtures.mixed, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "entity-filter (dark)", showBackground = false, widthDp = 381, heightDp = 149)
+@Composable
+fun EntityFilter_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(entityFilterCardConfig(), Fixtures.mixed, RemoteModifier.fillMaxWidth())
+}
+
+private fun entityFilterCardConfig() = card(
+    """{"type":"entity-filter","state_filter":["on"],
+        "entities":["light.kitchen","light.office_lamp","switch.coffee_maker","lock.front_door"],
+        "card":{"type":"glance","title":"On now"}}""",
+)
+
 // ——— tile, state variants via PreviewParameter ———
 
 @Preview(name = "tile light (light)", showBackground = false, widthDp = 187, heightDp = 43)

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
@@ -428,3 +428,25 @@ sealed interface HaPictureElement {
         val tapAction: HaAction,
     ) : HaPictureElement
 }
+
+/** `statistic` card model — single hero value for one entity, with
+ *  optional period label and unit. Used by HA's built-in `statistic`
+ *  card which surfaces one mean/min/max/sum statistic value. */
+data class HaStatisticCardData(
+    val name: RemoteString,
+    val valueLabel: RemoteString,
+    val unit: RemoteString?,
+    val periodLabel: RemoteString?,
+    val accent: Color,
+)
+
+/** `sensor` card model — entity name + big value + a small inline
+ *  sparkline of the recent history. Same shape as one history-graph
+ *  row, hoisted into a hero tile. */
+data class HaSensorCardData(
+    val name: RemoteString,
+    val valueLabel: RemoteString,
+    val accent: Color,
+    val points: List<Float>,
+    val rangeLabel: RemoteString?,
+)

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaSensorCard.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaSensorCard.kt
@@ -1,0 +1,36 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+
+/**
+ * `sensor` card — entity name + big value + small inline sparkline of
+ * the recent history. Implemented as a single-row reuse of the
+ * history-graph composable so the visual stays consistent.
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaSensorCard(
+    data: HaSensorCardData,
+    modifier: RemoteModifier = RemoteModifier,
+) {
+    RemoteHaHistoryGraph(
+        HaHistoryGraphData(
+            title = null,
+            rangeLabel = data.rangeLabel ?: "".rs,
+            rows = listOf(
+                HaHistoryGraphRow(
+                    name = data.name,
+                    summary = data.valueLabel,
+                    accent = data.accent,
+                    points = data.points,
+                ),
+            ),
+        ),
+        modifier = modifier,
+    )
+}

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaStatisticCard.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaStatisticCard.kt
@@ -1,0 +1,88 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+
+/**
+ * `statistic` card — single hero value (mean / min / max / sum) for one
+ * entity, with optional period label + unit suffix.
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaStatisticCard(
+    data: HaStatisticCardData,
+    modifier: RemoteModifier = RemoteModifier,
+) {
+    val theme = haTheme()
+    RemoteBox(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(horizontal = 14.rdp, vertical = 12.rdp),
+    ) {
+        RemoteColumn(verticalArrangement = RemoteArrangement.spacedBy(4.rdp)) {
+            RemoteText(
+                text = data.name,
+                color = theme.secondaryText.rc,
+                fontSize = 12.rsp,
+                fontWeight = FontWeight.Medium,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            RemoteRow(verticalAlignment = RemoteAlignment.Bottom) {
+                RemoteText(
+                    text = data.valueLabel,
+                    color = theme.primaryText.rc,
+                    fontSize = 32.rsp,
+                    fontWeight = FontWeight.SemiBold,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                )
+                if (data.unit != null) {
+                    RemoteBox(modifier = RemoteModifier.padding(start = 4.rdp, bottom = 4.rdp)) {
+                        RemoteText(
+                            text = data.unit,
+                            color = theme.secondaryText.rc,
+                            fontSize = 14.rsp,
+                            style = RemoteTextStyle.Default,
+                            maxLines = 1,
+                        )
+                    }
+                }
+            }
+            if (data.periodLabel != null) {
+                RemoteText(
+                    text = data.periodLabel,
+                    color = data.accent.rc,
+                    fontSize = 11.rsp,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                )
+            }
+        }
+    }
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/DefaultConverters.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/DefaultConverters.kt
@@ -56,6 +56,9 @@ fun defaultConverters(): List<CardConverter> = buildList {
     add(PictureCardConverter())
     add(PictureGlanceCardConverter())
     add(PictureElementsCardConverter())
+    add(StatisticCardConverter())
+    add(SensorCardConverter())
+    add(EntityFilterCardConverter())
 
     add(BambuLabAmsCardConverter())
     add(BambuLabSpoolCardConverter())
@@ -72,8 +75,5 @@ fun defaultConverters(): List<CardConverter> = buildList {
 fun defaultRegistry(): CardRegistry = CardRegistry(defaultConverters())
 
 private val PLACEHOLDER_CARD_TYPES: List<String> = listOf(
-    CardTypes.STATISTIC,
-    CardTypes.SENSOR,
-    CardTypes.ENTITY_FILTER,
     CardTypes.IFRAME,
 )

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/EntityFilterCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/EntityFilterCardConverter.kt
@@ -1,0 +1,98 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.runtime.Composable
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `entity-filter` card — filters the configured entity list against a
+ * `state_filter:` (each filter is either a string or
+ * `{ value: ..., operator: ==|!=|<|>|>=|<= }`) and forwards the kept
+ * entities to a sub-card (defaulting to `glance`). Uses the existing
+ * GlanceCardConverter / EntitiesCardConverter / TileCardConverter
+ * machinery rather than rendering its own visual.
+ */
+class EntityFilterCardConverter : CardConverter {
+    override val cardType: String = CardTypes.ENTITY_FILTER
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 150
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val ids = filteredEntities(card, snapshot)
+        val cardCfg = card.raw["card"] as? JsonObject
+        val targetType = cardCfg?.get("type")?.jsonPrimitive?.content ?: "glance"
+        val title = cardCfg?.get("title")?.jsonPrimitive?.content ?: "Entity filter"
+        val mergedRaw = buildJsonObject {
+            put("type", JsonPrimitive(targetType))
+            put("title", JsonPrimitive(title))
+            put("entities", buildJsonArray { ids.forEach { add(JsonPrimitive(it)) } })
+            cardCfg?.entries?.forEach { (k, v) ->
+                if (k != "type" && k != "title" && k != "entities") put(k, v)
+            }
+        }
+        val sub = ee.schimke.ha.model.CardConfig(type = targetType, raw = mergedRaw)
+        val converter: CardConverter = when (targetType) {
+            "glance" -> GlanceCardConverter()
+            "entities" -> EntitiesCardConverter()
+            "tile" -> TileCardConverter()
+            else -> GlanceCardConverter()
+        }
+        converter.Render(sub, snapshot, modifier)
+    }
+}
+
+private fun filteredEntities(card: CardConfig, snapshot: HaSnapshot): List<String> {
+    val arr = card.raw["entities"] as? JsonArray ?: return emptyList()
+    val filters = (card.raw["state_filter"] as? JsonArray)?.toList() ?: emptyList()
+    return arr.mapNotNull { el ->
+        when (el) {
+            is JsonPrimitive -> el.content
+            is JsonObject -> el["entity"]?.jsonPrimitive?.content
+            else -> null
+        }
+    }.filter { id ->
+        val state = snapshot.states[id]?.state ?: return@filter false
+        if (filters.isEmpty()) state == "on" || state == "open"
+        else filters.any { matches(state, it) }
+    }
+}
+
+private fun matches(state: String, filter: kotlinx.serialization.json.JsonElement): Boolean {
+    return when (filter) {
+        is JsonPrimitive -> filter.content == state
+        is JsonObject -> {
+            val value = filter["value"]?.jsonPrimitive?.content ?: return false
+            val op = filter["operator"]?.jsonPrimitive?.content ?: "=="
+            when (op) {
+                "==" -> state == value
+                "!=" -> state != value
+                ">", "<", ">=", "<=" -> {
+                    val a = state.toDoubleOrNull() ?: return false
+                    val b = value.toDoubleOrNull() ?: return false
+                    when (op) {
+                        ">" -> a > b
+                        "<" -> a < b
+                        ">=" -> a >= b
+                        "<=" -> a <= b
+                        else -> false
+                    }
+                }
+                "regex" -> Regex(value).matches(state)
+                else -> false
+            }
+        }
+        else -> false
+    }
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/SensorCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/SensorCardConverter.kt
@@ -1,0 +1,49 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.HaStateColor
+import ee.schimke.ha.rc.components.HaSensorCardData
+import ee.schimke.ha.rc.components.RemoteHaSensorCard
+import ee.schimke.ha.rc.formatState
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `sensor` card — entity name + big value + a small inline sparkline
+ * of recent values. Pulls history from `HaSnapshot.history[entityId]`
+ * and reuses the history-graph row visual as a hero tile.
+ */
+class SensorCardConverter : CardConverter {
+    override val cardType: String = CardTypes.SENSOR
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 120
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val entityId = card.raw["entity"]?.jsonPrimitive?.content
+        val entity = entityId?.let { snapshot.states[it] }
+        val name = card.raw["name"]?.jsonPrimitive?.content
+            ?: entity?.attributes?.get("friendly_name")?.jsonPrimitive?.content
+            ?: entityId
+            ?: "Sensor"
+        val hours = card.raw["hours_to_show"]?.jsonPrimitive?.content?.toIntOrNull() ?: 24
+        val history = entityId?.let { snapshot.history[it].orEmpty() } ?: emptyList()
+        val numeric = history.mapNotNull { it.state.toFloatOrNull() }
+
+        RemoteHaSensorCard(
+            HaSensorCardData(
+                name = name.rs,
+                valueLabel = formatState(entity).rs,
+                accent = HaStateColor.activeFor(entity),
+                points = numeric,
+                rangeLabel = "Last ${hours}h".rs,
+            ),
+            modifier = modifier,
+        )
+    }
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/StatisticCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/StatisticCardConverter.kt
@@ -1,0 +1,77 @@
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.runtime.Composable
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.CardTypes
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.HaStateColor
+import ee.schimke.ha.rc.components.HaStatisticCardData
+import ee.schimke.ha.rc.components.RemoteHaStatisticCard
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `statistic` card — single statistic value (mean / min / max / sum)
+ * for one entity. Reads `HaSnapshot.statistics[entityId]` and
+ * aggregates the configured `stat_type` over the snapshot's window.
+ * Falls back to the entity's current state when there's no statistic
+ * data — keeps the card useful even before recorder backfill.
+ */
+class StatisticCardConverter : CardConverter {
+    override val cardType: String = CardTypes.STATISTIC
+
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 110
+
+    @Composable
+    override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val entityId = card.raw["entity"]?.jsonPrimitive?.content
+        val entity = entityId?.let { snapshot.states[it] }
+        val name = card.raw["name"]?.jsonPrimitive?.content
+            ?: entity?.attributes?.get("friendly_name")?.jsonPrimitive?.content
+            ?: entityId
+            ?: "Statistic"
+        val unit = entity?.attributes?.get("unit_of_measurement")?.jsonPrimitive?.content
+        val statType = card.raw["stat_type"]?.jsonPrimitive?.content ?: "mean"
+        val period = card.raw["period"]?.jsonPrimitive?.content?.let { p ->
+            "${p.replaceFirstChar { it.uppercaseChar() }} • ${statType.replaceFirstChar { it.uppercaseChar() }}"
+        }
+
+        val statistics = entityId?.let { snapshot.statistics[it].orEmpty() } ?: emptyList()
+        val numericValue = if (statistics.isNotEmpty()) {
+            val values = statistics.mapNotNull {
+                when (statType) {
+                    "min" -> it.min
+                    "max" -> it.max
+                    "sum" -> it.sum
+                    "state" -> it.state
+                    else -> it.mean
+                }
+            }
+            when (statType) {
+                "min" -> values.minOrNull()
+                "max" -> values.maxOrNull()
+                "sum" -> values.sum().takeIf { values.isNotEmpty() }
+                else -> values.average().takeIf { values.isNotEmpty() }
+            }
+        } else null
+        val valueLabel = numericValue?.let { formatValue(it) }
+            ?: entity?.state?.takeUnless { it == "unknown" || it == "unavailable" }
+            ?: "—"
+
+        RemoteHaStatisticCard(
+            HaStatisticCardData(
+                name = name.rs,
+                valueLabel = valueLabel.rs,
+                unit = unit?.rs,
+                periodLabel = period?.rs,
+                accent = HaStateColor.activeFor(entity),
+            ),
+            modifier = modifier,
+        )
+    }
+}
+
+private fun formatValue(d: Double): String =
+    if (d == d.toLong().toDouble()) d.toLong().toString() else "%.2f".format(d)


### PR DESCRIPTION
## Summary

Last three card types out of `PLACEHOLDER_CARD_TYPES` from the dashboards backlog. After this only `iframe` remains a placeholder — it embeds an external URL that can't ride in a `.rc` document.

- **statistic** — hero tile showing one stat value (mean / min / max / sum / state) for one entity, with optional period label + unit. Aggregates `HaSnapshot.statistics[entity]` over the configured `stat_type`; falls back to the entity's current state when no statistic data is hydrated.
- **sensor** — entity name + value + small inline sparkline of recent history. Reuses `RemoteHaHistoryGraph` (one-row mode) so the sparkline shape stays consistent across cards.
- **entity-filter** — filters the entity list against `state_filter` (each filter is a literal string OR `{ value, operator: ==/!=/</>/<=/>=/regex }`) and forwards the kept entities to a sub-card (defaults to `glance`). Reuses `GlanceCardConverter` / `EntitiesCardConverter` / `TileCardConverter` rather than rendering its own visual.

## Previews

### Statistic — daily mean of house power

| Light | Dark |
|---|---|
| ![statistic light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/256e9b80df75a9b124bc23a18a4c099493200386/Statistic_Light.png) | ![statistic dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/256e9b80df75a9b124bc23a18a4c099493200386/Statistic_Dark.png) |

### Sensor — Outside temperature, last 24h

| Light | Dark |
|---|---|
| ![sensor light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/256e9b80df75a9b124bc23a18a4c099493200386/Sensor_Light.png) | ![sensor dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/256e9b80df75a9b124bc23a18a4c099493200386/Sensor_Dark.png) |

### Entity filter — only entities currently \"on\"

| Light | Dark |
|---|---|
| ![filter light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/256e9b80df75a9b124bc23a18a4c099493200386/EntityFilter_Light.png) | ![filter dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/256e9b80df75a9b124bc23a18a4c099493200386/EntityFilter_Dark.png) |

## Test plan

- [x] `./gradlew :rc-components:compileDebugKotlin :rc-converter:compileDebugKotlin :previews:assembleDebug` — green
- [x] `compose-preview render --filter Statistic_/Sensor_/EntityFilter_` — all 6 render real data (see images above)
- [x] No HA-derived data — synthetic fixtures
- [x] Closes `PLACEHOLDER_CARD_TYPES` down to a single entry: `iframe`