### PR TITLE
Add live time zone and seconds support to clock card

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
@@ -652,6 +652,26 @@ fun Clock_Dark() = CardHost(HaTheme.Dark) {
     RenderChild(clockCard(), Fixtures.mixed, RemoteModifier.fillMaxWidth())
 }
 
+@Preview(name = "clock (seconds)", showBackground = false, widthDp = 220, heightDp = 100)
+@Composable
+fun Clock_Seconds() = CardHost(HaTheme.Light) {
+    RenderChild(
+        card("""{"type":"clock","clock_size":"medium","time_format":"24","show_seconds":"true"}"""),
+        Fixtures.mixed,
+        RemoteModifier.fillMaxWidth(),
+    )
+}
+
+@Preview(name = "clock (zone)", showBackground = false, widthDp = 220, heightDp = 100)
+@Composable
+fun Clock_Zone() = CardHost(HaTheme.Light) {
+    RenderChild(
+        card("""{"type":"clock","clock_size":"medium","time_format":"24","time_zone":"America/Los_Angeles"}"""),
+        Fixtures.mixed,
+        RemoteModifier.fillMaxWidth(),
+    )
+}
+
 private fun clockCard() = card(
     """{"type":"clock","clock_size":"medium","time_format":"24"}""",
 )

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
@@ -311,13 +311,22 @@ data class HaArcDialData(
  *  `RemoteTimeDefaults.defaultTimeString` so the time text auto-ticks
  *  inside the playing document without re-encode. [staticTimeLabel]
  *  is an opt-in static override (kept for previews and for hosts that
- *  want a frozen capture). */
+ *  want a frozen capture).
+ *
+ *  When [zoneOffsetMinutes] is non-zero or [showSeconds] is true the
+ *  renderer composes a live RemoteString from `RemoteContext`'s
+ *  hour/minute/second floats so the player still ticks (no re-encode).
+ *  [zoneOffsetMinutes] is the static offset (target zone − host zone)
+ *  captured at encode time; DST transitions during playback fall to
+ *  the next host re-encode. */
 data class HaClockData(
     val title: RemoteString?,
     val staticTimeLabel: RemoteString?,
     val secondaryLabel: RemoteString?,
     val isLarge: Boolean,
     val use24Hour: Boolean,
+    val zoneOffsetMinutes: Int = 0,
+    val showSeconds: Boolean = false,
 )
 
 /** `statistics-graph` card model — mirrors history-graph, just with

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaClock.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaClock.kt
@@ -2,6 +2,7 @@
 
 package ee.schimke.ha.rc.components
 
+import androidx.compose.remote.core.RemoteContext
 import androidx.compose.remote.creation.compose.layout.RemoteAlignment
 import androidx.compose.remote.creation.compose.layout.RemoteArrangement
 import androidx.compose.remote.creation.compose.layout.RemoteBox
@@ -16,14 +17,20 @@ import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
 import androidx.compose.remote.creation.compose.modifier.padding
 import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
 import androidx.compose.remote.creation.compose.state.RemoteBoolean
+import androidx.compose.remote.creation.compose.state.RemoteFloat
+import androidx.compose.remote.creation.compose.state.RemoteString
+import androidx.compose.remote.creation.compose.state.floor
 import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rf
+import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.remote.creation.compose.state.rsp
 import androidx.compose.remote.creation.compose.text.RemoteTextStyle
 import androidx.compose.remote.creation.compose.text.RemoteTimeDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import java.text.DecimalFormat
 
 /**
  * `clock` card — local time text. The default path binds
@@ -31,6 +38,12 @@ import androidx.compose.ui.text.style.TextOverflow
  * time once a minute on the player without a re-encode round trip.
  * [HaClockData.staticTimeLabel] overrides for a frozen capture (used
  * by previews and any host that prefers snapshot-time text).
+ *
+ * `time_zone` / `show_seconds` overrides take a separate live path
+ * that builds the displayed `RemoteString` from the player's
+ * hour/minute/second floats (`RemoteContext.FLOAT_TIME_IN_*`) — same
+ * tick guarantee as the default, just with the offset and seconds
+ * baked into the formatting expression.
  */
 @Composable
 @RemoteComposable
@@ -60,9 +73,18 @@ fun RemoteHaClock(data: HaClockData, modifier: RemoteModifier = RemoteModifier) 
                     overflow = TextOverflow.Ellipsis,
                 )
             }
