### PR TITLE
Add bar chart and stacked bar support to statistics-graph card

### DIFF
--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
@@ -321,13 +321,15 @@ data class HaClockData(
 )
 
 /** `statistics-graph` card model — mirrors history-graph, just with
- *  pre-aggregated mean values from HA's `recorder.statistics_during_period`.
- *  [chartType] defaults to "line"; bar mode is a follow-up. */
+ *  pre-aggregated values from HA's `recorder.statistics_during_period`.
+ *  [chartType] is "line" or "bar"; [stacked] only applies to bar mode
+ *  and stacks the entity contributions per bucket (HA's `stack: true`). */
 data class HaStatisticsGraphData(
     val title: RemoteString?,
     val rangeLabel: RemoteString,
     val rows: List<HaHistoryGraphRow>,
     val chartType: String = "line",
+    val stacked: Boolean = false,
 )
 
 /** `alarm-panel` card model — title, status badge, ARM AWAY/HOME

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaStatisticsGraph.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaStatisticsGraph.kt
@@ -2,16 +2,51 @@
 
 package ee.schimke.ha.rc.components
 
+import android.graphics.Paint as AndroidPaint
+import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteCanvas
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
 import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteOffset
+import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteSize
+import androidx.compose.remote.creation.compose.layout.RemoteText
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.height
+import androidx.compose.remote.creation.compose.modifier.padding
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.asRemotePaint
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rf
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.text.RemoteTextStyle
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 
 /**
- * `statistics-graph` card — same visual shape as the history-graph
- * sparkline (one row per entity, chrome + range label + small line
- * graph). Implemented as a thin shim over [RemoteHaHistoryGraph]; if
- * the visual diverges later (axes, multi-series fill, bar mode) split
- * into its own canvas pass.
+ * `statistics-graph` card. Three visual modes:
+ *
+ *  - line (default) — one sparkline per row, identical to history-graph.
+ *  - bar — one bar per bucket per row, drawn as filled rects.
+ *  - stacked bar (only when [HaStatisticsGraphData.stacked]) — a single
+ *    combined canvas where each bucket is the sum of all rows, with
+ *    each row contributing a coloured segment. Rows whose lengths
+ *    differ are aligned to the longest series; missing samples count
+ *    as zero.
+ *
+ * Stacking only makes sense for non-negative sums (e.g. power per
+ * room); negative values render below the baseline at their own offset
+ * which matches HA's behaviour.
  */
 @Composable
 @RemoteComposable
@@ -19,12 +54,239 @@ fun RemoteHaStatisticsGraph(
     data: HaStatisticsGraphData,
     modifier: RemoteModifier = RemoteModifier,
 ) {
-    RemoteHaHistoryGraph(
-        HaHistoryGraphData(
-            title = data.title,
-            rangeLabel = data.rangeLabel,
-            rows = data.rows,
-        ),
-        modifier = modifier,
-    )
+    if (data.chartType != "bar") {
+        RemoteHaHistoryGraph(
+            HaHistoryGraphData(
+                title = data.title,
+                rangeLabel = data.rangeLabel,
+                rows = data.rows,
+            ),
+            modifier = modifier,
+        )
+        return
+    }
+
+    val theme = haTheme()
+    RemoteBox(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(horizontal = 14.rdp, vertical = 10.rdp),
+    ) {
+        RemoteColumn(verticalArrangement = RemoteArrangement.spacedBy(6.rdp)) {
+            if (data.title != null) {
+                RemoteText(
+                    text = data.title,
+                    color = theme.primaryText.rc,
+                    fontSize = 15.rsp,
+                    fontWeight = FontWeight.Medium,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            RemoteText(
+                text = data.rangeLabel,
+                color = theme.secondaryText.rc,
+                fontSize = 11.rsp,
+                style = RemoteTextStyle.Default,
+            )
+            if (data.rows.isEmpty()) {
+                RemoteText(
+                    text = "No entities".rs,
+                    color = theme.secondaryText.rc,
+                    fontSize = 13.rsp,
+                    style = RemoteTextStyle.Default,
+                )
+            } else if (data.stacked) {
+                StackedBars(data.rows, theme)
+                data.rows.forEach { row -> Legend(row, theme) }
+            } else {
+                data.rows.forEach { row -> BarRow(row, theme) }
+            }
+        }
+    }
 }
+
+@Composable
+private fun BarRow(row: HaHistoryGraphRow, theme: HaTheme) {
+    RemoteRow(
+        modifier = RemoteModifier.fillMaxWidth(),
+        verticalAlignment = RemoteAlignment.CenterVertically,
+        horizontalArrangement = RemoteArrangement.SpaceBetween,
+    ) {
+        RemoteText(
+            text = row.name,
+            color = theme.primaryText.rc,
+            fontSize = 12.rsp,
+            fontWeight = FontWeight.Medium,
+            style = RemoteTextStyle.Default,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        RemoteText(
+            text = row.summary,
+            color = theme.secondaryText.rc,
+            fontSize = 11.rsp,
+            style = RemoteTextStyle.Default,
+            maxLines = 1,
+        )
+    }
+    if (row.points.isEmpty()) {
+        RemoteText(
+            text = "No samples".rs,
+            color = theme.secondaryText.rc,
+            fontSize = 11.rsp,
+            style = RemoteTextStyle.Default,
+        )
+    } else {
+        Bars(row.points, row.accent, theme)
+    }
+}
+
+@Composable
+private fun Legend(row: HaHistoryGraphRow, theme: HaTheme) {
+    RemoteRow(
+        modifier = RemoteModifier.fillMaxWidth(),
+        verticalAlignment = RemoteAlignment.CenterVertically,
+        horizontalArrangement = RemoteArrangement.SpaceBetween,
+    ) {
+        RemoteRow(verticalAlignment = RemoteAlignment.CenterVertically) {
+            RemoteBox(
+                modifier = RemoteModifier
+                    .height(10.rdp)
+                    .clip(RemoteRoundedCornerShape(2.rdp))
+                    .background(row.accent.rc)
+                    .padding(horizontal = 5.rdp),
+            ) {}
+            RemoteText(
+                text = row.name,
+                color = theme.primaryText.rc,
+                fontSize = 11.rsp,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = RemoteModifier.padding(start = 6.rdp),
+            )
+        }
+        RemoteText(
+            text = row.summary,
+            color = theme.secondaryText.rc,
+            fontSize = 11.rsp,
+            style = RemoteTextStyle.Default,
+            maxLines = 1,
+        )
+    }
+}
+
+@Composable
+private fun Bars(points: List<Float>, accent: Color, theme: HaTheme) {
+    val minP = points.min()
+    val maxP = points.max()
+    // Anchor bars to zero when all values are non-negative; otherwise
+    // anchor at the row minimum so negative-only series still fill the
+    // canvas instead of collapsing to a single line.
+    val base = if (minP >= 0f) 0f else minP
+    val span = (maxP - base).takeIf { it > 0f } ?: 1f
+    val n = points.size
+    RemoteCanvas(modifier = RemoteModifier.fillMaxWidth().height(28.rdp)) {
+        val w = width
+        val h = height
+        val padX = 2f.rf
+        val padY = 3f.rf
+        val drawW = w - padX * 2f.rf
+        val drawH = h - padY * 2f.rf
+
+        val baseline = AndroidPaint().apply {
+            isAntiAlias = true
+            style = AndroidPaint.Style.STROKE
+            strokeWidth = 1f
+            color = theme.divider.toArgb()
+        }.asRemotePaint()
+        drawLine(
+            baseline,
+            RemoteOffset(padX, padY + drawH),
+            RemoteOffset(padX + drawW, padY + drawH),
+        )
+
+        val fill = AndroidPaint().apply {
+            isAntiAlias = true
+            style = AndroidPaint.Style.FILL
+            color = accent.toArgb()
+        }.asRemotePaint()
+
+        val slot = drawW / n.toFloat().rf
+        val barWidth = slot * 0.7f.rf
+        val gap = (slot - barWidth) * 0.5f.rf
+        for (i in 0 until n) {
+            val x0 = padX + slot * i.toFloat().rf + gap
+            val barHeight = drawH * ((points[i] - base) / span).rf
+            val y0 = padY + drawH - barHeight
+            drawRect(fill, RemoteOffset(x0, y0), RemoteSize(barWidth, barHeight))
+        }
+    }
+}
+
+@Composable
+private fun StackedBars(rows: List<HaHistoryGraphRow>, theme: HaTheme) {
+    val n = rows.maxOf { it.points.size }
+    val totals = FloatArray(n)
+    for (i in 0 until n) {
+        totals[i] = rows.sumOf { row ->
+            (row.points.getOrNull(i) ?: 0f).coerceAtLeast(0f).toDouble()
+        }.toFloat()
+    }
+    val maxTotal = totals.maxOrNull()?.takeIf { it > 0f } ?: 1f
+
+    RemoteCanvas(modifier = RemoteModifier.fillMaxWidth().height(64.rdp)) {
+        val w = width
+        val h = height
+        val padX = 2f.rf
+        val padY = 3f.rf
+        val drawW = w - padX * 2f.rf
+        val drawH = h - padY * 2f.rf
+
+        val baseline = AndroidPaint().apply {
+            isAntiAlias = true
+            style = AndroidPaint.Style.STROKE
+            strokeWidth = 1f
+            color = theme.divider.toArgb()
+        }.asRemotePaint()
+        drawLine(
+            baseline,
+            RemoteOffset(padX, padY + drawH),
+            RemoteOffset(padX + drawW, padY + drawH),
+        )
+
+        val slot = drawW / n.toFloat().rf
+        val barWidth = slot * 0.75f.rf
+        val gap = (slot - barWidth) * 0.5f.rf
+
+        for (i in 0 until n) {
+            val x0 = padX + slot * i.toFloat().rf + gap
+            var cumulative = 0f
+            for (row in rows) {
+                val v = (row.points.getOrNull(i) ?: 0f).coerceAtLeast(0f)
+                if (v <= 0f) continue
+                val segTop = padY + drawH * (1f - (cumulative + v) / maxTotal).rf
+                val segHeight = drawH * (v / maxTotal).rf
+                val fill = AndroidPaint().apply {
+                    isAntiAlias = true
+                    style = AndroidPaint.Style.FILL
+                    color = row.accent.toArgb()
+                }.asRemotePaint()
+                drawRect(fill, RemoteOffset(x0, segTop), RemoteSize(barWidth, segHeight))
+                cumulative += v
+            }
+        }
+    }
+}
+
+private fun Color.toArgb(): Int = android.graphics.Color.argb(
+    (alpha * 255f).toInt(),
+    (red * 255f).toInt(),
+    (green * 255f).toInt(),
+    (blue * 255f).toInt(),
+)

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/StatisticsGraphCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/StatisticsGraphCardConverter.kt
@@ -15,21 +15,25 @@ import ee.schimke.ha.rc.components.RemoteHaStatisticsGraph
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
- * `statistics-graph` card — same visual as history-graph but reads
- * pre-aggregated `mean` values from `HaSnapshot.statistics`. HA's
- * `chart_type: bar` and `stat_types` fan-out aren't visualised yet
- * (would need a per-bucket rect pass); the textual summary still
- * conveys range and sample count.
+ * `statistics-graph` card — mirrors history-graph but reads
+ * pre-aggregated values from `HaSnapshot.statistics`.
+ *
+ * Supports HA's `stat_types` fan-out: each declared stat (`mean`, `min`,
+ * `max`, `sum`, `state`) becomes its own row per entity, picking the
+ * matching field on [StatisticPoint]. `chart_type: bar` and the
+ * `stack: true` modifier are forwarded to the renderer; absent
+ * `stat_types` defaults to `[mean]`.
  */
 class StatisticsGraphCardConverter : CardConverter {
     override val cardType: String = CardTypes.STATISTICS_GRAPH
 
     override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int {
-        val rows = entityIds(card).size.coerceAtLeast(1)
+        val rows = (entityIds(card).size * statTypes(card).size).coerceAtLeast(1)
         val title = if (card.raw["title"] != null) 24 else 0
         return title + 16 + 52 * rows + 20
     }
@@ -39,19 +43,24 @@ class StatisticsGraphCardConverter : CardConverter {
         val title = card.raw["title"]?.jsonPrimitive?.content
         val period = card.raw["period"]?.jsonPrimitive?.content ?: "hour"
         val ids = entityIds(card)
+        val stats = statTypes(card)
         val chartType = card.raw["chart_type"]?.jsonPrimitive?.content ?: "line"
+        val stacked = card.raw["stack"]?.jsonPrimitive?.booleanOrNull == true && chartType == "bar"
 
-        val rows = ids.map { id ->
+        val rows = ids.flatMap { id ->
             val entity = snapshot.states[id]
-            val name = entity?.attributes?.get("friendly_name")?.jsonPrimitive?.content ?: id
+            val baseName = entity?.attributes?.get("friendly_name")?.jsonPrimitive?.content ?: id
             val statistics = snapshot.statistics[id].orEmpty()
-            val numeric = statistics.mapNotNull { it.mean?.toFloat() ?: it.state?.toFloat() }
-            HaHistoryGraphRow(
-                name = name.rs,
-                summary = summariseStatistics(statistics).rs,
-                accent = HaStateColor.activeFor(entity),
-                points = numeric,
-            )
+            stats.map { statType ->
+                val numeric = statistics.mapNotNull { selectStat(it, statType)?.toFloat() }
+                val rowName = if (stats.size > 1) "$baseName · $statType" else baseName
+                HaHistoryGraphRow(
+                    name = rowName.rs,
+                    summary = summariseStatistics(statistics, statType).rs,
+                    accent = HaStateColor.activeFor(entity),
+                    points = numeric,
+                )
+            }
         }
 
         RemoteHaStatisticsGraph(
@@ -60,15 +69,25 @@ class StatisticsGraphCardConverter : CardConverter {
                 rangeLabel = "Period: $period".rs,
                 rows = rows,
                 chartType = chartType,
+                stacked = stacked,
             ),
             modifier = modifier,
         )
     }
 }
 
-private fun summariseStatistics(points: List<StatisticPoint>): String {
+private fun selectStat(point: StatisticPoint, statType: String): Double? = when (statType) {
+    "mean" -> point.mean
+    "min" -> point.min
+    "max" -> point.max
+    "sum" -> point.sum
+    "state" -> point.state
+    else -> point.mean
+}
+
+private fun summariseStatistics(points: List<StatisticPoint>, statType: String): String {
     if (points.isEmpty()) return "no data"
-    val numeric = points.mapNotNull { it.mean ?: it.state }
+    val numeric = points.mapNotNull { selectStat(it, statType) }
     if (numeric.isEmpty()) return "${points.size} buckets"
     val min = numeric.min()
     val max = numeric.max()
@@ -76,6 +95,12 @@ private fun summariseStatistics(points: List<StatisticPoint>): String {
         if (d == d.toLong().toDouble()) d.toLong().toString() else "%.1f".format(d)
     }
     return "${fmt(min)} – ${fmt(max)} (${points.size})"
+}
+
+private fun statTypes(card: CardConfig): List<String> {
+    val arr = card.raw["stat_types"]?.jsonArray
+    val parsed = arr?.mapNotNull { (it as? JsonPrimitive)?.content }.orEmpty()
+    return parsed.ifEmpty { listOf("mean") }
 }
 
 private fun entityIds(card: CardConfig): List<String> {


### PR DESCRIPTION
## Summary
Extends the `statistics-graph` card renderer to support bar and stacked bar chart types, along with multi-stat fan-out via `stat_types` configuration. Previously, the card only rendered as a line graph (sparkline) regardless of HA's `chart_type` setting.

## Key Changes

- **Bar chart rendering**: Implemented `Bars()` composable that renders individual bar charts per entity row, with automatic baseline anchoring (zero for non-negative values, minimum for negative-only series)
- **Stacked bar chart rendering**: Added `StackedBars()` composable that combines all entity rows into a single canvas where each bucket shows the sum of all rows with color-coded segments per entity
- **Multi-stat support**: Extended `StatisticsGraphCardConverter` to parse and handle `stat_types` configuration, allowing users to display `mean`, `min`, `max`, `sum`, or `state` statistics as separate rows per entity
- **Legend component**: Added `Legend()` composable for stacked bar mode to identify which color represents which entity
- **Dynamic height calculation**: Updated `naturalHeightDp()` to account for multiple stats per entity (rows multiply by stat count)
- **Configuration forwarding**: Added `chartType` and `stacked` fields to `HaStatisticsGraphData` model; `stacked` only applies when `chart_type: bar` and `stack: true` are set

## Implementation Details

- Bar width and spacing are calculated proportionally to canvas width (70% bar, 30% gap)
- Stacked bars use 75% bar width with automatic cumulative height calculation
- Negative values in stacked mode are filtered out (coerced to zero) to match HA's behavior
- Missing data points in multi-stat rows are handled gracefully (treated as zero in stacked mode)
- Line chart mode (default) delegates to existing `RemoteHaHistoryGraph` for backward compatibility
- Color conversion utility `Color.toArgb()` added for Android Paint compatibility

https://claude.ai/code/session_01DJac9swydHTgoi2ePftCdR