### PR TITLE
Implement absolute positioning for picture-elements card

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
@@ -807,9 +807,12 @@ fun PictureElements_Dark() = CardHost(HaTheme.Dark) {
 private fun pictureElementsCardConfig() = card(
     """{"type":"picture-elements","image":"/local/floorplan.png",
         "elements":[
-          {"type":"state-icon","entity":"light.living_room_lamp"},
-          {"type":"state-icon","entity":"cover.living_room_blinds"},
-          {"type":"state-label","entity":"light.living_room_lamp"},
+          {"type":"state-icon","entity":"light.living_room_lamp",
+           "style":{"left":"22%","top":"30%"}},
+          {"type":"state-icon","entity":"cover.living_room_blinds",
+           "style":{"left":"68%","top":"22%"}},
+          {"type":"state-label","entity":"light.living_room_lamp",
+           "style":{"left":"30%","top":"55%"}},
           {"type":"service-button","title":"All off",
            "tap_action":{"action":"call-service","service":"light.turn_off","target":{"entity_id":"light.living_room_lamp"}}}
         ]}""",

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
@@ -413,30 +413,45 @@ data class HaPictureGlanceCell(
 )
 
 /** `picture-elements` card model — image with arbitrarily-positioned
- *  elements. We don't render the precise positions yet; v1 emits the
- *  elements as a strip below the image so all data shows. */
+ *  elements. Positioned children are overlaid on the placeholder at
+ *  their `(top, left)` fractions; elements without position metadata
+ *  fall back to a strip across the bottom of the canvas. */
 data class HaPictureElementsData(
     val captionUrl: RemoteString?,
     val placeholderIcon: ImageVector,
     val elements: List<HaPictureElement>,
 )
 
+/** Optional fractional placement of a [HaPictureElement] on the
+ *  picture-elements canvas. Both axes are 0f..1f (HA's `style.top` /
+ *  `style.left` percentages parsed into fractions). When null the
+ *  element falls back to the strip-below layout. */
+data class HaPictureElementPosition(
+    val leftFraction: Float,
+    val topFraction: Float,
+)
+
 sealed interface HaPictureElement {
+    val position: HaPictureElementPosition?
+
     data class StateIcon(
         val icon: ImageVector,
         val accent: Color,
         val isActive: Boolean,
         val tapAction: HaAction,
+        override val position: HaPictureElementPosition? = null,
     ) : HaPictureElement
 
     data class StateLabel(
         val text: RemoteString,
+        override val position: HaPictureElementPosition? = null,
     ) : HaPictureElement
 
     data class ServiceButton(
         val label: RemoteString,
         val accent: Color,
         val tapAction: HaAction,
+        override val position: HaPictureElementPosition? = null,
     ) : HaPictureElement
 }
 

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaPicture.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaPicture.kt
@@ -181,11 +181,19 @@ private fun Cell(cell: HaPictureGlanceCell, theme: HaTheme) {
     }
 }
 
+// HA's `style.top` / `style.left` are CSS percentages of the
+// parent's box. RC has no fraction-based offset, so we lock the
+// picture-elements canvas to a fixed dp size and convert percent →
+// dp at encode time. 360x180 matches `naturalHeightDp` and the
+// preview width; hosts that resize the card will see elements
+// pinned to the top-left of this canvas rather than scaling.
+private const val PICTURE_ELEMENTS_CANVAS_W_DP = 360
+private const val PICTURE_ELEMENTS_CANVAS_H_DP = 180
+
 /**
- * `picture-elements` card — image plus a list of elements. v1 lays the
- * elements out as a chip strip below the image; precise XY positioning
- * needs absolute placement that RC's RemoteBox parent doesn't expose
- * cleanly (follow-up).
+ * `picture-elements` card — image with elements overlaid at the
+ * `(top%, left%)` positions HA configures. Elements without a
+ * position fall back to a strip at the bottom of the canvas.
  */
 @Composable
 @RemoteComposable
@@ -194,52 +202,68 @@ fun RemoteHaPictureElements(
     modifier: RemoteModifier = RemoteModifier,
 ) {
     val theme = haTheme()
+    val (positioned, unpositioned) = data.elements.partition { it.position != null }
     RemoteBox(
         modifier = modifier
             .fillMaxWidth()
+            .height(PICTURE_ELEMENTS_CANVAS_H_DP.rdp)
             .clip(RemoteRoundedCornerShape(12.rdp))
-            .background(theme.cardBackground.rc)
+            .background(theme.divider.rc)
             .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp)),
+        contentAlignment = RemoteAlignment.TopStart,
     ) {
-        RemoteColumn {
-            RemoteBox(
+        RemoteBox(
+            modifier = RemoteModifier
+                .fillMaxWidth()
+                .height(PICTURE_ELEMENTS_CANVAS_H_DP.rdp),
+            contentAlignment = RemoteAlignment.Center,
+        ) {
+            RemoteIcon(
+                imageVector = data.placeholderIcon,
+                contentDescription = "elements".rs,
+                modifier = RemoteModifier.size(40.rdp),
+                tint = theme.placeholderAccent.rc,
+            )
+        }
+        positioned.forEach { element ->
+            val pos = element.position!!
+            val leftDp = (pos.leftFraction * PICTURE_ELEMENTS_CANVAS_W_DP).toInt().coerceAtLeast(0)
+            val topDp = (pos.topFraction * PICTURE_ELEMENTS_CANVAS_H_DP).toInt().coerceAtLeast(0)
+            Element(
+                element = element,
+                theme = theme,
+                modifier = RemoteModifier.padding(start = leftDp.rdp, top = topDp.rdp),
+            )
+        }
+        if (unpositioned.isNotEmpty()) {
+            RemoteRow(
                 modifier = RemoteModifier
+                    .padding(top = (PICTURE_ELEMENTS_CANVAS_H_DP - 44).rdp)
                     .fillMaxWidth()
-                    .height(120.rdp)
-                    .background(theme.divider.rc),
-                contentAlignment = RemoteAlignment.Center,
+                    .background(theme.cardBackground.rc.copy(alpha = theme.cardBackground.rc.alpha * 0.85f.rf))
+                    .padding(horizontal = 10.rdp, vertical = 8.rdp),
+                horizontalArrangement = RemoteArrangement.spacedBy(8.rdp, RemoteAlignment.Start),
+                verticalAlignment = RemoteAlignment.CenterVertically,
             ) {
-                RemoteIcon(
-                    imageVector = data.placeholderIcon,
-                    contentDescription = "elements".rs,
-                    modifier = RemoteModifier.size(40.rdp),
-                    tint = theme.placeholderAccent.rc,
-                )
-            }
-            if (data.elements.isNotEmpty()) {
-                RemoteRow(
-                    modifier = RemoteModifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 10.rdp, vertical = 8.rdp),
-                    horizontalArrangement = RemoteArrangement.spacedBy(8.rdp, RemoteAlignment.Start),
-                    verticalAlignment = RemoteAlignment.CenterVertically,
-                ) {
-                    data.elements.forEach { Element(it, theme) }
-                }
+                unpositioned.forEach { Element(it, theme) }
             }
         }
     }
 }
 
 @Composable
