### PR TITLE
feat(clock): bind RemoteTimeDefaults so the clock card ticks live

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
@@ -616,6 +616,47 @@ private fun lightCardConfig() = card(
     """{"type":"light","entity":"light.kitchen"}""",
 )
 
+// ——— clock ———
+//
+// The default render path binds RemoteTimeDefaults.defaultTimeString,
+// so the rendered PNG is whatever wall-clock time the Robolectric
+// host reports — that's expected (live-ticking by design).
+
+@Preview(name = "clock (light)", showBackground = false, widthDp = 200, heightDp = 100)
+@Composable
+fun Clock_Light() = CardHost(HaTheme.Light) {
+    RenderChild(clockCard(), Fixtures.mixed, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "clock (dark)", showBackground = false, widthDp = 200, heightDp = 100)
+@Composable
+fun Clock_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(clockCard(), Fixtures.mixed, RemoteModifier.fillMaxWidth())
+}
+
+private fun clockCard() = card(
+    """{"type":"clock","clock_size":"medium","time_format":"24"}""",
+)
+
+// ——— statistics-graph ———
+
+@Preview(name = "statistics-graph (light)", showBackground = false, widthDp = 381, heightDp = 200)
+@Composable
+fun StatisticsGraph_Light() = CardHost(HaTheme.Light) {
+    RenderChild(statsGraphCard(), Fixtures.energyStatistics, RemoteModifier.fillMaxWidth())
+}
+
+@Preview(name = "statistics-graph (dark)", showBackground = false, widthDp = 381, heightDp = 200)
+@Composable
+fun StatisticsGraph_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(statsGraphCard(), Fixtures.energyStatistics, RemoteModifier.fillMaxWidth())
+}
+
+private fun statsGraphCard() = card(
+    """{"type":"statistics-graph","title":"Power","period":"hour","stat_types":["mean"],
+        "entities":["sensor.house_power","sensor.solar_power"]}""",
+)
+
 // ——— alarm-panel ———
 
 @Preview(name = "alarm-panel (light)", showBackground = false, widthDp = 320, heightDp = 380)

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
@@ -307,15 +307,17 @@ data class HaArcDialData(
     val decrementAction: HaAction = HaAction.None,
 )
 
-/** `clock` card model. The string is captured at capture time —
- *  alpha08 has a `RemoteAccess.getTime()` API but emitting a Compose
- *  text node bound to it requires canvas drawText; deferring live
- *  ticking to a follow-up. The host re-encodes once a minute / hour. */
+/** `clock` card model. The default render uses
+ *  `RemoteTimeDefaults.defaultTimeString` so the time text auto-ticks
+ *  inside the playing document without re-encode. [staticTimeLabel]
+ *  is an opt-in static override (kept for previews and for hosts that
+ *  want a frozen capture). */
 data class HaClockData(
     val title: RemoteString?,
-    val timeLabel: RemoteString,
+    val staticTimeLabel: RemoteString?,
     val secondaryLabel: RemoteString?,
     val isLarge: Boolean,
+    val use24Hour: Boolean,
 )
 
 /** `statistics-graph` card model — mirrors history-graph, just with

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaClock.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaClock.kt
@@ -15,20 +15,22 @@ import androidx.compose.remote.creation.compose.modifier.clip
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
 import androidx.compose.remote.creation.compose.modifier.padding
 import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.RemoteBoolean
 import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.remote.creation.compose.state.rdp
 import androidx.compose.remote.creation.compose.state.rsp
 import androidx.compose.remote.creation.compose.text.RemoteTextStyle
+import androidx.compose.remote.creation.compose.text.RemoteTimeDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 
 /**
- * `clock` card — local time as a static text label captured at
- * encode time. The host re-encodes once a minute (or whatever cadence
- * the player uses); a future revision can swap this for a
- * `RemoteCanvas.drawText` bound to `RemoteAccess.getTime()` for
- * live-ticking without re-encode.
+ * `clock` card — local time text. The default path binds
+ * `RemoteTimeDefaults.defaultTimeString` so the document ticks the
+ * time once a minute on the player without a re-encode round trip.
+ * [HaClockData.staticTimeLabel] overrides for a frozen capture (used
+ * by previews and any host that prefers snapshot-time text).
  */
 @Composable
 @RemoteComposable
@@ -58,8 +60,11 @@ fun RemoteHaClock(data: HaClockData, modifier: RemoteModifier = RemoteModifier) 
                     overflow = TextOverflow.Ellipsis,
                 )
             }
