### PR TITLE
feat(arc-dial): draw target-position marker dot on the 270° sweep

### DIFF
--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaArcDial.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaArcDial.kt
@@ -52,10 +52,10 @@ import androidx.wear.compose.remote.material3.RemoteIcon
  * ```
  *
  * The arc starts at 135° (top-left), sweeps clockwise 270° to 45°
- * (top-right). The fill represents [HaArcDialData.valueFraction]; the
- * target appears as text in [HaArcDialData.supportingLabel] (drawing a
- * marker dot at an arbitrary angle requires scalar trig that
- * RemoteFloat doesn't expose at capture time — follow-up).
+ * (top-right). The fill represents [HaArcDialData.valueFraction]; when
+ * [HaArcDialData.targetFraction] is set, a small marker dot is drawn
+ * on the arc at that fraction (rendered as a near-zero-sweep arc with
+ * a round stroke cap, which avoids capture-time trig on RemoteFloat).
  */
 @Composable
 @RemoteComposable
@@ -179,6 +179,19 @@ private fun ArcCanvas(data: HaArcDialData, theme: HaTheme) {
                 color = data.accent.toArgb()
             }.asRemotePaint()
             drawArc(fill, 135f.rf, sweep.rf, false, topLeft, arcSize)
+        }
+
+        val target = data.targetFraction
+        if (target != null) {
+            val markerAngle = 135f + 270f * target.coerceIn(0f, 1f)
+            val marker = AndroidPaint().apply {
+                isAntiAlias = true
+                style = AndroidPaint.Style.STROKE
+                strokeWidth = 14f
+                strokeCap = AndroidPaint.Cap.ROUND
+                color = theme.primaryText.toArgb()
+            }.asRemotePaint()
+            drawArc(marker, markerAngle.rf, 0.1f.rf, false, topLeft, arcSize)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Renders a marker dot on the 270° arc at `HaArcDialData.targetFraction` (thermostat / humidifier setpoints), replacing the text-only target indicator on the arc itself.
- Implemented as a near-zero-sweep `drawArc` with `Cap.ROUND`, so no capture-time trig on `RemoteFloat` is needed.
- Uses `theme.primaryText` for a subtle read against the accent value-fill.

Closes #102.

## Test plan
- [ ] `./gradlew :rc-components:compileDebugKotlin` (passes locally)
- [ ] `./gradlew :rc-components:ktfmtCheck` (passes locally)
- [ ] Visual check: thermostat / humidifier cards show a dot at the setpoint angle; light card (no `targetFraction`) is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjukMVHcoNFzPweAV1t9Js)_