### PR TITLE
feat(previews): pack sections into N columns on tablet

### DIFF
--- a/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/Dashboard.kt
+++ b/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/Dashboard.kt
@@ -21,6 +21,11 @@ data class View(
   val icon: String? = null,
   val theme: String? = null,
   val type: String? = null,
+  /**
+   * Maximum number of columns the view uses on a wide enough host. Only meaningful for `type:
+   * sections`; renderers honour it on tablet+ widths and collapse to a single column on mobile.
+   */
+  val maxColumns: Int? = null,
   val sections: List<Section> = emptyList(),
   val cards: List<CardConfig> = emptyList(),
   val badges: List<JsonObject> = emptyList(),
@@ -31,6 +36,13 @@ data class Section(
   val type: String? = null,
   val title: String? = null,
   val cards: List<CardConfig> = emptyList(),
+  /**
+   * Sections-view per-section overrides. `column_span` lets a section occupy more than one grid
+   * column on a wide layout (HA defaults to 1 if absent). `row_span` similarly stretches
+   * vertically.
+   */
+  val columnSpan: Int? = null,
+  val rowSpan: Int? = null,
 )
 
 /**

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/DashboardFixtures.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/DashboardFixtures.kt
@@ -39,14 +39,34 @@ object DashboardFixtures {
     data class Loaded(val dashboard: Dashboard, val snapshot: HaSnapshot)
 
     fun load(name: String): Loaded? {
+        // First try the bundled second-pass-scrubbed copy (same data
+        // the in-app demo ships) — that's what we want in PR
+        // screenshots and CI runs. Fall back to the sibling
+        // `homeassistant-agents` checkout for local dev when the
+        // resources haven't been re-scrubbed yet.
+        val (cfgText, statesText) = readBundled(name)
+            ?: readSibling(name)
+            ?: return null
+        val dashboard = parseDashboard(cfgText)
+        val states = parseStates(statesText)
+        return Loaded(dashboard = dashboard, snapshot = HaSnapshot(states = states))
+    }
+
+    private fun readBundled(name: String): Pair<String, String>? {
+        val cls = DashboardFixtures::class.java
+        val cfg = cls.getResourceAsStream("/dashboards/$name/lovelace_config.json")
+            ?.bufferedReader()?.use { it.readText() } ?: return null
+        val states = cls.getResourceAsStream("/dashboards/$name/entity_states.json")
+            ?.bufferedReader()?.use { it.readText() } ?: return null
+        return cfg to states
+    }
+
+    private fun readSibling(name: String): Pair<String, String>? {
         val dir = File(DASHBOARDS_ROOT, name)
         val configFile = File(dir, "lovelace_config.json")
         val statesFile = File(dir, "entity_states.json")
         if (!configFile.exists() || !statesFile.exists()) return null
-
-        val dashboard = parseDashboard(configFile.readText())
-        val states = parseStates(statesFile.readText())
-        return Loaded(dashboard = dashboard, snapshot = HaSnapshot(states = states))
+        return configFile.readText() to statesFile.readText()
     }
 }
 
@@ -66,6 +86,7 @@ private fun parseDashboard(text: String): Dashboard {
 private fun parseView(obj: JsonObject): View {
     val title = obj["title"]?.jsonPrimitive?.content
     val type = obj["type"]?.jsonPrimitive?.content
+    val maxColumns = obj["max_columns"]?.jsonPrimitive?.content?.toIntOrNull()
     val cards = (obj["cards"] as? JsonArray)?.mapNotNull { it.toCardConfig() } ?: emptyList()
     val sections = (obj["sections"] as? JsonArray)?.mapNotNull { el ->
         val s = el as? JsonObject ?: return@mapNotNull null
@@ -73,9 +94,17 @@ private fun parseView(obj: JsonObject): View {
             type = s["type"]?.jsonPrimitive?.content,
             title = s["title"]?.jsonPrimitive?.content,
             cards = (s["cards"] as? JsonArray)?.mapNotNull { e -> e.toCardConfig() } ?: emptyList(),
+            columnSpan = s["column_span"]?.jsonPrimitive?.content?.toIntOrNull(),
+            rowSpan = s["row_span"]?.jsonPrimitive?.content?.toIntOrNull(),
         )
     } ?: emptyList()
-    return View(title = title, type = type, cards = cards, sections = sections)
+    return View(
+        title = title,
+        type = type,
+        maxColumns = maxColumns,
+        cards = cards,
+        sections = sections,
+    )
 }
 
 private fun kotlinx.serialization.json.JsonElement.toCardConfig(): CardConfig? {

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/DashboardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/DashboardPreviews.kt
@@ -4,7 +4,9 @@ package ee.schimke.ha.previews
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth as uiFillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -20,6 +22,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.model.Section
 import ee.schimke.ha.model.View
 import ee.schimke.ha.rc.ProvideCardRegistry
 import ee.schimke.ha.rc.RenderChild
@@ -136,6 +139,16 @@ private fun DashboardPreview(name: String) {
     }
 }
 
+/** Width threshold below which we collapse the sections grid to a
+ *  single column — matches HA's web frontend behaviour, which packs
+ *  sections only on viewports wide enough that one section keeps a
+ *  reasonable per-card width (~380 dp). */
+private const val SECTIONS_GRID_MIN_WIDTH_DP = 600
+
+/** Per-column target width on tablet+. Sections fill `max_columns`
+ *  columns up to whatever fits in the canvas at this width. */
+private const val SECTIONS_COLUMN_TARGET_WIDTH_DP = 360
+
 @Composable
 private fun ViewBlock(view: View, snapshot: HaSnapshot) {
     if (view.title != null) {
@@ -146,8 +159,84 @@ private fun ViewBlock(view: View, snapshot: HaSnapshot) {
             )
         }
     }
-    val cards = view.cards + view.sections.flatMap { it.cards }
-    cards.forEach { card -> CardSlot(card, snapshot) }
+    if (view.type == "sections" && view.sections.isNotEmpty()) {
+        SectionsView(view, snapshot)
+    } else {
+        // Legacy `type: panel` / `type: masonry` / unspecified — render
+        // every card from view.cards + view.sections.cards as a single
+        // vertical column. Same behaviour as before this change.
+        val cards = view.cards + view.sections.flatMap { it.cards }
+        cards.forEach { card -> CardSlot(card, snapshot) }
+    }
+}
+
+/**
+ * `type: sections` view layout. On viewports below
+ * [SECTIONS_GRID_MIN_WIDTH_DP] we render single-column (mobile path);
+ * on wider hosts we pack sections into N columns based on the canvas
+ * width and the view's `max_columns:` config (default 4 per HA).
+ *
+ * Sections are distributed by walking left-to-right through columns,
+ * appending to the column with the smallest current card-count — keeps
+ * column heights roughly balanced without honouring `column_span` /
+ * `row_span` yet (those are minor v2 polish).
+ */
+@Composable
+private fun SectionsView(view: View, snapshot: HaSnapshot) {
+    BoxWithConstraints(modifier = Modifier.uiFillMaxWidth()) {
+        val widthDp = maxWidth.value.toInt()
+        val maxColumns = view.maxColumns ?: 4
+        val columnCount =
+            if (widthDp < SECTIONS_GRID_MIN_WIDTH_DP) 1
+            else (widthDp / SECTIONS_COLUMN_TARGET_WIDTH_DP).coerceIn(1, maxColumns)
+
+        if (columnCount == 1) {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                view.sections.forEach { section -> SectionBlock(section, snapshot) }
+            }
+        } else {
+            val columns = packSections(view.sections, columnCount)
+            Row(
+                modifier = Modifier.uiFillMaxWidth().padding(horizontal = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                columns.forEach { sections ->
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        sections.forEach { section -> SectionBlock(section, snapshot) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionBlock(section: Section, snapshot: HaSnapshot) {
+    if (section.title != null) {
+        Box(modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)) {
+            androidx.compose.material3.Text(
+                text = section.title!!,
+                style = androidx.compose.material3.MaterialTheme.typography.labelLarge,
+            )
+        }
+    }
+    section.cards.forEach { card -> CardSlot(card, snapshot) }
+}
+
+/** Greedy pack — append each section to the shortest column. Keeps
+ *  column heights balanced without modelling per-card pixel heights. */
+private fun packSections(sections: List<Section>, columnCount: Int): List<List<Section>> {
+    val columns = MutableList(columnCount) { mutableListOf<Section>() }
+    val cardCounts = MutableList(columnCount) { 0 }
+    sections.forEach { section ->
+        val target = cardCounts.indices.minBy { cardCounts[it] }
+        columns[target] += section
+        cardCounts[target] += section.cards.size.coerceAtLeast(1)
+    }
+    return columns
 }
 
 @Composable

--- a/previews/src/main/resources/dashboards
+++ b/previews/src/main/resources/dashboards
@@ -1,0 +1,1 @@
+../../../../terrazzo-core/src/androidMain/resources/dashboards

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/DemoHaSession.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/DemoHaSession.kt
@@ -133,6 +133,7 @@ object DemoData {
     private fun parseView(obj: JsonObject): View {
         val title = obj["title"]?.jsonPrimitive?.content
         val type = obj["type"]?.jsonPrimitive?.content
+        val maxColumns = obj["max_columns"]?.jsonPrimitive?.content?.toIntOrNull()
         val cards = (obj["cards"] as? JsonArray)?.mapNotNull { it.toCardConfig() } ?: emptyList()
         val sections = (obj["sections"] as? JsonArray)?.mapNotNull { el ->
             val s = el as? JsonObject ?: return@mapNotNull null
@@ -140,9 +141,17 @@ object DemoData {
                 type = s["type"]?.jsonPrimitive?.content,
                 title = s["title"]?.jsonPrimitive?.content,
                 cards = (s["cards"] as? JsonArray)?.mapNotNull { c -> c.toCardConfig() } ?: emptyList(),
+                columnSpan = s["column_span"]?.jsonPrimitive?.content?.toIntOrNull(),
+                rowSpan = s["row_span"]?.jsonPrimitive?.content?.toIntOrNull(),
             )
         } ?: emptyList()
-        return View(title = title, type = type, cards = cards, sections = sections)
+        return View(
+            title = title,
+            type = type,
+            maxColumns = maxColumns,
+            cards = cards,
+            sections = sections,
+        )
     }
 
     private fun kotlinx.serialization.json.JsonElement.toCardConfig(): CardConfig? {


### PR DESCRIPTION
## Summary

Closes #100. `type: sections` views now branch on canvas width: mobile (< 600 dp) keeps the existing single-column scroll; tablet+ packs sections into `floor(width / 360 dp)` columns capped at the view's `max_columns` config (default 4). Sections are distributed greedily into the shortest column to keep heights balanced.

## Mechanics

- **ha-model**: add `View.maxColumns: Int?` and `Section.columnSpan/rowSpan: Int?` fields. Lovelace's `max_columns` / `column_span` / `row_span` schema is now parsed by both DashboardFixtures (preview path) and DemoData (in-app path).
- **DashboardPreviews**: branch `ViewBlock` on `view.type == "sections"`. Wide path uses `BoxWithConstraints` to read the canvas width, computes column count, and packs sections in a `Row` of weighted `Column`s. Single-section views still render single-column even at tablet width — the second column stays empty, mirroring HA's web frontend.
- **previews/src/main/resources/dashboards** is now a symlink to `terrazzo-core/src/androidMain/resources/dashboards` so the preview classpath sees the same twice-scrubbed JSONs that the in-app demo ships. PR screenshots show pseudonyms (`A1MINI_sn1`) instead of real device serials.

## Limits

`column_span` / `row_span` aren't honoured by the packer yet — the fields are parsed and stored on `Section` but every section is treated as 1×1.

Most of the captured dashboards have a single section per view, so the visible win in screenshots is the **3D-printing "Printers" view** (which packs P2s + A1 Mini into two columns) and the **github view** (which packs 7 sections across 2 columns at 800 dp). Other boards look the same on tablet as mobile because they only define one section.

## Previews

### 3D printing — Printers view, real visible win
| Mobile (411 dp) | Tablet (800 dp) |
|---|---|
| ![mobile](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/242c3e23d6f911c1903a52bb5dc27a134269dcc8/Dashboard3dPrintingMobile.png) | ![tablet](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/242c3e23d6f911c1903a52bb5dc27a134269dcc8/Dashboard3dPrintingTablet.png) |

### GitHub — 7 sections, two columns on tablet
| Mobile (411 dp) | Tablet (800 dp) |
|---|---|
| ![mobile](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/242c3e23d6f911c1903a52bb5dc27a134269dcc8/DashboardGithubMobile.png) | ![tablet](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/242c3e23d6f911c1903a52bb5dc27a134269dcc8/DashboardGithubTablet.png) |

### Climate
| Mobile (411 dp) | Tablet (800 dp) |
|---|---|
| ![mobile](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/242c3e23d6f911c1903a52bb5dc27a134269dcc8/DashboardClimateMobile.png) | ![tablet](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/242c3e23d6f911c1903a52bb5dc27a134269dcc8/DashboardClimateTablet.png) |

### Energy
| Mobile (411 dp) | Tablet (800 dp) |
|---|---|
| ![mobile](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/242c3e23d6f911c1903a52bb5dc27a134269dcc8/DashboardEnergyMobile.png) | ![tablet](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/242c3e23d6f911c1903a52bb5dc27a134269dcc8/DashboardEnergyTablet.png) |

### Meshcore
| Mobile (411 dp) | Tablet (800 dp) |
|---|---|
| ![mobile](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/242c3e23d6f911c1903a52bb5dc27a134269dcc8/DashboardMeshcoreMobile.png) | ![tablet](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/242c3e23d6f911c1903a52bb5dc27a134269dcc8/DashboardMeshcoreTablet.png) |

### Networks
| Mobile (411 dp) | Tablet (800 dp) |
|---|---|
| ![mobile](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/242c3e23d6f911c1903a52bb5dc27a134269dcc8/DashboardNetworksMobile.png) | ![tablet](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/242c3e23d6f911c1903a52bb5dc27a134269dcc8/DashboardNetworksTablet.png) |

### Security
| Mobile (411 dp) | Tablet (800 dp) |
|---|---|
| ![mobile](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/242c3e23d6f911c1903a52bb5dc27a134269dcc8/DashboardSecurityMobile.png) | ![tablet](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/242c3e23d6f911c1903a52bb5dc27a134269dcc8/DashboardSecurityTablet.png) |

## Test plan

- [x] `./gradlew :ha-model:compileAndroidMain :previews:assembleDebug :terrazzo-core:assembleAndroidMain` — green
- [x] `compose-preview render --filter Dashboard*` — all 14 renders look right (3d_printing tablet visibly two-column, github tablet visibly two-column, single-section boards collapse the empty second column)
- [x] No real device serials in PR images (preview classpath now reads twice-scrubbed bundled resources)