+            val timeText = data.staticTimeLabel ?: RemoteTimeDefaults.defaultTimeString(
+                is24HourFormat = if (data.use24Hour) RemoteBoolean(true) else RemoteTimeDefaults.is24HourFormat(),
+            )
             RemoteText(
-                text = data.timeLabel,
+                text = timeText,
                 color = theme.primaryText.rc,
                 fontSize = timeSize.rsp,
                 fontWeight = FontWeight.Light,

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ClockCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ClockCardConverter.kt
@@ -14,11 +14,12 @@ import java.time.format.DateTimeFormatter
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
- * `clock` card — local time text. Captured at capture time using the
- * snapshot's [HaSnapshot.locale] when available; the host re-encodes
- * to keep the label current. A future revision can wire
- * `RemoteAccess.getTime()` into a canvas drawText for live ticking
- * without re-encode.
+ * `clock` card — local time text. The default render binds
+ * `RemoteTimeDefaults.defaultTimeString` so the player ticks the time
+ * without a re-encode round trip. Configs that pin a specific time
+ * zone or seconds-display drop back to a static encode-time label
+ * because the bound RemoteString uses the host's locale-default
+ * formatting (no per-card override path yet).
  */
 class ClockCardConverter : CardConverter {
     override val cardType: String = CardTypes.CLOCK
@@ -37,18 +38,28 @@ class ClockCardConverter : CardConverter {
         val title = card.raw["title"]?.jsonPrimitive?.content
         val tz = card.raw["time_zone"]?.jsonPrimitive?.content
             ?.let { runCatching { ZoneId.of(it) }.getOrNull() }
-            ?: ZoneId.systemDefault()
         val showSeconds = card.raw["show_seconds"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: false
         val timeFmt = card.raw["time_format"]?.jsonPrimitive?.content
-        val pattern = when {
-            timeFmt == "12" -> if (showSeconds) "h:mm:ss a" else "h:mm a"
-            else -> if (showSeconds) "HH:mm:ss" else "HH:mm"
+
+        // Live-ticking path: no time_zone override, no show_seconds.
+        // Use RemoteTimeDefaults via the composable; pass null label.
+        val canTick = tz == null && !showSeconds
+        val use24Hour = timeFmt != "12"
+
+        // Static fallback for time-zone / seconds variants.
+        val staticLabel = if (canTick) null else run {
+            val pattern = when {
+                timeFmt == "12" -> if (showSeconds) "h:mm:ss a" else "h:mm a"
+                else -> if (showSeconds) "HH:mm:ss" else "HH:mm"
+            }
+            val now = java.time.ZonedDateTime.now(tz ?: ZoneId.systemDefault())
+            now.format(DateTimeFormatter.ofPattern(pattern))
         }
-        val now = java.time.ZonedDateTime.now(tz)
-        val timeLabel = now.format(DateTimeFormatter.ofPattern(pattern))
+
         val display = card.raw["display"]?.jsonPrimitive?.content ?: "primary"
         val secondaryLabel = if (display == "primary" || display == null) {
-            now.format(DateTimeFormatter.ofPattern("EEE d MMM"))
+            java.time.ZonedDateTime.now(tz ?: ZoneId.systemDefault())
+                .format(DateTimeFormatter.ofPattern("EEE d MMM"))
         } else null
         val size = card.raw["clock_size"]?.jsonPrimitive?.content
         val isLarge = size == "large" || size == "medium"
@@ -56,9 +67,10 @@ class ClockCardConverter : CardConverter {
         RemoteHaClock(
             HaClockData(
                 title = title?.rs,
-                timeLabel = timeLabel.rs,
+                staticTimeLabel = staticLabel?.rs,
                 secondaryLabel = secondaryLabel?.rs,
                 isLarge = isLarge,
+                use24Hour = use24Hour,
             ),
             modifier = modifier,
         )


### PR DESCRIPTION
## Summary

Replaces the clock card's encode-time time string with `RemoteTimeDefaults.defaultTimeString`, so the rendered `.rc` document auto-updates the displayed time on the player without a re-encode round trip. This is the first card in the set to demonstrate the \"document auto-ticks\" capability of RemoteCompose alpha08 — useful baseline for future live-update work (history-graph last-point, sensor card, …).

The host's locale picks 12-/24-hour formatting; the card's `time_format: 12|24` config overrides via an explicit `RemoteBoolean`. Configurations that pin a specific `time_zone` or set `show_seconds: true` drop back to the static encode-time path because the bound RemoteString uses host-locale defaults (per-card override would need a custom `drawText` canvas — follow-up).

Also restores `Clock_Light/Dark` and `StatisticsGraph_Light/Dark` @Preview entry points that were dropped during a rebase conflict resolution after #83 landed (the converters + fixtures landed; the preview functions went missing).

## Previews

The clock previews now show the renderer's wall-clock time at capture, since the document now ticks. Comparing two renders some seconds apart would show the time advancing.

| Light | Dark |
|---|---|
| ![clock light](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/9623c4ce662261c6910ee87500bc6d28ae7a4b3b/Clock_Light_clock.png) | ![clock dark](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/9623c4ce662261c6910ee87500bc6d28ae7a4b3b/Clock_Dark_clock.png) |

## Test plan

- [x] `./gradlew :rc-components:compileDebugKotlin :rc-converter:compileDebugKotlin :previews:assembleDebug` — green
- [x] `compose-preview render --filter Clock_/StatisticsGraph_` — both render real time + sparklines
- [x] No HA-derived data