-private fun Element(element: HaPictureElement, theme: HaTheme) {
+private fun Element(
+    element: HaPictureElement,
+    theme: HaTheme,
+    modifier: RemoteModifier = RemoteModifier,
+) {
     when (element) {
         is HaPictureElement.StateIcon -> {
             val click = element.tapAction.toRemoteAction()
                 ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
             val accent = element.accent.rc
             RemoteBox(
-                modifier = RemoteModifier.then(click)
+                modifier = modifier.then(click)
                     .size(28.rdp)
                     .clip(RemoteCircleShape)
                     .background(
@@ -264,6 +288,7 @@ private fun Element(element: HaPictureElement, theme: HaTheme) {
                 style = RemoteTextStyle.Default,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
+                modifier = modifier,
             )
         }
         is HaPictureElement.ServiceButton -> {
@@ -271,7 +296,7 @@ private fun Element(element: HaPictureElement, theme: HaTheme) {
                 ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
             val accent = element.accent.rc
             RemoteBox(
-                modifier = RemoteModifier.then(click)
+                modifier = modifier.then(click)
                     .clip(RemoteRoundedCornerShape(6.rdp))
                     .border(1.rdp, accent, RemoteRoundedCornerShape(6.rdp))
                     .padding(horizontal = 10.rdp, vertical = 6.rdp),

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/PictureElementsCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/PictureElementsCardConverter.kt
@@ -12,6 +12,7 @@ import ee.schimke.ha.rc.CardConverter
 import ee.schimke.ha.rc.HaStateColor
 import ee.schimke.ha.rc.components.HaAction
 import ee.schimke.ha.rc.components.HaPictureElement
+import ee.schimke.ha.rc.components.HaPictureElementPosition
 import ee.schimke.ha.rc.components.HaPictureElementsData
 import ee.schimke.ha.rc.components.RemoteHaPictureElements
 import ee.schimke.ha.rc.defaultTapActionFor
@@ -27,9 +28,11 @@ import kotlinx.serialization.json.jsonPrimitive
 /**
  * `picture-elements` card. Each element in the config has a `type:` —
  * we map state-icon / state-label / service-button / icon into the
- * corresponding [HaPictureElement] variant. Position metadata
- * (`style.top`, `style.left`) is parsed but not rendered yet — v1 lays
- * everything out as a chip strip below the image.
+ * corresponding [HaPictureElement] variant. `style.top` / `style.left`
+ * percentages are parsed into a [HaPictureElementPosition] so the
+ * renderer can overlay each element at its configured spot on the
+ * placeholder; elements without position metadata fall back to the
+ * strip across the bottom.
  */
 class PictureElementsCardConverter : CardConverter {
     override val cardType: String = CardTypes.PICTURE_ELEMENTS
@@ -59,20 +62,26 @@ private fun mapElement(obj: JsonObject, snapshot: HaSnapshot): HaPictureElement?
     val type = obj["type"]?.jsonPrimitive?.content ?: return null
     val entityId = obj["entity"]?.jsonPrimitive?.content
     val entity = entityId?.let { snapshot.states[it] }
+    val position = parsePosition(obj)
     return when (type) {
         "state-icon", "icon" -> HaPictureElement.StateIcon(
             icon = HaIconMap.resolve(obj["icon"]?.jsonPrimitive?.content, entity),
             accent = HaStateColor.activeFor(entity),
             isActive = entity?.state == "on" || entity?.state == "open",
             tapAction = parseTap(obj, entityId),
+            position = position,
         )
-        "state-label" -> HaPictureElement.StateLabel(text = formatState(entity).rs)
+        "state-label" -> HaPictureElement.StateLabel(
+            text = formatState(entity).rs,
+            position = position,
+        )
         "service-button" -> {
             val title = obj["title"]?.jsonPrimitive?.content ?: "Action"
             HaPictureElement.ServiceButton(
                 label = title.rs,
                 accent = androidx.compose.ui.graphics.Color(0xFF1565C0),
                 tapAction = parseTap(obj, entityId),
+                position = position,
             )
         }
         else -> null
@@ -83,4 +92,17 @@ private fun parseTap(obj: JsonObject, defaultEntity: String?): HaAction {
     val tapCfg = obj["tap_action"]?.jsonObject
     if (tapCfg != null) return parseHaAction(tapCfg, defaultEntity)
     return defaultTapActionFor(defaultEntity)
+}
+
+private fun parsePosition(obj: JsonObject): HaPictureElementPosition? {
+    val style = obj["style"] as? JsonObject ?: return null
+    val left = style["left"]?.jsonPrimitive?.content?.let(::parsePercent) ?: return null
+    val top = style["top"]?.jsonPrimitive?.content?.let(::parsePercent) ?: return null
+    return HaPictureElementPosition(leftFraction = left, topFraction = top)
+}
+
+private fun parsePercent(raw: String): Float? {
+    val trimmed = raw.trim().removeSuffix("%").trim()
+    val value = trimmed.toFloatOrNull() ?: return null
+    return (value / 100f).coerceIn(0f, 1f)
 }


### PR DESCRIPTION
## Summary
Implement support for absolute positioning of elements in the `picture-elements` card using Home Assistant's `style.top` and `style.left` CSS percentages. Elements with position metadata are now overlaid at their configured coordinates on a fixed canvas, while unpositioned elements fall back to a strip layout at the bottom.

## Key Changes

- **Canvas-based positioning**: Introduced fixed 360x180 dp canvas size that matches the preview width and `naturalHeightDp`, converting HA's percentage-based positioning to dp offsets at render time
- **Position parsing**: Added `HaPictureElementPosition` model to store fractional (0f..1f) left/top coordinates parsed from HA's `style.left`/`style.top` percentage strings
- **Dual layout strategy**: 
  - Positioned elements are rendered as overlays using `RemoteBox` with padding-based offsets
  - Unpositioned elements fall back to a horizontal strip at the bottom of the canvas with semi-transparent background
- **Model updates**: Extended `HaPictureElement` sealed interface with optional `position` property across all variants (StateIcon, StateLabel, ServiceButton)
- **Converter logic**: Implemented `parsePosition()` and `parsePercent()` functions to extract and normalize position metadata from card configuration JSON
- **Preview updates**: Added position metadata to preview card configuration to demonstrate the new positioning feature

## Implementation Details

- Elements are positioned relative to a fixed canvas rather than scaling with card resizing, keeping them pinned to the top-left of the 360x180 dp reference frame
- Position values are coerced to 0f..1f range to handle edge cases
- The unpositioned strip uses semi-transparent card background (85% alpha) to distinguish it from positioned overlays
- All positioned elements use `RemoteModifier.padding()` for offset application, maintaining consistency with RC's layout system

https://claude.ai/code/session_01XrFsHhMozL3zWZFQRzrCJU