### PR TITLE
feat(todo-list): wire row taps to todo.update_item

### DIFF
--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
@@ -370,8 +370,17 @@ data class HaMediaControlData(
 /** `todo-list` card model — title + active/completed item rows. */
 data class HaTodoListData(
     val title: RemoteString,
-    val activeItems: List<RemoteString>,
-    val completedItems: List<RemoteString>,
+    val activeItems: List<HaTodoItem>,
+    val completedItems: List<HaTodoItem>,
+)
+
+/** One row in a [HaTodoListData]. The [tapAction] flips the item's
+ *  status via `todo.update_item`; players that don't carry a service
+ *  channel back to HA will leave the row visually unchanged after a
+ *  tap (no optimistic update). */
+data class HaTodoItem(
+    val summary: RemoteString,
+    val tapAction: HaAction = HaAction.None,
 )
 
 /** `picture` card model — a static `image:` URL with an optional name

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaTodoList.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaTodoList.kt
@@ -15,6 +15,7 @@ import androidx.compose.remote.creation.compose.layout.RemoteText
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.background
 import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clickable
 import androidx.compose.remote.creation.compose.modifier.clip
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
 import androidx.compose.remote.creation.compose.modifier.padding
@@ -67,6 +68,7 @@ fun RemoteHaTodoList(data: HaTodoListData, modifier: RemoteModifier = RemoteModi
                 Section("Completed", theme)
                 data.completedItems.forEach { Row(it, completed = true, theme = theme) }
             }
+            // Note: an empty stub when both sections empty.
             if (data.activeItems.isEmpty() && data.completedItems.isEmpty()) {
                 RemoteText(
                     text = "No items".rs,
@@ -91,21 +93,26 @@ private fun Section(label: String, theme: HaTheme) {
 }
 
 @Composable
-private fun Row(label: androidx.compose.remote.creation.compose.state.RemoteString, completed: Boolean, theme: HaTheme) {
+private fun Row(item: HaTodoItem, completed: Boolean, theme: HaTheme) {
+    val click = item.tapAction.toRemoteAction()
+        ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
     RemoteRow(
-        modifier = RemoteModifier.fillMaxWidth().padding(vertical = 4.rdp),
+        modifier = RemoteModifier
+            .then(click)
+            .fillMaxWidth()
+            .padding(vertical = 4.rdp),
         verticalAlignment = RemoteAlignment.CenterVertically,
     ) {
         RemoteIcon(
             imageVector = if (completed) Icons.Filled.CheckBox
             else Icons.Outlined.CheckBoxOutlineBlank,
-            contentDescription = label,
+            contentDescription = item.summary,
             modifier = RemoteModifier.size(18.rdp),
             tint = if (completed) theme.placeholderAccent.rc else theme.secondaryText.rc,
         )
         RemoteBox(modifier = RemoteModifier.padding(start = 10.rdp)) {
             RemoteText(
-                text = label,
+                text = item.summary,
                 color = if (completed) theme.secondaryText.rc else theme.primaryText.rc,
                 fontSize = 13.rsp,
                 style = RemoteTextStyle.Default,

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/TodoListCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/TodoListCardConverter.kt
@@ -7,29 +7,29 @@ import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.components.HaAction
+import ee.schimke.ha.rc.components.HaTodoItem
 import ee.schimke.ha.rc.components.HaTodoListData
 import ee.schimke.ha.rc.components.RemoteHaTodoList
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * `todo-list` card. HA carries todo items in the entity's `items`
  * attribute (each item: {summary, status: needs_action | completed}).
- * The converter splits them into active and completed sections; mutating
- * items via `todo.update_item` is a follow-up.
+ * Tapping a row fires `todo.update_item` with the entity id, the
+ * item's summary as the lookup key, and the *flipped* status. Players
+ * without a service-call channel will leave the row visually
+ * unchanged after a tap (no in-document optimistic flip yet — would
+ * need a MutableRemoteString per item, follow-up).
  */
 class TodoListCardConverter : CardConverter {
     override val cardType: String = CardTypes.TODO_LIST
 
-    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int {
-        val entityId = card.raw["entity"]?.jsonPrimitive?.content ?: return 120
-        val items = ((card.raw["entity"]?.jsonPrimitive?.content
-            ?.let { id -> emptyList<Any>() }) ?: emptyList<Any>())
-        // Without a snapshot at compute time we estimate generously.
-        return 200
-    }
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 220
 
     @Composable
     override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
@@ -41,22 +41,54 @@ class TodoListCardConverter : CardConverter {
             ?: "To-do list"
 
         val items = entity?.attributes?.get("items") as? JsonArray ?: JsonArray(emptyList())
-        val active = mutableListOf<String>()
-        val completed = mutableListOf<String>()
+        val active = mutableListOf<HaTodoItem>()
+        val completed = mutableListOf<HaTodoItem>()
         items.forEach { el ->
             val obj = el as? JsonObject ?: return@forEach
             val summary = obj["summary"]?.jsonPrimitive?.content ?: return@forEach
             val status = obj["status"]?.jsonPrimitive?.content
-            if (status == "completed") completed += summary else active += summary
+            val isCompleted = status == "completed"
+            val tap = updateItemAction(entityId, summary, isCompleted)
+            val item = HaTodoItem(summary = summary.rs, tapAction = tap)
+            if (isCompleted) completed += item else active += item
         }
 
         RemoteHaTodoList(
             HaTodoListData(
                 title = title.rs,
-                activeItems = active.map { it.rs },
-                completedItems = completed.map { it.rs },
+                activeItems = active,
+                completedItems = completed,
             ),
             modifier = modifier,
         )
     }
+}
+
+/**
+ * Build the `todo.update_item` call-service action for one row. The
+ * service signature on the HA side is:
+ *
+ *   service: todo.update_item
+ *   target:  { entity_id }
+ *   data:    { item: <summary>, status: needs_action | completed }
+ *
+ * The `item:` field is a positional lookup — todo entities address
+ * items by their visible summary, not by an opaque id.
+ */
+private fun updateItemAction(
+    entityId: String?,
+    summary: String,
+    currentlyCompleted: Boolean,
+): HaAction {
+    if (entityId == null) return HaAction.None
+    val newStatus = if (currentlyCompleted) "needs_action" else "completed"
+    return HaAction.CallService(
+        domain = "todo",
+        service = "update_item",
+        entityId = entityId,
+        serviceData = buildJsonObject {
+            put("item", JsonPrimitive(summary))
+            put("status", JsonPrimitive(newStatus))
+        },
+    )
 }


### PR DESCRIPTION
Closes #107.

The todo-list card's checkbox rows now fire `todo.update_item` with the entity id, the item's summary as the positional lookup key, and the *flipped* status (`needs_action` ↔ `completed`) so a player connected to HA toggles the item server-side.

## Implementation
- `HaTodoItem(summary, tapAction)` replaces the bare `RemoteString` in `HaTodoListData.activeItems` / `completedItems`. The renderer attaches `tapAction.toRemoteAction()` as a clickable on each row.
- `TodoListCardConverter` builds the action: `domain=todo`, `service=update_item`, `target=entity_id`, `data={ item: <summary>, status: <flipped> }`.

## Limit

No optimistic in-document flip yet — players without a service channel back to HA leave the row unchanged after a tap. Adding a per-item `MutableRemoteString` that the click writes to (mirroring `RemoteHaToggleButton`) would let widgets show immediate feedback; that's the natural follow-up if pinned-widget interaction is in scope.

## Test plan
- [x] `./gradlew :rc-components:compileDebugKotlin :rc-converter:compileDebugKotlin :previews:assembleDebug` — green
- [x] `compose-preview render TodoList_Light/Dark` — visual unchanged (the click action is metadata in the `.rc` document, not pixels)