### PR TITLE
Refactor release workflows to support workflow_call pattern

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -8,13 +8,18 @@ on:
       tag:
         description: 'Tag to build (e.g. v0.1.1)'
         required: true
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g. v0.1.1)'
+        required: true
+        type: string
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 concurrency:
-  group: release-${{ github.ref_name }}
+  group: release-${{ inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 # Required secrets:
@@ -28,6 +33,9 @@ jobs:
     name: Build & publish release
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: write
+      packages: write
     env:
       TAG_NAME: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag }}
       HAS_SIGNING_KEYSTORE: ${{ secrets.SIGNING_KEYSTORE != '' }}
@@ -94,7 +102,7 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Attach assets to GitHub release
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_call'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.TAG_NAME }}
@@ -107,7 +115,7 @@ jobs:
             _release/*.aab
 
       - name: Upload workflow artifact
-        if: github.event_name != 'push'
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v7
         with:
           name: release-${{ steps.stage.outputs.version }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,13 +1,18 @@
 name: Release Please
 
+# Maintains a release PR from conventional-commit history. When merged,
+# release-please cuts the tag + GitHub Release, then this workflow calls
+# release-build.yml via workflow_call to build and publish artifacts.
+# This bypasses the GITHUB_TOKEN recursion guard that otherwise prevents
+# tag-push events from triggering downstream workflows.
+
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: release-please
@@ -17,6 +22,12 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v5
         id: release
@@ -24,3 +35,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
+
+  release:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/release-build.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}
+    secrets: inherit
+    permissions:
+      contents: write
+      packages: write


### PR DESCRIPTION
## Summary
Restructured the release workflow to use GitHub's `workflow_call` pattern, enabling `release-please` to trigger the build and publish workflow while bypassing the GITHUB_TOKEN recursion guard that prevents tag-push events from triggering downstream workflows.

## Key Changes

- **release-please.yml**
  - Added explanatory comment documenting the workflow_call pattern and recursion guard bypass
  - Moved `contents: write` and `pull-requests: write` permissions from workflow-level to job-level for the `release-please` job
  - Changed workflow-level permissions to `contents: read` (least privilege)
  - Added job outputs to expose `release_created` and `tag_name` from the release-please action
  - Added new `release` job that conditionally calls `release-build.yml` via `workflow_call` when a release is created
  - The `release` job passes the tag name and inherits secrets for downstream authentication

- **release-build.yml**
  - Added `workflow_call` trigger alongside existing `workflow_dispatch` trigger
  - Added `tag` input parameter for `workflow_call` with type specification
  - Changed workflow-level permissions to `contents: read` (least privilege)
  - Moved `contents: write` and `packages: write` permissions to job-level for the `build` job
  - Updated concurrency group to use `inputs.tag` when available (for workflow_call) or `github.ref_name` (for manual dispatch)
  - Updated asset attachment condition to include `workflow_call` events
  - Updated artifact upload condition to only trigger on `workflow_dispatch` (not on `workflow_call`)

## Implementation Details

The refactoring follows the principle of least privilege by scoping permissions to only the jobs that require them. The workflow_call pattern allows `release-please` to directly trigger the build workflow after creating a release, avoiding the GitHub Actions limitation where tag-push events cannot trigger other workflows due to the GITHUB_TOKEN recursion guard.

https://claude.ai/code/session_015jnw6Y1i9MCcwqFaSz9sF6