-            val timeText = data.staticTimeLabel ?: RemoteTimeDefaults.defaultTimeString(
-                is24HourFormat = if (data.use24Hour) RemoteBoolean(true) else RemoteTimeDefaults.is24HourFormat(),
-            )
+            val timeText = data.staticTimeLabel
+                ?: if (data.zoneOffsetMinutes != 0 || data.showSeconds) {
+                    liveClockTimeString(
+                        zoneOffsetMinutes = data.zoneOffsetMinutes,
+                        showSeconds = data.showSeconds,
+                        use24Hour = data.use24Hour,
+                    )
+                } else {
+                    RemoteTimeDefaults.defaultTimeString(
+                        is24HourFormat = if (data.use24Hour) RemoteBoolean(true) else RemoteTimeDefaults.is24HourFormat(),
+                    )
+                }
             RemoteText(
                 text = timeText,
                 color = theme.primaryText.rc,
@@ -83,4 +105,55 @@ fun RemoteHaClock(data: HaClockData, modifier: RemoteModifier = RemoteModifier) 
             }
         }
     }
+}
+
+private val twoDigits = DecimalFormat("00")
+private val oneDigit = DecimalFormat("0")
+
+/**
+ * Build a live time `RemoteString` from the player's hour/minute/second
+ * floats. Mirrors the shape of `RemoteTimeDefaults.defaultTimeString`
+ * but adds zone-offset shifting and an optional seconds component.
+ *
+ * `RemoteContext.FLOAT_TIME_IN_HR` is hour-of-day; `FLOAT_TIME_IN_MIN`
+ * and `FLOAT_TIME_IN_SEC` are minute / second since midnight, so the
+ * `% 60` reduces them to minute/second-of-the-current-unit. To shift
+ * into [zoneOffsetMinutes] (target zone − host zone) we recompose
+ * minute-of-day, add the offset, mod 1440, and re-split into hours
+ * and minutes.
+ */
+private fun liveClockTimeString(
+    zoneOffsetMinutes: Int,
+    showSeconds: Boolean,
+    use24Hour: Boolean,
+): RemoteString {
+    val hostHour = RemoteFloat(RemoteContext.FLOAT_TIME_IN_HR)
+    val hostMin = RemoteFloat(RemoteContext.FLOAT_TIME_IN_MIN).rem(60f)
+    val sec = RemoteFloat(RemoteContext.FLOAT_TIME_IN_SEC).rem(60f)
+
+    val (hour24, minute) = if (zoneOffsetMinutes == 0) {
+        hostHour to hostMin
+    } else {
+        // +1_440_000 keeps the modulo argument positive across any plausible
+        // zone offset before we wrap to minutes-of-day.
+        val totalMin = (hostHour * 60f + hostMin + (zoneOffsetMinutes + 1_440_000).toFloat()).rem(1440f)
+        floor(totalMin / 60f) to totalMin.rem(60f)
+    }
+
+    val hourText = if (use24Hour) {
+        hour24.toRemoteString(twoDigits)
+    } else {
+        // 12-hour clock: 0→12, 1..11→same, 12→12, 13..23→1..11.
+        val mod12 = hour24.rem(12f)
+        mod12.eq(0f.rf).select(12f.rf, mod12).toRemoteString(oneDigit)
+    }
+
+    var text: RemoteString = hourText + ":" + minute.toRemoteString(twoDigits)
+    if (showSeconds) {
+        text = text + ":" + sec.toRemoteString(twoDigits)
+    }
+    if (!use24Hour) {
+        text = text + " " + hour24.lt(12f.rf).select("AM".rs, "PM".rs)
+    }
+    return text
 }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ClockCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ClockCardConverter.kt
@@ -10,6 +10,7 @@ import ee.schimke.ha.rc.CardConverter
 import ee.schimke.ha.rc.LocalPreviewClock
 import ee.schimke.ha.rc.components.HaClockData
 import ee.schimke.ha.rc.components.RemoteHaClock
