### PR TITLE
fix(previews): freeze clock card time so preview diffs are stable

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
@@ -91,7 +91,7 @@ import java.time.ZonedDateTime
  * deterministic — the visual diff would otherwise drift each minute.
  */
 private val PreviewNow: ZonedDateTime =
-    ZonedDateTime.of(2026, 5, 5, 13, 42, 0, 0, ZoneOffset.UTC)
+    ZonedDateTime.of(2026, 5, 5, 10, 8, 0, 0, ZoneOffset.UTC)
 
 @Composable
 private fun CardHost(theme: HaTheme, content: @Composable () -> Unit) {

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
@@ -12,17 +12,21 @@ import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
 import androidx.compose.remote.tooling.preview.RemotePreview
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.LocalPreviewClock
 import ee.schimke.ha.rc.ProvideCardRegistry
 import ee.schimke.ha.rc.RenderChild
 import ee.schimke.ha.rc.androidXExperimental
 import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.components.HaTheme
 import ee.schimke.ha.rc.components.ProvideHaTheme
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
 
 /**
  * Previews for every card type.
@@ -81,11 +85,21 @@ import ee.schimke.ha.rc.components.ProvideHaTheme
  * state.
  */
 
+/**
+ * Frozen "now" so any converter that would otherwise read wall-clock
+ * time (clock card today) encodes a static label. Keeps preview PNGs
+ * deterministic — the visual diff would otherwise drift each minute.
+ */
+private val PreviewNow: ZonedDateTime =
+    ZonedDateTime.of(2026, 5, 5, 13, 42, 0, 0, ZoneOffset.UTC)
+
 @Composable
 private fun CardHost(theme: HaTheme, content: @Composable () -> Unit) {
     RemotePreview(profile = androidXExperimental) {
-        ProvideCardRegistry(defaultRegistry()) {
-            ProvideHaTheme(theme) { content() }
+        CompositionLocalProvider(LocalPreviewClock provides PreviewNow) {
+            ProvideCardRegistry(defaultRegistry()) {
+                ProvideHaTheme(theme) { content() }
+            }
         }
     }
 }
@@ -375,8 +389,10 @@ private fun PlayerSlot(
 ) {
     Box(modifier = Modifier.uiFillMaxWidth().height(heightDp.dp)) {
         RemotePreview(profile = androidXExperimental) {
-            ProvideCardRegistry(defaultRegistry()) {
-                ProvideHaTheme(theme) { content() }
+            CompositionLocalProvider(LocalPreviewClock provides PreviewNow) {
+                ProvideCardRegistry(defaultRegistry()) {
+                    ProvideHaTheme(theme) { content() }
+                }
             }
         }
     }
@@ -618,9 +634,11 @@ private fun lightCardConfig() = card(
 
 // ——— clock ———
 //
-// The default render path binds RemoteTimeDefaults.defaultTimeString,
-// so the rendered PNG is whatever wall-clock time the Robolectric
-// host reports — that's expected (live-ticking by design).
+// Production binds RemoteTimeDefaults.defaultTimeString so the player
+// ticks the time once a minute without a re-encode. Previews install
+// a frozen LocalPreviewClock via CardHost, which forces the converter
+// onto its static-label path — the rendered PNG always shows the same
+// time so the screenshot diff stays meaningful.
 
 @Preview(name = "clock (light)", showBackground = false, widthDp = 200, heightDp = 100)
 @Composable

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/LocalCardRegistry.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/LocalCardRegistry.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.staticCompositionLocalOf
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.HaSnapshot
+import java.time.ZonedDateTime
 
 /**
  * Composition local that lets stack / grid / conditional cards recurse
@@ -18,6 +19,15 @@ import ee.schimke.ha.model.HaSnapshot
 val LocalCardRegistry = staticCompositionLocalOf<CardRegistry> {
     error("No CardRegistry in scope — wrap with ProvideCardRegistry { }.")
 }
+
+/**
+ * Composition local for a frozen "now" used by converters that would
+ * otherwise read wall-clock time (clock card today; relative-time
+ * formatters in the future). When non-null, converters must encode a
+ * static label derived from this instant so the resulting `.rc`
+ * document is deterministic — required for preview screenshot diffs.
+ */
+val LocalPreviewClock = staticCompositionLocalOf<ZonedDateTime?> { null }
 
 @Composable
 fun ProvideCardRegistry(registry: CardRegistry, content: @Composable () -> Unit) {

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ClockCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ClockCardConverter.kt
@@ -7,9 +7,11 @@ import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.LocalPreviewClock
 import ee.schimke.ha.rc.components.HaClockData
 import ee.schimke.ha.rc.components.RemoteHaClock
 import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -41,25 +43,27 @@ class ClockCardConverter : CardConverter {
         val showSeconds = card.raw["show_seconds"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: false
         val timeFmt = card.raw["time_format"]?.jsonPrimitive?.content
 
-        // Live-ticking path: no time_zone override, no show_seconds.
-        // Use RemoteTimeDefaults via the composable; pass null label.
-        val canTick = tz == null && !showSeconds
+        // Live-ticking path: no time_zone override, no show_seconds, no
+        // preview-clock override. When a preview clock is in scope the
+        // rendered document must be deterministic, so fall back to the
+        // static-label encoding.
+        val previewNow = LocalPreviewClock.current
+        val canTick = tz == null && !showSeconds && previewNow == null
         val use24Hour = timeFmt != "12"
 
-        // Static fallback for time-zone / seconds variants.
+        // Static fallback for time-zone / seconds / preview variants.
         val staticLabel = if (canTick) null else run {
             val pattern = when {
                 timeFmt == "12" -> if (showSeconds) "h:mm:ss a" else "h:mm a"
                 else -> if (showSeconds) "HH:mm:ss" else "HH:mm"
             }
-            val now = java.time.ZonedDateTime.now(tz ?: ZoneId.systemDefault())
+            val now = clockNow(tz, previewNow)
             now.format(DateTimeFormatter.ofPattern(pattern))
         }
 
         val display = card.raw["display"]?.jsonPrimitive?.content ?: "primary"
         val secondaryLabel = if (display == "primary" || display == null) {
-            java.time.ZonedDateTime.now(tz ?: ZoneId.systemDefault())
-                .format(DateTimeFormatter.ofPattern("EEE d MMM"))
+            clockNow(tz, previewNow).format(DateTimeFormatter.ofPattern("EEE d MMM"))
         } else null
         val size = card.raw["clock_size"]?.jsonPrimitive?.content
         val isLarge = size == "large" || size == "medium"
@@ -75,4 +79,9 @@ class ClockCardConverter : CardConverter {
             modifier = modifier,
         )
     }
+}
+
+private fun clockNow(tz: ZoneId?, previewNow: ZonedDateTime?): ZonedDateTime {
+    val zone = tz ?: previewNow?.zone ?: ZoneId.systemDefault()
+    return previewNow?.withZoneSameInstant(zone) ?: ZonedDateTime.now(zone)
 }


### PR DESCRIPTION
## Summary

The clock converter reads wall-clock time — `RemoteTimeDefaults.defaultTimeString` for the time text and `ZonedDateTime.now()` for the date label — so every preview render produced a different PNG and the screenshot diff drifted minute-to-minute (see #99).

- New `LocalPreviewClock` CompositionLocal in `rc-converter`. Default `null`; production leaves it unset and keeps the live-ticking path.
- `ClockCardConverter` consults the local: when present, it forces the static-label encoding off the supplied instant for both the time text and the secondary date.
- `CardHost` / `PlayerSlot` in `previews/CardPreviews.kt` install a fixed instant (`2026-05-05T13:42 UTC`), matching the existing fixture base time.

Closes #99.

## Test plan

- [ ] Preview-baselines CI regenerates `Clock_Light` / `Clock_Dark` PNGs at the frozen time.
- [ ] Re-running the preview render produces byte-identical Clock PNGs.
- [ ] Production widget / dashboard render still ticks live (no `LocalPreviewClock` provider in app code).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XSZ6wXN7xSnxt9yio9Y85L)_