### PR TITLE
Fix garage door visualization to animate from top

### DIFF
--- a/rc-card-shutter/src/main/kotlin/ee/schimke/ha/rc/cards/shutter/RemoteHaGarage.kt
+++ b/rc-card-shutter/src/main/kotlin/ee/schimke/ha/rc/cards/shutter/RemoteHaGarage.kt
@@ -149,11 +149,12 @@ private fun GarageEntry(entry: HaGarageEntryData) {
 }
 
 /**
- * Sectional garage door from the front. The frame holds a sky/exterior
- * background that's revealed as the door rises; the door panel is
- * bottom-anchored and shrinks as [closedFraction] decreases. Four
- * horizontal "panel" lines on the door read as a sectional residential
- * garage (vs a one-piece tilt-up).
+ * Sectional garage door from the front. The frame holds an interior
+ * backdrop that's revealed below the door as it rises into the ceiling
+ * track; the door panel is top-anchored and its visible portion shrinks
+ * from the bottom up as [closedFraction] decreases. Four horizontal
+ * "panel" lines on the door read as a sectional residential garage
+ * (vs a one-piece tilt-up).
  *
  * A motion arrow overlays the centre of the door when [motion] is
  * non-idle — chevron-up while opening, chevron-down while closing —
@@ -168,7 +169,8 @@ private fun GarageDoorVisualisation(closedFraction: Float, motion: GarageMotion)
     // window shutter frame so a side-by-side card lineup (window +
     // garage) reads as different fixtures, not the same one twice.
     val frame = if (theme.isDark) Color(0xFF3A3530) else Color(0xFFD9D2C5)
-    // Sky / interior backdrop visible above the door when open.
+    // Interior backdrop visible below the door when it's raised into
+    // the ceiling track.
     val sky = if (theme.isDark) Color(0xFF0F1B24) else Color(0xFFD8ECF6)
     // Door panel base. Slightly desaturated white-ish for residential.
     val door = if (theme.isDark) Color(0xFFB7B2A8) else Color(0xFFF1EDE3)
@@ -193,7 +195,7 @@ private fun GarageDoorVisualisation(closedFraction: Float, motion: GarageMotion)
             .clip(RemoteRoundedCornerShape(6.rdp))
             .background(sky.rc)
             .border(borderDp.rdp, frame.rc, RemoteRoundedCornerShape(6.rdp)),
-        contentAlignment = RemoteAlignment.BottomCenter,
+        contentAlignment = RemoteAlignment.TopCenter,
     ) {
         if (doorHeightDp > 0) {
             RemoteBox(


### PR DESCRIPTION
## Summary
Corrected the garage door animation behavior to properly represent a sectional garage door that retracts upward into the ceiling track, rather than rising from the bottom.

## Key Changes
- Updated `GarageDoorVisualisation` documentation to accurately describe the door mechanics: the door is now top-anchored and retracts upward into the ceiling track, with the interior backdrop visible below as it opens
- Changed `contentAlignment` from `RemoteAlignment.BottomCenter` to `RemoteAlignment.TopCenter` to anchor the door panel at the top of the frame
- Clarified variable naming context: the `sky` color variable now represents the interior backdrop visible below the raised door, rather than above it
- Updated all related documentation comments to reflect the corrected animation direction and visual behavior

## Implementation Details
The change ensures that as `closedFraction` decreases (door opening), the visible portion of the door shrinks from the bottom up, with the door panel anchored at the top. This properly simulates a sectional residential garage door retracting into an overhead ceiling track.

https://claude.ai/code/session_01LAUBG2QR6YcVKXAYFbJGrN