### PR TITLE
feat(previews): whole-dashboard previews at mobile + tablet widths

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/DashboardFixtures.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/DashboardFixtures.kt
@@ -1,0 +1,95 @@
+package ee.schimke.ha.previews
+
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.Dashboard
+import ee.schimke.ha.model.EntityState
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.model.Section
+import ee.schimke.ha.model.View
+import java.io.File
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Loader for the per-dashboard JSON snapshots that live in the sibling
+ * [homeassistant-agents](../../../homeassistant-agents) checkout under
+ * `dashboards/<name>/{lovelace_config.json,entity_states.json}`. The
+ * JSONs are sanitised in that repo (IPs / MACs / tokens / camera tokens
+ * redacted) but entity ids and friendly names are kept — the
+ * homeassistant-agents README treats those as non-secret.
+ *
+ * Files are deliberately *not* copied into this repo; the loader points
+ * at the sibling checkout via [DASHBOARDS_ROOT]. When the directory
+ * isn't present (CI, fresh clones), [load] returns null and the preview
+ * function should skip rendering.
+ */
+object DashboardFixtures {
+    /** Override via `-Dha.dashboards.root=/path/to/dashboards`. */
+    private val DASHBOARDS_ROOT: File = File(
+        System.getProperty("ha.dashboards.root")
+            ?: "${System.getProperty("user.home")}/workspace/homeassistant-agents/dashboards",
+    )
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    data class Loaded(val dashboard: Dashboard, val snapshot: HaSnapshot)
+
+    fun load(name: String): Loaded? {
+        val dir = File(DASHBOARDS_ROOT, name)
+        val configFile = File(dir, "lovelace_config.json")
+        val statesFile = File(dir, "entity_states.json")
+        if (!configFile.exists() || !statesFile.exists()) return null
+
+        val dashboard = parseDashboard(configFile.readText())
+        val states = parseStates(statesFile.readText())
+        return Loaded(dashboard = dashboard, snapshot = HaSnapshot(states = states))
+    }
+}
+
+/**
+ * Parse a `lovelace/config` payload into [Dashboard]. The kotlinx
+ * `@Serializable` deserializer doesn't populate [CardConfig.raw] from
+ * the flat HA shape, so we walk the tree manually and stash the entire
+ * card object into `raw` for converters to read.
+ */
+private fun parseDashboard(text: String): Dashboard {
+    val root = Json.parseToJsonElement(text).jsonObject
+    val title = root["title"]?.jsonPrimitive?.content
+    val views = (root["views"] as? JsonArray)?.map { parseView(it.jsonObject) } ?: emptyList()
+    return Dashboard(title = title, views = views)
+}
+
+private fun parseView(obj: JsonObject): View {
+    val title = obj["title"]?.jsonPrimitive?.content
+    val type = obj["type"]?.jsonPrimitive?.content
+    val cards = (obj["cards"] as? JsonArray)?.mapNotNull { it.toCardConfig() } ?: emptyList()
+    val sections = (obj["sections"] as? JsonArray)?.mapNotNull { el ->
+        val s = el as? JsonObject ?: return@mapNotNull null
+        Section(
+            type = s["type"]?.jsonPrimitive?.content,
+            title = s["title"]?.jsonPrimitive?.content,
+            cards = (s["cards"] as? JsonArray)?.mapNotNull { e -> e.toCardConfig() } ?: emptyList(),
+        )
+    } ?: emptyList()
+    return View(title = title, type = type, cards = cards, sections = sections)
+}
+
+private fun kotlinx.serialization.json.JsonElement.toCardConfig(): CardConfig? {
+    val obj = this as? JsonObject ?: return null
+    val type = obj["type"]?.jsonPrimitive?.content ?: return null
+    return CardConfig(type = type, raw = obj)
+}
+
+private fun parseStates(text: String): Map<String, EntityState> {
+    val root = Json.parseToJsonElement(text).jsonObject
+    return root.entries.mapNotNull { (id, el) ->
+        val obj = el as? JsonObject ?: return@mapNotNull null
+        val state = obj["state"]?.jsonPrimitive?.content ?: return@mapNotNull null
+        val attrs = (obj["attributes"] as? JsonObject) ?: JsonObject(emptyMap())
+        id to EntityState(entityId = id, state = state, attributes = attrs)
+    }.toMap()
+}

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/DashboardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/DashboardPreviews.kt
@@ -1,0 +1,168 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.previews
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth as uiFillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.tooling.preview.RemotePreview
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.model.View
+import ee.schimke.ha.rc.ProvideCardRegistry
+import ee.schimke.ha.rc.RenderChild
+import ee.schimke.ha.rc.androidXExperimental
+import ee.schimke.ha.rc.cards.defaultRegistry
+import ee.schimke.ha.rc.cards.shutter.withEnhancedShutter
+import ee.schimke.ha.rc.cards.shutter.withGarageShutter
+import ee.schimke.ha.rc.components.HaTheme
+import ee.schimke.ha.rc.components.ProvideHaTheme
+
+/**
+ * Whole-dashboard previews — one column per card, stacked vertically.
+ * Used to compare adaptive-layout candidates: render each captured
+ * dashboard at mobile (411 dp wide) and tablet (800 dp wide) and look
+ * at the resulting PNGs side-by-side.
+ *
+ * Card heights come from each converter's `naturalHeightDp(card,
+ * snapshot)`, so vertical-stack / grid / sections cards size
+ * themselves correctly. The whole dashboard renders inside one
+ * `verticalScroll` so previews longer than the canvas crop instead of
+ * clipping silently.
+ *
+ * Skips rendering when the sibling [homeassistant-agents] checkout
+ * isn't present at the expected path (see [DashboardFixtures]). The
+ * preview lambda short-circuits with a single placeholder string in
+ * that case so CI runs of the previews module don't fail.
+ */
+private const val MOBILE_WIDTH = 411
+private const val MOBILE_HEIGHT = 1800
+private const val TABLET_WIDTH = 800
+private const val TABLET_HEIGHT = 1800
+
+@Preview(
+    name = "dashboard 3d-printing — mobile",
+    widthDp = MOBILE_WIDTH,
+    heightDp = MOBILE_HEIGHT,
+)
+@Composable
+fun Dashboard3dPrintingMobile() = DashboardPreview("3d_printing")
+
+@Preview(
+    name = "dashboard 3d-printing — tablet",
+    widthDp = TABLET_WIDTH,
+    heightDp = TABLET_HEIGHT,
+)
+@Composable
+fun Dashboard3dPrintingTablet() = DashboardPreview("3d_printing")
+
+@Preview(name = "dashboard climate — mobile", widthDp = MOBILE_WIDTH, heightDp = MOBILE_HEIGHT)
+@Composable
+fun DashboardClimateMobile() = DashboardPreview("climate")
+
+@Preview(name = "dashboard climate — tablet", widthDp = TABLET_WIDTH, heightDp = TABLET_HEIGHT)
+@Composable
+fun DashboardClimateTablet() = DashboardPreview("climate")
+
+@Preview(name = "dashboard energy — mobile", widthDp = MOBILE_WIDTH, heightDp = MOBILE_HEIGHT)
+@Composable
+fun DashboardEnergyMobile() = DashboardPreview("energy")
+
+@Preview(name = "dashboard energy — tablet", widthDp = TABLET_WIDTH, heightDp = TABLET_HEIGHT)
+@Composable
+fun DashboardEnergyTablet() = DashboardPreview("energy")
+
+@Preview(name = "dashboard github — mobile", widthDp = MOBILE_WIDTH, heightDp = MOBILE_HEIGHT)
+@Composable
+fun DashboardGithubMobile() = DashboardPreview("github")
+
+@Preview(name = "dashboard github — tablet", widthDp = TABLET_WIDTH, heightDp = TABLET_HEIGHT)
+@Composable
+fun DashboardGithubTablet() = DashboardPreview("github")
+
+@Preview(name = "dashboard meshcore — mobile", widthDp = MOBILE_WIDTH, heightDp = MOBILE_HEIGHT)
+@Composable
+fun DashboardMeshcoreMobile() = DashboardPreview("meshcore")
+
+@Preview(name = "dashboard meshcore — tablet", widthDp = TABLET_WIDTH, heightDp = TABLET_HEIGHT)
+@Composable
+fun DashboardMeshcoreTablet() = DashboardPreview("meshcore")
+
+@Preview(name = "dashboard networks — mobile", widthDp = MOBILE_WIDTH, heightDp = MOBILE_HEIGHT)
+@Composable
+fun DashboardNetworksMobile() = DashboardPreview("networks")
+
+@Preview(name = "dashboard networks — tablet", widthDp = TABLET_WIDTH, heightDp = TABLET_HEIGHT)
+@Composable
+fun DashboardNetworksTablet() = DashboardPreview("networks")
+
+@Preview(name = "dashboard security — mobile", widthDp = MOBILE_WIDTH, heightDp = MOBILE_HEIGHT)
+@Composable
+fun DashboardSecurityMobile() = DashboardPreview("security")
+
+@Preview(name = "dashboard security — tablet", widthDp = TABLET_WIDTH, heightDp = TABLET_HEIGHT)
+@Composable
+fun DashboardSecurityTablet() = DashboardPreview("security")
+
+@Composable
+private fun DashboardPreview(name: String) {
+    val loaded = DashboardFixtures.load(name) ?: return
+    Column(
+        modifier = Modifier.uiFillMaxWidth().verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Box(modifier = Modifier.padding(16.dp)) {
+            androidx.compose.material3.Text(
+                text = "${loaded.dashboard.title ?: name} — ${loaded.dashboard.views.size} view(s)",
+                style = androidx.compose.material3.MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+        loaded.dashboard.views.forEach { view ->
+            ViewBlock(view, loaded.snapshot)
+        }
+    }
+}
+
+@Composable
+private fun ViewBlock(view: View, snapshot: HaSnapshot) {
+    if (view.title != null) {
+        Box(modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)) {
+            androidx.compose.material3.Text(
+                text = view.title!!,
+                style = androidx.compose.material3.MaterialTheme.typography.titleSmall,
+            )
+        }
+    }
+    val cards = view.cards + view.sections.flatMap { it.cards }
+    cards.forEach { card -> CardSlot(card, snapshot) }
+}
+
+@Composable
+private fun CardSlot(card: CardConfig, snapshot: HaSnapshot) {
+    val registry = defaultRegistry().withEnhancedShutter().withGarageShutter()
+    val converter = registry.get(card.type)
+    val height = (converter?.naturalHeightDp(card, snapshot) ?: 96)
+        .coerceAtLeast(48)
+    Box(modifier = Modifier.uiFillMaxWidth().height(height.dp).padding(horizontal = 8.dp)) {
+        RemotePreview(profile = androidXExperimental) {
+            ProvideCardRegistry(registry) {
+                ProvideHaTheme(HaTheme.Light) {
+                    RenderChild(card, snapshot, RemoteModifier.fillMaxWidth())
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds whole-dashboard previews so we can sanity-check the full converter stack against real Lovelace configs and plan adaptive layouts.

- `DashboardFixtures.load(name)` reads the sibling `homeassistant-agents` checkout's `lovelace_config.json` + `entity_states.json` (default: `$HOME/workspace/homeassistant-agents/dashboards/<name>/`, override with `-Dha.dashboards.root=...`). Skips silently when the directory isn't there.
- `DashboardPreviews` emits one `@Preview` per dashboard at **mobile (411 dp)** and **tablet (800 dp)** widths, light theme. Each card sits in its own `RemotePreview` slot sized via the registry's `naturalHeightDp`, stacked vertically inside a `verticalScroll` `Column` so long dashboards crop rather than clip.

The kotlinx default deserialiser doesn't populate `CardConfig.raw` from the flat HA shape, so the loader walks the JSON tree manually and stashes the entire card object into `raw` for converters to read.

JSON files are deliberately *not* checked into this repo (they live in the sanitised sibling repo and the user explicitly asked we keep HA snapshots out of `homeassistant-remotecompose`).

## Goal

Compare mobile ↔ tablet renders side-by-side to decide adaptive-layout strategy: single-column scroll vs honouring HA's `type: sections` + `max_columns: N` grid. Today both widths render single-column; the tablet renders show how each card visually scales but the *layout* stays the same.

## Previews

### 3D printing
| Mobile (411 dp) | Tablet (800 dp) |
|---|---|
| ![mobile](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/b82d8fe5db80e1483e85e7a41233d347efa3c7bb/Dashboard3dPrintingMobile.png) | ![tablet](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/b82d8fe5db80e1483e85e7a41233d347efa3c7bb/Dashboard3dPrintingTablet.png) |

### Climate
| Mobile (411 dp) | Tablet (800 dp) |
|---|---|
| ![mobile](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/b82d8fe5db80e1483e85e7a41233d347efa3c7bb/DashboardClimateMobile.png) | ![tablet](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/b82d8fe5db80e1483e85e7a41233d347efa3c7bb/DashboardClimateTablet.png) |

### Energy
| Mobile (411 dp) | Tablet (800 dp) |
|---|---|
| ![mobile](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/b82d8fe5db80e1483e85e7a41233d347efa3c7bb/DashboardEnergyMobile.png) | ![tablet](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/b82d8fe5db80e1483e85e7a41233d347efa3c7bb/DashboardEnergyTablet.png) |

### GitHub
| Mobile (411 dp) | Tablet (800 dp) |
|---|---|
| ![mobile](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/b82d8fe5db80e1483e85e7a41233d347efa3c7bb/DashboardGithubMobile.png) | ![tablet](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/b82d8fe5db80e1483e85e7a41233d347efa3c7bb/DashboardGithubTablet.png) |

### Meshcore
| Mobile (411 dp) | Tablet (800 dp) |
|---|---|
| ![mobile](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/b82d8fe5db80e1483e85e7a41233d347efa3c7bb/DashboardMeshcoreMobile.png) | ![tablet](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/b82d8fe5db80e1483e85e7a41233d347efa3c7bb/DashboardMeshcoreTablet.png) |

### Networks
| Mobile (411 dp) | Tablet (800 dp) |
|---|---|
| ![mobile](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/b82d8fe5db80e1483e85e7a41233d347efa3c7bb/DashboardNetworksMobile.png) | ![tablet](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/b82d8fe5db80e1483e85e7a41233d347efa3c7bb/DashboardNetworksTablet.png) |

### Security
| Mobile (411 dp) | Tablet (800 dp) |
|---|---|
| ![mobile](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/b82d8fe5db80e1483e85e7a41233d347efa3c7bb/DashboardSecurityMobile.png) | ![tablet](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/b82d8fe5db80e1483e85e7a41233d347efa3c7bb/DashboardSecurityTablet.png) |

## Observations / follow-ups

- **HA's section grid isn't honoured** — both widths show single-column. Adding a sections grid host (`max_columns` from the view config, plus column-packing of compact-width cards) is the obvious next step.
- **Some cards still crop their content** at the natural-height heuristic (e.g. `entities` rows past row 4 on the climate dashboard). The heuristic should grow with row count for those.
- **Dashboard heights are pinned at 1800 dp** for the preview canvas — long dashboards (3D printing, meshcore) still extend past that. The PNGs show the top \~1800 dp; rendering more is a canvas-size knob.

## Test plan

- [x] `./gradlew :previews:assembleDebug` — green
- [x] `compose-preview render --filter Dashboard*Mobile` and `*Tablet` — all 14 dashboards render real captured data through the converter stack (see images above)
- [x] No HA-derived JSONs committed to this repo — loader points at the sibling `homeassistant-agents` checkout