+import java.time.Instant
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
@@ -18,10 +19,14 @@ import kotlinx.serialization.json.jsonPrimitive
 /**
  * `clock` card — local time text. The default render binds
  * `RemoteTimeDefaults.defaultTimeString` so the player ticks the time
- * without a re-encode round trip. Configs that pin a specific time
- * zone or seconds-display drop back to a static encode-time label
- * because the bound RemoteString uses the host's locale-default
- * formatting (no per-card override path yet).
+ * without a re-encode round trip. Configs that pin `time_zone` or
+ * `show_seconds` switch to a per-field live path that composes the
+ * displayed string from the player's hour/minute/second floats — so
+ * those variants tick live too. The zone shift is captured at encode
+ * time; DST transitions during playback fall to the next re-encode.
+ *
+ * When [LocalPreviewClock] is in scope the converter encodes a static
+ * label instead, so preview PNGs stay deterministic across renders.
  */
 class ClockCardConverter : CardConverter {
     override val cardType: String = CardTypes.CLOCK
@@ -43,23 +48,27 @@ class ClockCardConverter : CardConverter {
         val showSeconds = card.raw["show_seconds"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: false
         val timeFmt = card.raw["time_format"]?.jsonPrimitive?.content
 
-        // Live-ticking path: no time_zone override, no show_seconds, no
-        // preview-clock override. When a preview clock is in scope the
-        // rendered document must be deterministic, so fall back to the
-        // static-label encoding.
         val previewNow = LocalPreviewClock.current
-        val canTick = tz == null && !showSeconds && previewNow == null
         val use24Hour = timeFmt != "12"
 
-        // Static fallback for time-zone / seconds / preview variants.
-        val staticLabel = if (canTick) null else run {
+        // Preview clock in scope → freeze to a static label so preview
+        // PNGs are stable. Otherwise the time_zone / show_seconds path
+        // ticks live via per-field RemoteFloat formatting in the
+        // composable; no override at all → defaultTimeString.
+        val staticLabel = if (previewNow != null) {
             val pattern = when {
                 timeFmt == "12" -> if (showSeconds) "h:mm:ss a" else "h:mm a"
                 else -> if (showSeconds) "HH:mm:ss" else "HH:mm"
             }
-            val now = clockNow(tz, previewNow)
-            now.format(DateTimeFormatter.ofPattern(pattern))
-        }
+            clockNow(tz, previewNow).format(DateTimeFormatter.ofPattern(pattern))
+        } else null
+
+        val zoneOffsetMinutes = if (tz != null) {
+            val now = Instant.now()
+            val target = tz.rules.getOffset(now).totalSeconds / 60
+            val host = ZoneId.systemDefault().rules.getOffset(now).totalSeconds / 60
+            target - host
+        } else 0
 
         val display = card.raw["display"]?.jsonPrimitive?.content ?: "primary"
         val secondaryLabel = if (display == "primary" || display == null) {
@@ -75,6 +84,8 @@ class ClockCardConverter : CardConverter {
                 secondaryLabel = secondaryLabel?.rs,
                 isLarge = isLarge,
                 use24Hour = use24Hour,
+                zoneOffsetMinutes = zoneOffsetMinutes,
+                showSeconds = showSeconds,
             ),
             modifier = modifier,
         )


### PR DESCRIPTION
## Summary
Enhanced the clock card to support live time zone offsets and seconds display without requiring static re-encoding. The renderer now composes time strings dynamically from the player's hour/minute/second floats, enabling real-time ticking even with timezone and seconds configurations.

## Key Changes
- **RemoteHaClock**: Added conditional logic to use a new `liveClockTimeString()` function when timezone offset or seconds display is configured, falling back to the default `RemoteTimeDefaults.defaultTimeString()` for the standard case
- **liveClockTimeString()**: New private function that builds a live `RemoteString` from `RemoteContext` float values (FLOAT_TIME_IN_HR, FLOAT_TIME_IN_MIN, FLOAT_TIME_IN_SEC) with support for:
  - Timezone offset shifting (target zone − host zone) calculated at encode time
  - Optional seconds component in the formatted output
  - Both 12-hour and 24-hour time formats with proper AM/PM handling
- **HaClockData**: Added two new fields:
  - `zoneOffsetMinutes: Int` — the static offset between target and host timezones
  - `showSeconds: Boolean` — flag to include seconds in the display
- **ClockCardConverter**: Refactored to compute timezone offset at encode time rather than generating static labels, enabling the live path in the composable
- **Previews**: Added two new preview variants (`Clock_Seconds` and `Clock_Zone`) to demonstrate the new functionality

## Implementation Details
- The timezone offset calculation uses modulo arithmetic with a +1,440,000 buffer to handle negative offsets safely before wrapping to minutes-of-day
- The 12-hour format conversion properly handles the edge case where hour 0 should display as 12
- Both variants maintain the same tick guarantee as the default path (no re-encode round trip per minute)
- DST transitions during playback will fall to the next host re-encode, as the offset is captured statically at encode time

https://claude.ai/code/session_01EMSMbiSe2zAgkfmWy5xMgR