### PR TITLE
feat(demo): replace synthetic demo with the seven captured dashboards

### DIFF
--- a/app/src/test/kotlin/ee/schimke/terrazzo/core/session/DemoDataTest.kt
+++ b/app/src/test/kotlin/ee/schimke/terrazzo/core/session/DemoDataTest.kt
@@ -8,6 +8,14 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.serialization.json.jsonPrimitive
 
+/**
+ * Demo mode is now powered by the captured Lovelace dashboards bundled
+ * under `terrazzo-core/src/androidMain/resources/dashboards/<slug>/`
+ * (scrubbed by `terrazzo-core/scripts/scrub-demo-dashboards.py`). The
+ * tests assert the public surface — dashboard list, fallback, drifting
+ * values — without pinning specific entity ids, so re-scrubs that move
+ * pseudonyms around don't churn the test file.
+ */
 class DemoDataTest {
 
     @Test
@@ -18,91 +26,96 @@ class DemoDataTest {
     }
 
     @Test
-    fun dashboards_cover_expected_paths() {
-        val paths = DemoData.dashboards.map { it.urlPath }
-        assertEquals(listOf(null, "downstairs", "office"), paths)
+    fun dashboards_cover_seven_captured_boards() {
+        // The picker shows the seven captured dashboards. The first
+        // entry uses urlPath=null so the default-dashboard load still
+        // works; the rest carry their slug as urlPath.
+        val list = DemoData.dashboards
+        assertEquals(7, list.size, "demo mode should expose all 7 captured dashboards")
+        assertEquals(null, list.first().urlPath, "first board uses null urlPath as default")
+        assertTrue(list.drop(1).all { it.urlPath != null }, "every other board has a urlPath")
     }
 
     @Test
-    fun dashboard_falls_back_to_home_for_unknown_paths() {
-        // The picker shouldn't be able to send us an unknown path, but
-        // the default dashboard is a sensible fallback if it does.
-        assertEquals("Home", DemoData.dashboard(null).title)
-        assertEquals("Home", DemoData.dashboard("not-a-real-path").title)
-        assertEquals("Downstairs", DemoData.dashboard("downstairs").title)
-        assertEquals("Office", DemoData.dashboard("office").title)
+    fun dashboard_falls_back_to_default_for_unknown_paths() {
+        val defaultTitle = DemoData.dashboards.first().title
+        assertEquals(defaultTitle, DemoData.dashboard(null).title)
+        assertEquals(defaultTitle, DemoData.dashboard("not-a-real-path").title)
     }
 
     @Test
-    fun snapshot_contains_entities_referenced_by_demo_cards() {
-        // These ids are hard-coded in DemoData.homeCards / downstairsCards /
-        // officeCards. If the snapshot drops one, the corresponding card
-        // renders as "unavailable" instead of the intended demo state.
-        val referenced = setOf(
-            "sensor.living_room",
-            "sensor.office_temp",
-            "sensor.humidity",
-            "sensor.power",
-            "sensor.laptop_battery",
-            "light.kitchen",
-            "light.office_lamp",
-            "light.hallway",
-            "switch.coffee_maker",
-            "switch.desk_fan",
-            "lock.front_door",
-        )
+    fun snapshot_includes_entities_from_every_captured_board() {
+        // Every board's lovelace_config references entities that should
+        // resolve in the snapshot — otherwise the demo dashboard renders
+        // half the cards as "unavailable".
         val ids = DemoData.snapshot(nowMs = 0L).states.keys
-        val missing = referenced - ids
-        assertTrue(missing.isEmpty(), "snapshot missing entity ids: $missing")
+        assertTrue(ids.size > 200, "snapshot should aggregate hundreds of entities, was ${ids.size}")
     }
 
     @Test
-    fun snapshot_values_change_over_time() {
-        // The whole point of demo mode is animation: re-capturing the
-        // snapshot at later times must produce visibly different
-        // sensor values, otherwise the notification and widget
-        // refresh cadence show nothing moving.
+    fun snapshot_values_change_per_minute() {
+        // Numeric sensors drift on a per-minute cadence. Two snapshots
+        // a minute apart should differ in *some* numeric state.
         val early = DemoData.snapshot(nowMs = 0L)
-        val later = DemoData.snapshot(nowMs = 30_000L)
-        assertNotEquals(
-            early.states["sensor.living_room"]?.state,
-            later.states["sensor.living_room"]?.state,
-            "living-room temperature should drift over 30s of demo time",
+        val later = DemoData.snapshot(nowMs = 60_000L * 5L)
+        val differing = early.states.filter { (id, st) ->
+            later.states[id]?.state != st.state
+        }
+        assertTrue(
+            differing.isNotEmpty(),
+            "expected at least one entity to drift between minute 0 and minute 5",
         )
     }
 
     @Test
-    fun office_lamp_toggles_on_eight_second_cadence() {
-        // Lamp is on for 0..<8000ms, off for 8000..<16000ms, on again
-        // at 16000ms — a visible ~8s cadence so a viewer sees it flip.
-        assertEquals("on", DemoData.snapshot(nowMs = 0L).states["light.office_lamp"]?.state)
-        assertEquals("off", DemoData.snapshot(nowMs = 9_000L).states["light.office_lamp"]?.state)
-        assertEquals("on", DemoData.snapshot(nowMs = 17_000L).states["light.office_lamp"]?.state)
-    }
-
-    @Test
-    fun humidity_stays_in_sane_range() {
-        // Guardrail: if the sine-wave amplitude / baseline ever gets
-        // perturbed, we don't want humidity showing as "142%". The
-        // dashboard renders the attribute-declared unit (`%`) beside
-        // the state string as-is, so obviously-wrong values land on
-        // screen.
-        for (t in 0L until 300_000L step 5_000L) {
-            val raw = DemoData.snapshot(nowMs = t).states["sensor.humidity"]?.state
-            assertNotNull(raw, "humidity missing at t=$t")
-            val v = raw.toInt()
-            assertTrue(v in 20..80, "humidity out of sane range at t=$t: $v")
+    fun snapshot_within_minute_is_stable() {
+        // The drift bucket is `nowMs / 60_000`. Two snapshots inside
+        // the same minute must produce identical state strings (so the
+        // dashboard re-poll inside the minute doesn't flicker).
+        val a = DemoData.snapshot(nowMs = 1_500L)
+        val b = DemoData.snapshot(nowMs = 12_000L)
+        assertEquals(a.states.size, b.states.size)
+        a.states.forEach { (id, st) ->
+            assertEquals(st.state, b.states[id]?.state, "entity $id drifted within a minute")
         }
     }
 
     @Test
-    fun living_room_temp_attributes_declare_celsius() {
-        // The dashboard's entities card shows the unit_of_measurement
-        // next to the state; a silently-dropped attribute is a visible
-        // regression.
-        val attrs = DemoData.snapshot(nowMs = 0L).states["sensor.living_room"]?.attributes
-        assertNotNull(attrs, "living-room sensor missing from demo snapshot")
-        assertEquals("°C", attrs["unit_of_measurement"]?.jsonPrimitive?.content)
-        assertEquals("temperature", attrs["device_class"]?.jsonPrimitive?.content)
+    fun temperature_sensors_keep_celsius_unit() {
+        // The drift function preserves unit_of_measurement / device_class
+        // attributes — the dashboard renders the unit beside the value.
+        val temps = DemoData.snapshot(nowMs = 0L).states.values.filter {
+            it.attributes["device_class"]?.jsonPrimitive?.content == "temperature"
+        }
+        assertTrue(temps.isNotEmpty(), "expected at least one temperature sensor in demo data")
+        assertNotNull(
+            temps.first().attributes["unit_of_measurement"]?.jsonPrimitive?.content,
+            "temperature sensor must keep unit_of_measurement",
+        )
+    }
+
+    @Test
+    fun humidity_stays_in_sane_range() {
+        // Guardrail: drifted humidity values must remain plausible
+        // (0..100%) so the dashboard doesn't show "humidity 142%".
+        for (t in 0L until 60L * 60_000L step 60_000L) {
+            val humidities = DemoData.snapshot(nowMs = t).states.values.filter {
+                it.attributes["device_class"]?.jsonPrimitive?.content == "humidity"
+            }.mapNotNull { it.state.toDoubleOrNull() }
+            humidities.forEach {
+                assertTrue(it in 0.0..100.0, "humidity out of sane range at t=$t: $it")
+            }
+        }
+    }
+
+    @Test
+    fun snapshot_does_not_change_dashboard_size() {
+        // Drifting changes state strings, never the entity-id set.
+        // Pinned widgets cache id → slot mappings; a stable id set
+        // means a widget never has to re-discover its target.
+        val a = DemoData.snapshot(nowMs = 0L).states.keys
+        val b = DemoData.snapshot(nowMs = 60L * 60_000L).states.keys
+        assertEquals(a, b, "drift must not add/remove entities")
+        assertNotEquals(0, a.size)
     }
 }

--- a/app/src/test/kotlin/ee/schimke/terrazzo/core/session/DemoHaSessionTest.kt
+++ b/app/src/test/kotlin/ee/schimke/terrazzo/core/session/DemoHaSessionTest.kt
@@ -22,17 +22,20 @@ class DemoHaSessionTest {
     fun loadDashboard_threads_the_injected_clock() = runTest {
         // The dashboard screen re-polls on refreshIntervalMillis; each
         // call should see a fresh snapshot derived from the current
-        // clock, not a cached one from construction time.
+        // clock, not a cached one from construction time. Drift is on
+        // a per-minute cadence so step the clock by 5 minutes.
         var clockNow = 0L
         val session = DemoHaSession(clock = { clockNow })
 
         val (_, s1) = session.loadDashboard(null)
-        clockNow = 30_000L
+        clockNow = 60_000L * 5L
         val (_, s2) = session.loadDashboard(null)
 
+        val differing = s1.states.filter { (id, st) -> s2.states[id]?.state != st.state }
         assertNotEquals(
-            s1.states["sensor.living_room"]?.state,
-            s2.states["sensor.living_room"]?.state,
+            0,
+            differing.size,
+            "expected at least one entity to drift between minute 0 and minute 5",
         )
     }
 

--- a/terrazzo-core/scripts/scrub-demo-dashboards.py
+++ b/terrazzo-core/scripts/scrub-demo-dashboards.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Second-pass scrub of the homeassistant-agents dashboard fixtures
+before bundling them as the in-app demo.
+
+The first pass (_sanitize.py in homeassistant-agents) redacts IPs,
+MACs, tokens, lat/lon, sensitive attribute keys, etc. but keeps entity
+ids and friendly names because that repo is treating them as non-secret.
+
+For an app published to the Play Store, we want the entity ids + friendly
+names re-keyed too — anything that looks like a device serial (Bambu
+printer SN, UniFi MAC-fragment camera channels, Meshcore node ids,
+Blink network ids, Octopus meter ids, etc.) gets replaced with a stable
+readable pseudonym, applied consistently across the lovelace_config.json
+AND entity_states.json so card-to-entity references survive.
+
+Usage:
+    python3 terrazzo-core/scripts/scrub-demo-dashboards.py \\
+        --src ~/workspace/homeassistant-agents/dashboards \\
+        --dst terrazzo-core/src/androidMain/resources/dashboards
+"""
+import argparse
+import json
+import re
+from pathlib import Path
+
+# Tokens inside entity ids (split by `_` / `.`) that look like device
+# serials. We scrub anything that's:
+#  - 8+ chars long, AND mixed letters+digits  (e.g. 22e8bj5b2200526)
+#  - 9+ pure-digit chars                       (e.g. 1200028620880 meter id)
+#  - 6+ pure-hex chars with at least one digit (e.g. fa27efd5b4 meshcore id)
+SERIAL_TOKEN_RES = [
+    re.compile(r"^(?=.*[a-z])(?=.*[0-9])[a-z0-9]{8,}$"),
+    re.compile(r"^[0-9]{9,}$"),
+    re.compile(r"^[0-9a-f]{6,}$"),
+]
+
+# Entity-id rewrites — when the natural token-by-token scrub misses
+# a meaningful pseudonym, hardcode it. Applied before the generic
+# token pass.
+ENTITY_ID_REWRITES = [
+    (re.compile(r"^alarm_control_panel\.blink_[a-z0-9_]+$"), "alarm_control_panel.blink_panel"),
+    (re.compile(r"^binary_sensor\.blink_[a-z0-9_]+_motion$"), "binary_sensor.blink_motion"),
+    (re.compile(r"^binary_sensor\.blink_[a-z0-9_]+_status$"), "binary_sensor.blink_status"),
+]
+
+# Attributes whose values reveal personal/network identifiers; replaced
+# with `<redacted>` regardless of shape.
+EXTRA_REDACT_KEYS = {
+    "network_id",
+    "region_id",
+    "original_name",
+    "raw_value",
+    "device_id",
+    "config_entry_id",
+    "area_id",
+    "name_template",
+}
+
+
+def looks_like_serial(tok: str) -> bool:
+    return any(p.match(tok) for p in SERIAL_TOKEN_RES)
+
+
+# Friendly-name leaks: serial-shaped tokens in display text (mixed
+# upper-and-lower or 8+ digit runs).
+FRIENDLY_LEAK_RE = re.compile(r"\b[A-Z0-9]{8,}\b|\b[a-f0-9]{8,}\b|\b[0-9]{9,}\b")
+
+
+def make_id_mapper():
+    """Build a function that scrubs an entity id string in-place,
+    keeping a stable per-token mapping so referenced ids survive the
+    round-trip."""
+    token_map: dict[str, str] = {}
+    counter = {"n": 0}
+
+    def map_token(tok: str) -> str:
+        if tok in token_map:
+            return token_map[tok]
+        counter["n"] += 1
+        # Keep some readability: short pseudonyms like sn1, sn2, ...
+        repl = f"sn{counter['n']}"
+        token_map[tok] = repl
+        return repl
+
+    def scrub_id(eid: str) -> str:
+        for pattern, replacement in ENTITY_ID_REWRITES:
+            if pattern.match(eid):
+                return replacement
+        if "." not in eid:
+            return eid
+        domain, rest = eid.split(".", 1)
+        parts = rest.split("_")
+        out_parts = [map_token(p) if looks_like_serial(p) else p for p in parts]
+        return f"{domain}.{'_'.join(out_parts)}"
+
+    return scrub_id, token_map
+
+
+def scrub_string(s: str, token_map: dict[str, str], scrub_id) -> str:
+    # First: scrub any embedded `<domain>.<entity_id>` references
+    # (jinja templates, attribute strings, ...).
+    def _replace_eid(m: re.Match) -> str:
+        return scrub_id(m.group())
+    out = re.sub(r"\b[a-z_]+\.[a-zA-Z0-9_]+\b", _replace_eid, s)
+    # Apply token map (case-insensitive) to any leftover reference,
+    # using non-alphanumeric boundaries (so `_serial_` matches even
+    # though `_` is a regex word char).
+    for k, v in sorted(token_map.items(), key=lambda kv: -len(kv[0])):
+        out = re.sub(
+            rf"(?i)(?<![A-Za-z0-9]){re.escape(k)}(?![A-Za-z0-9])",
+            v,
+            out,
+        )
+    # Strip remaining serial-shaped tokens from display text. Use
+    # alphanumeric-only boundaries (treats `_` as a separator).
+    def _redact(m: re.Match) -> str:
+        tok = m.group()
+        if any(p.match(tok.lower()) for p in SERIAL_TOKEN_RES):
+            return "X" * len(tok)
+        return tok
+    out = re.sub(
+        r"(?<![A-Za-z0-9])[A-Za-z0-9]{8,}(?![A-Za-z0-9])",
+        _redact,
+        out,
+    )
+    return out
+
+
+def scrub_json(node, scrub_id, token_map):
+    if isinstance(node, dict):
+        out = {}
+        for k, v in node.items():
+            new_k = scrub_id(k) if "." in k and re.match(r"^[a-z_]+\.", k) else k
+            if k in EXTRA_REDACT_KEYS:
+                out[new_k] = "<redacted>"
+            else:
+                out[new_k] = scrub_json(v, scrub_id, token_map)
+        return out
+    if isinstance(node, list):
+        return [scrub_json(x, scrub_id, token_map) for x in node]
+    if isinstance(node, str):
+        if re.match(r"^[a-z_]+\.[a-zA-Z0-9_]+$", node):
+            return scrub_id(node)
+        return scrub_string(node, token_map, scrub_id)
+    return node
+
+
+def collect_entity_ids(states: dict, config: dict, scrub_id):
+    """Pre-warm the mapping by scrubbing every entity id we see, so
+    string scrubs that reference those ids in friendly-name attributes
+    or templates still find them in the cache."""
+    for eid in states.keys():
+        scrub_id(eid)
+    def walk(node):
+        if isinstance(node, dict):
+            for v in node.values():
+                walk(v)
+        elif isinstance(node, list):
+            for v in node:
+                walk(v)
+        elif isinstance(node, str) and re.match(r"^[a-z_]+\.[a-zA-Z0-9_]+$", node):
+            scrub_id(node)
+    walk(config)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--src", required=True, type=Path)
+    ap.add_argument("--dst", required=True, type=Path)
+    args = ap.parse_args()
+
+    args.dst.mkdir(parents=True, exist_ok=True)
+    for board in sorted(args.src.iterdir()):
+        if not board.is_dir():
+            continue
+        cfg_in = board / "lovelace_config.json"
+        states_in = board / "entity_states.json"
+        if not (cfg_in.exists() and states_in.exists()):
+            continue
+        out_dir = args.dst / board.name
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        cfg = json.loads(cfg_in.read_text())
+        states = json.loads(states_in.read_text())
+
+        scrub_id, token_map = make_id_mapper()
+        collect_entity_ids(states, cfg, scrub_id)
+
+        cfg_out = scrub_json(cfg, scrub_id, token_map)
+        states_out = scrub_json(states, scrub_id, token_map)
+
+        (out_dir / "lovelace_config.json").write_text(
+            json.dumps(cfg_out, indent=2, ensure_ascii=False)
+        )
+        (out_dir / "entity_states.json").write_text(
+            json.dumps(states_out, indent=2, ensure_ascii=False)
+        )
+        print(f"  {board.name}: {len(token_map)} unique serial tokens scrubbed")
+
+
+if __name__ == "__main__":
+    main()

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/DemoHaSession.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/DemoHaSession.kt
@@ -5,13 +5,17 @@ import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.Dashboard
 import ee.schimke.ha.model.EntityState
 import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.model.Section
 import ee.schimke.ha.model.View
 import kotlin.math.roundToInt
 import kotlin.math.sin
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * Offline session for the "Demo mode" toggle — no login, no network.
@@ -24,7 +28,10 @@ class DemoHaSession(
     private val clock: () -> Long = System::currentTimeMillis,
 ) : HaSession {
     override val baseUrl: String = DemoData.BASE_URL
-    override val refreshIntervalMillis: Long = 2_000L
+
+    /** Once a minute. The demo entities drift on a per-minute cadence so
+     *  the user sees values change without burning battery. */
+    override val refreshIntervalMillis: Long = 60_000L
 
     override suspend fun connect() = Unit
     override suspend fun listDashboards(): List<DashboardSummary> = DemoData.dashboards
@@ -34,187 +41,189 @@ class DemoHaSession(
 }
 
 /**
- * Fake dashboard + entity state for demo mode.
+ * Fake dashboard + entity state for demo mode. Powered by the seven
+ * captured Lovelace dashboards under
+ * `terrazzo-core/src/androidMain/resources/dashboards/<name>/` —
+ * scrubbed twice (the `homeassistant-agents` repo's `_sanitize.py`
+ * for IPs/MACs/tokens/lat-lon, then this repo's
+ * `terrazzo-core/scripts/scrub-demo-dashboards.py` for entity-id
+ * serials and friendly-name leaks).
  *
- * Values drift with wall-clock time (sine-wave temperatures, toggling
- * lights, slowly draining battery) so the app shows animation instead
- * of a frozen frame. Shared between [DemoHaSession] (in-app dashboards)
- * and the widget provider (pinned home-screen widgets) — any widget
- * whose stored `baseUrl == DemoData.BASE_URL` renders against
- * [DemoData.snapshot] instead of the empty default.
+ * Numeric sensor values drift on a per-minute cadence so the in-app
+ * demo and pinned widgets show animation — see [snapshot]. Toggle
+ * states (lights, switches) flip on a few different cadences too.
  */
 object DemoData {
-    /** Marker baseUrl used to identify demo-mode artefacts (stored on
-     *  pinned widgets so the provider knows to render demo state). */
     const val BASE_URL: String = "demo://terrazzo"
 
     fun isDemo(baseUrl: String?): Boolean = baseUrl == BASE_URL
 
-    val dashboards: List<DashboardSummary> = listOf(
-        DashboardSummary(urlPath = null, title = "Home", icon = null),
-        DashboardSummary(urlPath = "downstairs", title = "Downstairs", icon = null),
-        DashboardSummary(urlPath = "office", title = "Office", icon = null),
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    /** Captured boards bundled in resources, in dashboard-picker order. */
+    private val BOARDS: List<DemoBoard> = listOf(
+        DemoBoard(slug = "security", title = "Security"),
+        DemoBoard(slug = "3d_printing", title = "3D Printing"),
+        DemoBoard(slug = "climate", title = "Climate"),
+        DemoBoard(slug = "energy", title = "Energy"),
+        DemoBoard(slug = "github", title = "GitHub"),
+        DemoBoard(slug = "meshcore", title = "Meshcore"),
+        DemoBoard(slug = "networks", title = "Networks"),
     )
 
-    fun dashboard(urlPath: String?): Dashboard = when (urlPath) {
-        "downstairs" -> Dashboard(title = "Downstairs", views = listOf(View(cards = downstairsCards)))
-        "office" -> Dashboard(title = "Office", views = listOf(View(cards = officeCards)))
-        else -> Dashboard(title = "Home", views = listOf(View(cards = homeCards)))
-    }
-
-    fun snapshot(nowMs: Long = System.currentTimeMillis()): HaSnapshot {
-        val tSec = nowMs / 1000.0
-
-        // Slow sine wave → living-room temperature drifts 19.0–23.0°C.
-        val livingTemp = 21.0 + 2.0 * sin(tSec / 60.0)
-        // Faster wave → humidity 38–58%.
-        val humidity = (48.0 + 10.0 * sin(tSec / 20.0)).roundToInt()
-        // Power draw: 80–260W, noisy-looking sine.
-        val power = (170.0 + 90.0 * sin(tSec / 7.0)).roundToInt()
-        // Office temp: gentler 20–22°C.
-        val officeTemp = 21.0 + 1.0 * sin(tSec / 90.0)
-        // Laptop battery: drains 100% → 20% over 40 min, then resets.
-        val batteryPct = 100 - ((nowMs / 1000L / 30L) % 81L).toInt()
-        // Office lamp toggles every 8 s so you can see a light switch.
-        val officeLampOn = (nowMs / 8_000L) % 2L == 0L
-        // Hallway light pulses every 12 s.
-        val hallwayOn = (nowMs / 12_000L) % 3L == 0L
-
-        return HaSnapshot(
-            states = mapOf(
-                entity(
-                    "sensor.living_room",
-                    "%.1f".format(livingTemp),
-                    "friendly_name" to "Living Room",
-                    "unit_of_measurement" to "°C",
-                    "device_class" to "temperature",
-                ),
-                entity(
-                    "sensor.office_temp",
-                    "%.1f".format(officeTemp),
-                    "friendly_name" to "Office",
-                    "unit_of_measurement" to "°C",
-                    "device_class" to "temperature",
-                ),
-                entity(
-                    "sensor.humidity",
-                    humidity.toString(),
-                    "friendly_name" to "Humidity",
-                    "unit_of_measurement" to "%",
-                    "device_class" to "humidity",
-                ),
-                entity(
-                    "sensor.power",
-                    power.toString(),
-                    "friendly_name" to "Power",
-                    "unit_of_measurement" to "W",
-                    "device_class" to "power",
-                ),
-                entity(
-                    "sensor.laptop_battery",
-                    batteryPct.toString(),
-                    "friendly_name" to "Laptop",
-                    "unit_of_measurement" to "%",
-                    "device_class" to "battery",
-                ),
-                entity(
-                    "light.kitchen",
-                    "on",
-                    "friendly_name" to "Kitchen",
-                    "brightness" to "220",
-                ),
-                entity(
-                    "light.office_lamp",
-                    if (officeLampOn) "on" else "off",
-                    "friendly_name" to "Office lamp",
-                    "brightness" to if (officeLampOn) "180" else "0",
-                ),
-                entity(
-                    "light.hallway",
-                    if (hallwayOn) "on" else "off",
-                    "friendly_name" to "Hallway",
-                ),
-                entity(
-                    "switch.coffee_maker",
-                    "on",
-                    "friendly_name" to "Coffee maker",
-                ),
-                entity(
-                    "switch.desk_fan",
-                    "off",
-                    "friendly_name" to "Desk fan",
-                ),
-                entity(
-                    "lock.front_door",
-                    "locked",
-                    "friendly_name" to "Front door",
-                ),
-            ),
+    val dashboards: List<DashboardSummary> = BOARDS.mapIndexed { i, b ->
+        DashboardSummary(
+            urlPath = if (i == 0) null else b.slug.replace('_', '-'),
+            title = b.title,
+            icon = null,
         )
     }
 
-    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+    /** Pre-loaded dashboards (config + entity state) per slug. Reading
+     *  resources is JVM-cheap but we cache anyway since the picker
+     *  flips between boards frequently. */
+    private val cachedDashboards: Map<String, Dashboard> = BOARDS.associate { b ->
+        b.slug to loadDashboard(b)
+    }
 
-    private fun card(src: String): CardConfig {
-        val obj = json.parseToJsonElement(src).jsonObject
-        val type = obj["type"]!!.toString().trim('"')
+    private val baseStates: Map<String, EntityState> = BOARDS.flatMap { b ->
+        loadStates(b).entries
+    }.associate { it.key to it.value }
+
+    fun dashboard(urlPath: String?): Dashboard {
+        val slug = urlPathToSlug(urlPath)
+        return cachedDashboards[slug]
+            ?: cachedDashboards[BOARDS.first().slug]!!
+    }
+
+    fun snapshot(nowMs: Long = System.currentTimeMillis()): HaSnapshot {
+        val drifted = baseStates.mapValues { (id, st) -> drift(id, st, nowMs) }
+        return HaSnapshot(states = drifted)
+    }
+
+    private fun urlPathToSlug(urlPath: String?): String {
+        if (urlPath == null) return BOARDS.first().slug
+        return BOARDS.firstOrNull {
+            it.slug.replace('_', '-') == urlPath || it.slug == urlPath
+        }?.slug ?: BOARDS.first().slug
+    }
+
+    private fun loadDashboard(b: DemoBoard): Dashboard {
+        val text = readResource("/dashboards/${b.slug}/lovelace_config.json") ?: return emptyBoard(b)
+        return parseDashboard(text, b.title)
+    }
+
+    private fun loadStates(b: DemoBoard): Map<String, EntityState> {
+        val text = readResource("/dashboards/${b.slug}/entity_states.json") ?: return emptyMap()
+        return parseStates(text)
+    }
+
+    private fun emptyBoard(b: DemoBoard): Dashboard = Dashboard(title = b.title)
+
+    private fun readResource(path: String): String? =
+        DemoData::class.java.getResourceAsStream(path)?.bufferedReader()?.use { it.readText() }
+
+    private fun parseDashboard(text: String, fallbackTitle: String): Dashboard {
+        val root = Json.parseToJsonElement(text).jsonObject
+        val title = root["title"]?.jsonPrimitive?.content ?: fallbackTitle
+        val views = (root["views"] as? JsonArray)?.map { parseView(it.jsonObject) } ?: emptyList()
+        return Dashboard(title = title, views = views)
+    }
+
+    private fun parseView(obj: JsonObject): View {
+        val title = obj["title"]?.jsonPrimitive?.content
+        val type = obj["type"]?.jsonPrimitive?.content
+        val cards = (obj["cards"] as? JsonArray)?.mapNotNull { it.toCardConfig() } ?: emptyList()
+        val sections = (obj["sections"] as? JsonArray)?.mapNotNull { el ->
+            val s = el as? JsonObject ?: return@mapNotNull null
+            Section(
+                type = s["type"]?.jsonPrimitive?.content,
+                title = s["title"]?.jsonPrimitive?.content,
+                cards = (s["cards"] as? JsonArray)?.mapNotNull { c -> c.toCardConfig() } ?: emptyList(),
+            )
+        } ?: emptyList()
+        return View(title = title, type = type, cards = cards, sections = sections)
+    }
+
+    private fun kotlinx.serialization.json.JsonElement.toCardConfig(): CardConfig? {
+        val obj = this as? JsonObject ?: return null
+        val type = obj["type"]?.jsonPrimitive?.content ?: return null
         return CardConfig(type = type, raw = obj)
     }
 
-    private val homeCards = listOf(
-        card("""{"type":"heading","heading":"Home"}"""),
-        card("""{"type":"glance","title":"Overview","entities":[
-            "sensor.living_room",
-            "light.kitchen",
-            "lock.front_door"
-        ]}"""),
-        card("""{"type":"entities","title":"Living Room","entities":[
-            "sensor.living_room",
-            "sensor.humidity",
-            "light.kitchen",
-            "switch.coffee_maker"
-        ]}"""),
-        card("""{"type":"vertical-stack","cards":[
-            {"type":"tile","entity":"light.kitchen","color":"amber"},
-            {"type":"tile","entity":"lock.front_door"}
-        ]}"""),
-    )
-
-    private val downstairsCards = listOf(
-        card("""{"type":"heading","heading":"Downstairs"}"""),
-        card("""{"type":"grid","cards":[
-            {"type":"button","entity":"light.kitchen","name":"Kitchen"},
-            {"type":"button","entity":"light.hallway","name":"Hallway"},
-            {"type":"button","entity":"switch.coffee_maker","name":"Coffee"},
-            {"type":"button","entity":"lock.front_door","name":"Door","icon":"mdi:door"}
-        ]}"""),
-        card("""{"type":"entities","title":"Environment","entities":[
-            "sensor.living_room",
-            "sensor.humidity",
-            "sensor.power"
-        ]}"""),
-    )
-
-    private val officeCards = listOf(
-        card("""{"type":"heading","heading":"Office"}"""),
-        card("""{"type":"horizontal-stack","cards":[
-            {"type":"button","entity":"light.office_lamp","name":"Lamp"},
-            {"type":"button","entity":"switch.desk_fan","name":"Fan"}
-        ]}"""),
-        card("""{"type":"entities","title":"Desk","entities":[
-            "sensor.office_temp",
-            "sensor.laptop_battery",
-            "light.office_lamp"
-        ]}"""),
-        card("""{"type":"markdown","title":"Notes","content":"Demo mode — values change every two seconds."}"""),
-    )
-
-    private fun entity(
-        id: String,
-        state: String,
-        vararg attrs: Pair<String, String>,
-    ): Pair<String, EntityState> {
-        val obj = JsonObject(attrs.associate { (k, v) -> k to JsonPrimitive(v) })
-        return id to EntityState(entityId = id, state = state, attributes = obj)
+    private fun parseStates(text: String): Map<String, EntityState> {
+        val root = Json.parseToJsonElement(text).jsonObject
+        return root.entries.mapNotNull { (id, el) ->
+            val obj = el as? JsonObject ?: return@mapNotNull null
+            val state = obj["state"]?.jsonPrimitive?.content ?: return@mapNotNull null
+            val attrs = (obj["attributes"] as? JsonObject) ?: JsonObject(emptyMap())
+            id to EntityState(entityId = id, state = state, attributes = attrs)
+        }.toMap()
     }
+
+    /**
+     * Per-minute drift: numeric sensors get a small sinusoidal offset
+     * keyed by the entity id and the minute-bucket of `nowMs`, so each
+     * minute brings new but plausible values. Lights and switches
+     * toggle on coarser cadences (5/8/15 minutes) so the user sees the
+     * dashboard "live" without a jittery, fast feel.
+     */
+    private fun drift(entityId: String, base: EntityState, nowMs: Long): EntityState {
+        val minute = (nowMs / 60_000L).toInt()
+        val phase = (entityId.hashCode().toLong() and 0xFFFFL).toDouble()
+        val seed = (minute + phase / 1000.0)
+        val unit = base.attributes["unit_of_measurement"]?.jsonPrimitive?.content
+        val deviceClass = base.attributes["device_class"]?.jsonPrimitive?.content
+
+        val originalNumber = base.state.toDoubleOrNull()
+        val newState: String? = when {
+            originalNumber != null && unit != null -> {
+                val amplitude = when (deviceClass) {
+                    "battery" -> 1.0
+                    "humidity", "moisture" -> 1.5
+                    "temperature" -> 0.4
+                    "power", "energy", "current", "voltage" -> originalNumber * 0.08 + 5.0
+                    "pressure" -> 0.6
+                    "illuminance" -> originalNumber * 0.12 + 1.0
+                    else -> originalNumber * 0.05 + 0.5
+                }
+                val drifted = clampForDeviceClass(
+                    deviceClass,
+                    originalNumber + amplitude * sin(seed * 0.7),
+                )
+                formatLikeOriginal(base.state, drifted)
+            }
+            base.state == "on" || base.state == "off" -> {
+                if (entityId.startsWith("light.")) {
+                    val toggle = (minute + (phase.toLong() % 7)) % 8 == 0L
+                    if (toggle) flipBinary(base.state) else null
+                } else if (entityId.startsWith("switch.")) {
+                    val toggle = (minute + (phase.toLong() % 5)) % 15 == 0L
+                    if (toggle) flipBinary(base.state) else null
+                } else null
+            }
+            else -> null
+        }
+        return if (newState != null && newState != base.state) {
+            base.copy(state = newState)
+        } else base
+    }
+
+    private fun formatLikeOriginal(original: String, value: Double): String {
+        val dotIndex = original.indexOf('.')
+        val decimals = if (dotIndex == -1) 0 else original.length - dotIndex - 1
+        return if (decimals == 0) value.roundToInt().toString()
+        else "%.${decimals}f".format(value)
+    }
+
+    private fun flipBinary(state: String): String = if (state == "on") "off" else "on"
+
+    private fun clampForDeviceClass(deviceClass: String?, value: Double): Double = when (deviceClass) {
+        "battery", "humidity", "moisture" -> value.coerceIn(0.0, 100.0)
+        "illuminance", "power", "energy", "current", "voltage" -> value.coerceAtLeast(0.0)
+        "pressure" -> value.coerceAtLeast(900.0)
+        else -> value
+    }
+
+    private data class DemoBoard(val slug: String, val title: String)
 }

--- a/terrazzo-core/src/androidMain/resources/dashboards/3d_printing/entity_states.json
+++ b/terrazzo-core/src/androidMain/resources/dashboards/3d_printing/entity_states.json
@@ -1,0 +1,2557 @@
+{
+  "binary_sensor.a1mini_sn1_ams_1_active": {
+    "entity_id": "binary_sensor.a1mini_sn1_ams_1_active",
+    "state": "off",
+    "attributes": {
+      "device_class": "running",
+      "icon": "mdi:check",
+      "friendly_name": "A1MINI_sn1_AMS_1 Active"
+    },
+    "last_changed": "2026-04-30T18:08:21.481739+00:00",
+    "last_reported": "2026-04-30T18:13:55.265041+00:00",
+    "last_updated": "2026-04-30T18:08:21.481739+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.a1mini_sn1_externalspool_active": {
+    "entity_id": "binary_sensor.a1mini_sn1_externalspool_active",
+    "state": "off",
+    "attributes": {
+      "device_class": "running",
+      "icon": "mdi:check",
+      "friendly_name": "A1MINI_sn1_ExternalSpool Active"
+    },
+    "last_changed": "2026-04-30T18:08:21.482101+00:00",
+    "last_reported": "2026-04-30T18:13:55.265081+00:00",
+    "last_updated": "2026-04-30T18:08:21.482101+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.a1mini_sn1_extruder_filament_state": {
+    "entity_id": "binary_sensor.a1mini_sn1_extruder_filament_state",
+    "state": "off",
+    "attributes": {
+      "friendly_name": "A1MINI_sn1 Extruder filament"
+    },
+    "last_changed": "2026-04-30T18:08:21.478323+00:00",
+    "last_reported": "2026-04-30T18:13:55.264800+00:00",
+    "last_updated": "2026-04-30T18:08:21.478323+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.a1mini_sn1_firmware_update": {
+    "entity_id": "binary_sensor.a1mini_sn1_firmware_update",
+    "state": "off",
+    "attributes": {
+      "device_class": "update",
+      "friendly_name": "A1MINI_sn1 Firmware"
+    },
+    "last_changed": "2026-04-30T18:08:21.479265+00:00",
+    "last_reported": "2026-04-30T18:13:55.264882+00:00",
+    "last_updated": "2026-04-30T18:08:21.479265+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.a1mini_sn1_hms_errors": {
+    "entity_id": "binary_sensor.a1mini_sn1_hms_errors",
+    "state": "off",
+    "attributes": {
+      "Count": 0,
+      "device_class": "problem",
+      "friendly_name": "A1MINI_sn1 HMS errors"
+    },
+    "last_changed": "2026-04-30T18:08:21.478612+00:00",
+    "last_reported": "2026-04-30T18:13:55.264827+00:00",
+    "last_updated": "2026-04-30T18:08:21.478612+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.a1mini_sn1_online": {
+    "entity_id": "binary_sensor.a1mini_sn1_online",
+    "state": "on",
+    "attributes": {
+      "device_class": "running",
+      "friendly_name": "A1MINI_sn1 Online"
+    },
+    "last_changed": "2026-04-30T18:08:21.479046+00:00",
+    "last_reported": "2026-04-30T18:13:55.264865+00:00",
+    "last_updated": "2026-04-30T18:08:21.479046+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.a1mini_sn1_print_error": {
+    "entity_id": "binary_sensor.a1mini_sn1_print_error",
+    "state": "off",
+    "attributes": {
+      "device_class": "problem",
+      "friendly_name": "A1MINI_sn1 Print error"
+    },
+    "last_changed": "2026-04-30T18:08:21.478847+00:00",
+    "last_reported": "2026-04-30T18:13:55.264847+00:00",
+    "last_updated": "2026-04-30T18:08:21.478847+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.a1mini_sn1_recording_timelapse": {
+    "entity_id": "binary_sensor.a1mini_sn1_recording_timelapse",
+    "state": "off",
+    "attributes": {
+      "device_class": "running",
+      "icon": "mdi:camera",
+      "friendly_name": "A1MINI_sn1 Timelapse"
+    },
+    "last_changed": "2026-04-30T18:08:21.477071+00:00",
+    "last_reported": "2026-04-30T18:13:55.264741+00:00",
+    "last_updated": "2026-04-30T18:08:21.477071+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.p2s_sn2_ams_1_active": {
+    "entity_id": "binary_sensor.p2s_sn2_ams_1_active",
+    "state": "off",
+    "attributes": {
+      "device_class": "running",
+      "icon": "mdi:check",
+      "friendly_name": "P2S_sn2_AMS_1 Active"
+    },
+    "last_changed": "2026-04-30T18:08:22.870950+00:00",
+    "last_reported": "2026-04-30T18:08:24.387238+00:00",
+    "last_updated": "2026-04-30T18:08:22.870950+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.p2s_sn2_ams_1_drying": {
+    "entity_id": "binary_sensor.p2s_sn2_ams_1_drying",
+    "state": "off",
+    "attributes": {
+      "device_class": "running",
+      "icon": "mdi:heat-wave",
+      "friendly_name": "P2S_sn2_AMS_1 Drying"
+    },
+    "last_changed": "2026-04-30T18:08:22.871117+00:00",
+    "last_reported": "2026-04-30T18:08:24.387254+00:00",
+    "last_updated": "2026-04-30T18:08:22.871117+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.p2s_sn2_door": {
+    "entity_id": "binary_sensor.p2s_sn2_door",
+    "state": "off",
+    "attributes": {
+      "device_class": "door",
+      "friendly_name": "P2S_sn2 Door"
+    },
+    "last_changed": "2026-04-30T18:08:22.870270+00:00",
+    "last_reported": "2026-04-30T18:08:24.387134+00:00",
+    "last_updated": "2026-04-30T18:08:22.870270+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.p2s_sn2_externalspool_active": {
+    "entity_id": "binary_sensor.p2s_sn2_externalspool_active",
+    "state": "off",
+    "attributes": {
+      "device_class": "running",
+      "icon": "mdi:check",
+      "friendly_name": "P2S_sn2_ExternalSpool Active"
+    },
+    "last_changed": "2026-04-30T18:08:22.871319+00:00",
+    "last_reported": "2026-04-30T18:08:24.387281+00:00",
+    "last_updated": "2026-04-30T18:08:22.871319+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.p2s_sn2_extruder_filament": {
+    "entity_id": "binary_sensor.p2s_sn2_extruder_filament",
+    "state": "on",
+    "attributes": {
+      "friendly_name": "P2S_sn2 Extruder filament"
+    },
+    "last_changed": "2026-04-30T18:08:22.869408+00:00",
+    "last_reported": "2026-04-30T18:08:24.387048+00:00",
+    "last_updated": "2026-04-30T18:08:22.869408+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.p2s_sn2_firmware": {
+    "entity_id": "binary_sensor.p2s_sn2_firmware",
+    "state": "off",
+    "attributes": {
+      "device_class": "update",
+      "friendly_name": "P2S_sn2 Firmware"
+    },
+    "last_changed": "2026-04-30T18:08:22.870100+00:00",
+    "last_reported": "2026-04-30T18:08:24.387120+00:00",
+    "last_updated": "2026-04-30T18:08:22.870100+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.p2s_sn2_hms_errors": {
+    "entity_id": "binary_sensor.p2s_sn2_hms_errors",
+    "state": "on",
+    "attributes": {
+      "1-Code": "HMS_0500_0600_0002_0070",
+      "1-Error": "unknown",
+      "1-Wiki": "https://wiki.bambulab.com/en/x1/troubleshooting/hmscode/0500_0600_0002_0070",
+      "1-Severity": "serious",
+      "Count": 1,
+      "device_class": "problem",
+      "friendly_name": "P2S_sn2 HMS errors"
+    },
+    "last_changed": "2026-04-30T18:08:22.869601+00:00",
+    "last_reported": "2026-04-30T18:08:24.387070+00:00",
+    "last_updated": "2026-04-30T18:08:22.869601+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.p2s_sn2_online": {
+    "entity_id": "binary_sensor.p2s_sn2_online",
+    "state": "on",
+    "attributes": {
+      "device_class": "running",
+      "friendly_name": "P2S_sn2 Online"
+    },
+    "last_changed": "2026-04-30T18:08:22.869928+00:00",
+    "last_reported": "2026-04-30T18:08:24.387105+00:00",
+    "last_updated": "2026-04-30T18:08:22.869928+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.p2s_sn2_print_error": {
+    "entity_id": "binary_sensor.p2s_sn2_print_error",
+    "state": "off",
+    "attributes": {
+      "device_class": "problem",
+      "friendly_name": "P2S_sn2 Print error"
+    },
+    "last_changed": "2026-04-30T18:08:22.869765+00:00",
+    "last_reported": "2026-04-30T18:08:24.387088+00:00",
+    "last_updated": "2026-04-30T18:08:22.869765+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.p2s_sn2_timelapse": {
+    "entity_id": "binary_sensor.p2s_sn2_timelapse",
+    "state": "off",
+    "attributes": {
+      "device_class": "running",
+      "icon": "mdi:camera",
+      "friendly_name": "P2S_sn2 Timelapse"
+    },
+    "last_changed": "2026-04-30T18:08:22.869158+00:00",
+    "last_reported": "2026-04-30T18:08:24.386994+00:00",
+    "last_updated": "2026-04-30T18:08:22.869158+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "button.a1mini_sn1_force_refresh_data": {
+    "entity_id": "button.a1mini_sn1_force_refresh_data",
+    "state": "unknown",
+    "attributes": {
+      "icon": "mdi:refresh",
+      "friendly_name": "A1MINI_sn1 Force refresh"
+    },
+    "last_changed": "2026-04-30T18:08:21.483351+00:00",
+    "last_reported": "2026-04-30T18:13:20.059632+00:00",
+    "last_updated": "2026-04-30T18:08:21.483351+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "button.a1mini_sn1_pause_printing": {
+    "entity_id": "button.a1mini_sn1_pause_printing",
+    "state": "unavailable",
+    "attributes": {
+      "icon": "mdi:pause",
+      "friendly_name": "A1MINI_sn1 Pause"
+    },
+    "last_changed": "2026-04-30T18:08:21.482817+00:00",
+    "last_reported": "2026-04-30T18:13:20.059558+00:00",
+    "last_updated": "2026-04-30T18:08:21.482817+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "button.a1mini_sn1_resume_printing": {
+    "entity_id": "button.a1mini_sn1_resume_printing",
+    "state": "unavailable",
+    "attributes": {
+      "icon": "mdi:play",
+      "friendly_name": "A1MINI_sn1 Resume"
+    },
+    "last_changed": "2026-04-30T18:08:21.482999+00:00",
+    "last_reported": "2026-04-30T18:13:20.059583+00:00",
+    "last_updated": "2026-04-30T18:08:21.482999+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "button.a1mini_sn1_stop_printing": {
+    "entity_id": "button.a1mini_sn1_stop_printing",
+    "state": "unavailable",
+    "attributes": {
+      "icon": "mdi:stop",
+      "friendly_name": "A1MINI_sn1 Stop"
+    },
+    "last_changed": "2026-04-30T18:08:21.483176+00:00",
+    "last_reported": "2026-04-30T18:13:20.059609+00:00",
+    "last_updated": "2026-04-30T18:08:21.483176+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "camera.a1mini_sn1_camera": {
+    "entity_id": "camera.a1mini_sn1_camera",
+    "state": "streaming",
+    "attributes": {
+      "access_token": "<redacted>",
+      "brand": "Bambu Lab",
+      "entity_picture": "/api/camera_proxy/camera.a1mini_sn1_camera?token=REDACTED",
+      "icon": "mdi:camera",
+      "friendly_name": "A1MINI_sn1 Camera",
+      "supported_features": 0
+    },
+    "last_changed": "2026-04-30T18:08:21.483939+00:00",
+    "last_reported": "2026-05-05T22:13:12.373073+00:00",
+    "last_updated": "2026-05-05T22:13:07.553843+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "fan.a1mini_sn1_cooling_fan": {
+    "entity_id": "fan.a1mini_sn1_cooling_fan",
+    "state": "off",
+    "attributes": {
+      "preset_modes": null,
+      "percentage": 0,
+      "percentage_step": 1.0,
+      "preset_mode": null,
+      "friendly_name": "A1MINI_sn1 Cooling fan",
+      "supported_features": 49
+    },
+    "last_changed": "2026-04-30T18:08:21.484437+00:00",
+    "last_reported": "2026-04-30T18:13:55.265296+00:00",
+    "last_updated": "2026-04-30T18:08:21.484437+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "image.a1mini_sn1_cover_image": {
+    "entity_id": "image.a1mini_sn1_cover_image",
+    "state": "2026-04-30T19:08:24.869197",
+    "attributes": {
+      "access_token": "<redacted>",
+      "entity_picture": "/api/image_proxy/image.a1mini_sn1_cover_image?token=REDACTED",
+      "friendly_name": "A1MINI_sn1 Cover image"
+    },
+    "last_changed": "2026-04-30T18:08:24.869959+00:00",
+    "last_reported": "2026-05-05T22:13:12.373202+00:00",
+    "last_updated": "2026-05-05T22:13:07.627922+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "image.a1mini_sn1_pick_image": {
+    "entity_id": "image.a1mini_sn1_pick_image",
+    "state": "2026-04-30T19:08:24.936681",
+    "attributes": {
+      "access_token": "<redacted>",
+      "entity_picture": "/api/image_proxy/image.a1mini_sn1_pick_image?token=REDACTED",
+      "friendly_name": "A1MINI_sn1 Pick image"
+    },
+    "last_changed": "2026-04-30T18:08:24.995341+00:00",
+    "last_reported": "2026-05-05T22:13:12.373238+00:00",
+    "last_updated": "2026-05-05T22:13:07.628177+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "image.p2s_sn2_cover_image": {
+    "entity_id": "image.p2s_sn2_cover_image",
+    "state": "2026-04-30T19:08:24.089518",
+    "attributes": {
+      "access_token": "<redacted>",
+      "entity_picture": "/api/image_proxy/image.p2s_sn2_cover_image?token=REDACTED",
+      "friendly_name": "P2S_sn2 Cover image"
+    },
+    "last_changed": "2026-04-30T18:08:24.090199+00:00",
+    "last_reported": "2026-05-05T22:13:07.628278+00:00",
+    "last_updated": "2026-05-05T22:13:07.628278+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "image.p2s_sn2_pick_image": {
+    "entity_id": "image.p2s_sn2_pick_image",
+    "state": "2026-04-30T19:08:24.277409",
+    "attributes": {
+      "access_token": "<redacted>",
+      "entity_picture": "/api/image_proxy/image.p2s_sn2_pick_image?token=REDACTED",
+      "friendly_name": "P2S_sn2 Pick image"
+    },
+    "last_changed": "2026-04-30T18:08:24.387361+00:00",
+    "last_reported": "2026-05-05T22:13:07.628350+00:00",
+    "last_updated": "2026-05-05T22:13:07.628350+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "light.a1mini_sn1_chamber_light": {
+    "entity_id": "light.a1mini_sn1_chamber_light",
+    "state": "on",
+    "attributes": {
+      "supported_color_modes": [
+        "onoff"
+      ],
+      "color_mode": "onoff",
+      "icon": "mdi:led-strip-variant",
+      "friendly_name": "A1MINI_sn1 Chamber light",
+      "supported_features": 0
+    },
+    "last_changed": "2026-04-30T18:08:21.486475+00:00",
+    "last_reported": "2026-04-30T18:13:55.265446+00:00",
+    "last_updated": "2026-04-30T18:08:21.486475+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "light.p2s_sn2_chamber_light": {
+    "entity_id": "light.p2s_sn2_chamber_light",
+    "state": "off",
+    "attributes": {
+      "supported_color_modes": [
+        "onoff"
+      ],
+      "color_mode": null,
+      "icon": "mdi:led-strip-variant",
+      "friendly_name": "P2S_sn2 Chamber light",
+      "supported_features": 0
+    },
+    "last_changed": "2026-04-30T18:08:22.872820+00:00",
+    "last_reported": "2026-04-30T18:08:24.387450+00:00",
+    "last_updated": "2026-04-30T18:08:22.872820+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "select.a1mini_sn1_printing_speed": {
+    "entity_id": "select.a1mini_sn1_printing_speed",
+    "state": "unavailable",
+    "attributes": {
+      "options": [
+        "silent",
+        "standard",
+        "sport",
+        "ludicrous"
+      ],
+      "icon": "mdi:speedometer",
+      "friendly_name": "A1MINI_sn1 Printing speed"
+    },
+    "last_changed": "2026-04-30T18:08:21.487558+00:00",
+    "last_reported": "2026-04-30T18:13:55.265657+00:00",
+    "last_updated": "2026-04-30T18:08:21.487558+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_active_tray": {
+    "entity_id": "sensor.a1mini_sn1_active_tray",
+    "state": "none",
+    "attributes": {
+      "friendly_name": "A1MINI_sn1 Active tray"
+    },
+    "last_changed": "2026-04-30T18:08:21.497660+00:00",
+    "last_reported": "2026-04-30T18:13:55.266963+00:00",
+    "last_updated": "2026-04-30T18:08:21.497660+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_ams_1_humidity": {
+    "entity_id": "sensor.a1mini_sn1_ams_1_humidity",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "%",
+      "device_class": "humidity",
+      "friendly_name": "A1MINI_sn1_AMS_1 Humidity"
+    },
+    "last_changed": "2026-04-30T18:08:21.488539+00:00",
+    "last_reported": "2026-04-30T18:13:55.265832+00:00",
+    "last_updated": "2026-04-30T18:08:21.488539+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_ams_1_humidity_index": {
+    "entity_id": "sensor.a1mini_sn1_ams_1_humidity_index",
+    "state": "1",
+    "attributes": {
+      "state_class": "measurement",
+      "icon": "mdi:water-percent",
+      "friendly_name": "A1MINI_sn1_AMS_1 Humidity index"
+    },
+    "last_changed": "2026-04-30T18:08:21.488296+00:00",
+    "last_reported": "2026-04-30T18:13:55.265799+00:00",
+    "last_updated": "2026-04-30T18:08:21.488296+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_ams_1_temperature_2": {
+    "entity_id": "sensor.a1mini_sn1_ams_1_temperature_2",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "°C",
+      "device_class": "temperature",
+      "friendly_name": "A1MINI_sn1_AMS_1 Temperature"
+    },
+    "last_changed": "2026-04-30T18:08:21.488775+00:00",
+    "last_reported": "2026-04-30T18:13:55.265859+00:00",
+    "last_updated": "2026-04-30T18:08:21.488775+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_ams_1_tray_1": {
+    "entity_id": "sensor.a1mini_sn1_ams_1_tray_1",
+    "state": "Generic PLA",
+    "attributes": {
+      "slot": 1,
+      "active": false,
+      "bed_temp": "0",
+      "color": "#XXXXXXXX",
+      "cols": [
+        "#XXXXXXXX"
+      ],
+      "ctype": 0,
+      "dry_temp": "0",
+      "dry_time": "0",
+      "empty": false,
+      "filament_id": "<redacted>",
+      "k_value": "<redacted>",
+      "tray_weight": "0",
+      "name": "Generic PLA",
+      "nozzle_temp_min": "190",
+      "nozzle_temp_max": "240",
+      "remain": 100,
+      "remain_enabled": true,
+      "tag_uid": "<redacted>",
+      "tray_uuid": "<redacted>",
+      "type": "PLA",
+      "icon": "mdi:printer-3d-nozzle",
+      "friendly_name": "A1MINI_sn1_AMS_1 Tray 1"
+    },
+    "last_changed": "2026-04-30T18:08:21.489031+00:00",
+    "last_reported": "2026-04-30T18:13:55.265940+00:00",
+    "last_updated": "2026-04-30T18:08:21.489031+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_ams_1_tray_2": {
+    "entity_id": "sensor.a1mini_sn1_ams_1_tray_2",
+    "state": "Empty",
+    "attributes": {
+      "slot": 2,
+      "active": false,
+      "bed_temp": 0,
+      "color": "#XXXXXXXX",
+      "cols": [],
+      "ctype": 0,
+      "dry_temp": 0,
+      "dry_time": 0,
+      "empty": true,
+      "filament_id": "<redacted>",
+      "k_value": "<redacted>",
+      "tray_weight": 0,
+      "name": "Empty",
+      "nozzle_temp_min": 0,
+      "nozzle_temp_max": 0,
+      "remain": -1,
+      "remain_enabled": true,
+      "tag_uid": "<redacted>",
+      "tray_uuid": "<redacted>",
+      "type": "Empty",
+      "icon": "mdi:printer-3d-nozzle",
+      "friendly_name": "A1MINI_sn1_AMS_1 Tray 2"
+    },
+    "last_changed": "2026-04-30T18:08:21.489259+00:00",
+    "last_reported": "2026-04-30T18:13:55.265995+00:00",
+    "last_updated": "2026-04-30T18:08:21.489259+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_ams_1_tray_3": {
+    "entity_id": "sensor.a1mini_sn1_ams_1_tray_3",
+    "state": "Empty",
+    "attributes": {
+      "slot": 3,
+      "active": false,
+      "bed_temp": 0,
+      "color": "#XXXXXXXX",
+      "cols": [],
+      "ctype": 0,
+      "dry_temp": 0,
+      "dry_time": 0,
+      "empty": true,
+      "filament_id": "<redacted>",
+      "k_value": "<redacted>",
+      "tray_weight": 0,
+      "name": "Empty",
+      "nozzle_temp_min": 0,
+      "nozzle_temp_max": 0,
+      "remain": -1,
+      "remain_enabled": true,
+      "tag_uid": "<redacted>",
+      "tray_uuid": "<redacted>",
+      "type": "Empty",
+      "icon": "mdi:printer-3d-nozzle",
+      "friendly_name": "A1MINI_sn1_AMS_1 Tray 3"
+    },
+    "last_changed": "2026-04-30T18:08:21.489496+00:00",
+    "last_reported": "2026-04-30T18:13:55.266044+00:00",
+    "last_updated": "2026-04-30T18:08:21.489496+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_ams_1_tray_4": {
+    "entity_id": "sensor.a1mini_sn1_ams_1_tray_4",
+    "state": "Bambu PLA Basic",
+    "attributes": {
+      "slot": 4,
+      "active": false,
+      "bed_temp": "0",
+      "color": "#XXXXXXXX",
+      "cols": [
+        "#XXXXXXXX"
+      ],
+      "ctype": 0,
+      "dry_temp": "55",
+      "dry_time": "8",
+      "empty": false,
+      "filament_id": "<redacted>",
+      "k_value": "<redacted>",
+      "tray_weight": "1000",
+      "name": "Bambu PLA Basic",
+      "nozzle_temp_min": "190",
+      "nozzle_temp_max": "230",
+      "remain": 100,
+      "remain_enabled": true,
+      "tag_uid": "<redacted>",
+      "tray_uuid": "<redacted>",
+      "type": "PLA",
+      "icon": "mdi:printer-3d-nozzle",
+      "friendly_name": "A1MINI_sn1_AMS_1 Tray 4"
+    },
+    "last_changed": "2026-04-30T18:08:21.489715+00:00",
+    "last_reported": "2026-04-30T18:13:55.266094+00:00",
+    "last_updated": "2026-04-30T18:08:21.489715+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_bed_temperature": {
+    "entity_id": "sensor.a1mini_sn1_bed_temperature",
+    "state": "22",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "°C",
+      "device_class": "temperature",
+      "friendly_name": "A1MINI_sn1 Bed temperature"
+    },
+    "last_changed": "2026-05-05T22:17:51.888728+00:00",
+    "last_reported": "2026-05-05T22:18:02.243313+00:00",
+    "last_updated": "2026-05-05T22:17:51.888728+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_cooling_fan_speed": {
+    "entity_id": "sensor.a1mini_sn1_cooling_fan_speed",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "%",
+      "friendly_name": "A1MINI_sn1 Cooling fan speed"
+    },
+    "last_changed": "2026-04-30T18:08:21.491110+00:00",
+    "last_reported": "2026-04-30T18:13:55.266351+00:00",
+    "last_updated": "2026-04-30T18:08:21.491110+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_current_layer": {
+    "entity_id": "sensor.a1mini_sn1_current_layer",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "friendly_name": "A1MINI_sn1 Current layer"
+    },
+    "last_changed": "2026-04-30T18:08:21.495579+00:00",
+    "last_reported": "2026-04-30T18:13:55.266706+00:00",
+    "last_updated": "2026-04-30T18:08:21.495579+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_current_stage": {
+    "entity_id": "sensor.a1mini_sn1_current_stage",
+    "state": "idle",
+    "attributes": {
+      "options": [
+        "check_absolute_accuracy_after_calibration",
+        "preparing_hotend",
+        "paused_first_layer_error",
+        "paused_filament_runout",
+        "calibrating_micro_lidar",
+        "identifying_build_plate_type",
+        "paused_cutter_error",
+        "filament_loading",
+        "calibrate_birdeye_camera",
+        "preparing_ams",
+        "calibrating_extrusion",
+        "check_door_and_cover",
+        "paused_nozzle_temperature_malfunction",
+        "paused_chamber_temperature_control_error",
+        "inspecting_first_layer",
+        "heating_hotend",
+        "thermal_preconditioning",
+        "check_plaform",
+        "paused_user_gcode",
+        "laser_calibration",
+        "unknown",
+        "paused_user",
+        "scanning_bed_surface",
+        "paused_skipped_step",
+        "paused_heat_bed_temperature_malfunction",
+        "bed_level_high_temperature",
+        "paused_low_fan_speed_heat_break",
+        "m400_pause",
+        "calibrating_cutter_model_offset",
+        "purifying_chamber_air",
+        "calibrating_detection_nozzle_clumping",
+        "idle",
+        "heated_bedcooling",
+        "waiting_chamber_temperature_equalize",
+        "checking_extruder_temperature",
+        "paused_front_cover_falling",
+        "check_quick_release",
+        "bed_level_phase_2",
+        "heating_chamber",
+        "waiting_for_heatbed_temperature",
+        "hotend_pick_place_test",
+        "bed_level_phase_1",
+        "calibrating_blade_holder_position",
+        "auto_bed_leveling",
+        "cleaning_nozzle_tip",
+        "filament_unloading",
+        "calibrating_motor_noise",
+        "calibrating_live_view_camera",
+        "calibrating_camera_offset",
+        "check_absolute_accuracy_before_calibration",
+        "homing_blade_holder",
+        "absolute_accuracy_calibration",
+        "paused_nozzle_clog",
+        "check_material",
+        "homing_toolhead",
+        "paused_nozzle_filament_covered_detected",
+        "sweeping_xy_mech_mode",
+        "check_birdeye_camera_position",
+        "cooling_chamber",
+        "motor_noise_showoff",
+        "print_calibration_lines",
+        "printing",
+        "heatbed_preheating",
+        "changing_filament",
+        "calibrating_extrusion_flow",
+        "paused_ams_lost",
+        "check_material_position",
+        "measuring_surface",
+        "calibrate_nozzle_offset",
+        "offline"
+      ],
+      "device_class": "enum",
+      "friendly_name": "A1MINI_sn1 Current stage"
+    },
+    "last_changed": "2026-04-30T18:08:21.493172+00:00",
+    "last_reported": "2026-04-30T18:13:55.266453+00:00",
+    "last_updated": "2026-04-30T18:08:21.493172+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_end_time": {
+    "entity_id": "sensor.a1mini_sn1_end_time",
+    "state": "unavailable",
+    "attributes": {
+      "friendly_name": "A1MINI_sn1 End time"
+    },
+    "last_changed": "2026-04-30T18:08:21.495224+00:00",
+    "last_reported": "2026-04-30T18:13:55.266659+00:00",
+    "last_updated": "2026-04-30T18:08:21.495224+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_externalspool_external_spool": {
+    "entity_id": "sensor.a1mini_sn1_externalspool_external_spool",
+    "state": "Generic PLA",
+    "attributes": {
+      "active": false,
+      "bed_temp": "0",
+      "color": "#XXXXXXXX",
+      "cols": [],
+      "ctype": 0,
+      "dry_temp": "0",
+      "dry_time": "0",
+      "empty": false,
+      "filament_id": "<redacted>",
+      "k_value": "<redacted>",
+      "tray_weight": "0",
+      "name": "Generic PLA",
+      "nozzle_temp_min": "190",
+      "nozzle_temp_max": "240",
+      "remain": -1,
+      "remain_enabled": false,
+      "tag_uid": "<redacted>",
+      "tray_uuid": "<redacted>",
+      "type": "PLA",
+      "icon": "mdi:printer-3d-nozzle",
+      "friendly_name": "A1MINI_sn1_ExternalSpool External spool"
+    },
+    "last_changed": "2026-04-30T18:08:21.488043+00:00",
+    "last_reported": "2026-04-30T18:13:55.265756+00:00",
+    "last_updated": "2026-04-30T18:08:21.488043+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_gcode_file_downloaded": {
+    "entity_id": "sensor.a1mini_sn1_gcode_file_downloaded",
+    "state": "711381-0.2mm layer, 4 walls, 20% infill.gcode",
+    "attributes": {
+      "icon": "mdi:file",
+      "friendly_name": "A1MINI_sn1 Gcode file downloaded"
+    },
+    "last_changed": "2026-04-30T18:08:24.996378+00:00",
+    "last_reported": "2026-04-30T18:13:55.266767+00:00",
+    "last_updated": "2026-04-30T18:08:24.996378+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_gcode_filename": {
+    "entity_id": "sensor.a1mini_sn1_gcode_filename",
+    "state": "unavailable",
+    "attributes": {
+      "icon": "mdi:file",
+      "friendly_name": "A1MINI_sn1 Gcode filename"
+    },
+    "last_changed": "2026-04-30T18:08:21.495890+00:00",
+    "last_reported": "2026-04-30T18:13:55.266746+00:00",
+    "last_updated": "2026-04-30T18:08:21.495890+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_heatbreak_fan_speed": {
+    "entity_id": "sensor.a1mini_sn1_heatbreak_fan_speed",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "%",
+      "friendly_name": "A1MINI_sn1 Heatbreak fan speed"
+    },
+    "last_changed": "2026-04-30T18:08:21.491618+00:00",
+    "last_reported": "2026-04-30T18:13:55.266376+00:00",
+    "last_updated": "2026-04-30T18:08:21.491618+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_ip_address": {
+    "entity_id": "sensor.a1mini_sn1_ip_address",
+    "state": "<redacted>",
+    "attributes": {
+      "friendly_name": "A1MINI_sn1 IP address"
+    },
+    "last_changed": "2026-04-30T18:08:21.498200+00:00",
+    "last_reported": "2026-04-30T18:13:55.267030+00:00",
+    "last_updated": "2026-04-30T18:08:21.498200+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_model_download": {
+    "entity_id": "sensor.a1mini_sn1_model_download",
+    "state": "100",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "%",
+      "friendly_name": "A1MINI_sn1 Model download"
+    },
+    "last_changed": "2026-04-30T18:08:21.491887+00:00",
+    "last_reported": "2026-04-30T18:13:55.266400+00:00",
+    "last_updated": "2026-04-30T18:08:21.491887+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_mqtt_connection_mode": {
+    "entity_id": "sensor.a1mini_sn1_mqtt_connection_mode",
+    "state": "bambu_cloud",
+    "attributes": {
+      "options": [
+        "bambu_cloud",
+        "local"
+      ],
+      "device_class": "enum",
+      "friendly_name": "A1MINI_sn1 MQTT connection mode"
+    },
+    "last_changed": "2026-04-30T18:08:21.489952+00:00",
+    "last_reported": "2026-04-30T18:13:55.266131+00:00",
+    "last_updated": "2026-04-30T18:08:21.489952+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_nozzle_size": {
+    "entity_id": "sensor.a1mini_sn1_nozzle_size",
+    "state": "0.4",
+    "attributes": {
+      "unit_of_measurement": "mm",
+      "device_class": "distance",
+      "friendly_name": "A1MINI_sn1 Nozzle size"
+    },
+    "last_changed": "2026-04-30T18:08:21.497854+00:00",
+    "last_reported": "2026-04-30T18:13:55.266989+00:00",
+    "last_updated": "2026-04-30T18:08:21.497854+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_nozzle_target_temperature": {
+    "entity_id": "sensor.a1mini_sn1_nozzle_target_temperature",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "°C",
+      "device_class": "temperature",
+      "friendly_name": "A1MINI_sn1 Nozzle target temperature"
+    },
+    "last_changed": "2026-04-30T18:08:21.490916+00:00",
+    "last_reported": "2026-04-30T18:13:55.266326+00:00",
+    "last_updated": "2026-04-30T18:08:21.490916+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_nozzle_temperature": {
+    "entity_id": "sensor.a1mini_sn1_nozzle_temperature",
+    "state": "23",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "°C",
+      "device_class": "temperature",
+      "friendly_name": "A1MINI_sn1 Nozzle temperature"
+    },
+    "last_changed": "2026-05-05T20:28:39.946844+00:00",
+    "last_reported": "2026-05-05T20:28:44.090326+00:00",
+    "last_updated": "2026-05-05T20:28:39.946844+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_nozzle_type": {
+    "entity_id": "sensor.a1mini_sn1_nozzle_type",
+    "state": "stainless_steel",
+    "attributes": {
+      "friendly_name": "A1MINI_sn1 Nozzle type"
+    },
+    "last_changed": "2026-04-30T18:08:21.498013+00:00",
+    "last_reported": "2026-04-30T18:13:55.267010+00:00",
+    "last_updated": "2026-04-30T18:08:21.498013+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_print_bed_type": {
+    "entity_id": "sensor.a1mini_sn1_print_bed_type",
+    "state": "textured_plate",
+    "attributes": {
+      "friendly_name": "A1MINI_sn1 Print bed type"
+    },
+    "last_changed": "2026-04-30T18:08:24.996507+00:00",
+    "last_reported": "2026-04-30T18:13:55.266901+00:00",
+    "last_updated": "2026-04-30T18:08:24.996507+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_print_length": {
+    "entity_id": "sensor.a1mini_sn1_print_length",
+    "state": "4.94",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "m",
+      "device_class": "distance",
+      "friendly_name": "A1MINI_sn1 Print length"
+    },
+    "last_changed": "2026-04-30T18:08:24.996482+00:00",
+    "last_reported": "2026-04-30T18:13:55.266879+00:00",
+    "last_updated": "2026-04-30T18:08:24.996482+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_print_progress": {
+    "entity_id": "sensor.a1mini_sn1_print_progress",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "%",
+      "friendly_name": "A1MINI_sn1 Print progress"
+    },
+    "last_changed": "2026-04-30T18:08:21.493676+00:00",
+    "last_reported": "2026-04-30T18:13:55.266474+00:00",
+    "last_updated": "2026-04-30T18:08:21.493676+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_print_status": {
+    "entity_id": "sensor.a1mini_sn1_print_status",
+    "state": "idle",
+    "attributes": {
+      "options": [
+        "failed",
+        "finish",
+        "idle",
+        "init",
+        "offline",
+        "pause",
+        "prepare",
+        "running",
+        "slicing",
+        "unknown",
+        "offline"
+      ],
+      "device_class": "enum",
+      "friendly_name": "A1MINI_sn1 Print status"
+    },
+    "last_changed": "2026-04-30T18:08:21.493959+00:00",
+    "last_reported": "2026-04-30T18:13:55.266497+00:00",
+    "last_updated": "2026-04-30T18:08:21.493959+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_print_type": {
+    "entity_id": "sensor.a1mini_sn1_print_type",
+    "state": "idle",
+    "attributes": {
+      "options": [
+        "local",
+        "cloud",
+        "unknown",
+        "idle",
+        "system"
+      ],
+      "device_class": "enum",
+      "icon": "mdi:file",
+      "friendly_name": "A1MINI_sn1 Print type"
+    },
+    "last_changed": "2026-04-30T18:08:21.496595+00:00",
+    "last_reported": "2026-04-30T18:13:55.266810+00:00",
+    "last_updated": "2026-04-30T18:08:21.496595+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_print_weight": {
+    "entity_id": "sensor.a1mini_sn1_print_weight",
+    "state": "14.97",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "g",
+      "device_class": "weight",
+      "friendly_name": "A1MINI_sn1 Print weight"
+    },
+    "last_changed": "2026-04-30T18:08:24.996545+00:00",
+    "last_reported": "2026-04-30T18:13:55.266940+00:00",
+    "last_updated": "2026-04-30T18:08:24.996545+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_printable_objects": {
+    "entity_id": "sensor.a1mini_sn1_printable_objects",
+    "state": "1",
+    "attributes": {
+      "state_class": "measurement",
+      "objects": {
+        "290": "Body1"
+      },
+      "friendly_name": "A1MINI_sn1 Printable objects"
+    },
+    "last_changed": "2026-04-30T18:08:24.996157+00:00",
+    "last_reported": "2026-04-30T18:13:55.266523+00:00",
+    "last_updated": "2026-04-30T18:08:24.996157+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_printer_name": {
+    "entity_id": "sensor.a1mini_sn1_printer_name",
+    "state": "3DP-030-293",
+    "attributes": {
+      "friendly_name": "A1MINI_sn1 Printer name"
+    },
+    "last_changed": "2026-04-30T18:08:21.496845+00:00",
+    "last_reported": "2026-04-30T18:13:55.266833+00:00",
+    "last_updated": "2026-04-30T18:08:21.496845+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_remaining_time": {
+    "entity_id": "sensor.a1mini_sn1_remaining_time",
+    "state": "0.0",
+    "attributes": {
+      "unit_of_measurement": "h",
+      "device_class": "duration",
+      "friendly_name": "A1MINI_sn1 Remaining time"
+    },
+    "last_changed": "2026-04-30T18:08:21.495055+00:00",
+    "last_reported": "2026-04-30T18:13:55.266641+00:00",
+    "last_updated": "2026-04-30T18:08:21.495055+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_sd_card_status": {
+    "entity_id": "sensor.a1mini_sn1_sd_card_status",
+    "state": "normal",
+    "attributes": {
+      "options": [
+        "missing",
+        "normal",
+        "abnormal"
+      ],
+      "device_class": "enum",
+      "friendly_name": "A1MINI_sn1 SD card status"
+    },
+    "last_changed": "2026-04-30T18:08:21.494382+00:00",
+    "last_reported": "2026-04-30T18:13:55.266546+00:00",
+    "last_updated": "2026-04-30T18:08:21.494382+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_serial_number": {
+    "entity_id": "sensor.a1mini_sn1_serial_number",
+    "state": "<redacted>",
+    "attributes": {
+      "friendly_name": "A1MINI_sn1 Serial number"
+    },
+    "last_changed": "2026-04-30T18:08:21.498359+00:00",
+    "last_reported": "2026-04-30T18:13:55.267049+00:00",
+    "last_updated": "2026-04-30T18:08:21.498359+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_skipped_objects": {
+    "entity_id": "sensor.a1mini_sn1_skipped_objects",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "objects": [],
+      "friendly_name": "A1MINI_sn1 Skipped objects"
+    },
+    "last_changed": "2026-04-30T18:08:21.494577+00:00",
+    "last_reported": "2026-04-30T18:13:55.266569+00:00",
+    "last_updated": "2026-04-30T18:08:21.494577+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_speed_profile": {
+    "entity_id": "sensor.a1mini_sn1_speed_profile",
+    "state": "standard",
+    "attributes": {
+      "options": [
+        "silent",
+        "standard",
+        "sport",
+        "ludicrous"
+      ],
+      "modifier": 100,
+      "device_class": "enum",
+      "friendly_name": "A1MINI_sn1 Speed profile"
+    },
+    "last_changed": "2026-04-30T18:08:21.492092+00:00",
+    "last_reported": "2026-04-30T18:13:55.266426+00:00",
+    "last_updated": "2026-04-30T18:08:21.492092+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_start_time": {
+    "entity_id": "sensor.a1mini_sn1_start_time",
+    "state": "unavailable",
+    "attributes": {
+      "friendly_name": "A1MINI_sn1 Start time"
+    },
+    "last_changed": "2026-04-30T18:08:21.494831+00:00",
+    "last_reported": "2026-04-30T18:13:20.060980+00:00",
+    "last_updated": "2026-04-30T18:08:21.494831+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_target_bed_temperature": {
+    "entity_id": "sensor.a1mini_sn1_target_bed_temperature",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "°C",
+      "device_class": "temperature",
+      "friendly_name": "A1MINI_sn1 Bed target temperature"
+    },
+    "last_changed": "2026-04-30T18:08:21.490532+00:00",
+    "last_reported": "2026-04-30T18:13:55.266277+00:00",
+    "last_updated": "2026-04-30T18:08:21.490532+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_task_name": {
+    "entity_id": "sensor.a1mini_sn1_task_name",
+    "state": "unknown",
+    "attributes": {
+      "icon": "mdi:file",
+      "friendly_name": "A1MINI_sn1 Task name"
+    },
+    "last_changed": "2026-04-30T18:08:21.496199+00:00",
+    "last_reported": "2026-04-30T18:13:55.266788+00:00",
+    "last_updated": "2026-04-30T18:08:21.496199+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_total_layer_count": {
+    "entity_id": "sensor.a1mini_sn1_total_layer_count",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "friendly_name": "A1MINI_sn1 Total layer count"
+    },
+    "last_changed": "2026-04-30T18:08:21.495739+00:00",
+    "last_reported": "2026-04-30T18:13:55.266727+00:00",
+    "last_updated": "2026-04-30T18:08:21.495739+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_total_usage": {
+    "entity_id": "sensor.a1mini_sn1_total_usage",
+    "state": "0.0",
+    "attributes": {
+      "state_class": "total_increasing",
+      "unit_of_measurement": "h",
+      "device_class": "duration",
+      "friendly_name": "A1MINI_sn1 Total usage"
+    },
+    "last_changed": "2026-04-30T18:08:21.495405+00:00",
+    "last_reported": "2026-04-30T18:13:55.266685+00:00",
+    "last_updated": "2026-04-30T18:08:21.495405+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.a1mini_sn1_wi_fi_signal": {
+    "entity_id": "sensor.a1mini_sn1_wi_fi_signal",
+    "state": "-57",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "dBm",
+      "device_class": "signal_strength",
+      "friendly_name": "A1MINI_sn1 Wi-Fi signal"
+    },
+    "last_changed": "2026-05-05T22:18:02.243152+00:00",
+    "last_reported": "2026-05-05T22:18:02.243152+00:00",
+    "last_updated": "2026-05-05T22:18:02.243152+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_active_tray": {
+    "entity_id": "sensor.p2s_sn2_active_tray",
+    "state": "Generic TPU",
+    "attributes": {
+      "ams_index": 255,
+      "bed_temp": "0",
+      "color": "#XXXXXXXX",
+      "cols": [
+        "#XXXXXXXX"
+      ],
+      "ctype": 2,
+      "dry_temp": 0,
+      "dry_time": 0,
+      "filament_id": "<redacted>",
+      "tray_weight": "0",
+      "name": "Generic TPU",
+      "nozzle_temp_min": "200",
+      "nozzle_temp_max": "250",
+      "remain": -1,
+      "remain_enabled": false,
+      "tag_uid": "<redacted>",
+      "tray_index": 3,
+      "tray_uuid": "<redacted>",
+      "type": "TPU",
+      "friendly_name": "P2S_sn2 Active tray"
+    },
+    "last_changed": "2026-04-30T18:08:22.887706+00:00",
+    "last_reported": "2026-04-30T18:08:24.388581+00:00",
+    "last_updated": "2026-04-30T18:08:22.887706+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_airduct_mode": {
+    "entity_id": "sensor.p2s_sn2_airduct_mode",
+    "state": "cooling",
+    "attributes": {
+      "options": [
+        "cooling",
+        "heating"
+      ],
+      "device_class": "enum",
+      "friendly_name": "P2S_sn2 Airduct mode"
+    },
+    "last_changed": "2026-04-30T18:08:22.883008+00:00",
+    "last_reported": "2026-04-30T18:08:24.388100+00:00",
+    "last_updated": "2026-04-30T18:08:22.883008+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_ams_1_humidity": {
+    "entity_id": "sensor.p2s_sn2_ams_1_humidity",
+    "state": "36",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "%",
+      "device_class": "humidity",
+      "friendly_name": "P2S_sn2_AMS_1 Humidity"
+    },
+    "last_changed": "2026-05-05T06:21:11.774471+00:00",
+    "last_reported": "2026-05-05T06:21:11.774471+00:00",
+    "last_updated": "2026-05-05T06:21:11.774471+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_ams_1_humidity_index": {
+    "entity_id": "sensor.p2s_sn2_ams_1_humidity_index",
+    "state": "4",
+    "attributes": {
+      "state_class": "measurement",
+      "icon": "mdi:water-percent",
+      "friendly_name": "P2S_sn2_AMS_1 Humidity index"
+    },
+    "last_changed": "2026-04-30T18:08:22.873723+00:00",
+    "last_reported": "2026-04-30T18:08:24.387562+00:00",
+    "last_updated": "2026-04-30T18:08:22.873723+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_ams_1_remaining_drying_time": {
+    "entity_id": "sensor.p2s_sn2_ams_1_remaining_drying_time",
+    "state": "0.0",
+    "attributes": {
+      "unit_of_measurement": "h",
+      "device_class": "duration",
+      "icon": "mdi:fan-clock",
+      "friendly_name": "P2S_sn2_AMS_1 Remaining drying time"
+    },
+    "last_changed": "2026-04-30T18:08:22.878089+00:00",
+    "last_reported": "2026-04-30T18:08:24.387655+00:00",
+    "last_updated": "2026-04-30T18:08:22.878089+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_ams_1_temperature": {
+    "entity_id": "sensor.p2s_sn2_ams_1_temperature",
+    "state": "24.9",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "°C",
+      "device_class": "temperature",
+      "friendly_name": "P2S_sn2_AMS_1 Temperature"
+    },
+    "last_changed": "2026-05-05T10:20:06.712533+00:00",
+    "last_reported": "2026-05-05T10:20:06.712533+00:00",
+    "last_updated": "2026-05-05T10:20:06.712533+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_ams_1_tray_1": {
+    "entity_id": "sensor.p2s_sn2_ams_1_tray_1",
+    "state": "Bambu TPU for AMS",
+    "attributes": {
+      "slot": 1,
+      "active": false,
+      "bed_temp": "0",
+      "color": "#XXXXXXXX",
+      "cols": [
+        "#XXXXXXXX"
+      ],
+      "ctype": 2,
+      "dry_temp": 0,
+      "dry_time": 0,
+      "empty": false,
+      "filament_id": "<redacted>",
+      "tray_weight": "1000",
+      "name": "Bambu TPU for AMS",
+      "nozzle_temp_min": "220",
+      "nozzle_temp_max": "240",
+      "remain": 100,
+      "remain_enabled": true,
+      "tag_uid": "<redacted>",
+      "tray_uuid": "<redacted>",
+      "type": "TPU-AMS",
+      "icon": "mdi:printer-3d-nozzle",
+      "friendly_name": "P2S_sn2_AMS_1 Tray 1"
+    },
+    "last_changed": "2026-04-30T18:08:22.878361+00:00",
+    "last_reported": "2026-04-30T18:08:24.387709+00:00",
+    "last_updated": "2026-04-30T18:08:22.878361+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_ams_1_tray_2": {
+    "entity_id": "sensor.p2s_sn2_ams_1_tray_2",
+    "state": "Generic PLA",
+    "attributes": {
+      "slot": 2,
+      "active": false,
+      "bed_temp": "0",
+      "color": "#XXXXXXXX",
+      "cols": [
+        "#XXXXXXXX"
+      ],
+      "ctype": 2,
+      "dry_temp": 0,
+      "dry_time": 0,
+      "empty": false,
+      "filament_id": "<redacted>",
+      "tray_weight": "0",
+      "name": "Generic PLA",
+      "nozzle_temp_min": "190",
+      "nozzle_temp_max": "240",
+      "remain": -1,
+      "remain_enabled": true,
+      "tag_uid": "<redacted>",
+      "tray_uuid": "<redacted>",
+      "type": "PLA",
+      "icon": "mdi:printer-3d-nozzle",
+      "friendly_name": "P2S_sn2_AMS_1 Tray 2"
+    },
+    "last_changed": "2026-04-30T18:08:22.878616+00:00",
+    "last_reported": "2026-04-30T18:08:24.387747+00:00",
+    "last_updated": "2026-04-30T18:08:22.878616+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_ams_1_tray_3": {
+    "entity_id": "sensor.p2s_sn2_ams_1_tray_3",
+    "state": "Bambu PLA Glow",
+    "attributes": {
+      "slot": 3,
+      "active": false,
+      "bed_temp": "35",
+      "color": "#XXXXXXXX",
+      "cols": [
+        "#XXXXXXXX"
+      ],
+      "ctype": 2,
+      "dry_temp": 0,
+      "dry_time": 0,
+      "empty": false,
+      "filament_id": "<redacted>",
+      "tray_weight": "1000",
+      "name": "Bambu PLA Glow",
+      "nozzle_temp_min": "190",
+      "nozzle_temp_max": "230",
+      "remain": 100,
+      "remain_enabled": true,
+      "tag_uid": "<redacted>",
+      "tray_uuid": "<redacted>",
+      "type": "PLA",
+      "icon": "mdi:printer-3d-nozzle",
+      "friendly_name": "P2S_sn2_AMS_1 Tray 3"
+    },
+    "last_changed": "2026-04-30T18:08:22.878911+00:00",
+    "last_reported": "2026-04-30T18:08:24.387780+00:00",
+    "last_updated": "2026-04-30T18:08:22.878911+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_ams_1_tray_4": {
+    "entity_id": "sensor.p2s_sn2_ams_1_tray_4",
+    "state": "Bambu PETG Basic",
+    "attributes": {
+      "slot": 4,
+      "active": false,
+      "bed_temp": "70",
+      "color": "#XXXXXXXX",
+      "cols": [
+        "#XXXXXXXX"
+      ],
+      "ctype": 2,
+      "dry_temp": 0,
+      "dry_time": 0,
+      "empty": false,
+      "filament_id": "<redacted>",
+      "tray_weight": "1000",
+      "name": "Bambu PETG Basic",
+      "nozzle_temp_min": "220",
+      "nozzle_temp_max": "270",
+      "remain": 32,
+      "remain_enabled": true,
+      "tag_uid": "<redacted>",
+      "tray_uuid": "<redacted>",
+      "type": "PETG",
+      "icon": "mdi:printer-3d-nozzle",
+      "friendly_name": "P2S_sn2_AMS_1 Tray 4"
+    },
+    "last_changed": "2026-04-30T18:08:22.879152+00:00",
+    "last_reported": "2026-04-30T18:08:24.387814+00:00",
+    "last_updated": "2026-04-30T18:08:22.879152+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_aux_fan_speed": {
+    "entity_id": "sensor.p2s_sn2_aux_fan_speed",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "%",
+      "friendly_name": "P2S_sn2 Aux fan speed"
+    },
+    "last_changed": "2026-04-30T18:08:22.881342+00:00",
+    "last_reported": "2026-04-30T18:08:24.387984+00:00",
+    "last_updated": "2026-04-30T18:08:22.881342+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_bed_target_temperature": {
+    "entity_id": "sensor.p2s_sn2_bed_target_temperature",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "°C",
+      "device_class": "temperature",
+      "friendly_name": "P2S_sn2 Bed target temperature"
+    },
+    "last_changed": "2026-04-30T18:08:22.880254+00:00",
+    "last_reported": "2026-04-30T18:08:24.387908+00:00",
+    "last_updated": "2026-04-30T18:08:22.880254+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_bed_temperature": {
+    "entity_id": "sensor.p2s_sn2_bed_temperature",
+    "state": "20",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "°C",
+      "device_class": "temperature",
+      "friendly_name": "P2S_sn2 Bed temperature"
+    },
+    "last_changed": "2026-05-05T21:26:21.610431+00:00",
+    "last_reported": "2026-05-05T21:26:21.610431+00:00",
+    "last_updated": "2026-05-05T21:26:21.610431+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_chamber_fan_speed": {
+    "entity_id": "sensor.p2s_sn2_chamber_fan_speed",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "%",
+      "friendly_name": "P2S_sn2 Chamber fan speed"
+    },
+    "last_changed": "2026-04-30T18:08:22.881857+00:00",
+    "last_reported": "2026-04-30T18:08:24.388004+00:00",
+    "last_updated": "2026-04-30T18:08:22.881857+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_chamber_temperature": {
+    "entity_id": "sensor.p2s_sn2_chamber_temperature",
+    "state": "23",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "°C",
+      "device_class": "temperature",
+      "friendly_name": "P2S_sn2 Chamber temperature"
+    },
+    "last_changed": "2026-05-05T06:29:35.984383+00:00",
+    "last_reported": "2026-05-05T06:29:39.570736+00:00",
+    "last_updated": "2026-05-05T06:29:35.984383+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_cooling_fan_speed": {
+    "entity_id": "sensor.p2s_sn2_cooling_fan_speed",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "%",
+      "friendly_name": "P2S_sn2 Cooling fan speed"
+    },
+    "last_changed": "2026-04-30T18:08:22.882141+00:00",
+    "last_reported": "2026-04-30T18:08:24.388022+00:00",
+    "last_updated": "2026-04-30T18:08:22.882141+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_current_layer": {
+    "entity_id": "sensor.p2s_sn2_current_layer",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "friendly_name": "P2S_sn2 Current layer"
+    },
+    "last_changed": "2026-04-30T18:08:22.885340+00:00",
+    "last_reported": "2026-04-30T18:08:24.388324+00:00",
+    "last_updated": "2026-04-30T18:08:22.885340+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_current_stage": {
+    "entity_id": "sensor.p2s_sn2_current_stage",
+    "state": "idle",
+    "attributes": {
+      "options": [
+        "check_absolute_accuracy_after_calibration",
+        "preparing_hotend",
+        "paused_first_layer_error",
+        "paused_filament_runout",
+        "calibrating_micro_lidar",
+        "identifying_build_plate_type",
+        "paused_cutter_error",
+        "filament_loading",
+        "calibrate_birdeye_camera",
+        "preparing_ams",
+        "calibrating_extrusion",
+        "check_door_and_cover",
+        "paused_nozzle_temperature_malfunction",
+        "paused_chamber_temperature_control_error",
+        "inspecting_first_layer",
+        "heating_hotend",
+        "thermal_preconditioning",
+        "check_plaform",
+        "paused_user_gcode",
+        "laser_calibration",
+        "unknown",
+        "paused_user",
+        "scanning_bed_surface",
+        "paused_skipped_step",
+        "paused_heat_bed_temperature_malfunction",
+        "bed_level_high_temperature",
+        "paused_low_fan_speed_heat_break",
+        "m400_pause",
+        "calibrating_cutter_model_offset",
+        "purifying_chamber_air",
+        "calibrating_detection_nozzle_clumping",
+        "idle",
+        "heated_bedcooling",
+        "waiting_chamber_temperature_equalize",
+        "checking_extruder_temperature",
+        "paused_front_cover_falling",
+        "check_quick_release",
+        "bed_level_phase_2",
+        "heating_chamber",
+        "waiting_for_heatbed_temperature",
+        "hotend_pick_place_test",
+        "bed_level_phase_1",
+        "calibrating_blade_holder_position",
+        "auto_bed_leveling",
+        "cleaning_nozzle_tip",
+        "filament_unloading",
+        "calibrating_motor_noise",
+        "calibrating_live_view_camera",
+        "calibrating_camera_offset",
+        "check_absolute_accuracy_before_calibration",
+        "homing_blade_holder",
+        "absolute_accuracy_calibration",
+        "paused_nozzle_clog",
+        "check_material",
+        "homing_toolhead",
+        "paused_nozzle_filament_covered_detected",
+        "sweeping_xy_mech_mode",
+        "check_birdeye_camera_position",
+        "cooling_chamber",
+        "motor_noise_showoff",
+        "print_calibration_lines",
+        "printing",
+        "heatbed_preheating",
+        "changing_filament",
+        "calibrating_extrusion_flow",
+        "paused_ams_lost",
+        "check_material_position",
+        "measuring_surface",
+        "calibrate_nozzle_offset",
+        "offline"
+      ],
+      "device_class": "enum",
+      "friendly_name": "P2S_sn2 Current stage"
+    },
+    "last_changed": "2026-04-30T18:08:22.883466+00:00",
+    "last_reported": "2026-04-30T18:08:24.388119+00:00",
+    "last_updated": "2026-04-30T18:08:22.883466+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_end_time": {
+    "entity_id": "sensor.p2s_sn2_end_time",
+    "state": "unavailable",
+    "attributes": {
+      "friendly_name": "P2S_sn2 End time"
+    },
+    "last_changed": "2026-04-30T18:08:22.884980+00:00",
+    "last_reported": "2026-04-30T18:08:24.388287+00:00",
+    "last_updated": "2026-04-30T18:08:22.884980+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_externalspool_external_spool": {
+    "entity_id": "sensor.p2s_sn2_externalspool_external_spool",
+    "state": "Generic TPU",
+    "attributes": {
+      "active": false,
+      "bed_temp": "0",
+      "color": "#XXXXXXXX",
+      "cols": [
+        "#XXXXXXXX"
+      ],
+      "ctype": 2,
+      "dry_temp": 0,
+      "dry_time": 0,
+      "empty": false,
+      "filament_id": "<redacted>",
+      "tray_weight": "0",
+      "name": "Generic TPU",
+      "nozzle_temp_min": "200",
+      "nozzle_temp_max": "250",
+      "remain": -1,
+      "remain_enabled": false,
+      "tag_uid": "<redacted>",
+      "tray_uuid": "<redacted>",
+      "type": "TPU",
+      "icon": "mdi:printer-3d-nozzle",
+      "friendly_name": "P2S_sn2_ExternalSpool External spool"
+    },
+    "last_changed": "2026-04-30T18:08:22.873489+00:00",
+    "last_reported": "2026-04-30T18:08:24.387528+00:00",
+    "last_updated": "2026-04-30T18:08:22.873489+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_gcode_file_downloaded": {
+    "entity_id": "sensor.p2s_sn2_gcode_file_downloaded",
+    "state": "1009585-Pillars tat.gcode.gcode",
+    "attributes": {
+      "icon": "mdi:file",
+      "friendly_name": "P2S_sn2 Gcode file downloaded"
+    },
+    "last_changed": "2026-04-30T18:08:24.388383+00:00",
+    "last_reported": "2026-04-30T18:08:24.388383+00:00",
+    "last_updated": "2026-04-30T18:08:24.388383+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_gcode_filename": {
+    "entity_id": "sensor.p2s_sn2_gcode_filename",
+    "state": "unavailable",
+    "attributes": {
+      "icon": "mdi:file",
+      "friendly_name": "P2S_sn2 Gcode filename"
+    },
+    "last_changed": "2026-04-30T18:08:22.885682+00:00",
+    "last_reported": "2026-04-30T18:08:24.388353+00:00",
+    "last_updated": "2026-04-30T18:08:22.885682+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_heatbreak_fan_speed": {
+    "entity_id": "sensor.p2s_sn2_heatbreak_fan_speed",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "%",
+      "friendly_name": "P2S_sn2 Heatbreak fan speed"
+    },
+    "last_changed": "2026-04-30T18:08:22.882359+00:00",
+    "last_reported": "2026-04-30T18:08:24.388040+00:00",
+    "last_updated": "2026-04-30T18:08:22.882359+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_ip_address": {
+    "entity_id": "sensor.p2s_sn2_ip_address",
+    "state": "<redacted>",
+    "attributes": {
+      "friendly_name": "P2S_sn2 IP address"
+    },
+    "last_changed": "2026-04-30T18:08:22.888263+00:00",
+    "last_reported": "2026-04-30T18:08:24.388633+00:00",
+    "last_updated": "2026-04-30T18:08:22.888263+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_model_download": {
+    "entity_id": "sensor.p2s_sn2_model_download",
+    "state": "100",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "%",
+      "friendly_name": "P2S_sn2 Model download"
+    },
+    "last_changed": "2026-04-30T18:08:22.882591+00:00",
+    "last_reported": "2026-04-30T18:08:24.388060+00:00",
+    "last_updated": "2026-04-30T18:08:22.882591+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_mqtt_connection_mode": {
+    "entity_id": "sensor.p2s_sn2_mqtt_connection_mode",
+    "state": "bambu_cloud",
+    "attributes": {
+      "options": [
+        "bambu_cloud",
+        "local"
+      ],
+      "device_class": "enum",
+      "friendly_name": "P2S_sn2 MQTT connection mode"
+    },
+    "last_changed": "2026-04-30T18:08:22.879427+00:00",
+    "last_reported": "2026-04-30T18:08:24.387841+00:00",
+    "last_updated": "2026-04-30T18:08:22.879427+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_nozzle_size": {
+    "entity_id": "sensor.p2s_sn2_nozzle_size",
+    "state": "0.4",
+    "attributes": {
+      "unit_of_measurement": "mm",
+      "device_class": "distance",
+      "friendly_name": "P2S_sn2 Nozzle size"
+    },
+    "last_changed": "2026-04-30T18:08:22.887908+00:00",
+    "last_reported": "2026-04-30T18:08:24.388603+00:00",
+    "last_updated": "2026-04-30T18:08:22.887908+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_nozzle_target_temperature": {
+    "entity_id": "sensor.p2s_sn2_nozzle_target_temperature",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "°C",
+      "device_class": "temperature",
+      "friendly_name": "P2S_sn2 Nozzle target temperature"
+    },
+    "last_changed": "2026-04-30T18:08:22.880984+00:00",
+    "last_reported": "2026-04-30T18:08:24.387962+00:00",
+    "last_updated": "2026-04-30T18:08:22.880984+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_nozzle_temperature": {
+    "entity_id": "sensor.p2s_sn2_nozzle_temperature",
+    "state": "22",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "°C",
+      "device_class": "temperature",
+      "friendly_name": "P2S_sn2 Nozzle temperature"
+    },
+    "last_changed": "2026-05-05T22:16:00.544192+00:00",
+    "last_reported": "2026-05-05T22:16:00.544192+00:00",
+    "last_updated": "2026-05-05T22:16:00.544192+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_nozzle_type": {
+    "entity_id": "sensor.p2s_sn2_nozzle_type",
+    "state": "hardened_steel",
+    "attributes": {
+      "friendly_name": "P2S_sn2 Nozzle type"
+    },
+    "last_changed": "2026-04-30T18:08:22.888076+00:00",
+    "last_reported": "2026-04-30T18:08:24.388619+00:00",
+    "last_updated": "2026-04-30T18:08:22.888076+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_print_bed_type": {
+    "entity_id": "sensor.p2s_sn2_print_bed_type",
+    "state": "supertack_plate",
+    "attributes": {
+      "friendly_name": "P2S_sn2 Print bed type"
+    },
+    "last_changed": "2026-04-30T18:08:22.887190+00:00",
+    "last_reported": "2026-04-30T18:08:24.388504+00:00",
+    "last_updated": "2026-04-30T18:08:22.887190+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_print_length": {
+    "entity_id": "sensor.p2s_sn2_print_length",
+    "state": "56.88",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "m",
+      "device_class": "distance",
+      "friendly_name": "P2S_sn2 Print length"
+    },
+    "last_changed": "2026-04-30T18:08:22.886765+00:00",
+    "last_reported": "2026-04-30T18:08:24.388487+00:00",
+    "last_updated": "2026-04-30T18:08:24.092142+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_print_progress": {
+    "entity_id": "sensor.p2s_sn2_print_progress",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "%",
+      "friendly_name": "P2S_sn2 Print progress"
+    },
+    "last_changed": "2026-04-30T18:08:22.883655+00:00",
+    "last_reported": "2026-04-30T18:08:24.388135+00:00",
+    "last_updated": "2026-04-30T18:08:22.883655+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_print_status": {
+    "entity_id": "sensor.p2s_sn2_print_status",
+    "state": "idle",
+    "attributes": {
+      "options": [
+        "failed",
+        "finish",
+        "idle",
+        "init",
+        "offline",
+        "pause",
+        "prepare",
+        "running",
+        "slicing",
+        "unknown",
+        "offline"
+      ],
+      "device_class": "enum",
+      "friendly_name": "P2S_sn2 Print status"
+    },
+    "last_changed": "2026-04-30T18:08:22.883852+00:00",
+    "last_reported": "2026-04-30T18:08:24.388152+00:00",
+    "last_updated": "2026-04-30T18:08:22.883852+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_print_type": {
+    "entity_id": "sensor.p2s_sn2_print_type",
+    "state": "unknown",
+    "attributes": {
+      "options": [
+        "local",
+        "cloud",
+        "unknown",
+        "idle",
+        "system"
+      ],
+      "device_class": "enum",
+      "icon": "mdi:file",
+      "friendly_name": "P2S_sn2 Print type"
+    },
+    "last_changed": "2026-04-30T18:08:22.886361+00:00",
+    "last_reported": "2026-04-30T18:08:24.388428+00:00",
+    "last_updated": "2026-04-30T18:08:22.886361+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_print_weight": {
+    "entity_id": "sensor.p2s_sn2_print_weight",
+    "state": "169.66",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "g",
+      "device_class": "weight",
+      "friendly_name": "P2S_sn2 Print weight"
+    },
+    "last_changed": "2026-04-30T18:08:22.887461+00:00",
+    "last_reported": "2026-04-30T18:08:24.388535+00:00",
+    "last_updated": "2026-04-30T18:08:24.092261+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_printable_objects": {
+    "entity_id": "sensor.p2s_sn2_printable_objects",
+    "state": "32",
+    "attributes": {
+      "state_class": "measurement",
+      "objects": {
+        "1077": "Pillars tat.stl_16",
+        "1253": "Pillars tat.stl_24",
+        "1011": "Pillars tat.stl_13",
+        "1231": "Pillars tat.stl_23",
+        "857": "Pillars tat.stl_6",
+        "923": "Pillars tat.stl_9",
+        "1407": "Pillars tat.stl_31",
+        "967": "Pillars tat.stl_11",
+        "1275": "Pillars tat.stl_25",
+        "901": "Pillars tat.stl_8",
+        "813": "Pillars tat.stl_4",
+        "1385": "Pillars tat.stl_30",
+        "1165": "Pillars tat.stl_20",
+        "879": "Pillars tat.stl_7",
+        "1319": "Pillars tat.stl_27",
+        "1363": "Pillars tat.stl_29",
+        "989": "Pillars tat.stl_12",
+        "1209": "Pillars tat.stl_22",
+        "1143": "Pillars tat.stl_19",
+        "945": "Pillars tat.stl_10",
+        "835": "Pillars tat.stl_5",
+        "791": "Pillars tat.stl_3",
+        "1033": "Pillars tat.stl_14",
+        "769": "Pillars tat.stl_2",
+        "1099": "Pillars tat.stl_17",
+        "1121": "Pillars tat.stl_18",
+        "1055": "Pillars tat.stl_15",
+        "1429": "Pillars tat.stl_32",
+        "1187": "Pillars tat.stl_21",
+        "747": "Pillars tat.stl_1",
+        "1341": "Pillars tat.stl_28",
+        "1297": "Pillars tat.stl_26"
+      },
+      "friendly_name": "P2S_sn2 Printable objects"
+    },
+    "last_changed": "2026-04-30T18:08:24.388173+00:00",
+    "last_reported": "2026-04-30T18:08:24.388173+00:00",
+    "last_updated": "2026-04-30T18:08:24.388173+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_printer_name": {
+    "entity_id": "sensor.p2s_sn2_printer_name",
+    "state": "P2S Kodu ",
+    "attributes": {
+      "friendly_name": "P2S_sn2 Printer name"
+    },
+    "last_changed": "2026-04-30T18:08:22.886546+00:00",
+    "last_reported": "2026-04-30T18:08:24.388447+00:00",
+    "last_updated": "2026-04-30T18:08:22.886546+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_remaining_time": {
+    "entity_id": "sensor.p2s_sn2_remaining_time",
+    "state": "0.0",
+    "attributes": {
+      "unit_of_measurement": "h",
+      "device_class": "duration",
+      "friendly_name": "P2S_sn2 Remaining time"
+    },
+    "last_changed": "2026-04-30T18:08:22.884808+00:00",
+    "last_reported": "2026-04-30T18:08:24.388273+00:00",
+    "last_updated": "2026-04-30T18:08:22.884808+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_sd_card_status": {
+    "entity_id": "sensor.p2s_sn2_sd_card_status",
+    "state": "normal",
+    "attributes": {
+      "options": [
+        "missing",
+        "normal",
+        "abnormal"
+      ],
+      "device_class": "enum",
+      "friendly_name": "P2S_sn2 SD card status"
+    },
+    "last_changed": "2026-04-30T18:08:22.884210+00:00",
+    "last_reported": "2026-04-30T18:08:24.388208+00:00",
+    "last_updated": "2026-04-30T18:08:22.884210+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_serial_number": {
+    "entity_id": "sensor.p2s_sn2_serial_number",
+    "state": "<redacted>",
+    "attributes": {
+      "friendly_name": "P2S_sn2 Serial number"
+    },
+    "last_changed": "2026-04-30T18:08:22.888428+00:00",
+    "last_reported": "2026-04-30T18:08:24.388646+00:00",
+    "last_updated": "2026-04-30T18:08:22.888428+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_skipped_objects": {
+    "entity_id": "sensor.p2s_sn2_skipped_objects",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "objects": [],
+      "friendly_name": "P2S_sn2 Skipped objects"
+    },
+    "last_changed": "2026-04-30T18:08:22.884385+00:00",
+    "last_reported": "2026-04-30T18:08:24.388228+00:00",
+    "last_updated": "2026-04-30T18:08:22.884385+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_speed_profile": {
+    "entity_id": "sensor.p2s_sn2_speed_profile",
+    "state": "standard",
+    "attributes": {
+      "options": [
+        "silent",
+        "standard",
+        "sport",
+        "ludicrous"
+      ],
+      "modifier": 100,
+      "device_class": "enum",
+      "friendly_name": "P2S_sn2 Speed profile"
+    },
+    "last_changed": "2026-04-30T18:08:22.882793+00:00",
+    "last_reported": "2026-04-30T18:08:24.388080+00:00",
+    "last_updated": "2026-04-30T18:08:22.882793+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_start_time": {
+    "entity_id": "sensor.p2s_sn2_start_time",
+    "state": "unavailable",
+    "attributes": {
+      "friendly_name": "P2S_sn2 Start time"
+    },
+    "last_changed": "2026-04-30T18:08:22.884610+00:00",
+    "last_reported": "2026-04-30T18:08:24.388252+00:00",
+    "last_updated": "2026-04-30T18:08:22.884610+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_task_name": {
+    "entity_id": "sensor.p2s_sn2_task_name",
+    "state": "unknown",
+    "attributes": {
+      "icon": "mdi:file",
+      "friendly_name": "P2S_sn2 Task name"
+    },
+    "last_changed": "2026-04-30T18:08:22.886003+00:00",
+    "last_reported": "2026-04-30T18:08:24.388409+00:00",
+    "last_updated": "2026-04-30T18:08:22.886003+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_total_layer_count": {
+    "entity_id": "sensor.p2s_sn2_total_layer_count",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "friendly_name": "P2S_sn2 Total layer count"
+    },
+    "last_changed": "2026-04-30T18:08:22.885518+00:00",
+    "last_reported": "2026-04-30T18:08:24.388340+00:00",
+    "last_updated": "2026-04-30T18:08:22.885518+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_total_usage": {
+    "entity_id": "sensor.p2s_sn2_total_usage",
+    "state": "0.0",
+    "attributes": {
+      "state_class": "total_increasing",
+      "unit_of_measurement": "h",
+      "device_class": "duration",
+      "friendly_name": "P2S_sn2 Total usage"
+    },
+    "last_changed": "2026-04-30T18:08:22.885170+00:00",
+    "last_reported": "2026-04-30T18:08:24.388307+00:00",
+    "last_updated": "2026-04-30T18:08:22.885170+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.p2s_sn2_wi_fi_signal": {
+    "entity_id": "sensor.p2s_sn2_wi_fi_signal",
+    "state": "-70",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "dBm",
+      "device_class": "signal_strength",
+      "friendly_name": "P2S_sn2 Wi-Fi signal"
+    },
+    "last_changed": "2026-05-02T17:55:20.858537+00:00",
+    "last_reported": "2026-05-02T17:55:20.858537+00:00",
+    "last_updated": "2026-05-02T17:55:20.858537+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "switch.a1mini_sn1_enable_camera": {
+    "entity_id": "switch.a1mini_sn1_enable_camera",
+    "state": "on",
+    "attributes": {
+      "icon": "mdi:video",
+      "friendly_name": "A1MINI_sn1 Camera"
+    },
+    "last_changed": "2026-04-30T18:08:21.498980+00:00",
+    "last_reported": "2026-04-30T18:13:55.267075+00:00",
+    "last_updated": "2026-04-30T18:08:21.498980+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "switch.p2s_sn2_camera": {
+    "entity_id": "switch.p2s_sn2_camera",
+    "state": "on",
+    "attributes": {
+      "icon": "mdi:video",
+      "friendly_name": "P2S_sn2 Camera"
+    },
+    "last_changed": "2026-04-30T18:08:22.889784+00:00",
+    "last_reported": "2026-04-30T18:08:24.388665+00:00",
+    "last_updated": "2026-04-30T18:08:22.889784+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  }
+}

--- a/terrazzo-core/src/androidMain/resources/dashboards/3d_printing/lovelace_config.json
+++ b/terrazzo-core/src/androidMain/resources/dashboards/3d_printing/lovelace_config.json
@@ -1,0 +1,1490 @@
+{
+  "views": [
+    {
+      "title": "Printers",
+      "icon": "mdi:printer-3d",
+      "type": "sections",
+      "max_columns": 4,
+      "header": {
+        "card": {
+          "type": "markdown",
+          "text_only": true,
+          "content": "# 🏭 3D Printing\nTwo Bambu printers — tap a tab above for full detail"
+        }
+      },
+      "sections": [
+        {
+          "type": "grid",
+          "column_span": 2,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "🖨️ P2s",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:printer-3d"
+            },
+            {
+              "type": "conditional",
+              "conditions": [
+                {
+                  "condition": "state",
+                  "entity": "binary_sensor.p2s_sn2_online",
+                  "state": "on"
+                }
+              ],
+              "card": {
+                "type": "picture-entity",
+                "entity": "image.p2s_sn2_cover_image",
+                "name": "P2s",
+                "show_name": false,
+                "show_state": false,
+                "aspect_ratio": "16:9",
+                "tap_action": {
+                  "action": "navigate",
+                  "navigation_path": "/dashboard-bambu/p2s"
+                }
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 2,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.p2s_sn2_online",
+                  "name": "Online",
+                  "icon": "mdi:lan-connect"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_print_status",
+                  "name": "Status",
+                  "icon": "mdi:information-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_current_stage",
+                  "name": "Stage",
+                  "icon": "mdi:cog-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_print_progress",
+                  "name": "Progress",
+                  "icon": "mdi:progress-clock"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_nozzle_temperature",
+                  "name": "Nozzle",
+                  "icon": "mdi:printer-3d-nozzle-heat"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_bed_temperature",
+                  "name": "Bed",
+                  "icon": "mdi:radiator"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_remaining_time",
+                  "name": "Remaining",
+                  "icon": "mdi:timer-sand"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.p2s_sn2_hms_errors",
+                  "name": "HMS",
+                  "icon": "mdi:alert-circle"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "markdown",
+              "grid_options": {
+                "columns": "full"
+              },
+              "content": "[Open P2s detail →](/dashboard-bambu/p2s)"
+            }
+          ]
+        },
+        {
+          "type": "grid",
+          "column_span": 2,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "🖨️ A1 Mini",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:printer-3d"
+            },
+            {
+              "type": "conditional",
+              "conditions": [
+                {
+                  "condition": "state",
+                  "entity": "binary_sensor.a1mini_sn1_online",
+                  "state": "on"
+                }
+              ],
+              "card": {
+                "type": "picture-entity",
+                "entity": "camera.a1mini_sn1_camera",
+                "camera_image": "camera.a1mini_sn1_camera",
+                "camera_view": "live",
+                "name": "A1 Mini",
+                "show_name": false,
+                "show_state": false,
+                "aspect_ratio": "16:9",
+                "tap_action": {
+                  "action": "navigate",
+                  "navigation_path": "/dashboard-bambu/a1mini"
+                }
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 2,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.a1mini_sn1_online",
+                  "name": "Online",
+                  "icon": "mdi:lan-connect"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_print_status",
+                  "name": "Status",
+                  "icon": "mdi:information-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_current_stage",
+                  "name": "Stage",
+                  "icon": "mdi:cog-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_print_progress",
+                  "name": "Progress",
+                  "icon": "mdi:progress-clock"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_nozzle_temperature",
+                  "name": "Nozzle",
+                  "icon": "mdi:printer-3d-nozzle-heat"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_bed_temperature",
+                  "name": "Bed",
+                  "icon": "mdi:radiator"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_remaining_time",
+                  "name": "Remaining",
+                  "icon": "mdi:timer-sand"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.a1mini_sn1_hms_errors",
+                  "name": "HMS",
+                  "icon": "mdi:alert-circle"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "markdown",
+              "grid_options": {
+                "columns": "full"
+              },
+              "content": "[Open A1 Mini detail →](/dashboard-bambu/a1mini)"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "P2s",
+      "icon": "mdi:printer-3d",
+      "path": "p2s",
+      "type": "sections",
+      "max_columns": 4,
+      "header": {
+        "card": {
+          "type": "markdown",
+          "text_only": true,
+          "content": "# 🖨️ P2s\n**Status:** {{ states('sensor.p2s_sn2_print_status') }} · **Stage:** {{ states('sensor.p2s_sn2_current_stage') }} · **Progress:** {{ states('sensor.p2s_sn2_print_progress') }}% · {% set r = states('sensor.p2s_sn2_remaining_time') %}**Remaining:** {% if r not in ['unknown','unavailable','0','0.0'] %}{{ r }} h{% else %}–{% endif %}"
+        }
+      },
+      "sections": [
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "Current print",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:cube-scan"
+            },
+            {
+              "type": "custom:ha-bambulab-print_status-card",
+              "printer": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+              "style": "full",
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 2,
+              "square": false,
+              "cards": [
+                {
+                  "type": "picture-entity",
+                  "entity": "image.p2s_sn2_cover_image",
+                  "name": "Cover preview",
+                  "show_name": true,
+                  "show_state": false,
+                  "aspect_ratio": "1:1",
+                  "tap_action": {
+                    "action": "more-info"
+                  }
+                },
+                {
+                  "type": "picture-entity",
+                  "entity": "image.p2s_sn2_pick_image",
+                  "name": "Pick image",
+                  "show_name": true,
+                  "show_state": false,
+                  "aspect_ratio": "1:1",
+                  "tap_action": {
+                    "action": "more-info"
+                  }
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_print_progress",
+                  "name": "Progress",
+                  "icon": "mdi:progress-clock"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_current_layer",
+                  "name": "Current layer",
+                  "icon": "mdi:layers-triple"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_total_layer_count",
+                  "name": "Total layers",
+                  "icon": "mdi:layers-triple-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_remaining_time",
+                  "name": "Remaining",
+                  "icon": "mdi:timer-sand"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_start_time",
+                  "name": "Started",
+                  "icon": "mdi:clock-start"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_end_time",
+                  "name": "ETA",
+                  "icon": "mdi:clock-end"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "🎮 Controls",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:gamepad-variant"
+            },
+            {
+              "type": "custom:ha-bambulab-print_control-card",
+              "printer": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "light.p2s_sn2_chamber_light",
+                  "name": "Chamber light",
+                  "icon": "mdi:lightbulb"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_airduct_mode",
+                  "name": "Airduct mode",
+                  "icon": "mdi:air-filter"
+                },
+                {
+                  "type": "tile",
+                  "entity": "switch.p2s_sn2_camera",
+                  "name": "Camera",
+                  "icon": "mdi:cctv"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "🌡️ Temperatures",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:thermometer"
+            },
+            {
+              "type": "grid",
+              "columns": 5,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_nozzle_temperature",
+                  "name": "Nozzle",
+                  "icon": "mdi:printer-3d-nozzle-heat"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_nozzle_target_temperature",
+                  "name": "Nozzle target",
+                  "icon": "mdi:target"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_bed_temperature",
+                  "name": "Bed",
+                  "icon": "mdi:radiator"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_bed_target_temperature",
+                  "name": "Bed target",
+                  "icon": "mdi:target"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_chamber_temperature",
+                  "name": "Chamber",
+                  "icon": "mdi:home-thermometer"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "history-graph",
+              "title": "Temperatures (24h)",
+              "hours_to_show": 24,
+              "entities": [
+                {
+                  "entity": "sensor.p2s_sn2_nozzle_temperature",
+                  "name": "Nozzle"
+                },
+                {
+                  "entity": "sensor.p2s_sn2_bed_temperature",
+                  "name": "Bed"
+                },
+                {
+                  "entity": "sensor.p2s_sn2_chamber_temperature",
+                  "name": "Chamber"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "💨 Fans",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:fan"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_cooling_fan_speed",
+                  "name": "Part cooling %",
+                  "icon": "mdi:fan-speed-1"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_heatbreak_fan_speed",
+                  "name": "Heatbreak %",
+                  "icon": "mdi:fan-alert"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_aux_fan_speed",
+                  "name": "Aux fan %",
+                  "icon": "mdi:fan-plus"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_chamber_fan_speed",
+                  "name": "Chamber fan %",
+                  "icon": "mdi:fan-chevron-up"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "📦 Task details",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:file-document-outline"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_task_name",
+                  "name": "Task",
+                  "icon": "mdi:file-cog"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_gcode_filename",
+                  "name": "G-code",
+                  "icon": "mdi:file-code"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_gcode_file_downloaded",
+                  "name": "Downloaded",
+                  "icon": "mdi:download-circle"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_print_type",
+                  "name": "Type",
+                  "icon": "mdi:cog-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_print_bed_type",
+                  "name": "Bed type",
+                  "icon": "mdi:texture"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_print_length",
+                  "name": "Filament length",
+                  "icon": "mdi:tape-measure"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_print_weight",
+                  "name": "Filament weight",
+                  "icon": "mdi:weight-gram"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_nozzle_size",
+                  "name": "Nozzle size",
+                  "icon": "mdi:printer-3d-nozzle"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_nozzle_type",
+                  "name": "Nozzle type",
+                  "icon": "mdi:printer-3d-nozzle-alert"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_printable_objects",
+                  "name": "Objects",
+                  "icon": "mdi:cube"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_skipped_objects",
+                  "name": "Skipped",
+                  "icon": "mdi:cube-off"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_model_download",
+                  "name": "Model download",
+                  "icon": "mdi:download"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "🔧 Health & diagnostics",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:heart-pulse"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.p2s_sn2_online",
+                  "name": "Online",
+                  "icon": "mdi:lan-connect"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.p2s_sn2_door",
+                  "name": "Door",
+                  "icon": "mdi:door"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.p2s_sn2_hms_errors",
+                  "name": "HMS errors",
+                  "icon": "mdi:alert-circle"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.p2s_sn2_print_error",
+                  "name": "Print error",
+                  "icon": "mdi:alert"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.p2s_sn2_firmware",
+                  "name": "Firmware update",
+                  "icon": "mdi:update"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.p2s_sn2_timelapse",
+                  "name": "Timelapse",
+                  "icon": "mdi:video-box"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.p2s_sn2_extruder_filament",
+                  "name": "Filament loaded",
+                  "icon": "mdi:check-circle"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_wi_fi_signal",
+                  "name": "Wi-Fi",
+                  "icon": "mdi:wifi"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_total_usage",
+                  "name": "Total usage",
+                  "icon": "mdi:clock-check-outline"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_printer_name",
+                  "name": "Name",
+                  "icon": "mdi:printer-3d"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_serial_number",
+                  "name": "Serial",
+                  "icon": "mdi:barcode"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_ip_address",
+                  "name": "IP",
+                  "icon": "mdi:ip-network"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_sd_card_status",
+                  "name": "SD card",
+                  "icon": "mdi:sd"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_mqtt_connection_mode",
+                  "name": "MQTT mode",
+                  "icon": "mdi:connection"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_speed_profile",
+                  "name": "Speed profile",
+                  "icon": "mdi:speedometer-medium"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "A1 Mini",
+      "icon": "mdi:printer-3d",
+      "path": "a1mini",
+      "type": "sections",
+      "max_columns": 4,
+      "header": {
+        "card": {
+          "type": "markdown",
+          "text_only": true,
+          "content": "# 🖨️ A1 Mini\n**Status:** {{ states('sensor.a1mini_sn1_print_status') }} · **Stage:** {{ states('sensor.a1mini_sn1_current_stage') }} · **Progress:** {{ states('sensor.a1mini_sn1_print_progress') }}% · {% set r = states('sensor.a1mini_sn1_remaining_time') %}**Remaining:** {% if r not in ['unknown','unavailable','0','0.0'] %}{{ r }} h{% else %}–{% endif %}"
+        }
+      },
+      "sections": [
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "Current print",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:cube-scan"
+            },
+            {
+              "type": "custom:ha-bambulab-print_status-card",
+              "printer": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+              "style": "full",
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "picture-entity",
+                  "entity": "camera.a1mini_sn1_camera",
+                  "camera_image": "camera.a1mini_sn1_camera",
+                  "camera_view": "live",
+                  "name": "Live camera",
+                  "show_name": true,
+                  "show_state": false,
+                  "aspect_ratio": "16:9",
+                  "tap_action": {
+                    "action": "more-info"
+                  }
+                },
+                {
+                  "type": "picture-entity",
+                  "entity": "image.a1mini_sn1_cover_image",
+                  "name": "Cover preview",
+                  "show_name": true,
+                  "show_state": false,
+                  "aspect_ratio": "1:1",
+                  "tap_action": {
+                    "action": "more-info"
+                  }
+                },
+                {
+                  "type": "picture-entity",
+                  "entity": "image.a1mini_sn1_pick_image",
+                  "name": "Pick image",
+                  "show_name": true,
+                  "show_state": false,
+                  "aspect_ratio": "1:1",
+                  "tap_action": {
+                    "action": "more-info"
+                  }
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_print_progress",
+                  "name": "Progress",
+                  "icon": "mdi:progress-clock"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_current_layer",
+                  "name": "Current layer",
+                  "icon": "mdi:layers-triple"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_total_layer_count",
+                  "name": "Total layers",
+                  "icon": "mdi:layers-triple-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_remaining_time",
+                  "name": "Remaining",
+                  "icon": "mdi:timer-sand"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_start_time",
+                  "name": "Started",
+                  "icon": "mdi:clock-start"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_end_time",
+                  "name": "ETA",
+                  "icon": "mdi:clock-end"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "🎮 Controls",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:gamepad-variant"
+            },
+            {
+              "type": "custom:ha-bambulab-print_control-card",
+              "printer": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "button.a1mini_sn1_pause_printing",
+                  "name": "Pause",
+                  "icon": "mdi:pause",
+                  "color": "yellow"
+                },
+                {
+                  "type": "tile",
+                  "entity": "button.a1mini_sn1_resume_printing",
+                  "name": "Resume",
+                  "icon": "mdi:play",
+                  "color": "green"
+                },
+                {
+                  "type": "tile",
+                  "entity": "button.a1mini_sn1_stop_printing",
+                  "name": "Stop",
+                  "icon": "mdi:stop",
+                  "color": "red"
+                },
+                {
+                  "type": "tile",
+                  "entity": "button.a1mini_sn1_force_refresh_data",
+                  "name": "Refresh",
+                  "icon": "mdi:refresh"
+                },
+                {
+                  "type": "tile",
+                  "entity": "select.a1mini_sn1_printing_speed",
+                  "name": "Speed",
+                  "icon": "mdi:speedometer"
+                },
+                {
+                  "type": "tile",
+                  "entity": "light.a1mini_sn1_chamber_light",
+                  "name": "Chamber light",
+                  "icon": "mdi:lightbulb"
+                },
+                {
+                  "type": "tile",
+                  "entity": "switch.a1mini_sn1_enable_camera",
+                  "name": "Camera",
+                  "icon": "mdi:cctv"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "🌡️ Temperatures",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:thermometer"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_nozzle_temperature",
+                  "name": "Nozzle",
+                  "icon": "mdi:printer-3d-nozzle-heat"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_nozzle_target_temperature",
+                  "name": "Nozzle target",
+                  "icon": "mdi:target"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_bed_temperature",
+                  "name": "Bed",
+                  "icon": "mdi:radiator"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_target_bed_temperature",
+                  "name": "Bed target",
+                  "icon": "mdi:target"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "history-graph",
+              "title": "Temperatures (24h)",
+              "hours_to_show": 24,
+              "entities": [
+                {
+                  "entity": "sensor.a1mini_sn1_nozzle_temperature",
+                  "name": "Nozzle"
+                },
+                {
+                  "entity": "sensor.a1mini_sn1_bed_temperature",
+                  "name": "Bed"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "💨 Fans",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:fan"
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "fan.a1mini_sn1_cooling_fan",
+                  "name": "Part cooling",
+                  "icon": "mdi:fan"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_cooling_fan_speed",
+                  "name": "Part cooling %",
+                  "icon": "mdi:fan-speed-1"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_heatbreak_fan_speed",
+                  "name": "Heatbreak %",
+                  "icon": "mdi:fan-alert"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "📦 Task details",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:file-document-outline"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_task_name",
+                  "name": "Task",
+                  "icon": "mdi:file-cog"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_gcode_filename",
+                  "name": "G-code",
+                  "icon": "mdi:file-code"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_gcode_file_downloaded",
+                  "name": "Downloaded",
+                  "icon": "mdi:download-circle"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_print_type",
+                  "name": "Type",
+                  "icon": "mdi:cog-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_print_bed_type",
+                  "name": "Bed type",
+                  "icon": "mdi:texture"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_print_length",
+                  "name": "Filament length",
+                  "icon": "mdi:tape-measure"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_print_weight",
+                  "name": "Filament weight",
+                  "icon": "mdi:weight-gram"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_nozzle_size",
+                  "name": "Nozzle size",
+                  "icon": "mdi:printer-3d-nozzle"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_nozzle_type",
+                  "name": "Nozzle type",
+                  "icon": "mdi:printer-3d-nozzle-alert"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_printable_objects",
+                  "name": "Objects",
+                  "icon": "mdi:cube"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_skipped_objects",
+                  "name": "Skipped",
+                  "icon": "mdi:cube-off"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_model_download",
+                  "name": "Model download",
+                  "icon": "mdi:download"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "🔧 Health & diagnostics",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:heart-pulse"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.a1mini_sn1_online",
+                  "name": "Online",
+                  "icon": "mdi:lan-connect"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.a1mini_sn1_hms_errors",
+                  "name": "HMS errors",
+                  "icon": "mdi:alert-circle"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.a1mini_sn1_print_error",
+                  "name": "Print error",
+                  "icon": "mdi:alert"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.a1mini_sn1_firmware_update",
+                  "name": "Firmware update",
+                  "icon": "mdi:update"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.a1mini_sn1_recording_timelapse",
+                  "name": "Timelapse",
+                  "icon": "mdi:video-box"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.a1mini_sn1_extruder_filament_state",
+                  "name": "Filament loaded",
+                  "icon": "mdi:check-circle"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_wi_fi_signal",
+                  "name": "Wi-Fi",
+                  "icon": "mdi:wifi"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_total_usage",
+                  "name": "Total usage",
+                  "icon": "mdi:clock-check-outline"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_printer_name",
+                  "name": "Name",
+                  "icon": "mdi:printer-3d"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_serial_number",
+                  "name": "Serial",
+                  "icon": "mdi:barcode"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_ip_address",
+                  "name": "IP",
+                  "icon": "mdi:ip-network"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_sd_card_status",
+                  "name": "SD card",
+                  "icon": "mdi:sd"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_mqtt_connection_mode",
+                  "name": "MQTT mode",
+                  "icon": "mdi:connection"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_speed_profile",
+                  "name": "Speed profile",
+                  "icon": "mdi:speedometer-medium"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Filament",
+      "icon": "mdi:spool",
+      "path": "filament",
+      "type": "sections",
+      "max_columns": 4,
+      "sections": [
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "🖨️ P2s — AMS",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:spool"
+            },
+            {
+              "type": "custom:ha-bambulab-ams-card",
+              "ams": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+              "style": "full",
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.p2s_sn2_ams_1_active",
+                  "name": "AMS active",
+                  "icon": "mdi:spool"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_active_tray",
+                  "name": "Active tray",
+                  "icon": "mdi:arrow-right-bold-circle"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_ams_1_humidity",
+                  "name": "Humidity",
+                  "icon": "mdi:water-percent"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_ams_1_humidity_index",
+                  "name": "Humidity level",
+                  "icon": "mdi:water-alert"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_ams_1_temperature",
+                  "name": "AMS temp",
+                  "icon": "mdi:thermometer"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.p2s_sn2_ams_1_drying",
+                  "name": "Drying",
+                  "icon": "mdi:water-remove-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_ams_1_remaining_drying_time",
+                  "name": "Dry remaining",
+                  "icon": "mdi:timer-sand"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_ams_1_tray_1",
+                  "name": "Tray 1"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_ams_1_tray_2",
+                  "name": "Tray 2"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_ams_1_tray_3",
+                  "name": "Tray 3"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_ams_1_tray_4",
+                  "name": "Tray 4"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "🪢 External spool (P2s)",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:record-circle-outline"
+            },
+            {
+              "type": "custom:ha-bambulab-spool-card",
+              "spool": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 2,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.p2s_sn2_externalspool_active",
+                  "name": "External spool",
+                  "icon": "mdi:record-rec"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.p2s_sn2_externalspool_external_spool",
+                  "name": "Spool info",
+                  "icon": "mdi:information"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "🖨️ A1 Mini — AMS",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:spool"
+            },
+            {
+              "type": "custom:ha-bambulab-ams-card",
+              "ams": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+              "style": "full",
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.a1mini_sn1_ams_1_active",
+                  "name": "AMS active",
+                  "icon": "mdi:spool"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_active_tray",
+                  "name": "Active tray",
+                  "icon": "mdi:arrow-right-bold-circle"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_ams_1_humidity",
+                  "name": "Humidity",
+                  "icon": "mdi:water-percent"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_ams_1_humidity_index",
+                  "name": "Humidity level",
+                  "icon": "mdi:water-alert"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_ams_1_temperature_2",
+                  "name": "AMS temp",
+                  "icon": "mdi:thermometer"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_ams_1_tray_1",
+                  "name": "Tray 1"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_ams_1_tray_2",
+                  "name": "Tray 2"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_ams_1_tray_3",
+                  "name": "Tray 3"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_ams_1_tray_4",
+                  "name": "Tray 4"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "🪢 External spool (A1 Mini)",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:record-circle-outline"
+            },
+            {
+              "type": "custom:ha-bambulab-spool-card",
+              "spool": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 2,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.a1mini_sn1_externalspool_active",
+                  "name": "External spool",
+                  "icon": "mdi:record-rec"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.a1mini_sn1_externalspool_external_spool",
+                  "name": "Spool info",
+                  "icon": "mdi:information"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/terrazzo-core/src/androidMain/resources/dashboards/climate/entity_states.json
+++ b/terrazzo-core/src/androidMain/resources/dashboards/climate/entity_states.json
@@ -1,0 +1,508 @@
+{
+  "camera.back_door_camera": {
+    "entity_id": "camera.back_door_camera",
+    "state": "streaming",
+    "attributes": {
+      "access_token": "<redacted>",
+      "model_name": "Camera",
+      "brand": "Google Nest",
+      "entity_picture": "/api/camera_proxy/camera.back_door_camera?token=REDACTED",
+      "friendly_name": "Back door camera",
+      "supported_features": 2
+    },
+    "last_changed": "2026-04-30T18:08:21.992495+00:00",
+    "last_reported": "2026-05-05T22:13:07.553994+00:00",
+    "last_updated": "2026-05-05T22:13:07.553994+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "camera.g5_turret_ultra_high_resolution_channel": {
+    "entity_id": "camera.g5_turret_ultra_high_resolution_channel",
+    "state": "recording",
+    "attributes": {
+      "access_token": "<redacted>",
+      "width": 1504,
+      "height": 2688,
+      "fps": 30,
+      "bitrate": 7000000,
+      "channel_id": 0,
+      "attribution": "Powered by UniFi Protect Server",
+      "entity_picture": "/api/camera_proxy/camera.g5_turret_ultra_high_resolution_channel?token=REDACTED",
+      "friendly_name": "G5 Turret Ultra High resolution channel",
+      "supported_features": 2
+    },
+    "last_changed": "2026-04-30T18:08:15.096345+00:00",
+    "last_reported": "2026-05-05T22:13:07.553309+00:00",
+    "last_updated": "2026-05-05T22:13:07.553309+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "climate.downstairs": {
+    "entity_id": "climate.downstairs",
+    "state": "heat",
+    "attributes": {
+      "hvac_modes": [
+        "heat",
+        "off"
+      ],
+      "min_temp": 10,
+      "max_temp": 32,
+      "preset_modes": [
+        "none",
+        "eco"
+      ],
+      "current_temperature": 22.8,
+      "temperature": 21.8,
+      "current_humidity": 45.0,
+      "hvac_action": "idle",
+      "preset_mode": "none",
+      "friendly_name": "Downstairs",
+      "supported_features": 401
+    },
+    "last_changed": "2026-04-30T18:08:21.995766+00:00",
+    "last_reported": "2026-05-05T21:53:54.630289+00:00",
+    "last_updated": "2026-05-05T21:53:54.630289+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "climate.kids_room": {
+    "entity_id": "climate.kids_room",
+    "state": "heat",
+    "attributes": {
+      "hvac_modes": [
+        "heat",
+        "off"
+      ],
+      "min_temp": 10,
+      "max_temp": 32,
+      "preset_modes": [
+        "none",
+        "eco"
+      ],
+      "current_temperature": 21.8,
+      "temperature": 22.0,
+      "current_humidity": 58.0,
+      "hvac_action": "heating",
+      "preset_mode": "none",
+      "friendly_name": "Kitchen",
+      "supported_features": 401
+    },
+    "last_changed": "2026-04-30T18:08:21.994655+00:00",
+    "last_reported": "2026-05-05T21:52:32.159906+00:00",
+    "last_updated": "2026-05-05T21:52:32.159906+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "climate.upstairs": {
+    "entity_id": "climate.upstairs",
+    "state": "heat",
+    "attributes": {
+      "hvac_modes": [
+        "heat",
+        "off"
+      ],
+      "min_temp": 10,
+      "max_temp": 32,
+      "preset_modes": [
+        "none",
+        "eco"
+      ],
+      "current_temperature": 22.8,
+      "temperature": 22.7,
+      "current_humidity": 41.0,
+      "hvac_action": "idle",
+      "preset_mode": "none",
+      "friendly_name": "Upstairs",
+      "supported_features": 401
+    },
+    "last_changed": "2026-04-30T18:08:21.996686+00:00",
+    "last_reported": "2026-05-05T21:49:13.276997+00:00",
+    "last_updated": "2026-05-05T21:49:13.276997+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.downstairs_humidity": {
+    "entity_id": "sensor.downstairs_humidity",
+    "state": "45",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "%",
+      "device_class": "humidity",
+      "friendly_name": "Downstairs Humidity"
+    },
+    "last_changed": "2026-05-05T19:59:32.067238+00:00",
+    "last_reported": "2026-05-05T19:59:32.067238+00:00",
+    "last_updated": "2026-05-05T19:59:32.067238+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.downstairs_temperature": {
+    "entity_id": "sensor.downstairs_temperature",
+    "state": "22.8",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "°C",
+      "device_class": "temperature",
+      "friendly_name": "Downstairs Temperature"
+    },
+    "last_changed": "2026-05-05T21:53:54.630577+00:00",
+    "last_reported": "2026-05-05T21:53:54.630577+00:00",
+    "last_updated": "2026-05-05T21:53:54.630577+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.kids_room_humidity": {
+    "entity_id": "sensor.kids_room_humidity",
+    "state": "58",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "%",
+      "device_class": "humidity",
+      "friendly_name": "Kitchen Humidity"
+    },
+    "last_changed": "2026-05-05T21:52:32.160395+00:00",
+    "last_reported": "2026-05-05T21:52:32.160395+00:00",
+    "last_updated": "2026-05-05T21:52:32.160395+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.kids_room_temperature": {
+    "entity_id": "sensor.kids_room_temperature",
+    "state": "21.8",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "°C",
+      "device_class": "temperature",
+      "friendly_name": "Kitchen Temperature"
+    },
+    "last_changed": "2026-05-05T20:58:32.847879+00:00",
+    "last_reported": "2026-05-05T20:58:32.847879+00:00",
+    "last_updated": "2026-05-05T20:58:32.847879+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.openweathermap_cloud_coverage": {
+    "entity_id": "sensor.openweathermap_cloud_coverage",
+    "state": "100",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "%",
+      "attribution": "Data provided by OpenWeatherMap",
+      "friendly_name": "OpenWeatherMap Cloud coverage"
+    },
+    "last_changed": "2026-05-05T19:38:18.957007+00:00",
+    "last_reported": "2026-05-05T19:38:18.957007+00:00",
+    "last_updated": "2026-05-05T19:38:18.957007+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.openweathermap_dew_point": {
+    "entity_id": "sensor.openweathermap_dew_point",
+    "state": "7.79",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "°C",
+      "attribution": "Data provided by OpenWeatherMap",
+      "device_class": "temperature",
+      "friendly_name": "OpenWeatherMap Dew point temperature"
+    },
+    "last_changed": "2026-05-05T22:08:18.950232+00:00",
+    "last_reported": "2026-05-05T22:08:18.950232+00:00",
+    "last_updated": "2026-05-05T22:08:18.950232+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.openweathermap_feels_like_temperature": {
+    "entity_id": "sensor.openweathermap_feels_like_temperature",
+    "state": "10.73",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "°C",
+      "attribution": "Data provided by OpenWeatherMap",
+      "device_class": "temperature",
+      "friendly_name": "OpenWeatherMap Apparent temperature"
+    },
+    "last_changed": "2026-05-05T22:08:18.950464+00:00",
+    "last_reported": "2026-05-05T22:08:18.950464+00:00",
+    "last_updated": "2026-05-05T22:08:18.950464+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.openweathermap_humidity": {
+    "entity_id": "sensor.openweathermap_humidity",
+    "state": "78",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "%",
+      "attribution": "Data provided by OpenWeatherMap",
+      "device_class": "humidity",
+      "friendly_name": "OpenWeatherMap Humidity"
+    },
+    "last_changed": "2026-05-05T21:58:18.953638+00:00",
+    "last_reported": "2026-05-05T21:58:18.953638+00:00",
+    "last_updated": "2026-05-05T21:58:18.953638+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.openweathermap_pressure": {
+    "entity_id": "sensor.openweathermap_pressure",
+    "state": "1012",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "hPa",
+      "attribution": "Data provided by OpenWeatherMap",
+      "device_class": "pressure",
+      "friendly_name": "OpenWeatherMap Pressure"
+    },
+    "last_changed": "2026-05-05T22:08:18.950702+00:00",
+    "last_reported": "2026-05-05T22:08:18.950702+00:00",
+    "last_updated": "2026-05-05T22:08:18.950702+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.openweathermap_rain": {
+    "entity_id": "sensor.openweathermap_rain",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "mm/h",
+      "attribution": "Data provided by OpenWeatherMap",
+      "device_class": "precipitation_intensity",
+      "friendly_name": "OpenWeatherMap Rain intensity"
+    },
+    "last_changed": "2026-05-05T21:58:18.953761+00:00",
+    "last_reported": "2026-05-05T21:58:18.953761+00:00",
+    "last_updated": "2026-05-05T21:58:18.953761+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.openweathermap_temperature": {
+    "entity_id": "sensor.openweathermap_temperature",
+    "state": "11.49",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "°C",
+      "attribution": "Data provided by OpenWeatherMap",
+      "device_class": "temperature",
+      "friendly_name": "OpenWeatherMap Temperature"
+    },
+    "last_changed": "2026-05-05T22:08:18.950395+00:00",
+    "last_reported": "2026-05-05T22:08:18.950395+00:00",
+    "last_updated": "2026-05-05T22:08:18.950395+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.openweathermap_uv_index": {
+    "entity_id": "sensor.openweathermap_uv_index",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "UV index",
+      "attribution": "Data provided by OpenWeatherMap",
+      "friendly_name": "OpenWeatherMap UV index"
+    },
+    "last_changed": "2026-05-05T18:38:18.988289+00:00",
+    "last_reported": "2026-05-05T18:38:18.988289+00:00",
+    "last_updated": "2026-05-05T18:38:18.988289+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.openweathermap_visibility": {
+    "entity_id": "sensor.openweathermap_visibility",
+    "state": "10000",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "m",
+      "attribution": "Data provided by OpenWeatherMap",
+      "device_class": "distance",
+      "friendly_name": "OpenWeatherMap Visibility"
+    },
+    "last_changed": "2026-05-05T01:38:19.037556+00:00",
+    "last_reported": "2026-05-05T01:38:19.037556+00:00",
+    "last_updated": "2026-05-05T01:38:19.037556+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.openweathermap_wind_bearing": {
+    "entity_id": "sensor.openweathermap_wind_bearing",
+    "state": "50",
+    "attributes": {
+      "state_class": "measurement_angle",
+      "unit_of_measurement": "°",
+      "attribution": "Data provided by OpenWeatherMap",
+      "device_class": "wind_direction",
+      "friendly_name": "OpenWeatherMap Wind direction"
+    },
+    "last_changed": "2026-05-05T22:08:18.950618+00:00",
+    "last_reported": "2026-05-05T22:08:18.950618+00:00",
+    "last_updated": "2026-05-05T22:08:18.950618+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.openweathermap_wind_speed": {
+    "entity_id": "sensor.openweathermap_wind_speed",
+    "state": "11.124",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "km/h",
+      "attribution": "Data provided by OpenWeatherMap",
+      "device_class": "wind_speed",
+      "friendly_name": "OpenWeatherMap Wind speed"
+    },
+    "last_changed": "2026-05-05T22:08:18.950532+00:00",
+    "last_reported": "2026-05-05T22:08:18.950532+00:00",
+    "last_updated": "2026-05-05T22:08:18.950532+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.upstairs_humidity": {
+    "entity_id": "sensor.upstairs_humidity",
+    "state": "41",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "%",
+      "device_class": "humidity",
+      "friendly_name": "Upstairs Humidity"
+    },
+    "last_changed": "2026-05-05T19:57:11.117937+00:00",
+    "last_reported": "2026-05-05T19:57:21.063491+00:00",
+    "last_updated": "2026-05-05T19:57:11.117937+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.upstairs_temperature": {
+    "entity_id": "sensor.upstairs_temperature",
+    "state": "22.8",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "°C",
+      "device_class": "temperature",
+      "friendly_name": "Upstairs Temperature"
+    },
+    "last_changed": "2026-05-05T21:49:13.277295+00:00",
+    "last_reported": "2026-05-05T21:49:13.277295+00:00",
+    "last_updated": "2026-05-05T21:49:13.277295+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sun.sun": {
+    "entity_id": "sun.sun",
+    "state": "below_horizon",
+    "attributes": {
+      "next_dawn": "2026-05-06T03:43:08.471218+00:00",
+      "next_dusk": "2026-05-06T20:11:02.130404+00:00",
+      "next_midnight": "2026-05-05T23:56:27+00:00",
+      "next_noon": "2026-05-06T11:56:28+00:00",
+      "next_rising": "2026-05-06T04:23:07.763196+00:00",
+      "next_setting": "2026-05-06T19:30:46.918156+00:00",
+      "elevation": -18.0,
+      "azimuth": 332.51,
+      "rising": false,
+      "friendly_name": "Sun"
+    },
+    "last_changed": "2026-05-05T19:33:10.514814+00:00",
+    "last_reported": "2026-05-05T22:07:31.790236+00:00",
+    "last_updated": "2026-05-05T22:07:31.790236+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "weather.forecast_home": {
+    "entity_id": "weather.forecast_home",
+    "state": "rainy",
+    "attributes": {
+      "temperature": 11.2,
+      "dew_point": 8.5,
+      "temperature_unit": "°C",
+      "humidity": 84,
+      "cloud_coverage": 100.0,
+      "uv_index": 0.0,
+      "pressure": 1012.7,
+      "pressure_unit": "hPa",
+      "wind_bearing": 47.4,
+      "wind_speed": 14.4,
+      "wind_speed_unit": "km/h",
+      "visibility_unit": "km",
+      "precipitation_unit": "mm",
+      "attribution": "Weather forecast from met.no, delivered by the Norwegian Meteorological Institute.",
+      "friendly_name": "Forecast Home",
+      "supported_features": 3
+    },
+    "last_changed": "2026-05-05T19:07:17.911366+00:00",
+    "last_reported": "2026-05-05T22:10:18.063969+00:00",
+    "last_updated": "2026-05-05T22:10:18.063969+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  }
+}

--- a/terrazzo-core/src/androidMain/resources/dashboards/climate/lovelace_config.json
+++ b/terrazzo-core/src/androidMain/resources/dashboards/climate/lovelace_config.json
@@ -1,0 +1,348 @@
+{
+  "views": [
+    {
+      "title": "Home",
+      "icon": "mdi:home-thermometer",
+      "type": "sections",
+      "max_columns": 4,
+      "sections": [
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "🌤️  Outside right now",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:weather-partly-cloudy"
+            },
+            {
+              "type": "weather-forecast",
+              "entity": "weather.forecast_home",
+              "forecast_type": "daily",
+              "show_current": true,
+              "show_forecast": true,
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.openweathermap_temperature",
+                  "name": "Temp",
+                  "icon": "mdi:thermometer"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.openweathermap_feels_like_temperature",
+                  "name": "Feels like",
+                  "icon": "mdi:thermometer-lines"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.openweathermap_humidity",
+                  "name": "Humidity",
+                  "icon": "mdi:water-percent"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.openweathermap_wind_speed",
+                  "name": "Wind",
+                  "icon": "mdi:weather-windy"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.openweathermap_pressure",
+                  "name": "Pressure",
+                  "icon": "mdi:gauge"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.openweathermap_uv_index",
+                  "name": "UV index",
+                  "icon": "mdi:sun-wireless"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.openweathermap_cloud_coverage",
+                  "name": "Cloud cover",
+                  "icon": "mdi:cloud-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.openweathermap_rain",
+                  "name": "Rain",
+                  "icon": "mdi:weather-pouring"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "📷  Live view",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:cctv"
+            },
+            {
+              "type": "grid",
+              "columns": 2,
+              "square": false,
+              "cards": [
+                {
+                  "type": "picture-entity",
+                  "entity": "camera.g5_turret_ultra_high_resolution_channel",
+                  "camera_image": "camera.g5_turret_ultra_high_resolution_channel",
+                  "camera_view": "auto",
+                  "name": "Front (driveway)",
+                  "show_name": true,
+                  "show_state": false,
+                  "aspect_ratio": "16:9"
+                },
+                {
+                  "type": "picture-entity",
+                  "entity": "camera.back_door_camera",
+                  "camera_image": "camera.back_door_camera",
+                  "camera_view": "auto",
+                  "name": "Back",
+                  "show_name": true,
+                  "show_state": false,
+                  "aspect_ratio": "16:9"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "🏠  Indoor climate",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:home-floor-l"
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "climate.upstairs",
+                  "name": "Upstairs",
+                  "icon": "mdi:thermostat",
+                  "features": [
+                    {
+                      "type": "target-temperature"
+                    },
+                    {
+                      "type": "climate-hvac-modes",
+                      "style": "dropdown"
+                    }
+                  ]
+                },
+                {
+                  "type": "tile",
+                  "entity": "climate.downstairs",
+                  "name": "Downstairs",
+                  "icon": "mdi:thermostat",
+                  "features": [
+                    {
+                      "type": "target-temperature"
+                    },
+                    {
+                      "type": "climate-hvac-modes",
+                      "style": "dropdown"
+                    }
+                  ]
+                },
+                {
+                  "type": "tile",
+                  "entity": "climate.kids_room",
+                  "name": "Kitchen",
+                  "icon": "mdi:thermostat",
+                  "features": [
+                    {
+                      "type": "target-temperature"
+                    },
+                    {
+                      "type": "climate-hvac-modes",
+                      "style": "dropdown"
+                    }
+                  ]
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.upstairs_temperature",
+                  "name": "Upstairs temp",
+                  "icon": "mdi:thermometer"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.upstairs_humidity",
+                  "name": "Upstairs humidity",
+                  "icon": "mdi:water-percent"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.downstairs_temperature",
+                  "name": "Downstairs temp",
+                  "icon": "mdi:thermometer"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.downstairs_humidity",
+                  "name": "Downstairs humidity",
+                  "icon": "mdi:water-percent"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.kids_room_temperature",
+                  "name": "Kitchen temp",
+                  "icon": "mdi:thermometer"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.kids_room_humidity",
+                  "name": "Kitchen humidity",
+                  "icon": "mdi:water-percent"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "📊  Indoor vs outdoor (48h)",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:chart-line"
+            },
+            {
+              "type": "history-graph",
+              "title": "Temperature",
+              "hours_to_show": 48,
+              "entities": [
+                {
+                  "entity": "sensor.openweathermap_temperature",
+                  "name": "Outside"
+                },
+                {
+                  "entity": "sensor.upstairs_temperature",
+                  "name": "Upstairs"
+                },
+                {
+                  "entity": "sensor.downstairs_temperature",
+                  "name": "Downstairs"
+                },
+                {
+                  "entity": "sensor.kids_room_temperature",
+                  "name": "Kitchen"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "history-graph",
+              "title": "Humidity",
+              "hours_to_show": 48,
+              "entities": [
+                {
+                  "entity": "sensor.openweathermap_humidity",
+                  "name": "Outside"
+                },
+                {
+                  "entity": "sensor.upstairs_humidity",
+                  "name": "Upstairs"
+                },
+                {
+                  "entity": "sensor.downstairs_humidity",
+                  "name": "Downstairs"
+                },
+                {
+                  "entity": "sensor.kids_room_humidity",
+                  "name": "Kitchen"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "🌙  Sun & extras",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:weather-sunset"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sun.sun",
+                  "name": "Sun",
+                  "icon": "mdi:white-balance-sunny"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.openweathermap_dew_point",
+                  "name": "Dew point",
+                  "icon": "mdi:water-thermometer"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.openweathermap_visibility",
+                  "name": "Visibility",
+                  "icon": "mdi:eye-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.openweathermap_wind_bearing",
+                  "name": "Wind bearing",
+                  "icon": "mdi:compass"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/terrazzo-core/src/androidMain/resources/dashboards/energy/entity_states.json
+++ b/terrazzo-core/src/androidMain/resources/dashboards/energy/entity_states.json
@@ -1,0 +1,2751 @@
+{
+  "binary_sensor.octopus_energy_a_sn1_octoplus_saving_sessions": {
+    "entity_id": "binary_sensor.octopus_energy_a_sn1_octoplus_saving_sessions",
+    "state": "off",
+    "attributes": {
+      "current_joined_event_start": null,
+      "current_joined_event_end": null,
+      "current_joined_event_duration_in_minutes": null,
+      "next_joined_event_start": null,
+      "next_joined_event_end": null,
+      "next_joined_event_duration_in_minutes": null,
+      "icon": "mdi:leaf",
+      "friendly_name": "Octoplus (A-sn1) Octoplus Saving Sessions (A-sn1)"
+    },
+    "last_changed": "2026-04-30T18:08:19.021281+00:00",
+    "last_reported": "2026-04-30T18:13:18.636836+00:00",
+    "last_updated": "2026-04-30T18:08:19.021281+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.octopus_energy_electricity_sn2_sn3_off_peak": {
+    "entity_id": "binary_sensor.octopus_energy_electricity_sn2_sn3_off_peak",
+    "state": "off",
+    "attributes": {
+      "current_start": null,
+      "current_end": null,
+      "next_start": null,
+      "next_end": null,
+      "icon": "mdi:lightning-bolt",
+      "friendly_name": "Electricity Meter Off Peak Electricity (sn2/sn3)"
+    },
+    "last_changed": "2026-04-30T18:08:19.021695+00:00",
+    "last_reported": "2026-04-30T18:13:20.036952+00:00",
+    "last_updated": "2026-04-30T18:08:19.021695+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.octopus_energy_a_sn1_octoplus_points": {
+    "entity_id": "sensor.octopus_energy_a_sn1_octoplus_points",
+    "state": "500",
+    "attributes": {
+      "state_class": "total",
+      "redeemable_points": 496,
+      "icon": "mdi:trophy",
+      "friendly_name": "Octoplus (A-sn1) Octoplus Points (A-sn1)"
+    },
+    "last_changed": "2026-04-30T18:08:49.222081+00:00",
+    "last_reported": "2026-04-30T18:13:19.116670+00:00",
+    "last_updated": "2026-04-30T18:08:49.222081+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.octopus_energy_a_sn1_wheel_of_fortune_spins_electricity": {
+    "entity_id": "sensor.octopus_energy_a_sn1_wheel_of_fortune_spins_electricity",
+    "state": "2",
+    "attributes": {
+      "state_class": "total",
+      "icon": "mdi:star-circle",
+      "friendly_name": "Wheel Of Fortune Spins Electricity (A-sn1)"
+    },
+    "last_changed": "2026-04-30T18:09:19.173678+00:00",
+    "last_reported": "2026-04-30T18:13:18.997716+00:00",
+    "last_updated": "2026-04-30T18:09:19.173678+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.octopus_energy_a_sn1_wheel_of_fortune_spins_gas": {
+    "entity_id": "sensor.octopus_energy_a_sn1_wheel_of_fortune_spins_gas",
+    "state": "2",
+    "attributes": {
+      "state_class": "total",
+      "icon": "mdi:star-circle",
+      "friendly_name": "Wheel Of Fortune Spins Gas (A-sn1)"
+    },
+    "last_changed": "2026-04-30T18:09:19.173798+00:00",
+    "last_reported": "2026-04-30T18:13:18.997802+00:00",
+    "last_updated": "2026-04-30T18:09:19.173798+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.octopus_energy_electricity_sn2_sn3_current_rate": {
+    "entity_id": "sensor.octopus_energy_electricity_sn2_sn3_current_rate",
+    "state": "0.248962",
+    "attributes": {
+      "state_class": "total",
+      "mpan": "<redacted>",
+      "serial_number": "<redacted>",
+      "is_export": false,
+      "is_smart_meter": true,
+      "tariff": "<redacted>",
+      "start": "2026-05-04T00:00:00+01:00",
+      "end": "2026-05-07T00:00:00+01:00",
+      "is_capped": false,
+      "is_intelligent_adjusted": false,
+      "current_day_min_rate": 0.248962,
+      "current_day_max_rate": 0.248962,
+      "current_day_average_rate": 0.248962,
+      "unit_of_measurement": "GBP/kWh",
+      "device_class": "monetary",
+      "icon": "mdi:currency-gbp",
+      "friendly_name": "Electricity Meter Current Rate Electricity (sn2 sn3)"
+    },
+    "last_changed": "2026-04-30T18:08:19.100303+00:00",
+    "last_reported": "2026-05-04T23:09:36.428620+00:00",
+    "last_updated": "2026-05-04T23:09:36.428620+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.octopus_energy_electricity_sn2_sn3_current_standing_charge": {
+    "entity_id": "sensor.octopus_energy_electricity_sn2_sn3_current_standing_charge",
+    "state": "0.4428564",
+    "attributes": {
+      "state_class": "total",
+      "mpan": "<redacted>",
+      "serial_number": "<redacted>",
+      "is_export": false,
+      "is_smart_meter": true,
+      "start": "2026-04-01T00:00:00+01:00",
+      "end": null,
+      "unit_of_measurement": "GBP",
+      "device_class": "monetary",
+      "icon": "mdi:currency-gbp",
+      "friendly_name": "Electricity Meter Current Standing Charge Electricity (sn2/sn3)"
+    },
+    "last_changed": "2026-04-30T18:08:19.101005+00:00",
+    "last_reported": "2026-04-30T18:13:18.748962+00:00",
+    "last_updated": "2026-04-30T18:08:19.101005+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.octopus_energy_electricity_sn2_sn3_next_rate": {
+    "entity_id": "sensor.octopus_energy_electricity_sn2_sn3_next_rate",
+    "state": "unknown",
+    "attributes": {
+      "state_class": "total",
+      "mpan": "<redacted>",
+      "serial_number": "<redacted>",
+      "is_export": false,
+      "is_smart_meter": true,
+      "start": null,
+      "end": null,
+      "unit_of_measurement": "GBP/kWh",
+      "device_class": "monetary",
+      "icon": "mdi:currency-gbp",
+      "friendly_name": "Electricity Meter Next Rate Electricity (sn2/sn3)"
+    },
+    "last_changed": "2026-04-30T18:08:19.100751+00:00",
+    "last_reported": "2026-04-30T18:13:20.040280+00:00",
+    "last_updated": "2026-04-30T18:08:19.100751+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.octopus_energy_electricity_sn2_sn3_previous_accumulative_consumption": {
+    "entity_id": "sensor.octopus_energy_electricity_sn2_sn3_previous_accumulative_consumption",
+    "state": "13.78",
+    "attributes": {
+      "state_class": "total",
+      "last_reset": "2026-05-02T23:00:00+00:00",
+      "mpan": "<redacted>",
+      "serial_number": "<redacted>",
+      "is_export": false,
+      "is_smart_meter": true,
+      "total": 13.780000000000001,
+      "charges": [
+        {
+          "start": "2026-05-03T00:00:00+01:00",
+          "end": "2026-05-03T00:30:00+01:00",
+          "consumption": 0.561
+        },
+        {
+          "start": "2026-05-03T00:30:00+01:00",
+          "end": "2026-05-03T01:00:00+01:00",
+          "consumption": 0.527
+        },
+        {
+          "start": "2026-05-03T01:00:00+01:00",
+          "end": "2026-05-03T01:30:00+01:00",
+          "consumption": 0.39
+        },
+        {
+          "start": "2026-05-03T01:30:00+01:00",
+          "end": "2026-05-03T02:00:00+01:00",
+          "consumption": 0.353
+        },
+        {
+          "start": "2026-05-03T02:00:00+01:00",
+          "end": "2026-05-03T02:30:00+01:00",
+          "consumption": 0.304
+        },
+        {
+          "start": "2026-05-03T02:30:00+01:00",
+          "end": "2026-05-03T03:00:00+01:00",
+          "consumption": 0.271
+        },
+        {
+          "start": "2026-05-03T03:00:00+01:00",
+          "end": "2026-05-03T03:30:00+01:00",
+          "consumption": 0.24
+        },
+        {
+          "start": "2026-05-03T03:30:00+01:00",
+          "end": "2026-05-03T04:00:00+01:00",
+          "consumption": 0.251
+        },
+        {
+          "start": "2026-05-03T04:00:00+01:00",
+          "end": "2026-05-03T04:30:00+01:00",
+          "consumption": 0.317
+        },
+        {
+          "start": "2026-05-03T04:30:00+01:00",
+          "end": "2026-05-03T05:00:00+01:00",
+          "consumption": 0.273
+        },
+        {
+          "start": "2026-05-03T05:00:00+01:00",
+          "end": "2026-05-03T05:30:00+01:00",
+          "consumption": 0.256
+        },
+        {
+          "start": "2026-05-03T05:30:00+01:00",
+          "end": "2026-05-03T06:00:00+01:00",
+          "consumption": 0.26
+        },
+        {
+          "start": "2026-05-03T06:00:00+01:00",
+          "end": "2026-05-03T06:30:00+01:00",
+          "consumption": 0.237
+        },
+        {
+          "start": "2026-05-03T06:30:00+01:00",
+          "end": "2026-05-03T07:00:00+01:00",
+          "consumption": 0.226
+        },
+        {
+          "start": "2026-05-03T07:00:00+01:00",
+          "end": "2026-05-03T07:30:00+01:00",
+          "consumption": 0.432
+        },
+        {
+          "start": "2026-05-03T07:30:00+01:00",
+          "end": "2026-05-03T08:00:00+01:00",
+          "consumption": 0.292
+        },
+        {
+          "start": "2026-05-03T08:00:00+01:00",
+          "end": "2026-05-03T08:30:00+01:00",
+          "consumption": 0.022
+        },
+        {
+          "start": "2026-05-03T08:30:00+01:00",
+          "end": "2026-05-03T09:00:00+01:00",
+          "consumption": 0.063
+        },
+        {
+          "start": "2026-05-03T09:00:00+01:00",
+          "end": "2026-05-03T09:30:00+01:00",
+          "consumption": 0.065
+        },
+        {
+          "start": "2026-05-03T09:30:00+01:00",
+          "end": "2026-05-03T10:00:00+01:00",
+          "consumption": 0.254
+        },
+        {
+          "start": "2026-05-03T10:00:00+01:00",
+          "end": "2026-05-03T10:30:00+01:00",
+          "consumption": 0.181
+        },
+        {
+          "start": "2026-05-03T10:30:00+01:00",
+          "end": "2026-05-03T11:00:00+01:00",
+          "consumption": 0.298
+        },
+        {
+          "start": "2026-05-03T11:00:00+01:00",
+          "end": "2026-05-03T11:30:00+01:00",
+          "consumption": 0.011
+        },
+        {
+          "start": "2026-05-03T11:30:00+01:00",
+          "end": "2026-05-03T12:00:00+01:00",
+          "consumption": 0.003
+        },
+        {
+          "start": "2026-05-03T12:00:00+01:00",
+          "end": "2026-05-03T12:30:00+01:00",
+          "consumption": 0.101
+        },
+        {
+          "start": "2026-05-03T12:30:00+01:00",
+          "end": "2026-05-03T13:00:00+01:00",
+          "consumption": 0.003
+        },
+        {
+          "start": "2026-05-03T13:00:00+01:00",
+          "end": "2026-05-03T13:30:00+01:00",
+          "consumption": 0.082
+        },
+        {
+          "start": "2026-05-03T13:30:00+01:00",
+          "end": "2026-05-03T14:00:00+01:00",
+          "consumption": 0.103
+        },
+        {
+          "start": "2026-05-03T14:00:00+01:00",
+          "end": "2026-05-03T14:30:00+01:00",
+          "consumption": 0.969
+        },
+        {
+          "start": "2026-05-03T14:30:00+01:00",
+          "end": "2026-05-03T15:00:00+01:00",
+          "consumption": 0.155
+        },
+        {
+          "start": "2026-05-03T15:00:00+01:00",
+          "end": "2026-05-03T15:30:00+01:00",
+          "consumption": 0.044
+        },
+        {
+          "start": "2026-05-03T15:30:00+01:00",
+          "end": "2026-05-03T16:00:00+01:00",
+          "consumption": 0.018
+        },
+        {
+          "start": "2026-05-03T16:00:00+01:00",
+          "end": "2026-05-03T16:30:00+01:00",
+          "consumption": 0.029
+        },
+        {
+          "start": "2026-05-03T16:30:00+01:00",
+          "end": "2026-05-03T17:00:00+01:00",
+          "consumption": 0.02
+        },
+        {
+          "start": "2026-05-03T17:00:00+01:00",
+          "end": "2026-05-03T17:30:00+01:00",
+          "consumption": 0.078
+        },
+        {
+          "start": "2026-05-03T17:30:00+01:00",
+          "end": "2026-05-03T18:00:00+01:00",
+          "consumption": 0.07
+        },
+        {
+          "start": "2026-05-03T18:00:00+01:00",
+          "end": "2026-05-03T18:30:00+01:00",
+          "consumption": 0.336
+        },
+        {
+          "start": "2026-05-03T18:30:00+01:00",
+          "end": "2026-05-03T19:00:00+01:00",
+          "consumption": 0.275
+        },
+        {
+          "start": "2026-05-03T19:00:00+01:00",
+          "end": "2026-05-03T19:30:00+01:00",
+          "consumption": 0.357
+        },
+        {
+          "start": "2026-05-03T19:30:00+01:00",
+          "end": "2026-05-03T20:00:00+01:00",
+          "consumption": 0.581
+        },
+        {
+          "start": "2026-05-03T20:00:00+01:00",
+          "end": "2026-05-03T20:30:00+01:00",
+          "consumption": 0.669
+        },
+        {
+          "start": "2026-05-03T20:30:00+01:00",
+          "end": "2026-05-03T21:00:00+01:00",
+          "consumption": 0.557
+        },
+        {
+          "start": "2026-05-03T21:00:00+01:00",
+          "end": "2026-05-03T21:30:00+01:00",
+          "consumption": 0.513
+        },
+        {
+          "start": "2026-05-03T21:30:00+01:00",
+          "end": "2026-05-03T22:00:00+01:00",
+          "consumption": 0.577
+        },
+        {
+          "start": "2026-05-03T22:00:00+01:00",
+          "end": "2026-05-03T22:30:00+01:00",
+          "consumption": 0.71
+        },
+        {
+          "start": "2026-05-03T22:30:00+01:00",
+          "end": "2026-05-03T23:00:00+01:00",
+          "consumption": 0.55
+        },
+        {
+          "start": "2026-05-03T23:00:00+01:00",
+          "end": "2026-05-03T23:30:00+01:00",
+          "consumption": 0.509
+        },
+        {
+          "start": "2026-05-03T23:30:00+01:00",
+          "end": "2026-05-04T00:00:00+01:00",
+          "consumption": 0.387
+        }
+      ],
+      "unit_of_measurement": "kWh",
+      "device_class": "energy",
+      "icon": "mdi:lightning-bolt",
+      "friendly_name": "Electricity Meter Previous Accumulative Consumption Electricity (sn2/sn3)"
+    },
+    "last_changed": "2026-05-05T01:38:12.033561+00:00",
+    "last_reported": "2026-05-05T01:38:37.329614+00:00",
+    "last_updated": "2026-05-05T01:38:12.033561+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.octopus_energy_electricity_sn2_sn3_previous_accumulative_cost": {
+    "entity_id": "sensor.octopus_energy_electricity_sn2_sn3_previous_accumulative_cost",
+    "state": "3.84",
+    "attributes": {
+      "state_class": "total",
+      "last_reset": "2026-05-02T23:00:00+00:00",
+      "mpan": "<redacted>",
+      "serial_number": "<redacted>",
+      "is_export": false,
+      "is_smart_meter": true,
+      "tariff_code": "<redacted>",
+      "total": 3.84,
+      "charges": [
+        {
+          "start": "2026-05-03T00:00:00+01:00",
+          "end": "2026-05-03T00:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.561,
+          "cost": 0.14
+        },
+        {
+          "start": "2026-05-03T00:30:00+01:00",
+          "end": "2026-05-03T01:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.527,
+          "cost": 0.13
+        },
+        {
+          "start": "2026-05-03T01:00:00+01:00",
+          "end": "2026-05-03T01:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.39,
+          "cost": 0.1
+        },
+        {
+          "start": "2026-05-03T01:30:00+01:00",
+          "end": "2026-05-03T02:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.353,
+          "cost": 0.09
+        },
+        {
+          "start": "2026-05-03T02:00:00+01:00",
+          "end": "2026-05-03T02:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.304,
+          "cost": 0.07
+        },
+        {
+          "start": "2026-05-03T02:30:00+01:00",
+          "end": "2026-05-03T03:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.271,
+          "cost": 0.07
+        },
+        {
+          "start": "2026-05-03T03:00:00+01:00",
+          "end": "2026-05-03T03:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.24,
+          "cost": 0.06
+        },
+        {
+          "start": "2026-05-03T03:30:00+01:00",
+          "end": "2026-05-03T04:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.251,
+          "cost": 0.06
+        },
+        {
+          "start": "2026-05-03T04:00:00+01:00",
+          "end": "2026-05-03T04:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.317,
+          "cost": 0.08
+        },
+        {
+          "start": "2026-05-03T04:30:00+01:00",
+          "end": "2026-05-03T05:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.273,
+          "cost": 0.07
+        },
+        {
+          "start": "2026-05-03T05:00:00+01:00",
+          "end": "2026-05-03T05:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.256,
+          "cost": 0.06
+        },
+        {
+          "start": "2026-05-03T05:30:00+01:00",
+          "end": "2026-05-03T06:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.26,
+          "cost": 0.06
+        },
+        {
+          "start": "2026-05-03T06:00:00+01:00",
+          "end": "2026-05-03T06:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.237,
+          "cost": 0.06
+        },
+        {
+          "start": "2026-05-03T06:30:00+01:00",
+          "end": "2026-05-03T07:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.226,
+          "cost": 0.06
+        },
+        {
+          "start": "2026-05-03T07:00:00+01:00",
+          "end": "2026-05-03T07:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.432,
+          "cost": 0.11
+        },
+        {
+          "start": "2026-05-03T07:30:00+01:00",
+          "end": "2026-05-03T08:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.292,
+          "cost": 0.07
+        },
+        {
+          "start": "2026-05-03T08:00:00+01:00",
+          "end": "2026-05-03T08:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.022,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T08:30:00+01:00",
+          "end": "2026-05-03T09:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.063,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T09:00:00+01:00",
+          "end": "2026-05-03T09:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.065,
+          "cost": 0.02
+        },
+        {
+          "start": "2026-05-03T09:30:00+01:00",
+          "end": "2026-05-03T10:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.254,
+          "cost": 0.06
+        },
+        {
+          "start": "2026-05-03T10:00:00+01:00",
+          "end": "2026-05-03T10:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.181,
+          "cost": 0.04
+        },
+        {
+          "start": "2026-05-03T10:30:00+01:00",
+          "end": "2026-05-03T11:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.298,
+          "cost": 0.07
+        },
+        {
+          "start": "2026-05-03T11:00:00+01:00",
+          "end": "2026-05-03T11:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.011,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T11:30:00+01:00",
+          "end": "2026-05-03T12:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.003,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T12:00:00+01:00",
+          "end": "2026-05-03T12:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.101,
+          "cost": 0.02
+        },
+        {
+          "start": "2026-05-03T12:30:00+01:00",
+          "end": "2026-05-03T13:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.003,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T13:00:00+01:00",
+          "end": "2026-05-03T13:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.082,
+          "cost": 0.02
+        },
+        {
+          "start": "2026-05-03T13:30:00+01:00",
+          "end": "2026-05-03T14:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.103,
+          "cost": 0.02
+        },
+        {
+          "start": "2026-05-03T14:00:00+01:00",
+          "end": "2026-05-03T14:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.969,
+          "cost": 0.24
+        },
+        {
+          "start": "2026-05-03T14:30:00+01:00",
+          "end": "2026-05-03T15:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.155,
+          "cost": 0.04
+        },
+        {
+          "start": "2026-05-03T15:00:00+01:00",
+          "end": "2026-05-03T15:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.044,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T15:30:00+01:00",
+          "end": "2026-05-03T16:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.018,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T16:00:00+01:00",
+          "end": "2026-05-03T16:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.029,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T16:30:00+01:00",
+          "end": "2026-05-03T17:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.02,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T17:00:00+01:00",
+          "end": "2026-05-03T17:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.078,
+          "cost": 0.02
+        },
+        {
+          "start": "2026-05-03T17:30:00+01:00",
+          "end": "2026-05-03T18:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.07,
+          "cost": 0.02
+        },
+        {
+          "start": "2026-05-03T18:00:00+01:00",
+          "end": "2026-05-03T18:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.336,
+          "cost": 0.08
+        },
+        {
+          "start": "2026-05-03T18:30:00+01:00",
+          "end": "2026-05-03T19:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.275,
+          "cost": 0.07
+        },
+        {
+          "start": "2026-05-03T19:00:00+01:00",
+          "end": "2026-05-03T19:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.357,
+          "cost": 0.09
+        },
+        {
+          "start": "2026-05-03T19:30:00+01:00",
+          "end": "2026-05-03T20:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.581,
+          "cost": 0.14
+        },
+        {
+          "start": "2026-05-03T20:00:00+01:00",
+          "end": "2026-05-03T20:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.669,
+          "cost": 0.17
+        },
+        {
+          "start": "2026-05-03T20:30:00+01:00",
+          "end": "2026-05-03T21:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.557,
+          "cost": 0.14
+        },
+        {
+          "start": "2026-05-03T21:00:00+01:00",
+          "end": "2026-05-03T21:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.513,
+          "cost": 0.13
+        },
+        {
+          "start": "2026-05-03T21:30:00+01:00",
+          "end": "2026-05-03T22:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.577,
+          "cost": 0.14
+        },
+        {
+          "start": "2026-05-03T22:00:00+01:00",
+          "end": "2026-05-03T22:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.71,
+          "cost": 0.18
+        },
+        {
+          "start": "2026-05-03T22:30:00+01:00",
+          "end": "2026-05-03T23:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.55,
+          "cost": 0.14
+        },
+        {
+          "start": "2026-05-03T23:00:00+01:00",
+          "end": "2026-05-03T23:30:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.509,
+          "cost": 0.13
+        },
+        {
+          "start": "2026-05-03T23:30:00+01:00",
+          "end": "2026-05-04T00:00:00+01:00",
+          "rate": 0.248962,
+          "consumption": 0.387,
+          "cost": 0.1
+        }
+      ],
+      "standing_charge": 0.44,
+      "total_without_standing_charge": 3.4,
+      "unit_of_measurement": "GBP",
+      "device_class": "monetary",
+      "icon": "mdi:currency-gbp",
+      "friendly_name": "Electricity Meter Previous Accumulative Cost Electricity (sn2/sn3)"
+    },
+    "last_changed": "2026-05-05T01:38:37.340010+00:00",
+    "last_reported": "2026-05-05T01:38:37.340010+00:00",
+    "last_updated": "2026-05-05T01:38:37.340010+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.octopus_energy_electricity_sn2_sn4_export_current_rate": {
+    "entity_id": "sensor.octopus_energy_electricity_sn2_sn4_export_current_rate",
+    "state": "0.12",
+    "attributes": {
+      "state_class": "total",
+      "mpan": "<redacted>",
+      "serial_number": "<redacted>",
+      "is_export": true,
+      "is_smart_meter": true,
+      "tariff": "<redacted>",
+      "start": "2026-05-04T00:00:00+01:00",
+      "end": "2026-05-07T00:00:00+01:00",
+      "is_capped": false,
+      "is_intelligent_adjusted": false,
+      "current_day_min_rate": 0.12,
+      "current_day_max_rate": 0.12,
+      "current_day_average_rate": 0.12,
+      "unit_of_measurement": "GBP/kWh",
+      "device_class": "monetary",
+      "icon": "mdi:currency-gbp",
+      "friendly_name": "Electricity Meter Export Current Rate Export Electricity (sn2 sn4)"
+    },
+    "last_changed": "2026-04-30T18:08:19.103058+00:00",
+    "last_reported": "2026-05-04T23:09:35.052516+00:00",
+    "last_updated": "2026-05-04T23:09:35.052516+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.octopus_energy_electricity_sn2_sn4_export_next_rate": {
+    "entity_id": "sensor.octopus_energy_electricity_sn2_sn4_export_next_rate",
+    "state": "unknown",
+    "attributes": {
+      "state_class": "total",
+      "mpan": "<redacted>",
+      "serial_number": "<redacted>",
+      "is_export": true,
+      "is_smart_meter": true,
+      "start": null,
+      "end": null,
+      "unit_of_measurement": "GBP/kWh",
+      "device_class": "monetary",
+      "icon": "mdi:currency-gbp",
+      "friendly_name": "Electricity Meter Export Next Rate Export Electricity (sn2/sn4)"
+    },
+    "last_changed": "2026-04-30T18:08:19.103436+00:00",
+    "last_reported": "2026-04-30T18:13:18.676911+00:00",
+    "last_updated": "2026-04-30T18:08:19.103436+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.octopus_energy_electricity_sn2_sn4_export_previous_accumulative_consumption": {
+    "entity_id": "sensor.octopus_energy_electricity_sn2_sn4_export_previous_accumulative_consumption",
+    "state": "7.386",
+    "attributes": {
+      "state_class": "total",
+      "last_reset": "2026-05-02T23:00:00+00:00",
+      "mpan": "<redacted>",
+      "serial_number": "<redacted>",
+      "is_export": true,
+      "is_smart_meter": true,
+      "total": 7.385999999999999,
+      "charges": [
+        {
+          "start": "2026-05-03T00:00:00+01:00",
+          "end": "2026-05-03T00:30:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T00:30:00+01:00",
+          "end": "2026-05-03T01:00:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T01:00:00+01:00",
+          "end": "2026-05-03T01:30:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T01:30:00+01:00",
+          "end": "2026-05-03T02:00:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T02:00:00+01:00",
+          "end": "2026-05-03T02:30:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T02:30:00+01:00",
+          "end": "2026-05-03T03:00:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T03:00:00+01:00",
+          "end": "2026-05-03T03:30:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T03:30:00+01:00",
+          "end": "2026-05-03T04:00:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T04:00:00+01:00",
+          "end": "2026-05-03T04:30:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T04:30:00+01:00",
+          "end": "2026-05-03T05:00:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T05:00:00+01:00",
+          "end": "2026-05-03T05:30:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T05:30:00+01:00",
+          "end": "2026-05-03T06:00:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T06:00:00+01:00",
+          "end": "2026-05-03T06:30:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T06:30:00+01:00",
+          "end": "2026-05-03T07:00:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T07:00:00+01:00",
+          "end": "2026-05-03T07:30:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T07:30:00+01:00",
+          "end": "2026-05-03T08:00:00+01:00",
+          "consumption": 0.021
+        },
+        {
+          "start": "2026-05-03T08:00:00+01:00",
+          "end": "2026-05-03T08:30:00+01:00",
+          "consumption": 0.208
+        },
+        {
+          "start": "2026-05-03T08:30:00+01:00",
+          "end": "2026-05-03T09:00:00+01:00",
+          "consumption": 0.255
+        },
+        {
+          "start": "2026-05-03T09:00:00+01:00",
+          "end": "2026-05-03T09:30:00+01:00",
+          "consumption": 0.11
+        },
+        {
+          "start": "2026-05-03T09:30:00+01:00",
+          "end": "2026-05-03T10:00:00+01:00",
+          "consumption": 0.48
+        },
+        {
+          "start": "2026-05-03T10:00:00+01:00",
+          "end": "2026-05-03T10:30:00+01:00",
+          "consumption": 0.494
+        },
+        {
+          "start": "2026-05-03T10:30:00+01:00",
+          "end": "2026-05-03T11:00:00+01:00",
+          "consumption": 0.208
+        },
+        {
+          "start": "2026-05-03T11:00:00+01:00",
+          "end": "2026-05-03T11:30:00+01:00",
+          "consumption": 0.726
+        },
+        {
+          "start": "2026-05-03T11:30:00+01:00",
+          "end": "2026-05-03T12:00:00+01:00",
+          "consumption": 0.787
+        },
+        {
+          "start": "2026-05-03T12:00:00+01:00",
+          "end": "2026-05-03T12:30:00+01:00",
+          "consumption": 0.56
+        },
+        {
+          "start": "2026-05-03T12:30:00+01:00",
+          "end": "2026-05-03T13:00:00+01:00",
+          "consumption": 0.574
+        },
+        {
+          "start": "2026-05-03T13:00:00+01:00",
+          "end": "2026-05-03T13:30:00+01:00",
+          "consumption": 0.565
+        },
+        {
+          "start": "2026-05-03T13:30:00+01:00",
+          "end": "2026-05-03T14:00:00+01:00",
+          "consumption": 0.618
+        },
+        {
+          "start": "2026-05-03T14:00:00+01:00",
+          "end": "2026-05-03T14:30:00+01:00",
+          "consumption": 0.108
+        },
+        {
+          "start": "2026-05-03T14:30:00+01:00",
+          "end": "2026-05-03T15:00:00+01:00",
+          "consumption": 0.03
+        },
+        {
+          "start": "2026-05-03T15:00:00+01:00",
+          "end": "2026-05-03T15:30:00+01:00",
+          "consumption": 0.103
+        },
+        {
+          "start": "2026-05-03T15:30:00+01:00",
+          "end": "2026-05-03T16:00:00+01:00",
+          "consumption": 0.452
+        },
+        {
+          "start": "2026-05-03T16:00:00+01:00",
+          "end": "2026-05-03T16:30:00+01:00",
+          "consumption": 0.417
+        },
+        {
+          "start": "2026-05-03T16:30:00+01:00",
+          "end": "2026-05-03T17:00:00+01:00",
+          "consumption": 0.372
+        },
+        {
+          "start": "2026-05-03T17:00:00+01:00",
+          "end": "2026-05-03T17:30:00+01:00",
+          "consumption": 0.174
+        },
+        {
+          "start": "2026-05-03T17:30:00+01:00",
+          "end": "2026-05-03T18:00:00+01:00",
+          "consumption": 0.124
+        },
+        {
+          "start": "2026-05-03T18:00:00+01:00",
+          "end": "2026-05-03T18:30:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T18:30:00+01:00",
+          "end": "2026-05-03T19:00:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T19:00:00+01:00",
+          "end": "2026-05-03T19:30:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T19:30:00+01:00",
+          "end": "2026-05-03T20:00:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T20:00:00+01:00",
+          "end": "2026-05-03T20:30:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T20:30:00+01:00",
+          "end": "2026-05-03T21:00:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T21:00:00+01:00",
+          "end": "2026-05-03T21:30:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T21:30:00+01:00",
+          "end": "2026-05-03T22:00:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T22:00:00+01:00",
+          "end": "2026-05-03T22:30:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T22:30:00+01:00",
+          "end": "2026-05-03T23:00:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T23:00:00+01:00",
+          "end": "2026-05-03T23:30:00+01:00",
+          "consumption": 0.0
+        },
+        {
+          "start": "2026-05-03T23:30:00+01:00",
+          "end": "2026-05-04T00:00:00+01:00",
+          "consumption": 0.0
+        }
+      ],
+      "unit_of_measurement": "kWh",
+      "device_class": "energy",
+      "icon": "mdi:lightning-bolt",
+      "friendly_name": "Electricity Meter Export Previous Accumulative Consumption Export Electricity (sn2/sn4)"
+    },
+    "last_changed": "2026-05-04T22:38:08.141100+00:00",
+    "last_reported": "2026-05-04T22:38:17.056568+00:00",
+    "last_updated": "2026-05-04T22:38:08.141100+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.octopus_energy_electricity_sn2_sn4_export_previous_accumulative_cost": {
+    "entity_id": "sensor.octopus_energy_electricity_sn2_sn4_export_previous_accumulative_cost",
+    "state": "0.87",
+    "attributes": {
+      "state_class": "total",
+      "last_reset": "2026-05-02T23:00:00+00:00",
+      "mpan": "<redacted>",
+      "serial_number": "<redacted>",
+      "is_export": true,
+      "is_smart_meter": true,
+      "tariff_code": "<redacted>",
+      "total": 0.87,
+      "charges": [
+        {
+          "start": "2026-05-03T00:00:00+01:00",
+          "end": "2026-05-03T00:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T00:30:00+01:00",
+          "end": "2026-05-03T01:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T01:00:00+01:00",
+          "end": "2026-05-03T01:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T01:30:00+01:00",
+          "end": "2026-05-03T02:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T02:00:00+01:00",
+          "end": "2026-05-03T02:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T02:30:00+01:00",
+          "end": "2026-05-03T03:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T03:00:00+01:00",
+          "end": "2026-05-03T03:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T03:30:00+01:00",
+          "end": "2026-05-03T04:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T04:00:00+01:00",
+          "end": "2026-05-03T04:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T04:30:00+01:00",
+          "end": "2026-05-03T05:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T05:00:00+01:00",
+          "end": "2026-05-03T05:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T05:30:00+01:00",
+          "end": "2026-05-03T06:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T06:00:00+01:00",
+          "end": "2026-05-03T06:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T06:30:00+01:00",
+          "end": "2026-05-03T07:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T07:00:00+01:00",
+          "end": "2026-05-03T07:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T07:30:00+01:00",
+          "end": "2026-05-03T08:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.021,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T08:00:00+01:00",
+          "end": "2026-05-03T08:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.208,
+          "cost": 0.03
+        },
+        {
+          "start": "2026-05-03T08:30:00+01:00",
+          "end": "2026-05-03T09:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.255,
+          "cost": 0.03
+        },
+        {
+          "start": "2026-05-03T09:00:00+01:00",
+          "end": "2026-05-03T09:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.11,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T09:30:00+01:00",
+          "end": "2026-05-03T10:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.48,
+          "cost": 0.06
+        },
+        {
+          "start": "2026-05-03T10:00:00+01:00",
+          "end": "2026-05-03T10:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.494,
+          "cost": 0.06
+        },
+        {
+          "start": "2026-05-03T10:30:00+01:00",
+          "end": "2026-05-03T11:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.208,
+          "cost": 0.03
+        },
+        {
+          "start": "2026-05-03T11:00:00+01:00",
+          "end": "2026-05-03T11:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.726,
+          "cost": 0.09
+        },
+        {
+          "start": "2026-05-03T11:30:00+01:00",
+          "end": "2026-05-03T12:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.787,
+          "cost": 0.09
+        },
+        {
+          "start": "2026-05-03T12:00:00+01:00",
+          "end": "2026-05-03T12:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.56,
+          "cost": 0.07
+        },
+        {
+          "start": "2026-05-03T12:30:00+01:00",
+          "end": "2026-05-03T13:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.574,
+          "cost": 0.07
+        },
+        {
+          "start": "2026-05-03T13:00:00+01:00",
+          "end": "2026-05-03T13:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.565,
+          "cost": 0.07
+        },
+        {
+          "start": "2026-05-03T13:30:00+01:00",
+          "end": "2026-05-03T14:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.618,
+          "cost": 0.07
+        },
+        {
+          "start": "2026-05-03T14:00:00+01:00",
+          "end": "2026-05-03T14:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.108,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T14:30:00+01:00",
+          "end": "2026-05-03T15:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.03,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T15:00:00+01:00",
+          "end": "2026-05-03T15:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.103,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T15:30:00+01:00",
+          "end": "2026-05-03T16:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.452,
+          "cost": 0.05
+        },
+        {
+          "start": "2026-05-03T16:00:00+01:00",
+          "end": "2026-05-03T16:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.417,
+          "cost": 0.05
+        },
+        {
+          "start": "2026-05-03T16:30:00+01:00",
+          "end": "2026-05-03T17:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.372,
+          "cost": 0.04
+        },
+        {
+          "start": "2026-05-03T17:00:00+01:00",
+          "end": "2026-05-03T17:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.174,
+          "cost": 0.02
+        },
+        {
+          "start": "2026-05-03T17:30:00+01:00",
+          "end": "2026-05-03T18:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.124,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T18:00:00+01:00",
+          "end": "2026-05-03T18:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T18:30:00+01:00",
+          "end": "2026-05-03T19:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T19:00:00+01:00",
+          "end": "2026-05-03T19:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T19:30:00+01:00",
+          "end": "2026-05-03T20:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T20:00:00+01:00",
+          "end": "2026-05-03T20:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T20:30:00+01:00",
+          "end": "2026-05-03T21:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T21:00:00+01:00",
+          "end": "2026-05-03T21:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T21:30:00+01:00",
+          "end": "2026-05-03T22:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T22:00:00+01:00",
+          "end": "2026-05-03T22:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T22:30:00+01:00",
+          "end": "2026-05-03T23:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T23:00:00+01:00",
+          "end": "2026-05-03T23:30:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T23:30:00+01:00",
+          "end": "2026-05-04T00:00:00+01:00",
+          "rate": 0.12,
+          "consumption": 0.0,
+          "cost": 0.0
+        }
+      ],
+      "standing_charge": 0.0,
+      "total_without_standing_charge": 0.87,
+      "unit_of_measurement": "GBP",
+      "device_class": "monetary",
+      "icon": "mdi:currency-gbp",
+      "friendly_name": "Electricity Meter Export Previous Accumulative Cost Export Electricity (sn2/sn4)"
+    },
+    "last_changed": "2026-05-04T22:38:37.062989+00:00",
+    "last_reported": "2026-05-04T22:38:47.056188+00:00",
+    "last_updated": "2026-05-04T22:38:37.062989+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.octopus_energy_gas_sn5_sn6_current_rate": {
+    "entity_id": "sensor.octopus_energy_gas_sn5_sn6_current_rate",
+    "state": "0.059144",
+    "attributes": {
+      "state_class": "total",
+      "mprn": "<redacted>",
+      "serial_number": "<redacted>",
+      "is_smart_meter": true,
+      "tariff": "<redacted>",
+      "start": "2026-05-04T00:00:00+01:00",
+      "end": "2026-05-07T00:00:00+01:00",
+      "is_capped": false,
+      "unit_of_measurement": "GBP/kWh",
+      "device_class": "monetary",
+      "icon": "mdi:currency-gbp",
+      "friendly_name": "Gas Meter Current Rate Gas (sn5/sn6)"
+    },
+    "last_changed": "2026-04-30T18:08:19.106551+00:00",
+    "last_reported": "2026-05-04T23:09:33.135538+00:00",
+    "last_updated": "2026-05-04T23:09:33.135538+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.octopus_energy_gas_sn5_sn6_current_standing_charge": {
+    "entity_id": "sensor.octopus_energy_gas_sn5_sn6_current_standing_charge",
+    "state": "0.XXXXXXXX",
+    "attributes": {
+      "state_class": "total",
+      "mprn": "<redacted>",
+      "serial_number": "<redacted>",
+      "start": "2026-04-01T00:00:00+01:00",
+      "end": null,
+      "unit_of_measurement": "GBP",
+      "device_class": "monetary",
+      "icon": "mdi:currency-gbp",
+      "friendly_name": "Gas Meter Current Standing Charge Gas (sn5/sn6)"
+    },
+    "last_changed": "2026-04-30T18:08:19.107297+00:00",
+    "last_reported": "2026-04-30T18:13:18.867078+00:00",
+    "last_updated": "2026-04-30T18:08:19.107297+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.octopus_energy_gas_sn5_sn6_next_rate": {
+    "entity_id": "sensor.octopus_energy_gas_sn5_sn6_next_rate",
+    "state": "unknown",
+    "attributes": {
+      "state_class": "total",
+      "mprn": "<redacted>",
+      "serial_number": "<redacted>",
+      "is_smart_meter": true,
+      "start": null,
+      "end": null,
+      "unit_of_measurement": "GBP/kWh",
+      "device_class": "monetary",
+      "icon": "mdi:currency-gbp",
+      "friendly_name": "Gas Meter Next Rate Gas (sn5/sn6)"
+    },
+    "last_changed": "2026-04-30T18:08:19.107052+00:00",
+    "last_reported": "2026-04-30T18:13:18.702664+00:00",
+    "last_updated": "2026-04-30T18:08:19.107052+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.octopus_energy_gas_sn5_sn6_previous_accumulative_consumption_kwh": {
+    "entity_id": "sensor.octopus_energy_gas_sn5_sn6_previous_accumulative_consumption_kwh",
+    "state": "33.215",
+    "attributes": {
+      "state_class": "total",
+      "last_reset": "2026-05-02T23:00:00+00:00",
+      "mprn": "<redacted>",
+      "serial_number": "<redacted>",
+      "is_estimated": true,
+      "charges": [
+        {
+          "start": "2026-05-03T00:00:00+01:00",
+          "end": "2026-05-03T00:30:00+01:00",
+          "consumption_m3": 0.0,
+          "consumption_kwh": 0.0
+        },
+        {
+          "start": "2026-05-03T00:30:00+01:00",
+          "end": "2026-05-03T01:00:00+01:00",
+          "consumption_m3": 0.0,
+          "consumption_kwh": 0.0
+        },
+        {
+          "start": "2026-05-03T01:00:00+01:00",
+          "end": "2026-05-03T01:30:00+01:00",
+          "consumption_m3": 0.067,
+          "consumption_kwh": 0.761
+        },
+        {
+          "start": "2026-05-03T01:30:00+01:00",
+          "end": "2026-05-03T02:00:00+01:00",
+          "consumption_m3": 0.107,
+          "consumption_kwh": 1.216
+        },
+        {
+          "start": "2026-05-03T02:00:00+01:00",
+          "end": "2026-05-03T02:30:00+01:00",
+          "consumption_m3": 0.124,
+          "consumption_kwh": 1.409
+        },
+        {
+          "start": "2026-05-03T02:30:00+01:00",
+          "end": "2026-05-03T03:00:00+01:00",
+          "consumption_m3": 0.038,
+          "consumption_kwh": 0.432
+        },
+        {
+          "start": "2026-05-03T03:00:00+01:00",
+          "end": "2026-05-03T03:30:00+01:00",
+          "consumption_m3": 0.039,
+          "consumption_kwh": 0.443
+        },
+        {
+          "start": "2026-05-03T03:30:00+01:00",
+          "end": "2026-05-03T04:00:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T04:00:00+01:00",
+          "end": "2026-05-03T04:30:00+01:00",
+          "consumption_m3": 0.02,
+          "consumption_kwh": 0.227
+        },
+        {
+          "start": "2026-05-03T04:30:00+01:00",
+          "end": "2026-05-03T05:00:00+01:00",
+          "consumption_m3": 0.038,
+          "consumption_kwh": 0.432
+        },
+        {
+          "start": "2026-05-03T05:00:00+01:00",
+          "end": "2026-05-03T05:30:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T05:30:00+01:00",
+          "end": "2026-05-03T06:00:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T06:00:00+01:00",
+          "end": "2026-05-03T06:30:00+01:00",
+          "consumption_m3": 0.02,
+          "consumption_kwh": 0.227
+        },
+        {
+          "start": "2026-05-03T06:30:00+01:00",
+          "end": "2026-05-03T07:00:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T07:00:00+01:00",
+          "end": "2026-05-03T07:30:00+01:00",
+          "consumption_m3": 0.092,
+          "consumption_kwh": 1.045
+        },
+        {
+          "start": "2026-05-03T07:30:00+01:00",
+          "end": "2026-05-03T08:00:00+01:00",
+          "consumption_m3": 0.418,
+          "consumption_kwh": 4.75
+        },
+        {
+          "start": "2026-05-03T08:00:00+01:00",
+          "end": "2026-05-03T08:30:00+01:00",
+          "consumption_m3": 0.039,
+          "consumption_kwh": 0.443
+        },
+        {
+          "start": "2026-05-03T08:30:00+01:00",
+          "end": "2026-05-03T09:00:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T09:00:00+01:00",
+          "end": "2026-05-03T09:30:00+01:00",
+          "consumption_m3": 0.027,
+          "consumption_kwh": 0.307
+        },
+        {
+          "start": "2026-05-03T09:30:00+01:00",
+          "end": "2026-05-03T10:00:00+01:00",
+          "consumption_m3": 0.052,
+          "consumption_kwh": 0.591
+        },
+        {
+          "start": "2026-05-03T10:00:00+01:00",
+          "end": "2026-05-03T10:30:00+01:00",
+          "consumption_m3": 0.214,
+          "consumption_kwh": 2.432
+        },
+        {
+          "start": "2026-05-03T10:30:00+01:00",
+          "end": "2026-05-03T11:00:00+01:00",
+          "consumption_m3": 0.081,
+          "consumption_kwh": 0.92
+        },
+        {
+          "start": "2026-05-03T11:00:00+01:00",
+          "end": "2026-05-03T11:30:00+01:00",
+          "consumption_m3": 0.191,
+          "consumption_kwh": 2.17
+        },
+        {
+          "start": "2026-05-03T11:30:00+01:00",
+          "end": "2026-05-03T12:00:00+01:00",
+          "consumption_m3": 0.228,
+          "consumption_kwh": 2.591
+        },
+        {
+          "start": "2026-05-03T12:00:00+01:00",
+          "end": "2026-05-03T12:30:00+01:00",
+          "consumption_m3": 0.089,
+          "consumption_kwh": 1.011
+        },
+        {
+          "start": "2026-05-03T12:30:00+01:00",
+          "end": "2026-05-03T13:00:00+01:00",
+          "consumption_m3": 0.039,
+          "consumption_kwh": 0.443
+        },
+        {
+          "start": "2026-05-03T13:00:00+01:00",
+          "end": "2026-05-03T13:30:00+01:00",
+          "consumption_m3": 0.039,
+          "consumption_kwh": 0.443
+        },
+        {
+          "start": "2026-05-03T13:30:00+01:00",
+          "end": "2026-05-03T14:00:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T14:00:00+01:00",
+          "end": "2026-05-03T14:30:00+01:00",
+          "consumption_m3": 0.059,
+          "consumption_kwh": 0.67
+        },
+        {
+          "start": "2026-05-03T14:30:00+01:00",
+          "end": "2026-05-03T15:00:00+01:00",
+          "consumption_m3": 0.059,
+          "consumption_kwh": 0.67
+        },
+        {
+          "start": "2026-05-03T15:00:00+01:00",
+          "end": "2026-05-03T15:30:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T15:30:00+01:00",
+          "end": "2026-05-03T16:00:00+01:00",
+          "consumption_m3": 0.04,
+          "consumption_kwh": 0.455
+        },
+        {
+          "start": "2026-05-03T16:00:00+01:00",
+          "end": "2026-05-03T16:30:00+01:00",
+          "consumption_m3": 0.02,
+          "consumption_kwh": 0.227
+        },
+        {
+          "start": "2026-05-03T16:30:00+01:00",
+          "end": "2026-05-03T17:00:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T17:00:00+01:00",
+          "end": "2026-05-03T17:30:00+01:00",
+          "consumption_m3": 0.04,
+          "consumption_kwh": 0.455
+        },
+        {
+          "start": "2026-05-03T17:30:00+01:00",
+          "end": "2026-05-03T18:00:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T18:00:00+01:00",
+          "end": "2026-05-03T18:30:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T18:30:00+01:00",
+          "end": "2026-05-03T19:00:00+01:00",
+          "consumption_m3": 0.02,
+          "consumption_kwh": 0.227
+        },
+        {
+          "start": "2026-05-03T19:00:00+01:00",
+          "end": "2026-05-03T19:30:00+01:00",
+          "consumption_m3": 0.02,
+          "consumption_kwh": 0.227
+        },
+        {
+          "start": "2026-05-03T19:30:00+01:00",
+          "end": "2026-05-03T20:00:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T20:00:00+01:00",
+          "end": "2026-05-03T20:30:00+01:00",
+          "consumption_m3": 0.04,
+          "consumption_kwh": 0.455
+        },
+        {
+          "start": "2026-05-03T20:30:00+01:00",
+          "end": "2026-05-03T21:00:00+01:00",
+          "consumption_m3": 0.039,
+          "consumption_kwh": 0.443
+        },
+        {
+          "start": "2026-05-03T21:00:00+01:00",
+          "end": "2026-05-03T21:30:00+01:00",
+          "consumption_m3": 0.154,
+          "consumption_kwh": 1.75
+        },
+        {
+          "start": "2026-05-03T21:30:00+01:00",
+          "end": "2026-05-03T22:00:00+01:00",
+          "consumption_m3": 0.101,
+          "consumption_kwh": 1.148
+        },
+        {
+          "start": "2026-05-03T22:00:00+01:00",
+          "end": "2026-05-03T22:30:00+01:00",
+          "consumption_m3": 0.06,
+          "consumption_kwh": 0.682
+        },
+        {
+          "start": "2026-05-03T22:30:00+01:00",
+          "end": "2026-05-03T23:00:00+01:00",
+          "consumption_m3": 0.04,
+          "consumption_kwh": 0.455
+        },
+        {
+          "start": "2026-05-03T23:00:00+01:00",
+          "end": "2026-05-03T23:30:00+01:00",
+          "consumption_m3": 0.02,
+          "consumption_kwh": 0.227
+        },
+        {
+          "start": "2026-05-03T23:30:00+01:00",
+          "end": "2026-05-04T00:00:00+01:00",
+          "consumption_m3": 0.04,
+          "consumption_kwh": 0.455
+        }
+      ],
+      "calorific_value": 40.0,
+      "unit_of_measurement": "kWh",
+      "device_class": "energy",
+      "icon": "mdi:lightning-bolt",
+      "friendly_name": "Gas Meter Previous Accumulative Consumption (kWh) Gas (sn5/sn6)"
+    },
+    "last_changed": "2026-05-05T00:08:37.200185+00:00",
+    "last_reported": "2026-05-05T00:08:37.200185+00:00",
+    "last_updated": "2026-05-05T00:08:37.200185+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.octopus_energy_gas_sn5_sn6_previous_accumulative_consumption_m3": {
+    "entity_id": "sensor.octopus_energy_gas_sn5_sn6_previous_accumulative_consumption_m3",
+    "state": "2.923",
+    "attributes": {
+      "state_class": "total",
+      "last_reset": "2026-05-02T23:00:00+00:00",
+      "mprn": "<redacted>",
+      "serial_number": "<redacted>",
+      "is_estimated": false,
+      "total_kwh": 33.215,
+      "total_m3": 2.9230000000000014,
+      "charges": [
+        {
+          "start": "2026-05-03T00:00:00+01:00",
+          "end": "2026-05-03T00:30:00+01:00",
+          "consumption_m3": 0.0,
+          "consumption_kwh": 0.0
+        },
+        {
+          "start": "2026-05-03T00:30:00+01:00",
+          "end": "2026-05-03T01:00:00+01:00",
+          "consumption_m3": 0.0,
+          "consumption_kwh": 0.0
+        },
+        {
+          "start": "2026-05-03T01:00:00+01:00",
+          "end": "2026-05-03T01:30:00+01:00",
+          "consumption_m3": 0.067,
+          "consumption_kwh": 0.761
+        },
+        {
+          "start": "2026-05-03T01:30:00+01:00",
+          "end": "2026-05-03T02:00:00+01:00",
+          "consumption_m3": 0.107,
+          "consumption_kwh": 1.216
+        },
+        {
+          "start": "2026-05-03T02:00:00+01:00",
+          "end": "2026-05-03T02:30:00+01:00",
+          "consumption_m3": 0.124,
+          "consumption_kwh": 1.409
+        },
+        {
+          "start": "2026-05-03T02:30:00+01:00",
+          "end": "2026-05-03T03:00:00+01:00",
+          "consumption_m3": 0.038,
+          "consumption_kwh": 0.432
+        },
+        {
+          "start": "2026-05-03T03:00:00+01:00",
+          "end": "2026-05-03T03:30:00+01:00",
+          "consumption_m3": 0.039,
+          "consumption_kwh": 0.443
+        },
+        {
+          "start": "2026-05-03T03:30:00+01:00",
+          "end": "2026-05-03T04:00:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T04:00:00+01:00",
+          "end": "2026-05-03T04:30:00+01:00",
+          "consumption_m3": 0.02,
+          "consumption_kwh": 0.227
+        },
+        {
+          "start": "2026-05-03T04:30:00+01:00",
+          "end": "2026-05-03T05:00:00+01:00",
+          "consumption_m3": 0.038,
+          "consumption_kwh": 0.432
+        },
+        {
+          "start": "2026-05-03T05:00:00+01:00",
+          "end": "2026-05-03T05:30:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T05:30:00+01:00",
+          "end": "2026-05-03T06:00:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T06:00:00+01:00",
+          "end": "2026-05-03T06:30:00+01:00",
+          "consumption_m3": 0.02,
+          "consumption_kwh": 0.227
+        },
+        {
+          "start": "2026-05-03T06:30:00+01:00",
+          "end": "2026-05-03T07:00:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T07:00:00+01:00",
+          "end": "2026-05-03T07:30:00+01:00",
+          "consumption_m3": 0.092,
+          "consumption_kwh": 1.045
+        },
+        {
+          "start": "2026-05-03T07:30:00+01:00",
+          "end": "2026-05-03T08:00:00+01:00",
+          "consumption_m3": 0.418,
+          "consumption_kwh": 4.75
+        },
+        {
+          "start": "2026-05-03T08:00:00+01:00",
+          "end": "2026-05-03T08:30:00+01:00",
+          "consumption_m3": 0.039,
+          "consumption_kwh": 0.443
+        },
+        {
+          "start": "2026-05-03T08:30:00+01:00",
+          "end": "2026-05-03T09:00:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T09:00:00+01:00",
+          "end": "2026-05-03T09:30:00+01:00",
+          "consumption_m3": 0.027,
+          "consumption_kwh": 0.307
+        },
+        {
+          "start": "2026-05-03T09:30:00+01:00",
+          "end": "2026-05-03T10:00:00+01:00",
+          "consumption_m3": 0.052,
+          "consumption_kwh": 0.591
+        },
+        {
+          "start": "2026-05-03T10:00:00+01:00",
+          "end": "2026-05-03T10:30:00+01:00",
+          "consumption_m3": 0.214,
+          "consumption_kwh": 2.432
+        },
+        {
+          "start": "2026-05-03T10:30:00+01:00",
+          "end": "2026-05-03T11:00:00+01:00",
+          "consumption_m3": 0.081,
+          "consumption_kwh": 0.92
+        },
+        {
+          "start": "2026-05-03T11:00:00+01:00",
+          "end": "2026-05-03T11:30:00+01:00",
+          "consumption_m3": 0.191,
+          "consumption_kwh": 2.17
+        },
+        {
+          "start": "2026-05-03T11:30:00+01:00",
+          "end": "2026-05-03T12:00:00+01:00",
+          "consumption_m3": 0.228,
+          "consumption_kwh": 2.591
+        },
+        {
+          "start": "2026-05-03T12:00:00+01:00",
+          "end": "2026-05-03T12:30:00+01:00",
+          "consumption_m3": 0.089,
+          "consumption_kwh": 1.011
+        },
+        {
+          "start": "2026-05-03T12:30:00+01:00",
+          "end": "2026-05-03T13:00:00+01:00",
+          "consumption_m3": 0.039,
+          "consumption_kwh": 0.443
+        },
+        {
+          "start": "2026-05-03T13:00:00+01:00",
+          "end": "2026-05-03T13:30:00+01:00",
+          "consumption_m3": 0.039,
+          "consumption_kwh": 0.443
+        },
+        {
+          "start": "2026-05-03T13:30:00+01:00",
+          "end": "2026-05-03T14:00:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T14:00:00+01:00",
+          "end": "2026-05-03T14:30:00+01:00",
+          "consumption_m3": 0.059,
+          "consumption_kwh": 0.67
+        },
+        {
+          "start": "2026-05-03T14:30:00+01:00",
+          "end": "2026-05-03T15:00:00+01:00",
+          "consumption_m3": 0.059,
+          "consumption_kwh": 0.67
+        },
+        {
+          "start": "2026-05-03T15:00:00+01:00",
+          "end": "2026-05-03T15:30:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T15:30:00+01:00",
+          "end": "2026-05-03T16:00:00+01:00",
+          "consumption_m3": 0.04,
+          "consumption_kwh": 0.455
+        },
+        {
+          "start": "2026-05-03T16:00:00+01:00",
+          "end": "2026-05-03T16:30:00+01:00",
+          "consumption_m3": 0.02,
+          "consumption_kwh": 0.227
+        },
+        {
+          "start": "2026-05-03T16:30:00+01:00",
+          "end": "2026-05-03T17:00:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T17:00:00+01:00",
+          "end": "2026-05-03T17:30:00+01:00",
+          "consumption_m3": 0.04,
+          "consumption_kwh": 0.455
+        },
+        {
+          "start": "2026-05-03T17:30:00+01:00",
+          "end": "2026-05-03T18:00:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T18:00:00+01:00",
+          "end": "2026-05-03T18:30:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T18:30:00+01:00",
+          "end": "2026-05-03T19:00:00+01:00",
+          "consumption_m3": 0.02,
+          "consumption_kwh": 0.227
+        },
+        {
+          "start": "2026-05-03T19:00:00+01:00",
+          "end": "2026-05-03T19:30:00+01:00",
+          "consumption_m3": 0.02,
+          "consumption_kwh": 0.227
+        },
+        {
+          "start": "2026-05-03T19:30:00+01:00",
+          "end": "2026-05-03T20:00:00+01:00",
+          "consumption_m3": 0.019,
+          "consumption_kwh": 0.216
+        },
+        {
+          "start": "2026-05-03T20:00:00+01:00",
+          "end": "2026-05-03T20:30:00+01:00",
+          "consumption_m3": 0.04,
+          "consumption_kwh": 0.455
+        },
+        {
+          "start": "2026-05-03T20:30:00+01:00",
+          "end": "2026-05-03T21:00:00+01:00",
+          "consumption_m3": 0.039,
+          "consumption_kwh": 0.443
+        },
+        {
+          "start": "2026-05-03T21:00:00+01:00",
+          "end": "2026-05-03T21:30:00+01:00",
+          "consumption_m3": 0.154,
+          "consumption_kwh": 1.75
+        },
+        {
+          "start": "2026-05-03T21:30:00+01:00",
+          "end": "2026-05-03T22:00:00+01:00",
+          "consumption_m3": 0.101,
+          "consumption_kwh": 1.148
+        },
+        {
+          "start": "2026-05-03T22:00:00+01:00",
+          "end": "2026-05-03T22:30:00+01:00",
+          "consumption_m3": 0.06,
+          "consumption_kwh": 0.682
+        },
+        {
+          "start": "2026-05-03T22:30:00+01:00",
+          "end": "2026-05-03T23:00:00+01:00",
+          "consumption_m3": 0.04,
+          "consumption_kwh": 0.455
+        },
+        {
+          "start": "2026-05-03T23:00:00+01:00",
+          "end": "2026-05-03T23:30:00+01:00",
+          "consumption_m3": 0.02,
+          "consumption_kwh": 0.227
+        },
+        {
+          "start": "2026-05-03T23:30:00+01:00",
+          "end": "2026-05-04T00:00:00+01:00",
+          "consumption_m3": 0.04,
+          "consumption_kwh": 0.455
+        }
+      ],
+      "calorific_value": 40.0,
+      "unit_of_measurement": "m³",
+      "device_class": "gas",
+      "icon": "mdi:fire",
+      "friendly_name": "Gas Meter Previous Accumulative Consumption Gas (sn5/sn6)"
+    },
+    "last_changed": "2026-05-05T00:08:11.136228+00:00",
+    "last_reported": "2026-05-05T00:08:11.136228+00:00",
+    "last_updated": "2026-05-05T00:08:11.136228+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.octopus_energy_gas_sn5_sn6_previous_accumulative_cost": {
+    "entity_id": "sensor.octopus_energy_gas_sn5_sn6_previous_accumulative_cost",
+    "state": "2.22",
+    "attributes": {
+      "state_class": "total",
+      "last_reset": "2026-05-02T23:00:00+00:00",
+      "mprn": "<redacted>",
+      "serial_number": "<redacted>",
+      "tariff_code": "<redacted>",
+      "standing_charge": 0.29,
+      "total_without_standing_charge": 1.93,
+      "total": 2.2199999999999998,
+      "charges": [
+        {
+          "start": "2026-05-03T00:00:00+01:00",
+          "end": "2026-05-03T00:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T00:30:00+01:00",
+          "end": "2026-05-03T01:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.0,
+          "cost": 0.0
+        },
+        {
+          "start": "2026-05-03T01:00:00+01:00",
+          "end": "2026-05-03T01:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.761,
+          "cost": 0.04
+        },
+        {
+          "start": "2026-05-03T01:30:00+01:00",
+          "end": "2026-05-03T02:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 1.216,
+          "cost": 0.07
+        },
+        {
+          "start": "2026-05-03T02:00:00+01:00",
+          "end": "2026-05-03T02:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 1.409,
+          "cost": 0.08
+        },
+        {
+          "start": "2026-05-03T02:30:00+01:00",
+          "end": "2026-05-03T03:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.432,
+          "cost": 0.03
+        },
+        {
+          "start": "2026-05-03T03:00:00+01:00",
+          "end": "2026-05-03T03:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.443,
+          "cost": 0.03
+        },
+        {
+          "start": "2026-05-03T03:30:00+01:00",
+          "end": "2026-05-03T04:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.216,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T04:00:00+01:00",
+          "end": "2026-05-03T04:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.227,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T04:30:00+01:00",
+          "end": "2026-05-03T05:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.432,
+          "cost": 0.03
+        },
+        {
+          "start": "2026-05-03T05:00:00+01:00",
+          "end": "2026-05-03T05:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.216,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T05:30:00+01:00",
+          "end": "2026-05-03T06:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.216,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T06:00:00+01:00",
+          "end": "2026-05-03T06:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.227,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T06:30:00+01:00",
+          "end": "2026-05-03T07:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.216,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T07:00:00+01:00",
+          "end": "2026-05-03T07:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 1.045,
+          "cost": 0.06
+        },
+        {
+          "start": "2026-05-03T07:30:00+01:00",
+          "end": "2026-05-03T08:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 4.75,
+          "cost": 0.28
+        },
+        {
+          "start": "2026-05-03T08:00:00+01:00",
+          "end": "2026-05-03T08:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.443,
+          "cost": 0.03
+        },
+        {
+          "start": "2026-05-03T08:30:00+01:00",
+          "end": "2026-05-03T09:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.216,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T09:00:00+01:00",
+          "end": "2026-05-03T09:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.307,
+          "cost": 0.02
+        },
+        {
+          "start": "2026-05-03T09:30:00+01:00",
+          "end": "2026-05-03T10:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.591,
+          "cost": 0.03
+        },
+        {
+          "start": "2026-05-03T10:00:00+01:00",
+          "end": "2026-05-03T10:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 2.432,
+          "cost": 0.14
+        },
+        {
+          "start": "2026-05-03T10:30:00+01:00",
+          "end": "2026-05-03T11:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.92,
+          "cost": 0.05
+        },
+        {
+          "start": "2026-05-03T11:00:00+01:00",
+          "end": "2026-05-03T11:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 2.17,
+          "cost": 0.13
+        },
+        {
+          "start": "2026-05-03T11:30:00+01:00",
+          "end": "2026-05-03T12:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 2.591,
+          "cost": 0.15
+        },
+        {
+          "start": "2026-05-03T12:00:00+01:00",
+          "end": "2026-05-03T12:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 1.011,
+          "cost": 0.06
+        },
+        {
+          "start": "2026-05-03T12:30:00+01:00",
+          "end": "2026-05-03T13:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.443,
+          "cost": 0.03
+        },
+        {
+          "start": "2026-05-03T13:00:00+01:00",
+          "end": "2026-05-03T13:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.443,
+          "cost": 0.03
+        },
+        {
+          "start": "2026-05-03T13:30:00+01:00",
+          "end": "2026-05-03T14:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.216,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T14:00:00+01:00",
+          "end": "2026-05-03T14:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.67,
+          "cost": 0.04
+        },
+        {
+          "start": "2026-05-03T14:30:00+01:00",
+          "end": "2026-05-03T15:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.67,
+          "cost": 0.04
+        },
+        {
+          "start": "2026-05-03T15:00:00+01:00",
+          "end": "2026-05-03T15:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.216,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T15:30:00+01:00",
+          "end": "2026-05-03T16:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.455,
+          "cost": 0.03
+        },
+        {
+          "start": "2026-05-03T16:00:00+01:00",
+          "end": "2026-05-03T16:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.227,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T16:30:00+01:00",
+          "end": "2026-05-03T17:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.216,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T17:00:00+01:00",
+          "end": "2026-05-03T17:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.455,
+          "cost": 0.03
+        },
+        {
+          "start": "2026-05-03T17:30:00+01:00",
+          "end": "2026-05-03T18:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.216,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T18:00:00+01:00",
+          "end": "2026-05-03T18:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.216,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T18:30:00+01:00",
+          "end": "2026-05-03T19:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.227,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T19:00:00+01:00",
+          "end": "2026-05-03T19:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.227,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T19:30:00+01:00",
+          "end": "2026-05-03T20:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.216,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T20:00:00+01:00",
+          "end": "2026-05-03T20:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.455,
+          "cost": 0.03
+        },
+        {
+          "start": "2026-05-03T20:30:00+01:00",
+          "end": "2026-05-03T21:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.443,
+          "cost": 0.03
+        },
+        {
+          "start": "2026-05-03T21:00:00+01:00",
+          "end": "2026-05-03T21:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 1.75,
+          "cost": 0.1
+        },
+        {
+          "start": "2026-05-03T21:30:00+01:00",
+          "end": "2026-05-03T22:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 1.148,
+          "cost": 0.07
+        },
+        {
+          "start": "2026-05-03T22:00:00+01:00",
+          "end": "2026-05-03T22:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.682,
+          "cost": 0.04
+        },
+        {
+          "start": "2026-05-03T22:30:00+01:00",
+          "end": "2026-05-03T23:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.455,
+          "cost": 0.03
+        },
+        {
+          "start": "2026-05-03T23:00:00+01:00",
+          "end": "2026-05-03T23:30:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.227,
+          "cost": 0.01
+        },
+        {
+          "start": "2026-05-03T23:30:00+01:00",
+          "end": "2026-05-04T00:00:00+01:00",
+          "rate": 0.059144,
+          "consumption": 0.455,
+          "cost": 0.03
+        }
+      ],
+      "calorific_value": 40.0,
+      "unit_of_measurement": "GBP",
+      "device_class": "monetary",
+      "icon": "mdi:currency-gbp",
+      "friendly_name": "Gas Meter Previous Accumulative Cost Gas (sn5/sn6)"
+    },
+    "last_changed": "2026-05-05T00:08:37.198823+00:00",
+    "last_reported": "2026-05-05T00:08:37.198823+00:00",
+    "last_updated": "2026-05-05T00:08:37.198823+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.openweathermap_cloud_coverage": {
+    "entity_id": "sensor.openweathermap_cloud_coverage",
+    "state": "100",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "%",
+      "attribution": "Data provided by OpenWeatherMap",
+      "friendly_name": "OpenWeatherMap Cloud coverage"
+    },
+    "last_changed": "2026-05-05T19:38:18.957007+00:00",
+    "last_reported": "2026-05-05T19:38:18.957007+00:00",
+    "last_updated": "2026-05-05T19:38:18.957007+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.openweathermap_condition": {
+    "entity_id": "sensor.openweathermap_condition",
+    "state": "cloudy",
+    "attributes": {
+      "attribution": "Data provided by OpenWeatherMap",
+      "friendly_name": "OpenWeatherMap Condition"
+    },
+    "last_changed": "2026-05-05T21:58:18.953938+00:00",
+    "last_reported": "2026-05-05T21:58:18.953938+00:00",
+    "last_updated": "2026-05-05T21:58:18.953938+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.openweathermap_uv_index": {
+    "entity_id": "sensor.openweathermap_uv_index",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "UV index",
+      "attribution": "Data provided by OpenWeatherMap",
+      "friendly_name": "OpenWeatherMap UV index"
+    },
+    "last_changed": "2026-05-05T18:38:18.988289+00:00",
+    "last_reported": "2026-05-05T18:38:18.988289+00:00",
+    "last_updated": "2026-05-05T18:38:18.988289+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.solaredge_current_power": {
+    "entity_id": "sensor.solaredge_current_power",
+    "state": "0.0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "W",
+      "device_class": "power",
+      "friendly_name": "solaredge Current power"
+    },
+    "last_changed": "2026-05-04T19:08:26.978878+00:00",
+    "last_reported": "2026-05-04T19:08:26.978878+00:00",
+    "last_updated": "2026-05-04T19:08:26.978878+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.solaredge_lifetime_energy": {
+    "entity_id": "sensor.solaredge_lifetime_energy",
+    "state": "XXXXXXXX.0",
+    "attributes": {
+      "state_class": "total_increasing",
+      "unit_of_measurement": "Wh",
+      "device_class": "energy",
+      "friendly_name": "solaredge Lifetime energy"
+    },
+    "last_changed": "2026-05-05T20:38:28.040120+00:00",
+    "last_reported": "2026-05-05T20:38:28.040120+00:00",
+    "last_updated": "2026-05-05T20:38:28.040120+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.sun_next_dawn": {
+    "entity_id": "sensor.sun_next_dawn",
+    "state": "2026-05-06T03:43:08+00:00",
+    "attributes": {
+      "device_class": "timestamp",
+      "friendly_name": "Sun Next dawn"
+    },
+    "last_changed": "2026-05-05T03:45:08.023536+00:00",
+    "last_reported": "2026-05-05T03:45:08.023536+00:00",
+    "last_updated": "2026-05-05T03:45:08.023536+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.sun_next_dusk": {
+    "entity_id": "sensor.sun_next_dusk",
+    "state": "2026-05-06T20:11:02+00:00",
+    "attributes": {
+      "device_class": "timestamp",
+      "friendly_name": "Sun Next dusk"
+    },
+    "last_changed": "2026-05-05T20:09:11.999338+00:00",
+    "last_reported": "2026-05-05T20:09:11.999338+00:00",
+    "last_updated": "2026-05-05T20:09:11.999338+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.sun_next_midnight": {
+    "entity_id": "sensor.sun_next_midnight",
+    "state": "2026-05-05T23:56:27+00:00",
+    "attributes": {
+      "device_class": "timestamp",
+      "friendly_name": "Sun Next midnight"
+    },
+    "last_changed": "2026-05-04T23:56:31.002637+00:00",
+    "last_reported": "2026-05-04T23:56:31.002637+00:00",
+    "last_updated": "2026-05-04T23:56:31.002637+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.sun_next_noon": {
+    "entity_id": "sensor.sun_next_noon",
+    "state": "2026-05-06T11:56:28+00:00",
+    "attributes": {
+      "device_class": "timestamp",
+      "friendly_name": "Sun Next noon"
+    },
+    "last_changed": "2026-05-05T11:56:33.002074+00:00",
+    "last_reported": "2026-05-05T11:56:33.002074+00:00",
+    "last_updated": "2026-05-05T11:56:33.002074+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.sun_next_rising": {
+    "entity_id": "sensor.sun_next_rising",
+    "state": "2026-05-06T04:23:07+00:00",
+    "attributes": {
+      "device_class": "timestamp",
+      "friendly_name": "Sun Next rising"
+    },
+    "last_changed": "2026-05-05T04:24:53.725938+00:00",
+    "last_reported": "2026-05-05T04:24:53.725938+00:00",
+    "last_updated": "2026-05-05T04:24:53.725938+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.sun_next_setting": {
+    "entity_id": "sensor.sun_next_setting",
+    "state": "2026-05-06T19:30:46+00:00",
+    "attributes": {
+      "device_class": "timestamp",
+      "friendly_name": "Sun Next setting"
+    },
+    "last_changed": "2026-05-05T19:29:10.512930+00:00",
+    "last_reported": "2026-05-05T19:29:10.512930+00:00",
+    "last_updated": "2026-05-05T19:29:10.512930+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  }
+}

--- a/terrazzo-core/src/androidMain/resources/dashboards/energy/lovelace_config.json
+++ b/terrazzo-core/src/androidMain/resources/dashboards/energy/lovelace_config.json
@@ -1,0 +1,442 @@
+{
+  "views": [
+    {
+      "title": "Overview",
+      "icon": "mdi:lightning-bolt",
+      "type": "sections",
+      "max_columns": 4,
+      "header": {
+        "card": {
+          "type": "markdown",
+          "text_only": true,
+          "content": "# ⚡ Energy\n☀️ Solar now: **{{ states('sensor.solaredge_current_power') | float(0) | round(0) }} W** · ⚡ Import rate: **{{ (states('sensor.octopus_energy_electricity_sn2_sn3_current_rate') | float(0) * 100) | round(2) }} p/kWh** · ⤴️ Export rate: **{{ (states('sensor.octopus_energy_electricity_sn2_sn4_export_current_rate') | float(0) * 100) | round(2) }} p/kWh** · 🔥 Gas rate: **{{ (states('sensor.octopus_energy_gas_sn5_sn6_current_rate') | float(0) * 100) | round(2) }} p/kWh**"
+        }
+      },
+      "sections": [
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "☀️ Right now",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:solar-power"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.solaredge_current_power",
+                  "name": "Solar production",
+                  "icon": "mdi:solar-power-variant"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.octopus_energy_electricity_sn2_sn3_off_peak",
+                  "name": "Off-peak import?",
+                  "icon": "mdi:lightning-bolt-circle"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.octopus_energy_a_sn1_octoplus_saving_sessions",
+                  "name": "Saving session?",
+                  "icon": "mdi:leaf-circle-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.openweathermap_cloud_coverage",
+                  "name": "Cloud cover",
+                  "icon": "mdi:weather-cloudy"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "💷 Octopus rates (today)",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:cash"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.octopus_energy_electricity_sn2_sn3_current_rate",
+                  "name": "Import rate",
+                  "icon": "mdi:transmission-tower-import"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.octopus_energy_electricity_sn2_sn4_export_current_rate",
+                  "name": "Export rate",
+                  "icon": "mdi:transmission-tower-export"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.octopus_energy_gas_sn5_sn6_current_rate",
+                  "name": "Gas rate",
+                  "icon": "mdi:fire"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.octopus_energy_electricity_sn2_sn3_current_standing_charge",
+                  "name": "Elec. standing",
+                  "icon": "mdi:clock-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.octopus_energy_gas_sn5_sn6_current_standing_charge",
+                  "name": "Gas standing",
+                  "icon": "mdi:clock-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.octopus_energy_electricity_sn2_sn3_next_rate",
+                  "name": "Elec. next rate",
+                  "icon": "mdi:transmission-tower-import"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.octopus_energy_electricity_sn2_sn4_export_next_rate",
+                  "name": "Export next rate",
+                  "icon": "mdi:transmission-tower-export"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.octopus_energy_gas_sn5_sn6_next_rate",
+                  "name": "Gas next rate",
+                  "icon": "mdi:fire"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "📅 Yesterday",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:calendar-yesterday"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.octopus_energy_electricity_sn2_sn3_previous_accumulative_consumption",
+                  "name": "Imported",
+                  "icon": "mdi:transmission-tower-import"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.octopus_energy_electricity_sn2_sn3_previous_accumulative_cost",
+                  "name": "Import cost",
+                  "icon": "mdi:currency-gbp"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.octopus_energy_electricity_sn2_sn4_export_previous_accumulative_consumption",
+                  "name": "Exported",
+                  "icon": "mdi:transmission-tower-export"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.octopus_energy_electricity_sn2_sn4_export_previous_accumulative_cost",
+                  "name": "Export income",
+                  "icon": "mdi:currency-gbp"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.octopus_energy_gas_sn5_sn6_previous_accumulative_consumption_kwh",
+                  "name": "Gas (kWh)",
+                  "icon": "mdi:fire"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.octopus_energy_gas_sn5_sn6_previous_accumulative_consumption_m3",
+                  "name": "Gas (m³)",
+                  "icon": "mdi:fire-circle"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.octopus_energy_gas_sn5_sn6_previous_accumulative_cost",
+                  "name": "Gas cost",
+                  "icon": "mdi:currency-gbp"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.solaredge_lifetime_energy",
+                  "name": "Solar lifetime",
+                  "icon": "mdi:solar-panel"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "📈 Solar production (7 days)",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:chart-line"
+            },
+            {
+              "type": "history-graph",
+              "title": "SolarEdge current power",
+              "hours_to_show": 168,
+              "entities": [
+                {
+                  "entity": "sensor.solaredge_current_power",
+                  "name": "Power"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "history-graph",
+              "title": "Today's rates (import/export/gas)",
+              "hours_to_show": 24,
+              "entities": [
+                {
+                  "entity": "sensor.octopus_energy_electricity_sn2_sn3_current_rate",
+                  "name": "Import"
+                },
+                {
+                  "entity": "sensor.octopus_energy_electricity_sn2_sn4_export_current_rate",
+                  "name": "Export"
+                },
+                {
+                  "entity": "sensor.octopus_energy_gas_sn5_sn6_current_rate",
+                  "name": "Gas"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "🎁 Octoplus perks",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:gift-outline"
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.octopus_energy_a_sn1_octoplus_points",
+                  "name": "Octoplus points",
+                  "icon": "mdi:star-four-points-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.octopus_energy_a_sn1_wheel_of_fortune_spins_electricity",
+                  "name": "Wheel spins (elec)",
+                  "icon": "mdi:ferris-wheel"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.octopus_energy_a_sn1_wheel_of_fortune_spins_gas",
+                  "name": "Wheel spins (gas)",
+                  "icon": "mdi:ferris-wheel"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Sun",
+      "icon": "mdi:weather-sunny",
+      "path": "sun",
+      "type": "sections",
+      "max_columns": 4,
+      "header": {
+        "card": {
+          "type": "markdown",
+          "text_only": true,
+          "content": "# 🌞 Sun\n{% set sun = states.sun.sun %}{% set e = sun.attributes.elevation | float(0) %}{% set a = sun.attributes.azimuth | float(0) %}**State:** {{ 'above horizon' if sun.state == 'above_horizon' else 'below horizon' }} · **Elevation:** {{ e | round(1) }}° · **Azimuth:** {{ a | round(0) }}° {% if sun.state == 'above_horizon' %}— next setting in {{ (as_timestamp(states('sensor.sun_next_setting')) - as_timestamp(now())) | int // 60 }} min{% else %}— next rising in {{ ((as_timestamp(states('sensor.sun_next_rising')) - as_timestamp(now())) | int // 60) }} min{% endif %}"
+        }
+      },
+      "sections": [
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "🌅 Timings today",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:weather-sunset"
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.sun_next_dawn",
+                  "name": "Dawn",
+                  "icon": "mdi:weather-sunset-up"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.sun_next_rising",
+                  "name": "Sunrise",
+                  "icon": "mdi:weather-sunset-up"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.sun_next_noon",
+                  "name": "Solar noon",
+                  "icon": "mdi:white-balance-sunny"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.sun_next_setting",
+                  "name": "Sunset",
+                  "icon": "mdi:weather-sunset-down"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.sun_next_dusk",
+                  "name": "Dusk",
+                  "icon": "mdi:weather-sunset-down"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.sun_next_midnight",
+                  "name": "Solar midnight",
+                  "icon": "mdi:weather-night"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "🔭 Position & conditions",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:compass-outline"
+            },
+            {
+              "type": "markdown",
+              "grid_options": {
+                "columns": "full"
+              },
+              "content": "{% set sun = states.sun.sun %}{% set e = sun.attributes.elevation | float(0) %}{% set a = sun.attributes.azimuth | float(0) %}{% set comp = ['N','NNE','NE','ENE','E','ESE','SE','SSE','S','SSW','SW','WSW','W','WNW','NW','NNW','N'] %}{% set idx = ((a / 22.5) | round(0, 'floor')) | int %}## {{ '☀️' if sun.state == 'above_horizon' else '🌙' }} Elevation **{{ e | round(1) }}°** · Azimuth **{{ a | round(0) }}° ({{ comp[idx] }})**\n\n_Rising_: {{ 'yes' if sun.attributes.rising else 'no' }} · _Cloud_: {{ states('sensor.openweathermap_cloud_coverage') }}% · _UV_: {{ states('sensor.openweathermap_uv_index') }} · _Condition_: {{ states('sensor.openweathermap_condition') | replace('-', ' ') | title }}"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.openweathermap_cloud_coverage",
+                  "name": "Cloud cover",
+                  "icon": "mdi:weather-cloudy"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.openweathermap_uv_index",
+                  "name": "UV index",
+                  "icon": "mdi:sun-wireless"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.openweathermap_condition",
+                  "name": "Condition",
+                  "icon": "mdi:weather-partly-cloudy"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.solaredge_current_power",
+                  "name": "Solar production",
+                  "icon": "mdi:solar-power-variant"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "📊 Solar vs cloud vs UV (48h)",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:chart-multiline"
+            },
+            {
+              "type": "history-graph",
+              "title": "Production vs sky",
+              "hours_to_show": 48,
+              "entities": [
+                {
+                  "entity": "sensor.solaredge_current_power",
+                  "name": "Solar power"
+                },
+                {
+                  "entity": "sensor.openweathermap_cloud_coverage",
+                  "name": "Cloud %"
+                },
+                {
+                  "entity": "sensor.openweathermap_uv_index",
+                  "name": "UV index"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/terrazzo-core/src/androidMain/resources/dashboards/github/entity_states.json
+++ b/terrazzo-core/src/androidMain/resources/dashboards/github/entity_states.json
@@ -1,0 +1,532 @@
+{
+  "sensor.google_horologist_stars": {
+    "entity_id": "sensor.google_horologist_stars",
+    "state": "681",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "stars",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "google/horologist Stars"
+    },
+    "last_changed": "2026-05-04T10:37:10.335273+00:00",
+    "last_reported": "2026-05-04T10:37:10.335273+00:00",
+    "last_updated": "2026-05-04T10:37:10.335273+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.square_okhttp_stars": {
+    "entity_id": "sensor.square_okhttp_stars",
+    "state": "46950",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "stars",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "square/okhttp Stars"
+    },
+    "last_changed": "2026-05-05T20:09:09.364635+00:00",
+    "last_reported": "2026-05-05T20:09:09.364635+00:00",
+    "last_updated": "2026-05-05T20:09:09.364635+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_cadence_issues": {
+    "entity_id": "sensor.yschimke_cadence_issues",
+    "state": "2",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "issues",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/cadence Issues"
+    },
+    "last_changed": "2026-05-05T04:43:24.390671+00:00",
+    "last_reported": "2026-05-05T04:43:24.390671+00:00",
+    "last_updated": "2026-05-05T04:43:24.390671+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_cadence_latest_issue": {
+    "entity_id": "sensor.yschimke_cadence_latest_issue",
+    "state": "Feature to split audiobooks or podcasts",
+    "attributes": {
+      "url": "<redacted>",
+      "number": 33,
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/cadence Latest issue"
+    },
+    "last_changed": "2026-05-05T04:43:24.390990+00:00",
+    "last_reported": "2026-05-05T04:43:24.390990+00:00",
+    "last_updated": "2026-05-05T04:43:24.390990+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_cadence_latest_pull_request": {
+    "entity_id": "sensor.yschimke_cadence_latest_pull_request",
+    "state": "unavailable",
+    "attributes": {
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/cadence Latest pull request"
+    },
+    "last_changed": "2026-05-05T04:44:25.066592+00:00",
+    "last_reported": "2026-05-05T04:44:25.066592+00:00",
+    "last_updated": "2026-05-05T04:44:25.066592+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_cadence_latest_release": {
+    "entity_id": "sensor.yschimke_cadence_latest_release",
+    "state": "v0.1.2",
+    "attributes": {
+      "url": "<redacted>",
+      "tag": "<redacted>",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/cadence Latest release"
+    },
+    "last_changed": "2026-04-30T18:08:19.353986+00:00",
+    "last_reported": "2026-04-30T18:08:19.353986+00:00",
+    "last_updated": "2026-04-30T18:08:19.353986+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_cadence_latest_tag": {
+    "entity_id": "sensor.yschimke_cadence_latest_tag",
+    "state": "v0.1.2",
+    "attributes": {
+      "url": "<redacted>",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/cadence Latest tag"
+    },
+    "last_changed": "2026-04-30T18:08:19.356219+00:00",
+    "last_reported": "2026-04-30T18:08:19.356219+00:00",
+    "last_updated": "2026-04-30T18:08:19.356219+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_cadence_pull_requests": {
+    "entity_id": "sensor.yschimke_cadence_pull_requests",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "pull requests",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/cadence Pull requests"
+    },
+    "last_changed": "2026-05-05T04:44:25.066254+00:00",
+    "last_reported": "2026-05-05T04:44:25.066254+00:00",
+    "last_updated": "2026-05-05T04:44:25.066254+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_cadence_stars": {
+    "entity_id": "sensor.yschimke_cadence_stars",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "stars",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/cadence Stars"
+    },
+    "last_changed": "2026-04-30T18:08:19.346346+00:00",
+    "last_reported": "2026-04-30T18:08:19.346346+00:00",
+    "last_updated": "2026-04-30T18:08:19.346346+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_compose_ai_tools_issues": {
+    "entity_id": "sensor.yschimke_compose_ai_tools_issues",
+    "state": "17",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "issues",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/compose-ai-tools Issues"
+    },
+    "last_changed": "2026-05-05T21:34:18.970716+00:00",
+    "last_reported": "2026-05-05T21:34:29.310669+00:00",
+    "last_updated": "2026-05-05T21:34:18.970716+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_compose_ai_tools_latest_issue": {
+    "entity_id": "sensor.yschimke_compose_ai_tools_latest_issue",
+    "state": "v1.0 cleanup checklist",
+    "attributes": {
+      "url": "<redacted>",
+      "number": 798,
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/compose-ai-tools Latest issue"
+    },
+    "last_changed": "2026-05-05T21:18:04.287416+00:00",
+    "last_reported": "2026-05-05T21:18:14.781775+00:00",
+    "last_updated": "2026-05-05T21:18:04.287416+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_compose_ai_tools_latest_pull_request": {
+    "entity_id": "sensor.yschimke_compose_ai_tools_latest_pull_request",
+    "state": "refactor(data-history): lift diff payload schema to data-history-core",
+    "attributes": {
+      "url": "<redacted>",
+      "number": 804,
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/compose-ai-tools Latest pull request"
+    },
+    "last_changed": "2026-05-05T22:15:02.926550+00:00",
+    "last_reported": "2026-05-05T22:15:02.926550+00:00",
+    "last_updated": "2026-05-05T22:15:02.926550+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_compose_ai_tools_latest_release": {
+    "entity_id": "sensor.yschimke_compose_ai_tools_latest_release",
+    "state": "v0.9.3",
+    "attributes": {
+      "url": "<redacted>",
+      "tag": "<redacted>",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/compose-ai-tools Latest release"
+    },
+    "last_changed": "2026-05-05T18:40:29.970543+00:00",
+    "last_reported": "2026-05-05T18:40:29.970543+00:00",
+    "last_updated": "2026-05-05T18:40:29.970543+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_compose_ai_tools_latest_tag": {
+    "entity_id": "sensor.yschimke_compose_ai_tools_latest_tag",
+    "state": "v0.9.3",
+    "attributes": {
+      "url": "<redacted>",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/compose-ai-tools Latest tag"
+    },
+    "last_changed": "2026-05-05T18:40:29.970692+00:00",
+    "last_reported": "2026-05-05T18:40:29.970692+00:00",
+    "last_updated": "2026-05-05T18:40:29.970692+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_compose_ai_tools_pull_requests": {
+    "entity_id": "sensor.yschimke_compose_ai_tools_pull_requests",
+    "state": "3",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "pull requests",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/compose-ai-tools Pull requests"
+    },
+    "last_changed": "2026-05-05T22:15:02.926303+00:00",
+    "last_reported": "2026-05-05T22:15:02.926303+00:00",
+    "last_updated": "2026-05-05T22:15:02.926303+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_compose_ai_tools_stars": {
+    "entity_id": "sensor.yschimke_compose_ai_tools_stars",
+    "state": "64",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "stars",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/compose-ai-tools Stars"
+    },
+    "last_changed": "2026-05-05T22:13:51.401854+00:00",
+    "last_reported": "2026-05-05T22:13:51.401854+00:00",
+    "last_updated": "2026-05-05T22:13:51.401854+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_homeassistant_remotecompose_issues": {
+    "entity_id": "sensor.yschimke_homeassistant_remotecompose_issues",
+    "state": "1",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "issues",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/homeassistant-remotecompose Issues"
+    },
+    "last_changed": "2026-05-05T16:00:48.103017+00:00",
+    "last_reported": "2026-05-05T16:00:48.103017+00:00",
+    "last_updated": "2026-05-05T16:00:48.103017+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_homeassistant_remotecompose_latest_issue": {
+    "entity_id": "sensor.yschimke_homeassistant_remotecompose_latest_issue",
+    "state": "Dependency Dashboard",
+    "attributes": {
+      "url": "<redacted>",
+      "number": 20,
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/homeassistant-remotecompose Latest issue"
+    },
+    "last_changed": "2026-05-05T16:00:48.103326+00:00",
+    "last_reported": "2026-05-05T16:00:48.103326+00:00",
+    "last_updated": "2026-05-05T16:00:48.103326+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_homeassistant_remotecompose_latest_pull_request": {
+    "entity_id": "sensor.yschimke_homeassistant_remotecompose_latest_pull_request",
+    "state": "chore(deps): update eclipse-temurin docker tag to v25.0.3_9-jdk-jammy",
+    "attributes": {
+      "url": "<redacted>",
+      "number": 70,
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/homeassistant-remotecompose Latest pull request"
+    },
+    "last_changed": "2026-05-05T16:00:48.103385+00:00",
+    "last_reported": "2026-05-05T16:00:48.103385+00:00",
+    "last_updated": "2026-05-05T16:00:48.103385+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_homeassistant_remotecompose_latest_release": {
+    "entity_id": "sensor.yschimke_homeassistant_remotecompose_latest_release",
+    "state": "v0.1.2",
+    "attributes": {
+      "url": "<redacted>",
+      "tag": "<redacted>",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/homeassistant-remotecompose Latest release"
+    },
+    "last_changed": "2026-05-05T16:00:48.103266+00:00",
+    "last_reported": "2026-05-05T16:00:48.103266+00:00",
+    "last_updated": "2026-05-05T16:00:48.103266+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_homeassistant_remotecompose_latest_tag": {
+    "entity_id": "sensor.yschimke_homeassistant_remotecompose_latest_tag",
+    "state": "v0.1.2",
+    "attributes": {
+      "url": "<redacted>",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/homeassistant-remotecompose Latest tag"
+    },
+    "last_changed": "2026-05-05T16:00:48.103441+00:00",
+    "last_reported": "2026-05-05T16:00:48.103441+00:00",
+    "last_updated": "2026-05-05T16:00:48.103441+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_homeassistant_remotecompose_pull_requests": {
+    "entity_id": "sensor.yschimke_homeassistant_remotecompose_pull_requests",
+    "state": "2",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "pull requests",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/homeassistant-remotecompose Pull requests"
+    },
+    "last_changed": "2026-05-05T16:00:48.103067+00:00",
+    "last_reported": "2026-05-05T16:00:48.103067+00:00",
+    "last_updated": "2026-05-05T16:00:48.103067+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_homeassistant_remotecompose_stars": {
+    "entity_id": "sensor.yschimke_homeassistant_remotecompose_stars",
+    "state": "5",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "stars",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/homeassistant-remotecompose Stars"
+    },
+    "last_changed": "2026-05-05T16:00:48.102842+00:00",
+    "last_reported": "2026-05-05T16:00:48.102842+00:00",
+    "last_updated": "2026-05-05T16:00:48.102842+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_meshcore_mobile_issues": {
+    "entity_id": "sensor.yschimke_meshcore_mobile_issues",
+    "state": "2",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "issues",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/meshcore-mobile Issues"
+    },
+    "last_changed": "2026-05-04T16:03:26.153661+00:00",
+    "last_reported": "2026-05-04T16:03:26.153661+00:00",
+    "last_updated": "2026-05-04T16:03:26.153661+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_meshcore_mobile_latest_issue": {
+    "entity_id": "sensor.yschimke_meshcore_mobile_latest_issue",
+    "state": "MESH_SERVICE permission name still namespaced under old applicationId",
+    "attributes": {
+      "url": "<redacted>",
+      "number": 31,
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/meshcore-mobile Latest issue"
+    },
+    "last_changed": "2026-05-04T16:03:26.153922+00:00",
+    "last_reported": "2026-05-04T16:03:26.153922+00:00",
+    "last_updated": "2026-05-04T16:03:26.153922+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_meshcore_mobile_latest_pull_request": {
+    "entity_id": "sensor.yschimke_meshcore_mobile_latest_pull_request",
+    "state": "unavailable",
+    "attributes": {
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/meshcore-mobile Latest pull request"
+    },
+    "last_changed": "2026-05-05T04:47:46.083188+00:00",
+    "last_reported": "2026-05-05T04:47:46.083188+00:00",
+    "last_updated": "2026-05-05T04:47:46.083188+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_meshcore_mobile_latest_release": {
+    "entity_id": "sensor.yschimke_meshcore_mobile_latest_release",
+    "state": "unavailable",
+    "attributes": {
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/meshcore-mobile Latest release"
+    },
+    "last_changed": "2026-04-30T18:08:19.353463+00:00",
+    "last_reported": "2026-04-30T18:08:19.353463+00:00",
+    "last_updated": "2026-04-30T18:08:19.353463+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_meshcore_mobile_latest_tag": {
+    "entity_id": "sensor.yschimke_meshcore_mobile_latest_tag",
+    "state": "v0.1.1",
+    "attributes": {
+      "url": "<redacted>",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/meshcore-mobile Latest tag"
+    },
+    "last_changed": "2026-04-30T18:08:19.355860+00:00",
+    "last_reported": "2026-04-30T18:08:19.355860+00:00",
+    "last_updated": "2026-04-30T18:08:19.355860+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_meshcore_mobile_pull_requests": {
+    "entity_id": "sensor.yschimke_meshcore_mobile_pull_requests",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "pull requests",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/meshcore-mobile Pull requests"
+    },
+    "last_changed": "2026-05-05T04:47:46.082820+00:00",
+    "last_reported": "2026-05-05T04:47:46.082820+00:00",
+    "last_updated": "2026-05-05T04:47:46.082820+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.yschimke_meshcore_mobile_stars": {
+    "entity_id": "sensor.yschimke_meshcore_mobile_stars",
+    "state": "1",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "stars",
+      "attribution": "Data provided by the GitHub API",
+      "friendly_name": "yschimke/meshcore-mobile Stars"
+    },
+    "last_changed": "2026-05-04T04:37:30.772394+00:00",
+    "last_reported": "2026-05-04T04:37:41.212990+00:00",
+    "last_updated": "2026-05-04T04:37:30.772394+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  }
+}

--- a/terrazzo-core/src/androidMain/resources/dashboards/github/lovelace_config.json
+++ b/terrazzo-core/src/androidMain/resources/dashboards/github/lovelace_config.json
@@ -1,0 +1,483 @@
+{
+  "views": [
+    {
+      "title": "Projects",
+      "icon": "mdi:github",
+      "type": "sections",
+      "max_columns": 4,
+      "header": {
+        "card": {
+          "type": "markdown",
+          "text_only": true,
+          "content": "# 🐙 GitHub Projects\nRepositories under **yschimke** with build status on `main`. Stars / PRs / issues / latest commit come from the HA GitHub integration; build badges come from GitHub Actions directly."
+        }
+      },
+      "sections": [
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "🐛 Open issues — last 2 weeks",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:chart-line"
+            },
+            {
+              "type": "history-graph",
+              "title": "Open issues per repo",
+              "hours_to_show": 336,
+              "entities": [
+                {
+                  "entity": "sensor.yschimke_meshcore_mobile_issues",
+                  "name": "meshcore-mobile"
+                },
+                {
+                  "entity": "sensor.yschimke_compose_ai_tools_issues",
+                  "name": "compose-ai-tools"
+                },
+                {
+                  "entity": "sensor.yschimke_homeassistant_remotecompose_issues",
+                  "name": "homeassistant-remotecompose"
+                },
+                {
+                  "entity": "sensor.yschimke_cadence_issues",
+                  "name": "cadence"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            }
+          ]
+        },
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "meshcore-mobile",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:source-branch"
+            },
+            {
+              "type": "markdown",
+              "content": "## [meshcore-mobile](https://github.com/yschimke/meshcore-mobile)\n_Mobile companion for MeshCore_\n\n[![ci](https://github.com/yschimke/meshcore-mobile/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/yschimke/meshcore-mobile/actions/workflows/ci.yml) [![ktfmt](https://github.com/yschimke/meshcore-mobile/actions/workflows/ktfmt.yml/badge.svg?branch=main)](https://github.com/yschimke/meshcore-mobile/actions/workflows/ktfmt.yml) [![Last commit](https://img.shields.io/github/last-commit/yschimke/meshcore-mobile/main?label=last%XXXXXXXX)](https://github.com/yschimke/meshcore-mobile/commits/main) [![License](https://img.shields.io/github/license/yschimke/meshcore-mobile)](https://github.com/yschimke/meshcore-mobile/blob/main/LICENSE)",
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_meshcore_mobile_stars",
+                  "name": "Stars",
+                  "icon": "mdi:star"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_meshcore_mobile_issues",
+                  "name": "Open issues",
+                  "icon": "mdi:alert-circle-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_meshcore_mobile_pull_requests",
+                  "name": "Open PRs",
+                  "icon": "mdi:source-pull"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "markdown",
+              "content": "{% set s = states['sensor.yschimke_meshcore_mobile_latest_commit'] %}{% if s and s.state not in ['unavailable','unknown'] %}**Latest commit:** {{ s.state }}\n\n[`{{ state_attr('sensor.yschimke_meshcore_mobile_latest_commit', 'sha')[:7] }}`]({{ state_attr('sensor.yschimke_meshcore_mobile_latest_commit', 'url') }}){% else %}_no recent commit data_{% endif %}",
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_meshcore_mobile_latest_pull_request",
+                  "name": "Latest PR",
+                  "icon": "mdi:source-pull"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_meshcore_mobile_latest_issue",
+                  "name": "Latest issue",
+                  "icon": "mdi:alert"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_meshcore_mobile_latest_release",
+                  "name": "Latest release",
+                  "icon": "mdi:tag"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_meshcore_mobile_latest_tag",
+                  "name": "Latest tag",
+                  "icon": "mdi:tag-outline"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            }
+          ]
+        },
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "compose-ai-tools",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:source-branch"
+            },
+            {
+              "type": "markdown",
+              "content": "## [compose-ai-tools](https://github.com/yschimke/compose-ai-tools)\n_Helping the Agents Compose the Things_\n\n[![ci](https://github.com/yschimke/compose-ai-tools/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/yschimke/compose-ai-tools/actions/workflows/ci.yml) [![format](https://github.com/yschimke/compose-ai-tools/actions/workflows/format.yml/badge.svg?branch=main)](https://github.com/yschimke/compose-ai-tools/actions/workflows/format.yml) [![codeql](https://github.com/yschimke/compose-ai-tools/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/yschimke/compose-ai-tools/actions/workflows/codeql.yml) [![gitleaks](https://github.com/yschimke/compose-ai-tools/actions/workflows/gitleaks.yml/badge.svg?branch=main)](https://github.com/yschimke/compose-ai-tools/actions/workflows/gitleaks.yml) [![Last commit](https://img.shields.io/github/last-commit/yschimke/compose-ai-tools/main?label=last%XXXXXXXX)](https://github.com/yschimke/compose-ai-tools/commits/main) [![License](https://img.shields.io/github/license/yschimke/compose-ai-tools)](https://github.com/yschimke/compose-ai-tools/blob/main/LICENSE)",
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_compose_ai_tools_stars",
+                  "name": "Stars",
+                  "icon": "mdi:star"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_compose_ai_tools_issues",
+                  "name": "Open issues",
+                  "icon": "mdi:alert-circle-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_compose_ai_tools_pull_requests",
+                  "name": "Open PRs",
+                  "icon": "mdi:source-pull"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "markdown",
+              "content": "{% set s = states['sensor.yschimke_compose_ai_tools_latest_commit'] %}{% if s and s.state not in ['unavailable','unknown'] %}**Latest commit:** {{ s.state }}\n\n[`{{ state_attr('sensor.yschimke_compose_ai_tools_latest_commit', 'sha')[:7] }}`]({{ state_attr('sensor.yschimke_compose_ai_tools_latest_commit', 'url') }}){% else %}_no recent commit data_{% endif %}",
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_compose_ai_tools_latest_pull_request",
+                  "name": "Latest PR",
+                  "icon": "mdi:source-pull"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_compose_ai_tools_latest_issue",
+                  "name": "Latest issue",
+                  "icon": "mdi:alert"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_compose_ai_tools_latest_release",
+                  "name": "Latest release",
+                  "icon": "mdi:tag"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_compose_ai_tools_latest_tag",
+                  "name": "Latest tag",
+                  "icon": "mdi:tag-outline"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            }
+          ]
+        },
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "homeassistant-remotecompose",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:source-branch"
+            },
+            {
+              "type": "markdown",
+              "content": "## [homeassistant-remotecompose](https://github.com/yschimke/homeassistant-remotecompose)\n_Compose-based HA dashboards_\n\n[![ci](https://github.com/yschimke/homeassistant-remotecompose/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/yschimke/homeassistant-remotecompose/actions/workflows/ci.yml) [![ktfmt](https://github.com/yschimke/homeassistant-remotecompose/actions/workflows/ktfmt.yml/badge.svg?branch=main)](https://github.com/yschimke/homeassistant-remotecompose/actions/workflows/ktfmt.yml) [![preview-baselines](https://github.com/yschimke/homeassistant-remotecompose/actions/workflows/preview-baselines.yml/badge.svg?branch=main)](https://github.com/yschimke/homeassistant-remotecompose/actions/workflows/preview-baselines.yml) [![Last commit](https://img.shields.io/github/last-commit/yschimke/homeassistant-remotecompose/main?label=last%XXXXXXXX)](https://github.com/yschimke/homeassistant-remotecompose/commits/main) [![License](https://img.shields.io/github/license/yschimke/homeassistant-remotecompose)](https://github.com/yschimke/homeassistant-remotecompose/blob/main/LICENSE)",
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_homeassistant_remotecompose_stars",
+                  "name": "Stars",
+                  "icon": "mdi:star"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_homeassistant_remotecompose_issues",
+                  "name": "Open issues",
+                  "icon": "mdi:alert-circle-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_homeassistant_remotecompose_pull_requests",
+                  "name": "Open PRs",
+                  "icon": "mdi:source-pull"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "markdown",
+              "content": "{% set s = states['sensor.yschimke_homeassistant_remotecompose_latest_commit'] %}{% if s and s.state not in ['unavailable','unknown'] %}**Latest commit:** {{ s.state }}\n\n[`{{ state_attr('sensor.yschimke_homeassistant_remotecompose_latest_commit', 'sha')[:7] }}`]({{ state_attr('sensor.yschimke_homeassistant_remotecompose_latest_commit', 'url') }}){% else %}_no recent commit data_{% endif %}",
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_homeassistant_remotecompose_latest_pull_request",
+                  "name": "Latest PR",
+                  "icon": "mdi:source-pull"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_homeassistant_remotecompose_latest_issue",
+                  "name": "Latest issue",
+                  "icon": "mdi:alert"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_homeassistant_remotecompose_latest_release",
+                  "name": "Latest release",
+                  "icon": "mdi:tag"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_homeassistant_remotecompose_latest_tag",
+                  "name": "Latest tag",
+                  "icon": "mdi:tag-outline"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            }
+          ]
+        },
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "cadence",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:source-branch"
+            },
+            {
+              "type": "markdown",
+              "content": "## [cadence](https://github.com/yschimke/cadence)\n__\n\n[![build](https://github.com/yschimke/cadence/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/yschimke/cadence/actions/workflows/build.yml) [![ktfmt](https://github.com/yschimke/cadence/actions/workflows/ktfmt.yml/badge.svg?branch=main)](https://github.com/yschimke/cadence/actions/workflows/ktfmt.yml) [![preview-baselines](https://github.com/yschimke/cadence/actions/workflows/preview-baselines.yml/badge.svg?branch=main)](https://github.com/yschimke/cadence/actions/workflows/preview-baselines.yml) [![Last commit](https://img.shields.io/github/last-commit/yschimke/cadence/main?label=last%XXXXXXXX)](https://github.com/yschimke/cadence/commits/main) [![License](https://img.shields.io/github/license/yschimke/cadence)](https://github.com/yschimke/cadence/blob/main/LICENSE)",
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_cadence_stars",
+                  "name": "Stars",
+                  "icon": "mdi:star"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_cadence_issues",
+                  "name": "Open issues",
+                  "icon": "mdi:alert-circle-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_cadence_pull_requests",
+                  "name": "Open PRs",
+                  "icon": "mdi:source-pull"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "markdown",
+              "content": "{% set s = states['sensor.yschimke_cadence_latest_commit'] %}{% if s and s.state not in ['unavailable','unknown'] %}**Latest commit:** {{ s.state }}\n\n[`{{ state_attr('sensor.yschimke_cadence_latest_commit', 'sha')[:7] }}`]({{ state_attr('sensor.yschimke_cadence_latest_commit', 'url') }}){% else %}_no recent commit data_{% endif %}",
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_cadence_latest_pull_request",
+                  "name": "Latest PR",
+                  "icon": "mdi:source-pull"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_cadence_latest_issue",
+                  "name": "Latest issue",
+                  "icon": "mdi:alert"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_cadence_latest_release",
+                  "name": "Latest release",
+                  "icon": "mdi:tag"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.yschimke_cadence_latest_tag",
+                  "name": "Latest tag",
+                  "icon": "mdi:tag-outline"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            }
+          ]
+        },
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "⭐ Other watched repos",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:bookmark-multiple-outline"
+            },
+            {
+              "type": "grid",
+              "columns": 2,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.square_okhttp_stars",
+                  "name": "square/okhttp",
+                  "icon": "mdi:star"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.google_horologist_stars",
+                  "name": "google/horologist",
+                  "icon": "mdi:star"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            }
+          ]
+        },
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "📝 Notes",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:information-outline"
+            },
+            {
+              "type": "markdown",
+              "grid_options": {
+                "columns": "full"
+              },
+              "content": "- Build badges above use GitHub's `badge.svg` URL. For private repos these require the *viewer* to be logged into github.com in the same browser. If shared/public access is needed, swap to a REST sensor calling `/repos/.../actions/workflows/<wf>/runs?branch=main&per_page=1` with the stored PAT."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/terrazzo-core/src/androidMain/resources/dashboards/meshcore/entity_states.json
+++ b/terrazzo-core/src/androidMain/resources/dashboards/meshcore/entity_states.json
@@ -1,0 +1,1170 @@
+{
+  "binary_sensor.meshcore_sn1_ch_0_messages": {
+    "entity_id": "binary_sensor.meshcore_sn1_ch_0_messages",
+    "state": "Active",
+    "attributes": {
+      "channel_index": "0",
+      "device_class": "connectivity",
+      "icon": "mdi:message-bulleted",
+      "friendly_name": "MeshCore Kodu Heltec (sn1) Public Messages"
+    },
+    "last_changed": "2026-04-30T18:08:20.159842+00:00",
+    "last_reported": "2026-04-30T18:13:55.012657+00:00",
+    "last_updated": "2026-04-30T18:08:20.159842+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.meshcore_sn1_mqtt_broker_1_connection": {
+    "entity_id": "binary_sensor.meshcore_sn1_mqtt_broker_1_connection",
+    "state": "off",
+    "attributes": {
+      "broker_number": "<redacted>",
+      "server": "mqtt-eu-v1.letsmesh.net",
+      "device_class": "connectivity",
+      "friendly_name": "MeshCore Kodu Heltec (sn1) MQTT Broker 1 Connection"
+    },
+    "last_changed": "2026-04-30T18:08:18.554925+00:00",
+    "last_reported": "2026-04-30T18:13:55.012035+00:00",
+    "last_updated": "2026-04-30T18:08:18.554925+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.meshcore_kodu_room_sn2_contact": {
+    "entity_id": "binary_sensor.meshcore_kodu_room_sn2_contact",
+    "state": "stale",
+    "attributes": {
+      "latitude": "<redacted>",
+      "longitude": "<redacted>",
+      "public_key": "<redacted>",
+      "type": 3,
+      "flags": 1,
+      "out_path_hash_mode": "<redacted>",
+      "out_path_len": "<redacted>",
+      "out_path": "<redacted>",
+      "adv_name": "<redacted>",
+      "last_advert": 1717239154,
+      "adv_lat": "<redacted>",
+      "adv_lon": "<redacted>",
+      "lastmod": 1778017124,
+      "pubkey_prefix": "<redacted>",
+      "added_to_node": true,
+      "pubkey_short": "<redacted>",
+      "node_type_str": "Room Server",
+      "entity_picture": "/api/meshcore/static/room_server.svg",
+      "last_advert_formatted": "2024-06-01T11:52:34",
+      "device_class": "connectivity",
+      "icon": "mdi:forum-outline",
+      "friendly_name": "MeshCore Kodu Heltec (sn1) Kodu Room (Room Server)"
+    },
+    "last_changed": "2026-04-30T18:08:18.554369+00:00",
+    "last_reported": "2026-05-05T22:13:41.011980+00:00",
+    "last_updated": "2026-05-05T22:13:41.011980+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.meshcore_kodu_t1000e_sn3_contact": {
+    "entity_id": "binary_sensor.meshcore_kodu_t1000e_sn3_contact",
+    "state": "stale",
+    "attributes": {
+      "latitude": "<redacted>",
+      "longitude": "<redacted>",
+      "public_key": "<redacted>",
+      "type": 1,
+      "flags": 1,
+      "out_path_hash_mode": "<redacted>",
+      "out_path_len": "<redacted>",
+      "out_path": "<redacted>",
+      "adv_name": "<redacted>",
+      "last_advert": 1776711664,
+      "adv_lat": "<redacted>",
+      "adv_lon": "<redacted>",
+      "lastmod": 1777487762,
+      "pubkey_prefix": "<redacted>",
+      "added_to_node": true,
+      "pubkey_short": "<redacted>",
+      "node_type_str": "Client",
+      "entity_picture": "/api/meshcore/static/client.svg",
+      "last_advert_formatted": "2026-04-20T20:01:04",
+      "device_class": "connectivity",
+      "icon": "mdi:account-off",
+      "friendly_name": "MeshCore Kodu Heltec (sn1) Kodu T1000E (Client)"
+    },
+    "last_changed": "2026-04-30T18:08:18.554024+00:00",
+    "last_reported": "2026-04-30T18:08:23.372384+00:00",
+    "last_updated": "2026-04-30T18:08:18.554024+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.meshcore_sensecap_solar_repeater_sn4_contact": {
+    "entity_id": "binary_sensor.meshcore_sensecap_solar_repeater_sn4_contact",
+    "state": "fresh",
+    "attributes": {
+      "latitude": "<redacted>",
+      "longitude": "<redacted>",
+      "public_key": "<redacted>",
+      "type": 2,
+      "flags": 1,
+      "out_path_hash_mode": "<redacted>",
+      "out_path_len": "<redacted>",
+      "out_path": "<redacted>",
+      "adv_name": "<redacted>",
+      "last_advert": 1778001245,
+      "adv_lat": "<redacted>",
+      "adv_lon": "<redacted>",
+      "lastmod": 1778005848,
+      "pubkey_prefix": "<redacted>",
+      "added_to_node": true,
+      "pubkey_short": "<redacted>",
+      "node_type_str": "Repeater",
+      "entity_picture": "/api/meshcore/static/repeater-green.svg",
+      "last_advert_formatted": "2026-05-05T18:14:05",
+      "device_class": "connectivity",
+      "icon": "mdi:radio-tower",
+      "friendly_name": "MeshCore Kodu Heltec (sn1) Kodu Repeater (Repeater)"
+    },
+    "last_changed": "2026-05-03T18:11:34.011698+00:00",
+    "last_reported": "2026-05-05T19:13:36.010412+00:00",
+    "last_updated": "2026-05-05T19:13:36.010412+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "select.meshcore_channel": {
+    "entity_id": "select.meshcore_channel",
+    "state": "Public (0)",
+    "attributes": {
+      "options": [
+        "Public (0)",
+        " (1)",
+        " (2)",
+        " (3)",
+        " (4)",
+        " (5)",
+        " (6)",
+        " (7)",
+        " (8)",
+        " (9)",
+        " (10)",
+        " (11)",
+        " (12)",
+        " (13)",
+        " (14)",
+        " (15)",
+        " (16)",
+        " (17)",
+        " (18)",
+        " (19)",
+        " (20)",
+        " (21)",
+        " (22)",
+        " (23)",
+        " (24)",
+        " (25)",
+        " (26)",
+        " (27)",
+        " (28)",
+        " (29)",
+        " (30)",
+        " (31)",
+        " (32)",
+        " (33)",
+        " (34)",
+        " (35)",
+        " (36)",
+        " (37)",
+        " (38)",
+        " (39)"
+      ],
+      "channel_idx": 0,
+      "icon": "mdi:tune-vertical",
+      "friendly_name": "MeshCore Channel"
+    },
+    "last_changed": "2026-04-30T18:08:23.373170+00:00",
+    "last_reported": "2026-04-30T18:13:55.012235+00:00",
+    "last_updated": "2026-04-30T18:08:23.373170+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "select.meshcore_contact": {
+    "entity_id": "select.meshcore_contact",
+    "state": "Kodu Room (sn2)",
+    "attributes": {
+      "options": [
+        "Kodu Room (sn2)",
+        "Kodu T1000E (sn3)"
+      ],
+      "public_key_prefix": "sn2",
+      "public_key": "<redacted>",
+      "contact_name": "<redacted>",
+      "icon": "mdi:account-multiple",
+      "friendly_name": "MeshCore Contact"
+    },
+    "last_changed": "2026-04-30T18:08:18.556945+00:00",
+    "last_reported": "2026-04-30T18:13:55.012375+00:00",
+    "last_updated": "2026-04-30T18:08:18.556945+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "select.meshcore_recipient_type": {
+    "entity_id": "select.meshcore_recipient_type",
+    "state": "Channel",
+    "attributes": {
+      "options": [
+        "Channel",
+        "Contact"
+      ],
+      "icon": "mdi:account-switch",
+      "friendly_name": "MeshCore Recipient Type"
+    },
+    "last_changed": "2026-04-30T18:08:18.557068+00:00",
+    "last_reported": "2026-04-30T18:13:55.012405+00:00",
+    "last_updated": "2026-04-30T18:08:18.557068+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn1_bandwidth_kodu_heltec": {
+    "entity_id": "sensor.meshcore_sn1_bandwidth_kodu_heltec",
+    "state": "62.5",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "kHz",
+      "icon": "mdi:radio",
+      "friendly_name": "MeshCore Kodu Heltec (sn1) Bandwidth"
+    },
+    "last_changed": "2026-04-30T18:08:23.010466+00:00",
+    "last_reported": "2026-04-30T18:13:55.009587+00:00",
+    "last_updated": "2026-04-30T18:08:23.010466+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn1_frequency_kodu_heltec": {
+    "entity_id": "sensor.meshcore_sn1_frequency_kodu_heltec",
+    "state": "869.618",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "MHz",
+      "icon": "mdi:radio",
+      "friendly_name": "MeshCore Kodu Heltec (sn1) Frequency"
+    },
+    "last_changed": "2026-04-30T18:08:23.010412+00:00",
+    "last_reported": "2026-04-30T18:13:55.009561+00:00",
+    "last_updated": "2026-04-30T18:08:23.010412+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn1_last_message_delivery_kodu_heltec": {
+    "entity_id": "sensor.meshcore_sn1_last_message_delivery_kodu_heltec",
+    "state": "Idle",
+    "attributes": {
+      "icon": "mdi:radio-tower",
+      "friendly_name": "MeshCore Kodu Heltec (sn1) Last Message Delivery"
+    },
+    "last_changed": "2026-04-30T18:08:18.544211+00:00",
+    "last_reported": "2026-04-30T18:13:55.011961+00:00",
+    "last_updated": "2026-04-30T18:08:18.544211+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn1_node_count_kodu_heltec": {
+    "entity_id": "sensor.meshcore_sn1_node_count_kodu_heltec",
+    "state": "4",
+    "attributes": {
+      "state_class": "measurement",
+      "icon": "mdi:account-group",
+      "friendly_name": "MeshCore Kodu Heltec (sn1) Node Count"
+    },
+    "last_changed": "2026-04-30T18:09:00.011446+00:00",
+    "last_reported": "2026-04-30T18:13:55.009426+00:00",
+    "last_updated": "2026-04-30T18:09:00.011446+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn1_node_status_kodu_heltec": {
+    "entity_id": "sensor.meshcore_sn1_node_status_kodu_heltec",
+    "state": "online",
+    "attributes": {
+      "icon": "mdi:radio-tower",
+      "friendly_name": "MeshCore Kodu Heltec (sn1) Node Status"
+    },
+    "last_changed": "2026-04-30T18:08:23.370669+00:00",
+    "last_reported": "2026-04-30T18:13:55.009288+00:00",
+    "last_updated": "2026-04-30T18:08:23.370669+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn1_spreading_factor_kodu_heltec": {
+    "entity_id": "sensor.meshcore_sn1_spreading_factor_kodu_heltec",
+    "state": "8",
+    "attributes": {
+      "icon": "mdi:radio",
+      "friendly_name": "MeshCore Kodu Heltec (sn1) Spreading Factor"
+    },
+    "last_changed": "2026-04-30T18:08:23.010513+00:00",
+    "last_reported": "2026-04-30T18:13:55.009607+00:00",
+    "last_updated": "2026-04-30T18:08:23.010513+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn1_tx_power_kodu_heltec": {
+    "entity_id": "sensor.meshcore_sn1_tx_power_kodu_heltec",
+    "state": "10",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "dBm",
+      "device_class": "signal_strength",
+      "icon": "mdi:power",
+      "friendly_name": "MeshCore Kodu Heltec (sn1) TX Power"
+    },
+    "last_changed": "2026-04-30T18:08:23.010191+00:00",
+    "last_reported": "2026-04-30T18:13:55.009455+00:00",
+    "last_updated": "2026-04-30T18:08:23.010191+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn5_battery_percentage_kodu_room": {
+    "entity_id": "sensor.meshcore_sn5_battery_percentage_kodu_room",
+    "state": "88.83",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:40:09.828745",
+      "unit_of_measurement": "%",
+      "device_class": "battery",
+      "icon": "mdi:battery",
+      "friendly_name": "MeshCore Repeater: Kodu Room (f1f680) Battery Percentage"
+    },
+    "last_changed": "2026-05-05T20:40:09.828844+00:00",
+    "last_reported": "2026-05-05T20:40:15.011287+00:00",
+    "last_updated": "2026-05-05T20:40:09.828844+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn5_ch1_temperature_kodu_room": {
+    "entity_id": "sensor.meshcore_sn5_ch1_temperature_kodu_room",
+    "state": "24.7",
+    "attributes": {
+      "state_class": "measurement",
+      "channel": 1,
+      "lpp_type": "temperature",
+      "pubkey_prefix": "<redacted>",
+      "node_type": "repeater",
+      "node_name": "<redacted>",
+      "last_updated": "2026-05-05T21:40:34.221830",
+      "raw_value": "<redacted>",
+      "unit_of_measurement": "°C",
+      "device_class": "temperature",
+      "icon": "mdi:thermometer",
+      "friendly_name": "MeshCore Repeater: Kodu Room (f1f680) Ch1 Temperature"
+    },
+    "last_changed": "2026-05-05T20:40:34.221879+00:00",
+    "last_reported": "2026-05-05T20:40:46.012449+00:00",
+    "last_updated": "2026-05-05T20:40:34.221879+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn5_last_rssi_kodu_room": {
+    "entity_id": "sensor.meshcore_sn5_last_rssi_kodu_room",
+    "state": "-17",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:40:09.830216",
+      "unit_of_measurement": "dBm",
+      "icon": "mdi:signal",
+      "friendly_name": "MeshCore Repeater: Kodu Room (f1f680) Last RSSI"
+    },
+    "last_changed": "2026-05-05T20:40:09.830257+00:00",
+    "last_reported": "2026-05-05T20:40:15.011456+00:00",
+    "last_updated": "2026-05-05T20:40:09.830257+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn5_last_snr_kodu_room": {
+    "entity_id": "sensor.meshcore_sn5_last_snr_kodu_room",
+    "state": "12.75",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:40:09.830343",
+      "unit_of_measurement": "dB",
+      "icon": "mdi:signal",
+      "friendly_name": "MeshCore Repeater: Kodu Room (f1f680) Last SNR"
+    },
+    "last_changed": "2026-05-05T20:40:09.830382+00:00",
+    "last_reported": "2026-05-05T20:40:15.011489+00:00",
+    "last_updated": "2026-05-05T20:40:09.830382+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn5_nb_recv_kodu_room": {
+    "entity_id": "sensor.meshcore_sn5_nb_recv_kodu_room",
+    "state": "173130",
+    "attributes": {
+      "state_class": "total_increasing",
+      "last_updated": "2026-05-05T21:40:09.830459",
+      "icon": "mdi:message-arrow-left",
+      "friendly_name": "MeshCore Repeater: Kodu Room (f1f680) Messages Received"
+    },
+    "last_changed": "2026-05-05T20:40:09.830487+00:00",
+    "last_reported": "2026-05-05T20:40:15.011522+00:00",
+    "last_updated": "2026-05-05T20:40:09.830487+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn5_nb_recv_rate_kodu_room": {
+    "entity_id": "sensor.meshcore_sn5_nb_recv_rate_kodu_room",
+    "state": "5.6",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:40:09.831877",
+      "uptime_seconds": "1465291",
+      "nb_recv_total": "173130",
+      "nb_recv_since_last_update": "678",
+      "uptime_delta_seconds": "7215",
+      "unit_of_measurement": "msg/min",
+      "icon": "mdi:message-arrow-left",
+      "friendly_name": "MeshCore Repeater: Kodu Room (f1f680) Messages Received Rate"
+    },
+    "last_changed": "2026-05-05T20:40:09.831904+00:00",
+    "last_reported": "2026-05-05T20:40:15.012047+00:00",
+    "last_updated": "2026-05-05T20:40:09.831904+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn5_nb_sent_kodu_room": {
+    "entity_id": "sensor.meshcore_sn5_nb_sent_kodu_room",
+    "state": "495",
+    "attributes": {
+      "state_class": "total_increasing",
+      "last_updated": "2026-05-05T21:40:09.829458",
+      "icon": "mdi:message-arrow-right",
+      "friendly_name": "MeshCore Repeater: Kodu Room (f1f680) Messages Sent"
+    },
+    "last_changed": "2026-05-05T20:40:09.830050+00:00",
+    "last_reported": "2026-05-05T20:40:15.011424+00:00",
+    "last_updated": "2026-05-05T20:40:09.830050+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn5_nb_sent_rate_kodu_room": {
+    "entity_id": "sensor.meshcore_sn5_nb_sent_rate_kodu_room",
+    "state": "0.0",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:40:09.831962",
+      "uptime_seconds": "1465291",
+      "nb_sent_total": "495",
+      "nb_sent_since_last_update": "2",
+      "uptime_delta_seconds": "7215",
+      "unit_of_measurement": "msg/min",
+      "icon": "mdi:message-arrow-right",
+      "friendly_name": "MeshCore Repeater: Kodu Room (f1f680) Messages Sent Rate"
+    },
+    "last_changed": "2026-04-30T20:09:03.096604+00:00",
+    "last_reported": "2026-05-05T20:40:15.012086+00:00",
+    "last_updated": "2026-05-05T20:40:09.831990+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn5_noise_floor_kodu_room": {
+    "entity_id": "sensor.meshcore_sn5_noise_floor_kodu_room",
+    "state": "-106",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:40:09.830651",
+      "unit_of_measurement": "dBm",
+      "icon": "mdi:waveform",
+      "friendly_name": "MeshCore Repeater: Kodu Room (f1f680) Noise Floor"
+    },
+    "last_changed": "2026-05-05T18:39:54.715138+00:00",
+    "last_reported": "2026-05-05T20:40:15.011584+00:00",
+    "last_updated": "2026-05-05T20:40:09.830676+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn5_recv_direct_rate_kodu_room": {
+    "entity_id": "sensor.meshcore_sn5_recv_direct_rate_kodu_room",
+    "state": "0.0",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:40:09.832046",
+      "uptime_seconds": "1465291",
+      "recv_direct_total": "1655",
+      "recv_direct_since_last_update": "6",
+      "uptime_delta_seconds": "7215",
+      "unit_of_measurement": "msg/min",
+      "icon": "mdi:message-arrow-left",
+      "friendly_name": "MeshCore Repeater: Kodu Room (f1f680) Received Direct Messages Rate"
+    },
+    "last_changed": "2026-05-05T20:40:09.832073+00:00",
+    "last_reported": "2026-05-05T20:40:15.012126+00:00",
+    "last_updated": "2026-05-05T20:40:09.832073+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn5_recv_flood_rate_kodu_room": {
+    "entity_id": "sensor.meshcore_sn5_recv_flood_rate_kodu_room",
+    "state": "5.6",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:40:09.832129",
+      "uptime_seconds": "1465291",
+      "recv_flood_total": "171436",
+      "recv_flood_since_last_update": "672",
+      "uptime_delta_seconds": "7215",
+      "unit_of_measurement": "msg/min",
+      "icon": "mdi:message-arrow-left-outline",
+      "friendly_name": "MeshCore Repeater: Kodu Room (f1f680) Received Flood Messages Rate"
+    },
+    "last_changed": "2026-05-05T20:40:09.832156+00:00",
+    "last_reported": "2026-05-05T20:40:15.012167+00:00",
+    "last_updated": "2026-05-05T20:40:09.832156+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn5_sent_direct_rate_kodu_room": {
+    "entity_id": "sensor.meshcore_sn5_sent_direct_rate_kodu_room",
+    "state": "0.0",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:40:09.832211",
+      "uptime_seconds": "1465291",
+      "sent_direct_total": "448",
+      "sent_direct_since_last_update": "2",
+      "uptime_delta_seconds": "7215",
+      "unit_of_measurement": "msg/min",
+      "icon": "mdi:message-arrow-right",
+      "friendly_name": "MeshCore Repeater: Kodu Room (f1f680) Sent Direct Messages Rate"
+    },
+    "last_changed": "2026-04-30T20:09:03.096910+00:00",
+    "last_reported": "2026-05-05T20:40:15.012205+00:00",
+    "last_updated": "2026-05-05T20:40:09.832235+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn5_tx_queue_len_kodu_room": {
+    "entity_id": "sensor.meshcore_sn5_tx_queue_len_kodu_room",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:40:09.830555",
+      "icon": "mdi:playlist-edit",
+      "friendly_name": "MeshCore Repeater: Kodu Room (f1f680) TX Queue Length"
+    },
+    "last_changed": "2026-04-30T18:08:54.856641+00:00",
+    "last_reported": "2026-05-05T20:40:15.011553+00:00",
+    "last_updated": "2026-05-05T20:40:09.830583+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn5_uptime_kodu_room": {
+    "entity_id": "sensor.meshcore_sn5_uptime_kodu_room",
+    "state": "16.959375",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:40:09.829013",
+      "human_readable": "16d 23h 1m 31s",
+      "unit_of_measurement": "d",
+      "device_class": "duration",
+      "icon": "mdi:clock",
+      "friendly_name": "MeshCore Repeater: Kodu Room (f1f680) Uptime"
+    },
+    "last_changed": "2026-05-05T20:40:09.829101+00:00",
+    "last_reported": "2026-05-05T20:40:15.011349+00:00",
+    "last_updated": "2026-05-05T20:40:09.829101+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn6_out_path_len_kodu_t1000e": {
+    "entity_id": "sensor.meshcore_sn6_out_path_len_kodu_t1000e",
+    "state": "unknown",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "hops",
+      "icon": "mdi:counter",
+      "friendly_name": "MeshCore Client: Kodu T1000E (f27490) Path Length"
+    },
+    "last_changed": "2026-04-30T18:08:18.543822+00:00",
+    "last_reported": "2026-04-30T18:13:55.011888+00:00",
+    "last_updated": "2026-04-30T18:08:18.543822+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn6_request_failures_kodu_t1000e": {
+    "entity_id": "sensor.meshcore_sn6_request_failures_kodu_t1000e",
+    "state": "66",
+    "attributes": {
+      "state_class": "total_increasing",
+      "unit_of_measurement": "requests",
+      "icon": "mdi:alert-circle",
+      "friendly_name": "MeshCore Client: Kodu T1000E (f27490) Request Failures"
+    },
+    "last_changed": "2026-05-05T20:36:11.011072+00:00",
+    "last_reported": "2026-05-05T20:36:16.013596+00:00",
+    "last_updated": "2026-05-05T20:36:11.011072+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn6_request_successes_kodu_t1000e": {
+    "entity_id": "sensor.meshcore_sn6_request_successes_kodu_t1000e",
+    "state": "0",
+    "attributes": {
+      "state_class": "total_increasing",
+      "unit_of_measurement": "requests",
+      "icon": "mdi:check-circle",
+      "friendly_name": "MeshCore Client: Kodu T1000E (f27490) Request Successes"
+    },
+    "last_changed": "2026-04-30T18:08:18.543951+00:00",
+    "last_reported": "2026-04-30T18:13:55.011908+00:00",
+    "last_updated": "2026-04-30T18:08:18.543951+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn7_airtime_utilization_kodu_repeater": {
+    "entity_id": "sensor.meshcore_sn7_airtime_utilization_kodu_repeater",
+    "state": "7.1",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:31:19.890987",
+      "uptime_seconds": "2776724",
+      "airtime_seconds": "184368",
+      "airtime_since_last_update": "8.6",
+      "unit_of_measurement": "%",
+      "device_class": "power_factor",
+      "icon": "mdi:percent",
+      "friendly_name": "MeshCore Repeater: Kodu Repeater (fa27ef) Airtime Utilization"
+    },
+    "last_changed": "2026-05-05T20:31:19.891030+00:00",
+    "last_reported": "2026-05-05T20:31:43.011091+00:00",
+    "last_updated": "2026-05-05T20:31:19.891030+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn7_bat_kodu_repeater": {
+    "entity_id": "sensor.meshcore_sn7_bat_kodu_repeater",
+    "state": "4.13",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:31:19.889083",
+      "raw_millivolts": "<redacted>",
+      "unit_of_measurement": "V",
+      "device_class": "voltage",
+      "icon": "mdi:battery",
+      "friendly_name": "MeshCore Repeater: Kodu Repeater (fa27ef) Battery Voltage"
+    },
+    "last_changed": "2026-05-05T20:31:19.889198+00:00",
+    "last_reported": "2026-05-05T20:31:43.010541+00:00",
+    "last_updated": "2026-05-05T20:31:19.889198+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn7_battery_percentage_kodu_repeater": {
+    "entity_id": "sensor.meshcore_sn7_battery_percentage_kodu_repeater",
+    "state": "94.17",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:31:19.889377",
+      "unit_of_measurement": "%",
+      "device_class": "battery",
+      "icon": "mdi:battery",
+      "friendly_name": "MeshCore Repeater: Kodu Repeater (fa27ef) Battery Percentage"
+    },
+    "last_changed": "2026-05-05T20:31:19.889433+00:00",
+    "last_reported": "2026-05-05T20:31:43.010581+00:00",
+    "last_updated": "2026-05-05T20:31:19.889433+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn7_ch1_temperature_kodu_repeater": {
+    "entity_id": "sensor.meshcore_sn7_ch1_temperature_kodu_repeater",
+    "state": "13.5",
+    "attributes": {
+      "state_class": "measurement",
+      "channel": 1,
+      "lpp_type": "temperature",
+      "pubkey_prefix": "<redacted>",
+      "node_type": "repeater",
+      "node_name": "<redacted>",
+      "last_updated": "2026-05-05T22:58:30.133697",
+      "raw_value": "<redacted>",
+      "unit_of_measurement": "°C",
+      "device_class": "temperature",
+      "icon": "mdi:thermometer",
+      "friendly_name": "MeshCore Repeater: Kodu Repeater (fa27ef) Ch1 Temperature"
+    },
+    "last_changed": "2026-05-05T21:58:30.133747+00:00",
+    "last_reported": "2026-05-05T21:58:39.012943+00:00",
+    "last_updated": "2026-05-05T21:58:30.133747+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn7_ch1_voltage_kodu_repeater": {
+    "entity_id": "sensor.meshcore_sn7_ch1_voltage_kodu_repeater",
+    "state": "4.11",
+    "attributes": {
+      "state_class": "measurement",
+      "channel": 1,
+      "lpp_type": "voltage",
+      "pubkey_prefix": "<redacted>",
+      "node_type": "repeater",
+      "node_name": "<redacted>",
+      "last_updated": "2026-05-05T22:58:30.133413",
+      "raw_value": "<redacted>",
+      "unit_of_measurement": "V",
+      "device_class": "voltage",
+      "icon": "mdi:flash",
+      "friendly_name": "MeshCore Repeater: Kodu Repeater (fa27ef) Ch1 Voltage"
+    },
+    "last_changed": "2026-05-05T21:58:30.133529+00:00",
+    "last_reported": "2026-05-05T21:58:39.012908+00:00",
+    "last_updated": "2026-05-05T21:58:30.133529+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn7_flood_dups_rate_kodu_repeater": {
+    "entity_id": "sensor.meshcore_sn7_flood_dups_rate_kodu_repeater",
+    "state": "8.0",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:31:19.891402",
+      "uptime_seconds": "2776724",
+      "flood_dups_total": "54000",
+      "flood_dups_since_last_update": "968",
+      "uptime_delta_seconds": "7232",
+      "unit_of_measurement": "msg/min",
+      "icon": "mdi:content-duplicate",
+      "friendly_name": "MeshCore Repeater: Kodu Repeater (fa27ef) Flood Duplicates Rate"
+    },
+    "last_changed": "2026-05-05T20:31:19.891437+00:00",
+    "last_reported": "2026-05-05T20:31:43.011248+00:00",
+    "last_updated": "2026-05-05T20:31:19.891437+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn7_last_rssi_kodu_repeater": {
+    "entity_id": "sensor.meshcore_sn7_last_rssi_kodu_repeater",
+    "state": "-73",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:31:19.889974",
+      "unit_of_measurement": "dBm",
+      "icon": "mdi:signal",
+      "friendly_name": "MeshCore Repeater: Kodu Repeater (fa27ef) Last RSSI"
+    },
+    "last_changed": "2026-05-05T18:30:47.432586+00:00",
+    "last_reported": "2026-05-05T20:31:43.010726+00:00",
+    "last_updated": "2026-05-05T20:31:19.890001+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn7_last_snr_kodu_repeater": {
+    "entity_id": "sensor.meshcore_sn7_last_snr_kodu_repeater",
+    "state": "13.5",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:31:19.890068",
+      "unit_of_measurement": "dB",
+      "icon": "mdi:signal",
+      "friendly_name": "MeshCore Repeater: Kodu Repeater (fa27ef) Last SNR"
+    },
+    "last_changed": "2026-05-05T18:30:47.432689+00:00",
+    "last_reported": "2026-05-05T20:31:43.010758+00:00",
+    "last_updated": "2026-05-05T20:31:19.890095+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn7_nb_recv_kodu_repeater": {
+    "entity_id": "sensor.meshcore_sn7_nb_recv_kodu_repeater",
+    "state": "635508",
+    "attributes": {
+      "state_class": "total_increasing",
+      "last_updated": "2026-05-05T21:31:19.890161",
+      "icon": "mdi:message-arrow-left",
+      "friendly_name": "MeshCore Repeater: Kodu Repeater (fa27ef) Messages Received"
+    },
+    "last_changed": "2026-05-05T20:31:19.890187+00:00",
+    "last_reported": "2026-05-05T20:31:43.010788+00:00",
+    "last_updated": "2026-05-05T20:31:19.890187+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn7_nb_recv_rate_kodu_repeater": {
+    "entity_id": "sensor.meshcore_sn7_nb_recv_rate_kodu_repeater",
+    "state": "13.6",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:31:19.891504",
+      "uptime_seconds": "2776724",
+      "nb_recv_total": "635508",
+      "nb_recv_since_last_update": "1641",
+      "uptime_delta_seconds": "7232",
+      "unit_of_measurement": "msg/min",
+      "icon": "mdi:message-arrow-left",
+      "friendly_name": "MeshCore Repeater: Kodu Repeater (fa27ef) Messages Received Rate"
+    },
+    "last_changed": "2026-05-05T20:31:19.891539+00:00",
+    "last_reported": "2026-05-05T20:31:43.011286+00:00",
+    "last_updated": "2026-05-05T20:31:19.891539+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn7_nb_sent_kodu_repeater": {
+    "entity_id": "sensor.meshcore_sn7_nb_sent_kodu_repeater",
+    "state": "250088",
+    "attributes": {
+      "state_class": "total_increasing",
+      "last_updated": "2026-05-05T21:31:19.889874",
+      "icon": "mdi:message-arrow-right",
+      "friendly_name": "MeshCore Repeater: Kodu Repeater (fa27ef) Messages Sent"
+    },
+    "last_changed": "2026-05-05T20:31:19.889903+00:00",
+    "last_reported": "2026-05-05T20:31:43.010695+00:00",
+    "last_updated": "2026-05-05T20:31:19.889903+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn7_nb_sent_rate_kodu_repeater": {
+    "entity_id": "sensor.meshcore_sn7_nb_sent_rate_kodu_repeater",
+    "state": "5.5",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:31:19.891605",
+      "uptime_seconds": "2776724",
+      "nb_sent_total": "250088",
+      "nb_sent_since_last_update": "665",
+      "uptime_delta_seconds": "7232",
+      "unit_of_measurement": "msg/min",
+      "icon": "mdi:message-arrow-right",
+      "friendly_name": "MeshCore Repeater: Kodu Repeater (fa27ef) Messages Sent Rate"
+    },
+    "last_changed": "2026-05-05T20:31:19.891638+00:00",
+    "last_reported": "2026-05-05T20:31:43.011325+00:00",
+    "last_updated": "2026-05-05T20:31:19.891638+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn7_noise_floor_kodu_repeater": {
+    "entity_id": "sensor.meshcore_sn7_noise_floor_kodu_repeater",
+    "state": "-105",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:31:19.890337",
+      "unit_of_measurement": "dBm",
+      "icon": "mdi:waveform",
+      "friendly_name": "MeshCore Repeater: Kodu Repeater (fa27ef) Noise Floor"
+    },
+    "last_changed": "2026-05-05T20:31:19.890360+00:00",
+    "last_reported": "2026-05-05T20:31:43.010845+00:00",
+    "last_updated": "2026-05-05T20:31:19.890360+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn7_rx_airtime_utilization_kodu_repeater": {
+    "entity_id": "sensor.meshcore_sn7_rx_airtime_utilization_kodu_repeater",
+    "state": "17.2",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:31:19.891190",
+      "uptime_seconds": "2776724",
+      "rx_airtime_seconds": "448921",
+      "rx_airtime_since_last_update": "20.7",
+      "unit_of_measurement": "%",
+      "device_class": "power_factor",
+      "icon": "mdi:percent",
+      "friendly_name": "MeshCore Repeater: Kodu Repeater (fa27ef) RX Airtime Utilization"
+    },
+    "last_changed": "2026-05-05T20:31:19.891228+00:00",
+    "last_reported": "2026-05-05T20:31:43.011169+00:00",
+    "last_updated": "2026-05-05T20:31:19.891228+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn7_tx_queue_len_kodu_repeater": {
+    "entity_id": "sensor.meshcore_sn7_tx_queue_len_kodu_repeater",
+    "state": "0",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:31:19.890250",
+      "icon": "mdi:playlist-edit",
+      "friendly_name": "MeshCore Repeater: Kodu Repeater (fa27ef) TX Queue Length"
+    },
+    "last_changed": "2026-05-04T13:32:42.758401+00:00",
+    "last_reported": "2026-05-05T20:31:43.010818+00:00",
+    "last_updated": "2026-05-05T20:31:19.890275+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.meshcore_sn7_uptime_kodu_repeater": {
+    "entity_id": "sensor.meshcore_sn7_uptime_kodu_repeater",
+    "state": "32.XXXXXXXXXXXXX",
+    "attributes": {
+      "state_class": "measurement",
+      "last_updated": "2026-05-05T21:31:19.889600",
+      "human_readable": "32d 3h 18m 44s",
+      "unit_of_measurement": "d",
+      "device_class": "duration",
+      "icon": "mdi:clock",
+      "friendly_name": "MeshCore Repeater: Kodu Repeater (fa27ef) Uptime"
+    },
+    "last_changed": "2026-05-05T20:31:19.889660+00:00",
+    "last_reported": "2026-05-05T20:31:43.010626+00:00",
+    "last_updated": "2026-05-05T20:31:19.889660+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "text.meshcore_command": {
+    "entity_id": "text.meshcore_command",
+    "state": "",
+    "attributes": {
+      "mode": "text",
+      "min": 0,
+      "max": 255,
+      "pattern": null,
+      "icon": "mdi:console",
+      "friendly_name": "MeshCore Command"
+    },
+    "last_changed": "2026-04-30T18:08:18.558160+00:00",
+    "last_reported": "2026-04-30T18:13:55.012620+00:00",
+    "last_updated": "2026-04-30T18:08:18.558160+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "text.meshcore_message": {
+    "entity_id": "text.meshcore_message",
+    "state": "",
+    "attributes": {
+      "mode": "text",
+      "min": 0,
+      "max": 200,
+      "pattern": null,
+      "icon": "mdi:message-text",
+      "friendly_name": "MeshCore Message"
+    },
+    "last_changed": "2026-04-30T18:08:18.557991+00:00",
+    "last_reported": "2026-04-30T18:13:55.012593+00:00",
+    "last_updated": "2026-04-30T18:08:18.557991+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "update.meshcore_proxy_update": {
+    "entity_id": "update.meshcore_proxy_update",
+    "state": "off",
+    "attributes": {
+      "auto_update": false,
+      "display_precision": 0,
+      "installed_version": "0.1.0",
+      "in_progress": false,
+      "latest_version": "0.1.0",
+      "release_summary": null,
+      "release_url": "<redacted>",
+      "skipped_version": null,
+      "title": "MeshCore Proxy",
+      "update_percentage": null,
+      "friendly_name": "MeshCore Proxy Update",
+      "supported_features": 29
+    },
+    "last_changed": "2026-05-02T03:08:16.240015+00:00",
+    "last_reported": "2026-05-02T03:08:16.240015+00:00",
+    "last_updated": "2026-05-02T03:08:16.240015+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "update.meshcore_update": {
+    "entity_id": "update.meshcore_update",
+    "state": "off",
+    "attributes": {
+      "auto_update": false,
+      "display_precision": 0,
+      "installed_version": "v2.6.0",
+      "in_progress": false,
+      "latest_version": "v2.6.0",
+      "release_summary": null,
+      "release_url": "<redacted>",
+      "skipped_version": null,
+      "title": null,
+      "update_percentage": null,
+      "entity_picture": "https://brands.home-assistant.io/_/meshcore/icon.png",
+      "friendly_name": "MeshCore Update",
+      "supported_features": 23
+    },
+    "last_changed": "2026-04-30T18:08:15.650771+00:00",
+    "last_reported": "2026-04-30T18:08:15.650771+00:00",
+    "last_updated": "2026-04-30T18:08:15.650771+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "zone.home": {
+    "entity_id": "zone.home",
+    "state": "1",
+    "attributes": {
+      "latitude": "<redacted>",
+      "longitude": "<redacted>",
+      "radius": 100,
+      "passive": false,
+      "persons": "<redacted>",
+      "editable": true,
+      "icon": "mdi:home",
+      "friendly_name": "Home"
+    },
+    "last_changed": "2026-05-05T06:31:00.892272+00:00",
+    "last_reported": "2026-05-05T06:31:00.892272+00:00",
+    "last_updated": "2026-05-05T06:31:00.892272+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  }
+}

--- a/terrazzo-core/src/androidMain/resources/dashboards/meshcore/lovelace_config.json
+++ b/terrazzo-core/src/androidMain/resources/dashboards/meshcore/lovelace_config.json
@@ -1,0 +1,981 @@
+{
+  "views": [
+    {
+      "title": "Overview",
+      "icon": "mdi:view-dashboard",
+      "type": "sections",
+      "max_columns": 4,
+      "header": {
+        "card": {
+          "type": "markdown",
+          "text_only": true,
+          "content": "# 📡 MeshCore\n**Hub:** {{ states('sensor.meshcore_sn1_node_status_kodu_heltec') | title }} · **Nodes seen:** {{ states('sensor.meshcore_sn1_node_count_kodu_heltec') }} · **Last delivery:** {{ states('sensor.meshcore_sn1_last_message_delivery_kodu_heltec') }}"
+        }
+      },
+      "sections": [
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "Hub — Kodu Heltec",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:usb-port"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn1_node_status_kodu_heltec",
+                  "name": "Status",
+                  "icon": "mdi:chip",
+                  "color": "blue"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn1_node_count_kodu_heltec",
+                  "name": "Nodes seen",
+                  "icon": "mdi:radio-tower"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.meshcore_sn1_mqtt_broker_1_connection",
+                  "name": "MQTT broker",
+                  "icon": "mdi:cloud-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.meshcore_sn1_ch_0_messages",
+                  "name": "Public msgs",
+                  "icon": "mdi:message-bulleted"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "Contacts",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:check-network"
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.meshcore_kodu_t1000e_sn3_contact",
+                  "name": "🎒 Card (T1000E)",
+                  "icon": "mdi:card-account-details-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.meshcore_kodu_room_sn2_contact",
+                  "name": "🏠 Room Server",
+                  "icon": "mdi:server-network"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.meshcore_sensecap_solar_repeater_sn4_contact",
+                  "name": "☀️ Solar Repeater",
+                  "icon": "mdi:solar-power-variant"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "🎒 Card Tracker  —  Am I close to home?",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:card-account-details-outline"
+            },
+            {
+              "type": "grid",
+              "columns": 2,
+              "square": false,
+              "cards": [
+                {
+                  "type": "markdown",
+                  "content": "{% set e = 'binary_sensor.meshcore_kodu_t1000e_sn3_contact' %}\n{% set lat = state_attr(e, 'latitude') %}\n{% set lon = state_attr(e, 'longitude') %}\n{% set d = distance(lat, lon) if lat is number and lon is number else none %}\n{% set d = d | float(0) if d is not none else none %}\n### {% if states(e) == 'fresh' %}🟢 Online{% else %}🔴 Stale{% endif %}\n\n{% if d is not none %}## {% if d < 0.15 %}🏠 At home{% elif d < 1 %}🚶 {{ (d*1000)|round(0)|int }} m from home{% elif d < 50 %}🚗 {{ d|round(2) }} km from home{% else %}✈️ {{ d|round(0)|int }} km from home{% endif %}\n\n{% else %}*No location advertised yet.*\n\n{% endif %}**Last heard:** {{ state_attr(e, 'last_advert_formatted') or '–' }}\n\n**Hops to hub:** {% set h = state_attr(e, 'out_path_len') %}{% if h is number and h >= 0 %}{{ h }}{% else %}– (no direct route){% endif %}"
+                },
+                {
+                  "type": "grid",
+                  "columns": 2,
+                  "square": false,
+                  "cards": [
+                    {
+                      "type": "tile",
+                      "entity": "sensor.meshcore_sn6_out_path_len_kodu_t1000e",
+                      "name": "Path length",
+                      "icon": "mdi:map-marker-path"
+                    },
+                    {
+                      "type": "tile",
+                      "entity": "sensor.meshcore_sn6_request_successes_kodu_t1000e",
+                      "name": "Req OK",
+                      "icon": "mdi:check-circle-outline",
+                      "color": "green"
+                    },
+                    {
+                      "type": "tile",
+                      "entity": "sensor.meshcore_sn6_request_failures_kodu_t1000e",
+                      "name": "Req fail",
+                      "icon": "mdi:alert-circle-outline",
+                      "color": "red"
+                    },
+                    {
+                      "type": "tile",
+                      "entity": "binary_sensor.meshcore_kodu_t1000e_sn3_contact",
+                      "name": "Contact",
+                      "icon": "mdi:lan-connect"
+                    }
+                  ],
+                  "grid_options": {
+                    "columns": "full"
+                  }
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "Mesh map",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:map"
+            },
+            {
+              "type": "map",
+              "default_zoom": 13,
+              "hours_to_show": 168,
+              "aspect_ratio": "21:9",
+              "entities": [
+                {
+                  "entity": "zone.home"
+                },
+                {
+                  "entity": "binary_sensor.meshcore_kodu_t1000e_sn3_contact"
+                },
+                {
+                  "entity": "binary_sensor.meshcore_kodu_room_sn2_contact"
+                },
+                {
+                  "entity": "binary_sensor.meshcore_sensecap_solar_repeater_sn4_contact"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "☀️ Solar Repeater battery",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:solar-power-variant"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn7_battery_percentage_kodu_repeater",
+                  "name": "Battery %",
+                  "icon": "mdi:battery"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn7_bat_kodu_repeater",
+                  "name": "Battery V",
+                  "icon": "mdi:battery-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn7_ch1_voltage_kodu_repeater",
+                  "name": "Ch1 voltage",
+                  "icon": "mdi:current-dc"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn7_uptime_kodu_repeater",
+                  "name": "Uptime",
+                  "icon": "mdi:clock-outline"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "history-graph",
+              "title": "Solar repeater battery (2 weeks)",
+              "hours_to_show": 336,
+              "entities": [
+                {
+                  "entity": "sensor.meshcore_sn7_battery_percentage_kodu_repeater",
+                  "name": "Battery %"
+                },
+                {
+                  "entity": "sensor.meshcore_sn7_bat_kodu_repeater",
+                  "name": "Battery V"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "💬 Send to a room",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:chat-outline"
+            },
+            {
+              "type": "entities",
+              "entities": [
+                {
+                  "entity": "select.meshcore_recipient_type",
+                  "name": "Recipient type"
+                },
+                {
+                  "entity": "select.meshcore_channel",
+                  "name": "Channel"
+                },
+                {
+                  "entity": "select.meshcore_contact",
+                  "name": "Contact / Room"
+                },
+                {
+                  "entity": "text.meshcore_message",
+                  "name": "Message"
+                },
+                {
+                  "entity": "sensor.meshcore_sn1_last_message_delivery_kodu_heltec",
+                  "name": "Last delivery"
+                }
+              ],
+              "state_color": true,
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "🏠 Room server activity",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:chat-processing-outline"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.meshcore_kodu_room_sn2_contact",
+                  "name": "Contact",
+                  "icon": "mdi:lan-connect"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.meshcore_sn1_ch_0_messages",
+                  "name": "Messages",
+                  "icon": "mdi:chat-processing-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn5_nb_recv_rate_kodu_room",
+                  "name": "Recv rate",
+                  "icon": "mdi:download"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn5_recv_direct_rate_kodu_room",
+                  "name": "Direct recv rate",
+                  "icon": "mdi:message-arrow-left"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Solar Repeater",
+      "icon": "mdi:solar-power-variant",
+      "path": "repeater",
+      "type": "sections",
+      "max_columns": 4,
+      "sections": [
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "🔋 Solar Repeater — battery & power",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:battery"
+            },
+            {
+              "type": "grid",
+              "columns": 2,
+              "square": false,
+              "cards": [
+                {
+                  "type": "gauge",
+                  "entity": "sensor.meshcore_sn7_battery_percentage_kodu_repeater",
+                  "min": 0,
+                  "max": 100,
+                  "needle": true,
+                  "name": "Battery %",
+                  "severity": {
+                    "green": 60,
+                    "yellow": 30,
+                    "red": 0
+                  }
+                },
+                {
+                  "type": "grid",
+                  "columns": 2,
+                  "square": false,
+                  "cards": [
+                    {
+                      "type": "tile",
+                      "entity": "sensor.meshcore_sn7_bat_kodu_repeater",
+                      "name": "Battery V",
+                      "icon": "mdi:battery-outline"
+                    },
+                    {
+                      "type": "tile",
+                      "entity": "sensor.meshcore_sn7_ch1_voltage_kodu_repeater",
+                      "name": "Ch1 V",
+                      "icon": "mdi:current-dc"
+                    },
+                    {
+                      "type": "tile",
+                      "entity": "sensor.meshcore_sn7_ch1_temperature_kodu_repeater",
+                      "name": "Ch1 temp",
+                      "icon": "mdi:thermometer"
+                    },
+                    {
+                      "type": "tile",
+                      "entity": "sensor.meshcore_sn7_uptime_kodu_repeater",
+                      "name": "Uptime",
+                      "icon": "mdi:clock-outline"
+                    }
+                  ],
+                  "grid_options": {
+                    "columns": "full"
+                  }
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "history-graph",
+              "title": "Solar Repeater battery & Ch1 (2 weeks)",
+              "hours_to_show": 336,
+              "entities": [
+                {
+                  "entity": "sensor.meshcore_sn7_battery_percentage_kodu_repeater",
+                  "name": "Battery %"
+                },
+                {
+                  "entity": "sensor.meshcore_sn7_bat_kodu_repeater",
+                  "name": "Battery V"
+                },
+                {
+                  "entity": "sensor.meshcore_sn7_ch1_voltage_kodu_repeater",
+                  "name": "Ch1 V"
+                },
+                {
+                  "entity": "sensor.meshcore_sn7_ch1_temperature_kodu_repeater",
+                  "name": "Ch1 temp"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "📶 Link quality",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:signal"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.meshcore_sensecap_solar_repeater_sn4_contact",
+                  "name": "Contact",
+                  "icon": "mdi:lan-connect"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn7_last_rssi_kodu_repeater",
+                  "name": "RSSI",
+                  "icon": "mdi:signal"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn7_last_snr_kodu_repeater",
+                  "name": "SNR",
+                  "icon": "mdi:signal-variant"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn7_noise_floor_kodu_repeater",
+                  "name": "Noise floor",
+                  "icon": "mdi:waveform"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "📈 Traffic",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:chart-line"
+            },
+            {
+              "type": "grid",
+              "columns": 2,
+              "square": false,
+              "cards": [
+                {
+                  "type": "gauge",
+                  "entity": "sensor.meshcore_sn7_airtime_utilization_kodu_repeater",
+                  "min": 0,
+                  "max": 100,
+                  "needle": true,
+                  "name": "Airtime util %",
+                  "severity": {
+                    "green": 0,
+                    "yellow": 10,
+                    "red": 25
+                  }
+                },
+                {
+                  "type": "gauge",
+                  "entity": "sensor.meshcore_sn7_rx_airtime_utilization_kodu_repeater",
+                  "min": 0,
+                  "max": 100,
+                  "needle": true,
+                  "name": "RX airtime util %",
+                  "severity": {
+                    "green": 0,
+                    "yellow": 25,
+                    "red": 50
+                  }
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn7_nb_recv_rate_kodu_repeater",
+                  "name": "Recv rate",
+                  "icon": "mdi:download"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn7_nb_sent_rate_kodu_repeater",
+                  "name": "Sent rate",
+                  "icon": "mdi:upload"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn7_flood_dups_rate_kodu_repeater",
+                  "name": "Flood dups",
+                  "icon": "mdi:content-duplicate"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn7_tx_queue_len_kodu_repeater",
+                  "name": "TX queue",
+                  "icon": "mdi:playlist-play"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn7_nb_recv_kodu_repeater",
+                  "name": "Recv total",
+                  "icon": "mdi:counter"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn7_nb_sent_kodu_repeater",
+                  "name": "Sent total",
+                  "icon": "mdi:counter"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "history-graph",
+              "title": "Solar Repeater traffic & link (24h)",
+              "hours_to_show": 24,
+              "entities": [
+                {
+                  "entity": "sensor.meshcore_sn7_nb_recv_rate_kodu_repeater",
+                  "name": "Recv/min"
+                },
+                {
+                  "entity": "sensor.meshcore_sn7_nb_sent_rate_kodu_repeater",
+                  "name": "Sent/min"
+                },
+                {
+                  "entity": "sensor.meshcore_sn7_flood_dups_rate_kodu_repeater",
+                  "name": "Flood dups/min"
+                },
+                {
+                  "entity": "sensor.meshcore_sn7_last_rssi_kodu_repeater",
+                  "name": "RSSI"
+                },
+                {
+                  "entity": "sensor.meshcore_sn7_last_snr_kodu_repeater",
+                  "name": "SNR"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Room Server",
+      "icon": "mdi:server-network",
+      "path": "room",
+      "type": "sections",
+      "max_columns": 4,
+      "sections": [
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "🏠 Room Server (Kodu Room) — mains-powered",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:server-network"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.meshcore_kodu_room_sn2_contact",
+                  "name": "Contact",
+                  "icon": "mdi:lan-connect"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn5_uptime_kodu_room",
+                  "name": "Uptime",
+                  "icon": "mdi:clock-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn5_ch1_temperature_kodu_room",
+                  "name": "Ch1 temp",
+                  "icon": "mdi:thermometer"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn5_battery_percentage_kodu_room",
+                  "name": "Battery (backup)",
+                  "icon": "mdi:battery-charging-outline"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "💬 Send to this room",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:chat-outline"
+            },
+            {
+              "type": "entities",
+              "entities": [
+                {
+                  "entity": "select.meshcore_recipient_type",
+                  "name": "Recipient type"
+                },
+                {
+                  "entity": "select.meshcore_contact",
+                  "name": "Contact / Room"
+                },
+                {
+                  "entity": "text.meshcore_message",
+                  "name": "Message"
+                },
+                {
+                  "entity": "sensor.meshcore_sn1_last_message_delivery_kodu_heltec",
+                  "name": "Last delivery"
+                }
+              ],
+              "state_color": true,
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "📨 Room messages",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:chat-processing-outline"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.meshcore_sn1_ch_0_messages",
+                  "name": "Activity",
+                  "icon": "mdi:chat-processing-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn5_nb_recv_kodu_room",
+                  "name": "Recv total",
+                  "icon": "mdi:counter"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn5_nb_sent_kodu_room",
+                  "name": "Sent total",
+                  "icon": "mdi:counter"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn5_nb_recv_rate_kodu_room",
+                  "name": "Recv rate",
+                  "icon": "mdi:download"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn5_nb_sent_rate_kodu_room",
+                  "name": "Sent rate",
+                  "icon": "mdi:upload"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn5_recv_direct_rate_kodu_room",
+                  "name": "Direct recv",
+                  "icon": "mdi:message-arrow-left"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn5_sent_direct_rate_kodu_room",
+                  "name": "Direct sent",
+                  "icon": "mdi:message-arrow-right"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn5_recv_flood_rate_kodu_room",
+                  "name": "Flood recv",
+                  "icon": "mdi:broadcast"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "history-graph",
+              "title": "Room message rates (24h)",
+              "hours_to_show": 24,
+              "entities": [
+                {
+                  "entity": "sensor.meshcore_sn5_nb_recv_rate_kodu_room",
+                  "name": "Recv/min"
+                },
+                {
+                  "entity": "sensor.meshcore_sn5_nb_sent_rate_kodu_room",
+                  "name": "Sent/min"
+                },
+                {
+                  "entity": "sensor.meshcore_sn5_recv_direct_rate_kodu_room",
+                  "name": "Direct recv/min"
+                },
+                {
+                  "entity": "sensor.meshcore_sn5_sent_direct_rate_kodu_room",
+                  "name": "Direct sent/min"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "📶 Link quality",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:signal"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn5_last_rssi_kodu_room",
+                  "name": "RSSI",
+                  "icon": "mdi:signal"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn5_last_snr_kodu_room",
+                  "name": "SNR",
+                  "icon": "mdi:signal-variant"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn5_noise_floor_kodu_room",
+                  "name": "Noise floor",
+                  "icon": "mdi:waveform"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn5_tx_queue_len_kodu_room",
+                  "name": "TX queue",
+                  "icon": "mdi:playlist-play"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "logbook",
+              "title": "Room server contact history",
+              "hours_to_show": 168,
+              "entities": [
+                "binary_sensor.meshcore_kodu_room_sn2_contact",
+                "binary_sensor.meshcore_sn1_ch_0_messages"
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "Controls",
+      "icon": "mdi:tune",
+      "path": "controls",
+      "type": "sections",
+      "max_columns": 4,
+      "sections": [
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "💬 Send Message",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:chat-outline"
+            },
+            {
+              "type": "entities",
+              "entities": [
+                {
+                  "entity": "select.meshcore_recipient_type",
+                  "name": "Recipient type"
+                },
+                {
+                  "entity": "select.meshcore_channel",
+                  "name": "Channel"
+                },
+                {
+                  "entity": "select.meshcore_contact",
+                  "name": "Contact"
+                },
+                {
+                  "entity": "text.meshcore_message",
+                  "name": "Message"
+                },
+                {
+                  "entity": "text.meshcore_command",
+                  "name": "Command"
+                },
+                {
+                  "entity": "sensor.meshcore_sn1_last_message_delivery_kodu_heltec",
+                  "name": "Last delivery"
+                }
+              ],
+              "state_color": true,
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "📻 Radio config",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:radio"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn1_frequency_kodu_heltec",
+                  "name": "Frequency",
+                  "icon": "mdi:sine-wave"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn1_bandwidth_kodu_heltec",
+                  "name": "Bandwidth",
+                  "icon": "mdi:arrow-expand-horizontal"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn1_spreading_factor_kodu_heltec",
+                  "name": "Spreading factor",
+                  "icon": "mdi:chart-sankey"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.meshcore_sn1_tx_power_kodu_heltec",
+                  "name": "TX power",
+                  "icon": "mdi:antenna"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "🔧 Maintenance",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:wrench-outline"
+            },
+            {
+              "type": "grid",
+              "columns": 2,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "update.meshcore_update",
+                  "name": "Hub firmware",
+                  "icon": "mdi:chip"
+                },
+                {
+                  "type": "tile",
+                  "entity": "update.meshcore_proxy_update",
+                  "name": "Proxy",
+                  "icon": "mdi:update"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/terrazzo-core/src/androidMain/resources/dashboards/networks/entity_states.json
+++ b/terrazzo-core/src/androidMain/resources/dashboards/networks/entity_states.json
@@ -1,0 +1,319 @@
+{
+  "device_tracker.unifi_default_0e_19_1f_4e_fe_6f": {
+    "entity_id": "device_tracker.unifi_default_0e_19_1f_4e_fe_6f",
+    "state": "home",
+    "attributes": {
+      "source_type": "router",
+      "ip": "<redacted>",
+      "mac": "<redacted>",
+      "host_name": "<redacted>",
+      "_is_guest_by_uap": false,
+      "ap_mac": "<redacted>",
+      "essid": "<redacted>",
+      "is_11r": true,
+      "is_guest": false,
+      "qos_policy_applied": true,
+      "radio": "6e",
+      "radio_proto": "be",
+      "oui": "",
+      "friendly_name": "iPad"
+    },
+    "last_changed": "2026-05-05T12:00:05.363514+00:00",
+    "last_reported": "2026-05-05T12:00:54.430871+00:00",
+    "last_updated": "2026-05-05T12:00:45.315824+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "device_tracker.unifi_default_3e_c4_4a_88_9b_fe": {
+    "entity_id": "device_tracker.unifi_default_3e_c4_4a_88_9b_fe",
+    "state": "not_home",
+    "attributes": {
+      "source_type": "router",
+      "mac": "<redacted>",
+      "host_name": "<redacted>",
+      "oui": "",
+      "friendly_name": "iPhone"
+    },
+    "last_changed": "2026-05-01T02:48:12.768332+00:00",
+    "last_reported": "2026-05-01T02:48:12.768332+00:00",
+    "last_updated": "2026-05-01T02:48:12.768332+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "device_tracker.unifi_default_4e_b2_24_77_4b_1b": {
+    "entity_id": "device_tracker.unifi_default_4e_b2_24_77_4b_1b",
+    "state": "not_home",
+    "attributes": {
+      "source_type": "router",
+      "mac": "<redacted>",
+      "host_name": "<redacted>",
+      "oui": "",
+      "friendly_name": "iPhone iPhone"
+    },
+    "last_changed": "2026-05-01T02:48:12.767199+00:00",
+    "last_reported": "2026-05-01T02:48:12.767199+00:00",
+    "last_updated": "2026-05-01T02:48:12.767199+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "device_tracker.unifi_default_84_2f_57_64_26_00": {
+    "entity_id": "device_tracker.unifi_default_84_2f_57_64_26_00",
+    "state": "not_home",
+    "attributes": {
+      "source_type": "router",
+      "mac": "<redacted>",
+      "host_name": "<redacted>",
+      "oui": "",
+      "friendly_name": "MacBook-Pro"
+    },
+    "last_changed": "2026-05-01T02:48:12.767936+00:00",
+    "last_reported": "2026-05-01T02:48:12.767936+00:00",
+    "last_updated": "2026-05-01T02:48:12.767936+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "device_tracker.unifi_default_b6_5b_07_32_f7_38": {
+    "entity_id": "device_tracker.unifi_default_b6_5b_07_32_f7_38",
+    "state": "not_home",
+    "attributes": {
+      "source_type": "router",
+      "mac": "<redacted>",
+      "host_name": "<redacted>",
+      "oui": "",
+      "friendly_name": "iPhone"
+    },
+    "last_changed": "2026-05-01T02:48:12.768382+00:00",
+    "last_reported": "2026-05-01T02:48:12.768382+00:00",
+    "last_updated": "2026-05-01T02:48:12.768382+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "device_tracker.unifi_default_be_94_67_11_9a_a9": {
+    "entity_id": "device_tracker.unifi_default_be_94_67_11_9a_a9",
+    "state": "not_home",
+    "attributes": {
+      "source_type": "router",
+      "mac": "<redacted>",
+      "host_name": "<redacted>",
+      "oui": "",
+      "friendly_name": "Mac"
+    },
+    "last_changed": "2026-05-01T02:48:12.768280+00:00",
+    "last_reported": "2026-05-01T02:48:12.768280+00:00",
+    "last_updated": "2026-05-01T02:48:12.768280+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "device_tracker.unifi_default_da_f1_88_71_ae_2a": {
+    "entity_id": "device_tracker.unifi_default_da_f1_88_71_ae_2a",
+    "state": "home",
+    "attributes": {
+      "source_type": "router",
+      "ip": "<redacted>",
+      "mac": "<redacted>",
+      "host_name": "<redacted>",
+      "_is_guest_by_uap": false,
+      "ap_mac": "<redacted>",
+      "essid": "<redacted>",
+      "is_11r": false,
+      "is_guest": false,
+      "qos_policy_applied": true,
+      "radio": "6e",
+      "radio_proto": "ax",
+      "oui": "",
+      "friendly_name": "Mac"
+    },
+    "last_changed": "2026-05-05T08:17:55.406712+00:00",
+    "last_reported": "2026-05-05T08:18:15.560051+00:00",
+    "last_updated": "2026-05-05T08:18:03.770793+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "device_tracker.unifi_default_e2_ce_9c_67_d8_81": {
+    "entity_id": "device_tracker.unifi_default_e2_ce_9c_67_d8_81",
+    "state": "not_home",
+    "attributes": {
+      "source_type": "router",
+      "mac": "<redacted>",
+      "host_name": "<redacted>",
+      "oui": "",
+      "friendly_name": "iPhone"
+    },
+    "last_changed": "2026-05-01T02:48:12.769078+00:00",
+    "last_reported": "2026-05-01T02:48:12.769078+00:00",
+    "last_updated": "2026-05-01T02:48:12.769078+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "person.nikolai": {
+    "entity_id": "person.nikolai",
+    "state": "unknown",
+    "attributes": {
+      "editable": true,
+      "id": "<redacted>",
+      "device_trackers": "<redacted>",
+      "friendly_name": "Nikolai"
+    },
+    "last_changed": "2026-04-30T18:08:05.168232+00:00",
+    "last_reported": "2026-04-30T18:13:22.143187+00:00",
+    "last_updated": "2026-04-30T18:13:22.143187+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "person.tatjana": {
+    "entity_id": "person.tatjana",
+    "state": "unknown",
+    "attributes": {
+      "editable": true,
+      "id": "<redacted>",
+      "device_trackers": "<redacted>",
+      "user_id": "<redacted>",
+      "friendly_name": "Tatjana"
+    },
+    "last_changed": "2026-04-30T18:08:05.168393+00:00",
+    "last_reported": "2026-04-30T18:13:22.143233+00:00",
+    "last_updated": "2026-04-30T18:13:22.143233+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "person.yuri_schimke": {
+    "entity_id": "person.yuri_schimke",
+    "state": "home",
+    "attributes": {
+      "editable": true,
+      "id": "<redacted>",
+      "device_trackers": "<redacted>",
+      "latitude": "<redacted>",
+      "longitude": "<redacted>",
+      "gps_accuracy": "<redacted>",
+      "source": "device_tracker.pixel_10a_2",
+      "user_id": "<redacted>",
+      "friendly_name": "Yuri Schimke"
+    },
+    "last_changed": "2026-05-05T06:31:00.892102+00:00",
+    "last_reported": "2026-05-05T21:17:47.040298+00:00",
+    "last_updated": "2026-05-05T21:17:47.040298+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.fast_com_download": {
+    "entity_id": "sensor.fast_com_download",
+    "state": "551.XXXXXXXXXXXX",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "Mbit/s",
+      "device_class": "data_rate",
+      "friendly_name": "Fast.com Download"
+    },
+    "last_changed": "2026-05-05T21:33:36.484891+00:00",
+    "last_reported": "2026-05-05T21:33:36.484891+00:00",
+    "last_updated": "2026-05-05T21:33:36.484891+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.garage_fast_com_download": {
+    "entity_id": "sensor.garage_fast_com_download",
+    "state": "61.XXXXXXXXXXXXX",
+    "attributes": {
+      "state_class": "measurement",
+      "unit_of_measurement": "Mbit/s",
+      "device_class": "data_rate",
+      "friendly_name": "Garage Fast.com Download",
+      "unique_id": "XXXXXXXXXXXXXXXX_sensor.garage_fast_com_download"
+    },
+    "last_changed": "2026-05-05T22:00:10.885333+00:00",
+    "last_reported": "2026-05-05T22:00:10.885333+00:00",
+    "last_updated": "2026-05-05T22:00:10.885333+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "sensor.remote_connection_to_192_168_0_252_8123": {
+    "entity_id": "sensor.remote_connection_to_192_168_0_252_8123",
+    "state": "connected",
+    "attributes": {
+      "host": "<redacted>",
+      "port": 8123,
+      "secure": false,
+      "verify_ssl": true,
+      "max_msg_size": 0,
+      "entity_prefix": "garage_",
+      "entity_friendly_name_prefix": "Garage ",
+      "uuid": "<redacted>",
+      "friendly_name": "Garage Remote connection to REDACTED_IP"
+    },
+    "last_changed": "2026-05-03T02:36:56.561362+00:00",
+    "last_reported": "2026-05-03T02:36:56.561362+00:00",
+    "last_updated": "2026-05-03T02:36:56.561362+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "update.unifi_network_application_update": {
+    "entity_id": "update.unifi_network_application_update",
+    "state": "off",
+    "attributes": {
+      "auto_update": false,
+      "display_precision": 0,
+      "installed_version": "5.1.1",
+      "in_progress": false,
+      "latest_version": "5.1.1",
+      "release_summary": null,
+      "release_url": "<redacted>",
+      "skipped_version": null,
+      "title": "UniFi Network Application",
+      "update_percentage": null,
+      "entity_picture": "/api/hassio/addons/XXXXXXXX_unifi/icon",
+      "friendly_name": "UniFi Network Application Update",
+      "supported_features": 29
+    },
+    "last_changed": "2026-05-02T03:08:16.239803+00:00",
+    "last_reported": "2026-05-02T03:08:16.239803+00:00",
+    "last_updated": "2026-05-02T03:08:16.239803+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  }
+}

--- a/terrazzo-core/src/androidMain/resources/dashboards/networks/lovelace_config.json
+++ b/terrazzo-core/src/androidMain/resources/dashboards/networks/lovelace_config.json
@@ -1,0 +1,197 @@
+{
+  "views": [
+    {
+      "title": "Broadband",
+      "icon": "mdi:lan",
+      "type": "sections",
+      "max_columns": 4,
+      "header": {
+        "card": {
+          "type": "markdown",
+          "text_only": true,
+          "content": "# 🌐 Networks\n**Download:** {{ states('sensor.fast_com_download') | float(0) | round(0) }} Mbit/s · **Garage:** {{ states('sensor.garage_fast_com_download') | float(0) | round(0) }} Mbit/s · **UniFi devices home:** {{ states.device_tracker | selectattr('entity_id', 'match', '^device_tracker.unifi_default_') | selectattr('state', 'eq', 'home') | list | count }}"
+        }
+      },
+      "sections": [
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "🚀 Broadband speeds",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:speedometer"
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "sensor.fast_com_download",
+                  "name": "Home download",
+                  "icon": "mdi:download-network"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.garage_fast_com_download",
+                  "name": "Garage download",
+                  "icon": "mdi:download-network-outline"
+                },
+                {
+                  "type": "tile",
+                  "entity": "sensor.remote_connection_to_192_168_0_252_8123",
+                  "name": "Garage link",
+                  "icon": "mdi:connection"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "history-graph",
+              "title": "Download speeds (1 month)",
+              "hours_to_show": 720,
+              "entities": [
+                {
+                  "entity": "sensor.fast_com_download",
+                  "name": "Home"
+                },
+                {
+                  "entity": "sensor.garage_fast_com_download",
+                  "name": "Garage"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "📶 UniFi",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:router-network"
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "update.unifi_network_application_update",
+                  "name": "Controller update",
+                  "icon": "mdi:cloud-sync-outline"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "markdown",
+              "grid_options": {
+                "columns": "full"
+              },
+              "content": "### UniFi clients\n{% set trackers = states.device_tracker | selectattr('entity_id', 'match', '^device_tracker.unifi_default_') | list %}**Total:** {{ trackers | count }} · 🟢 **Home:** {{ trackers | selectattr('state','eq','home') | list | count }} · 🔴 **Away:** {{ trackers | selectattr('state','eq','not_home') | list | count }} · ⚫ **Unavailable:** {{ trackers | selectattr('state','eq','unavailable') | list | count }}"
+            },
+            {
+              "type": "heading",
+              "heading": "Known devices",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:account-multiple"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "device_tracker.unifi_default_da_f1_88_71_ae_2a"
+                },
+                {
+                  "type": "tile",
+                  "entity": "device_tracker.unifi_default_84_2f_57_64_26_00"
+                },
+                {
+                  "type": "tile",
+                  "entity": "device_tracker.unifi_default_4e_b2_24_77_4b_1b"
+                },
+                {
+                  "type": "tile",
+                  "entity": "device_tracker.unifi_default_3e_c4_4a_88_9b_fe"
+                },
+                {
+                  "type": "tile",
+                  "entity": "device_tracker.unifi_default_b6_5b_07_32_f7_38"
+                },
+                {
+                  "type": "tile",
+                  "entity": "device_tracker.unifi_default_e2_ce_9c_67_d8_81"
+                },
+                {
+                  "type": "tile",
+                  "entity": "device_tracker.unifi_default_0e_19_1f_4e_fe_6f"
+                },
+                {
+                  "type": "tile",
+                  "entity": "device_tracker.unifi_default_be_94_67_11_9a_a9"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "👥 People",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:account-group"
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "person.yuri_schimke",
+                  "name": "Yuri"
+                },
+                {
+                  "type": "tile",
+                  "entity": "person.nikolai",
+                  "name": "Nikolai"
+                },
+                {
+                  "type": "tile",
+                  "entity": "person.tatjana",
+                  "name": "Tatjana"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/terrazzo-core/src/androidMain/resources/dashboards/security/entity_states.json
+++ b/terrazzo-core/src/androidMain/resources/dashboards/security/entity_states.json
@@ -1,0 +1,288 @@
+{
+  "alarm_control_panel.blink_panel": {
+    "entity_id": "alarm_control_panel.blink_panel",
+    "state": "disarmed",
+    "attributes": {
+      "code_format": null,
+      "changed_by": null,
+      "code_arm_required": false,
+      "name": "BlinkA1",
+      "id": "<redacted>",
+      "network_id": "<redacted>",
+      "serial": "<redacted>",
+      "version": null,
+      "status": false,
+      "region_id": "<redacted>",
+      "local_storage": false,
+      "friendly_name": "BlinkA1",
+      "supported_features": 2
+    },
+    "last_changed": "2026-04-30T18:08:18.592819+00:00",
+    "last_reported": "2026-04-30T18:13:19.439131+00:00",
+    "last_updated": "2026-04-30T18:08:18.600304+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.g4_instant_motion": {
+    "entity_id": "binary_sensor.g4_instant_motion",
+    "state": "unavailable",
+    "attributes": {
+      "attribution": "Powered by UniFi Protect Server",
+      "device_class": "motion",
+      "friendly_name": "G4 Instant Motion"
+    },
+    "last_changed": "2026-04-30T18:08:15.091028+00:00",
+    "last_reported": "2026-04-30T18:08:15.091028+00:00",
+    "last_updated": "2026-04-30T18:08:15.091028+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.g5_turret_ultra_motion": {
+    "entity_id": "binary_sensor.g5_turret_ultra_motion",
+    "state": "unavailable",
+    "attributes": {
+      "attribution": "Powered by UniFi Protect Server",
+      "device_class": "motion",
+      "friendly_name": "G5 Turret Ultra Motion"
+    },
+    "last_changed": "2026-04-30T18:08:15.089621+00:00",
+    "last_reported": "2026-04-30T18:08:15.089621+00:00",
+    "last_updated": "2026-04-30T18:08:15.089621+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.g8t1_9401_3255_0m5u_motion": {
+    "entity_id": "binary_sensor.g8t1_9401_3255_0m5u_motion",
+    "state": "off",
+    "attributes": {
+      "device_class": "motion",
+      "friendly_name": "BlinkA1 Motion"
+    },
+    "last_changed": "2026-04-30T18:08:18.596078+00:00",
+    "last_reported": "2026-04-30T18:13:19.439276+00:00",
+    "last_updated": "2026-04-30T18:08:18.600356+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.garage_door_garage_door_relay_state": {
+    "entity_id": "binary_sensor.garage_door_garage_door_relay_state",
+    "state": "off",
+    "attributes": {
+      "friendly_name": "Garage Door Garage Door Relay state"
+    },
+    "last_changed": "2026-05-05T06:29:01.568838+00:00",
+    "last_reported": "2026-05-05T06:29:01.568838+00:00",
+    "last_updated": "2026-05-05T06:29:01.568838+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "binary_sensor.garage_door_hcpbridge_connected": {
+    "entity_id": "binary_sensor.garage_door_hcpbridge_connected",
+    "state": "on",
+    "attributes": {
+      "device_class": "connectivity",
+      "friendly_name": "Garage Door hcpbridge Connected"
+    },
+    "last_changed": "2026-05-03T02:47:23.130649+00:00",
+    "last_reported": "2026-05-03T02:47:23.130649+00:00",
+    "last_updated": "2026-05-03T02:47:23.130649+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "button.garage_door_garage_door_half": {
+    "entity_id": "button.garage_door_garage_door_half",
+    "state": "unknown",
+    "attributes": {
+      "icon": "mdi:fraction-one-half",
+      "friendly_name": "Garage Door Garage Door Half"
+    },
+    "last_changed": "2026-05-03T02:47:23.111511+00:00",
+    "last_reported": "2026-05-03T02:47:23.111511+00:00",
+    "last_updated": "2026-05-03T02:47:23.111511+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "button.garage_door_garage_door_impulse": {
+    "entity_id": "button.garage_door_garage_door_impulse",
+    "state": "unknown",
+    "attributes": {
+      "icon": "mdi:arrow-up-down",
+      "friendly_name": "Garage Door Garage Door Impulse"
+    },
+    "last_changed": "2026-05-03T02:47:23.111260+00:00",
+    "last_reported": "2026-05-03T02:47:23.111260+00:00",
+    "last_updated": "2026-05-03T02:47:23.111260+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "button.garage_door_garage_door_vent": {
+    "entity_id": "button.garage_door_garage_door_vent",
+    "state": "unknown",
+    "attributes": {
+      "icon": "mdi:fan",
+      "friendly_name": "Garage Door Garage Door Vent"
+    },
+    "last_changed": "2026-05-03T02:47:23.111447+00:00",
+    "last_reported": "2026-05-03T02:47:23.111447+00:00",
+    "last_updated": "2026-05-03T02:47:23.111447+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "camera.back_door_camera": {
+    "entity_id": "camera.back_door_camera",
+    "state": "streaming",
+    "attributes": {
+      "access_token": "<redacted>",
+      "model_name": "Camera",
+      "brand": "Google Nest",
+      "entity_picture": "/api/camera_proxy/camera.back_door_camera?token=REDACTED",
+      "friendly_name": "Back door camera",
+      "supported_features": 2
+    },
+    "last_changed": "2026-04-30T18:08:21.992495+00:00",
+    "last_reported": "2026-05-05T22:13:07.553994+00:00",
+    "last_updated": "2026-05-05T22:13:07.553994+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "camera.g4_instant_high_resolution_channel": {
+    "entity_id": "camera.g4_instant_high_resolution_channel",
+    "state": "recording",
+    "attributes": {
+      "access_token": "<redacted>",
+      "width": 2688,
+      "height": 1512,
+      "fps": 30,
+      "bitrate": 5000000,
+      "channel_id": 0,
+      "attribution": "Powered by UniFi Protect Server",
+      "entity_picture": "/api/camera_proxy/camera.g4_instant_high_resolution_channel?token=REDACTED",
+      "friendly_name": "G4 Instant High resolution channel",
+      "supported_features": 2
+    },
+    "last_changed": "2026-05-05T22:08:51.854153+00:00",
+    "last_reported": "2026-05-05T22:13:07.553562+00:00",
+    "last_updated": "2026-05-05T22:13:07.553562+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "camera.g5_turret_ultra_high_resolution_channel": {
+    "entity_id": "camera.g5_turret_ultra_high_resolution_channel",
+    "state": "recording",
+    "attributes": {
+      "access_token": "<redacted>",
+      "width": 1504,
+      "height": 2688,
+      "fps": 30,
+      "bitrate": 7000000,
+      "channel_id": 0,
+      "attribution": "Powered by UniFi Protect Server",
+      "entity_picture": "/api/camera_proxy/camera.g5_turret_ultra_high_resolution_channel?token=REDACTED",
+      "friendly_name": "G5 Turret Ultra High resolution channel",
+      "supported_features": 2
+    },
+    "last_changed": "2026-04-30T18:08:15.096345+00:00",
+    "last_reported": "2026-05-05T22:13:07.553309+00:00",
+    "last_updated": "2026-05-05T22:13:07.553309+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "cover.garage_door_garage_door_2": {
+    "entity_id": "cover.garage_door_garage_door_2",
+    "state": "closed",
+    "attributes": {
+      "is_closed": true,
+      "current_position": 0,
+      "device_class": "garage",
+      "friendly_name": "Garage Door Garage Door",
+      "supported_features": 15
+    },
+    "last_changed": "2026-05-05T06:27:01.631676+00:00",
+    "last_reported": "2026-05-05T06:27:01.631676+00:00",
+    "last_updated": "2026-05-05T06:27:01.631676+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "event.back_door_camera_motion": {
+    "entity_id": "event.back_door_camera_motion",
+    "state": "2026-04-20T12:22:53.298+00:00",
+    "attributes": {
+      "event_types": [
+        "camera_motion",
+        "camera_person",
+        "camera_sound"
+      ],
+      "event_type": "camera_person",
+      "nest_event_id": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "device_class": "motion",
+      "friendly_name": "Back door camera Motion"
+    },
+    "last_changed": "2026-04-30T18:08:21.998655+00:00",
+    "last_reported": "2026-04-30T18:13:22.004163+00:00",
+    "last_updated": "2026-04-30T18:08:21.998655+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  },
+  "light.garage_door_garage_door_light": {
+    "entity_id": "light.garage_door_garage_door_light",
+    "state": "off",
+    "attributes": {
+      "supported_color_modes": [
+        "onoff"
+      ],
+      "color_mode": null,
+      "friendly_name": "Garage Door Garage Door Light",
+      "supported_features": 8
+    },
+    "last_changed": "2026-05-05T06:29:01.569179+00:00",
+    "last_reported": "2026-05-05T06:29:01.569179+00:00",
+    "last_updated": "2026-05-05T06:29:01.569179+00:00",
+    "context": {
+      "id": "XXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "parent_id": null,
+      "user_id": null
+    }
+  }
+}

--- a/terrazzo-core/src/androidMain/resources/dashboards/security/lovelace_config.json
+++ b/terrazzo-core/src/androidMain/resources/dashboards/security/lovelace_config.json
@@ -1,0 +1,230 @@
+{
+  "views": [
+    {
+      "title": "Security",
+      "icon": "mdi:shield-home",
+      "type": "sections",
+      "max_columns": 4,
+      "sections": [
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
+            {
+              "type": "heading",
+              "heading": "🚪 Garage door",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:garage"
+            },
+            {
+              "type": "custom:enhanced-shutter-card",
+              "grid_options": {
+                "columns": "full"
+              },
+              "entities": [
+                {
+                  "entity": "cover.garage_door_garage_door_2",
+                  "name": "Garage Door",
+                  "top_offset_pct": 13,
+                  "button_up_hide_states": [
+                    "open",
+                    "opening",
+                    "closing"
+                  ],
+                  "button_stop_hide_states": [
+                    "open",
+                    "closed",
+                    "partial_open"
+                  ],
+                  "button_down_hide_states": [
+                    "closed",
+                    "opening",
+                    "closing"
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "cover.garage_door_garage_door_2",
+                  "name": "State",
+                  "icon": "mdi:garage"
+                },
+                {
+                  "type": "tile",
+                  "entity": "light.garage_door_garage_door_light",
+                  "name": "Garage light",
+                  "icon": "mdi:lightbulb"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.garage_door_hcpbridge_connected",
+                  "name": "HCP bridge",
+                  "icon": "mdi:connection"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.garage_door_garage_door_relay_state",
+                  "name": "Relay",
+                  "icon": "mdi:electric-switch"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "button.garage_door_garage_door_vent",
+                  "name": "Vent",
+                  "icon": "mdi:fan"
+                },
+                {
+                  "type": "tile",
+                  "entity": "button.garage_door_garage_door_half",
+                  "name": "Half open",
+                  "icon": "mdi:arrow-split-horizontal"
+                },
+                {
+                  "type": "tile",
+                  "entity": "button.garage_door_garage_door_impulse",
+                  "name": "Impulse",
+                  "icon": "mdi:flash"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "📷 Outdoor cameras",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:cctv"
+            },
+            {
+              "type": "grid",
+              "columns": 3,
+              "square": false,
+              "cards": [
+                {
+                  "type": "picture-entity",
+                  "entity": "camera.g5_turret_ultra_high_resolution_channel",
+                  "camera_image": "camera.g5_turret_ultra_high_resolution_channel",
+                  "camera_view": "auto",
+                  "name": "Driveway",
+                  "show_name": true,
+                  "aspect_ratio": "16:9"
+                },
+                {
+                  "type": "picture-entity",
+                  "entity": "camera.back_door_camera",
+                  "camera_image": "camera.back_door_camera",
+                  "camera_view": "auto",
+                  "name": "Back door",
+                  "show_name": true,
+                  "aspect_ratio": "16:9"
+                },
+                {
+                  "type": "picture-entity",
+                  "entity": "camera.g4_instant_high_resolution_channel",
+                  "camera_image": "camera.g4_instant_high_resolution_channel",
+                  "camera_view": "auto",
+                  "name": "Garage",
+                  "show_name": true,
+                  "aspect_ratio": "16:9"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "🚶 Motion",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:motion-sensor"
+            },
+            {
+              "type": "grid",
+              "columns": 4,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.g5_turret_ultra_motion",
+                  "name": "Driveway",
+                  "icon": "mdi:motion-sensor"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.g4_instant_motion",
+                  "name": "Garage",
+                  "icon": "mdi:motion-sensor"
+                },
+                {
+                  "type": "tile",
+                  "entity": "binary_sensor.g8t1_9401_3255_0m5u_motion",
+                  "name": "Front room",
+                  "icon": "mdi:motion-sensor"
+                },
+                {
+                  "type": "tile",
+                  "entity": "event.back_door_camera_motion",
+                  "name": "Back door (last event)",
+                  "icon": "mdi:motion-sensor"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            },
+            {
+              "type": "heading",
+              "heading": "🔔 Alarm",
+              "heading_style": "title",
+              "grid_options": {
+                "columns": "full"
+              },
+              "icon": "mdi:shield-alert"
+            },
+            {
+              "type": "grid",
+              "columns": 1,
+              "square": false,
+              "cards": [
+                {
+                  "type": "tile",
+                  "entity": "alarm_control_panel.blink_panel",
+                  "name": "Blink hub"
+                }
+              ],
+              "grid_options": {
+                "columns": "full"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Demo mode now ships the seven sanitised Lovelace dashboards bundled under `terrazzo-core/src/androidMain/resources/dashboards/<slug>/`, so a fresh install renders the same boards the preview suite (#97) already covers. Refresh cadence drops from 2 s to once a minute, with per-minute drift on numeric sensors so the dashboard visibly ticks without burning battery.

## Sanitisation

Two passes:

1. **First pass** — `homeassistant-agents/_sanitize.py` (already published). Redacts IPs / MACs / lat-lon / tokens / sensitive attribute keys. Output is what gets committed in `homeassistant-agents/dashboards/`.

2. **Second pass** — `terrazzo-core/scripts/scrub-demo-dashboards.py` (added by this PR). Re-keys *serial-shaped tokens* inside entity ids and friendly names — Bambu printer SNs, UniFi camera channels, Meshcore node ids, Blink panel ids, Octopus meter ids — into stable readable pseudonyms (`sn1`, `sn2`, …) so a Play-Store-published app doesn't carry the user's real device serials. Network ids / region ids / device ids / config-entry ids are redacted outright. Script is idempotent and re-runnable:

   ```sh
   python3 terrazzo-core/scripts/scrub-demo-dashboards.py \
       --src ~/workspace/homeassistant-agents/dashboards \
       --dst terrazzo-core/src/androidMain/resources/dashboards
   ```

The output is checked in alongside the script so reviewers can see exactly what ships.

## Drift model

`DemoData.snapshot(nowMs)` derives values from the minute-bucket of `nowMs`:

- **Numeric sensors** get a small sinusoidal offset keyed by entity id and minute. Amplitudes are device-class-aware (battery ±1 %, humidity ±1.5 %, temperature ±0.4 °C, power ~8 % + 5 W, …) and clamped to plausible ranges (humidity ∈ 0..100, pressure ≥ 900, …).
- **Lights** flip on an 8-minute cadence with per-entity phase, switches on 15-minute cadence — fast enough to see, slow enough not to feel jittery.
- **Entity-id set never changes** across snapshots so pinned widgets keep their id-to-slot mappings.

Two snapshots inside the same minute return identical state strings (no flicker on dashboard re-poll); two snapshots a minute apart show movement.

## Tests

- `DemoDataTest` moves off pinned synthetic ids (the old test asserted `sensor.living_room` etc. existed) and asserts behaviour: snapshot grows past 200 entities, drift differs across minutes, drift is stable *within* a minute, humidity stays in 0..100, entity-id set is shape-stable, temperature sensors keep `unit_of_measurement`.
- `DemoHaSessionTest` clock threading now steps by 5 minutes (was 30 s) to match the new cadence.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests "*.session.Demo*"` — 13 tests pass
- [x] `./gradlew :app:assembleDebug` — green
- [x] No HA-derived data leaks: `grep -rE "REDACTED_IP|0309ba430700293|22e8bj5b2200526|fa27efd5b4|20m1132325|1200028620880" terrazzo-core/src/androidMain/resources/` returns only one harmless friendly-name placeholder ("Garage Remote connection to REDACTED_IP" — the IP itself is gone).

## Follow-ups

- Re-running `scrub-demo-dashboards.py` against an updated `homeassistant-agents` snapshot (when a new dashboard is added or sensors get re-keyed upstream) is the only step needed to refresh the demo data; could automate via a Renovate-style PR if useful.
- The `friendly_name` of one networks entity still reads "Garage Remote connection to REDACTED_IP". Could either sub `REDACTED_IP` → `<network>` in the second-pass scrubber, or leave it as-is (the placeholder is honest about the redaction).