### PR TITLE
Add CoilBitmapLoader for RemoteCompose named-bitmap resolution

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,9 @@ mockserver = "5.15.0"
 compose-preview-plugin = "0.10.0"
 tapmoc = "0.4.2"
 
+# Image loading (BitmapLoader / RemoteCompose named-bitmap resolution)
+coil = "3.4.0"
+
 # Formatting
 ktfmt-gradle = "0.26.0"
 
@@ -118,6 +121,13 @@ logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "lo
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
+
+# Coil 3 — image loading. Used by rc-image-coil to back the
+# RemoteCompose `BitmapLoader` for named-bitmap resolution. The
+# `coil` artifact pulls in the singleton + Android decoders; apps
+# wanting HTTP add `coil-network-okhttp` themselves.
+coil = { module = "io.coil-kt.coil3:coil", version.ref = "coil" }
+coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
 
 # Wear data layer (sync mobile ↔ watch). Horologist's data-layer
 # helpers ride on Google Play Services Wearable; both peers share a

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/ImagePreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/ImagePreviews.kt
@@ -1,0 +1,113 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.previews
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.height
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rs
+import androidx.compose.remote.tooling.preview.RemotePreview
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.layout.fillMaxWidth as uiFillMaxWidth
+import androidx.compose.foundation.layout.height as uiHeight
+import androidx.compose.ui.tooling.preview.Preview
+import ee.schimke.ha.rc.androidXExperimental
+import ee.schimke.ha.rc.components.HaTheme
+import ee.schimke.ha.rc.components.ProvideHaTheme
+import ee.schimke.ha.rc.components.RemoteHaImageInline
+import ee.schimke.ha.rc.components.RemoteHaImageNamed
+
+/**
+ * Image samples — exercise the two ways RemoteCompose carries images:
+ *
+ * - `RemoteHaImageInline` bakes the bitmap bytes into the `.rc`
+ *   document. Renders identically in `RemotePreview` (no loader
+ *   needed) and in any player.
+ * - `RemoteHaImageNamed` references the image by name. Players that
+ *   provide a `BitmapLoader` resolve the bytes at playback; everyone
+ *   else (including these previews) sees the placeholder bitmap.
+ *
+ * Both previews use a programmatically-generated [sampleBitmap] so
+ * they don't depend on a drawable resource — making the document
+ * size visible (~few KB inline vs. just-the-name for the named form
+ * is a deliberate part of the demo).
+ */
+
+private const val IMAGE_BOX_HEIGHT_DP = 96
+private const val SAMPLE_BITMAP_PX = 96
+
+private fun sampleBitmap(): ImageBitmap {
+    val size = SAMPLE_BITMAP_PX.toFloat()
+    val bmp = ImageBitmap(SAMPLE_BITMAP_PX, SAMPLE_BITMAP_PX)
+    val canvas = Canvas(bmp)
+    val paint = Paint()
+    paint.color = Color(0xFF1565C0)
+    canvas.drawRect(0f, 0f, size, size, paint)
+    paint.color = Color(0xFFFFC107)
+    canvas.drawCircle(Offset(size / 2f, size / 2f), size * 0.32f, paint)
+    return bmp
+}
+
+@Preview(name = "image-inline (light)", showBackground = false, widthDp = 200, heightDp = IMAGE_BOX_HEIGHT_DP)
+@Composable
+fun ImageInline_Light() = ImageHost(HaTheme.Light) {
+    RemoteHaImageInline(
+        bitmap = sampleBitmap(),
+        contentDescription = "inline sample".rs,
+        modifier = RemoteModifier.fillMaxWidth().height(IMAGE_BOX_HEIGHT_DP.rdp),
+    )
+}
+
+@Preview(name = "image-inline (dark)", showBackground = false, widthDp = 200, heightDp = IMAGE_BOX_HEIGHT_DP)
+@Composable
+fun ImageInline_Dark() = ImageHost(HaTheme.Dark) {
+    RemoteHaImageInline(
+        bitmap = sampleBitmap(),
+        contentDescription = "inline sample".rs,
+        modifier = RemoteModifier.fillMaxWidth().height(IMAGE_BOX_HEIGHT_DP.rdp),
+    )
+}
+
+@Preview(name = "image-named (light)", showBackground = false, widthDp = 200, heightDp = IMAGE_BOX_HEIGHT_DP)
+@Composable
+fun ImageNamed_Light() = ImageHost(HaTheme.Light) {
+    RemoteHaImageNamed(
+        name = "samples/weather-now",
+        placeholder = sampleBitmap(),
+        contentDescription = "named sample".rs,
+        modifier = RemoteModifier.fillMaxWidth().height(IMAGE_BOX_HEIGHT_DP.rdp),
+    )
+}
+
+@Preview(name = "image-named (dark)", showBackground = false, widthDp = 200, heightDp = IMAGE_BOX_HEIGHT_DP)
+@Composable
+fun ImageNamed_Dark() = ImageHost(HaTheme.Dark) {
+    RemoteHaImageNamed(
+        name = "samples/weather-now",
+        placeholder = sampleBitmap(),
+        contentDescription = "named sample".rs,
+        modifier = RemoteModifier.fillMaxWidth().height(IMAGE_BOX_HEIGHT_DP.rdp),
+    )
+}
+
+@Composable
+private fun ImageHost(
+    theme: HaTheme,
+    content: @Composable @RemoteComposable () -> Unit,
+) {
+    Box(modifier = Modifier.uiFillMaxWidth().uiHeight(IMAGE_BOX_HEIGHT_DP.dp)) {
+        RemotePreview(profile = androidXExperimental) {
+            ProvideHaTheme(theme) { content() }
+        }
+    }
+}

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaImage.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaImage.kt
@@ -25,6 +25,23 @@ import androidx.compose.ui.layout.ContentScale
  *   placeholder is what `RemotePreview` and any player without a
  *   loader will show. Pair this with `CoilBitmapLoader` from
  *   `rc-image-coil` for HTTP / disk-cached resolution.
+ *
+ * ### Which form to pick
+ *
+ * Use [RemoteHaImageInline] when the image is **static / config-driven**
+ * — it lives in the source tree, ships with the app, or is otherwise
+ * fixed at document-encode time (e.g. a vendor logo, a state-icon
+ * pre-baked from a vector, an integration's brand mark). The bytes
+ * travel with the document, so playback is fully offline and the
+ * widget host needs no extra plumbing.
+ *
+ * Use [RemoteHaImageNamed] when the image is **external and may
+ * change** independently of the document — typically an
+ * `entity_picture` URL, a media-player thumbnail, or any HA-served
+ * resource that updates without the dashboard config changing. The
+ * document carries only the name, so the same `.rc` survives image
+ * swaps and the bytes stay in the host's image cache (e.g. Coil's
+ * disk cache) instead of bloating every snapshot.
  */
 
 /** Bake [bitmap] into the document. */

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaImage.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaImage.kt
@@ -1,0 +1,74 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.compose.layout.RemoteImage
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.state.RemoteState
+import androidx.compose.remote.creation.compose.state.RemoteString
+import androidx.compose.remote.creation.compose.state.rememberMutableRemoteBitmap
+import androidx.compose.remote.creation.compose.state.rememberNamedRemoteBitmap
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.layout.ContentScale
+
+/**
+ * Sample image composables that exercise the two ways RemoteCompose can
+ * carry an image into a `.rc` document.
+ *
+ * - [RemoteHaImageInline] embeds the bitmap bytes directly. The
+ *   document is fully self-contained (works in `RemotePreview` with
+ *   no extra wiring) at the cost of bloating the `.rc` payload.
+ * - [RemoteHaImageNamed] embeds only the image *name*. At playback
+ *   time the host's `BitmapLoader` resolves the name to bytes; the
+ *   placeholder is what `RemotePreview` and any player without a
+ *   loader will show. Pair this with `CoilBitmapLoader` from
+ *   `rc-image-coil` for HTTP / disk-cached resolution.
+ */
+
+/** Bake [bitmap] into the document. */
+@Composable
+@RemoteComposable
+fun RemoteHaImageInline(
+    bitmap: ImageBitmap,
+    contentDescription: RemoteString,
+    modifier: RemoteModifier = RemoteModifier,
+    contentScale: ContentScale = ContentScale.Fit,
+) {
+    val rb = rememberMutableRemoteBitmap(bitmap)
+    RemoteImage(
+        remoteBitmap = rb,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        contentScale = contentScale,
+    )
+}
+
+/**
+ * Reference [name] in the document; the player resolves it via its
+ * `BitmapLoader`. [placeholder] is rendered before the loader returns
+ * (and remains in players that do not provide one).
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaImageNamed(
+    name: String,
+    placeholder: ImageBitmap,
+    contentDescription: RemoteString,
+    modifier: RemoteModifier = RemoteModifier,
+    contentScale: ContentScale = ContentScale.Fit,
+    domain: RemoteState.Domain = RemoteState.Domain.User,
+) {
+    val rb = rememberNamedRemoteBitmap(
+        name = name,
+        domain = domain,
+        content = { placeholder },
+    )
+    RemoteImage(
+        remoteBitmap = rb,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        contentScale = contentScale,
+    )
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardCapture.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardCapture.kt
@@ -10,6 +10,7 @@ import androidx.compose.remote.creation.compose.capture.RemoteCreationDisplayInf
 import androidx.compose.remote.creation.compose.capture.captureSingleRemoteDocument
 import androidx.compose.remote.creation.compose.capture.rememberRemoteDocument
 import androidx.compose.remote.player.compose.RemoteDocumentPlayer
+import androidx.compose.remote.player.core.platform.BitmapLoader
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import ee.schimke.ha.model.CardConfig
@@ -77,6 +78,12 @@ suspend fun captureCardDocument(
  * In-composition capture — for previews and in-app playback. Encodes once
  * per (card, snapshot) change, then hands the document to
  * [RemoteDocumentPlayer].
+ *
+ * [bitmapLoader] resolves the names referenced by named-bitmap
+ * documents (`RemoteHaImageNamed` / `rememberNamedRemoteBitmap(...)`).
+ * Defaults to [BitmapLoader.UNSUPPORTED]; cards that don't use named
+ * bitmaps are unaffected. See `rc-image-coil`'s `CoilBitmapLoader`
+ * for an HTTP / disk-cached impl.
  */
 @Composable
 fun CardPlayer(
@@ -87,6 +94,7 @@ fun CardPlayer(
     densityDpi: Int,
     registry: CardRegistry,
     modifier: Modifier = Modifier,
+    bitmapLoader: BitmapLoader = BitmapLoader.UNSUPPORTED,
 ) {
     val converter = registry.get(card.type) ?: return
     val doc = rememberRemoteDocument(
@@ -100,5 +108,6 @@ fun CardPlayer(
         documentWidth = widthPx,
         documentHeight = heightPx,
         modifier = modifier,
+        bitmapLoader = bitmapLoader,
     )
 }

--- a/rc-image-coil/build.gradle.kts
+++ b/rc-image-coil/build.gradle.kts
@@ -9,6 +9,12 @@ android {
     targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
   }
   kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
+  // The unit tests don't touch any Android-only API on the
+  // CoilBitmapLoader paths under test (Bitmap, Canvas, Resources, …);
+  // the only Android type referenced is `ContextWrapper`, which has a
+  // pure-Java constructor. Defaults-on lets a future test reach into
+  // an Android stub without NPE.
+  testOptions { unitTests { isReturnDefaultValues = true } }
 }
 
 dependencies {
@@ -18,4 +24,5 @@ dependencies {
   implementation(libs.coil)
 
   testImplementation(libs.kotlin.test)
+  testImplementation(libs.kotlin.test.junit)
 }

--- a/rc-image-coil/build.gradle.kts
+++ b/rc-image-coil/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins { alias(libs.plugins.android.library) }
+
+android {
+  namespace = "ee.schimke.ha.rc.image"
+  compileSdk = libs.versions.android.compileSdk.get().toInt()
+  defaultConfig { minSdk = libs.versions.android.minSdk.get().toInt() }
+  compileOptions {
+    sourceCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+    targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
+  }
+  kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
+}
+
+dependencies {
+  // BitmapLoader interface lives in remote-player-core.
+  api(libs.remote.player.core)
+
+  implementation(libs.coil)
+
+  testImplementation(libs.kotlin.test)
+}

--- a/rc-image-coil/src/main/AndroidManifest.xml
+++ b/rc-image-coil/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest />

--- a/rc-image-coil/src/main/kotlin/ee/schimke/ha/rc/image/CoilBitmapLoader.kt
+++ b/rc-image-coil/src/main/kotlin/ee/schimke/ha/rc/image/CoilBitmapLoader.kt
@@ -1,0 +1,89 @@
+package ee.schimke.ha.rc.image
+
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.compose.remote.player.core.platform.BitmapLoader
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.executeBlocking
+import coil3.request.CachePolicy
+import coil3.request.ImageRequest
+import coil3.request.SuccessResult
+import coil3.toBitmap
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+
+/**
+ * Non-blocking [BitmapLoader] backed by Coil. Used by the
+ * RemoteCompose player to resolve named-bitmap references
+ * (`RemoteHaImageNamed` / `rememberNamedRemoteBitmap(...)`).
+ *
+ * **Never blocks the caller.** `loadBitmap` is invoked on the player's
+ * decode path; we only consult Coil's in-memory cache, so the call is
+ * effectively a hash-map lookup. If the bytes are not in memory we
+ * return an empty stream (the player decodes that to a null bitmap
+ * and keeps the placeholder visible) and enqueue a full async fetch
+ * via [ImageLoader.enqueue] — Coil's standard pipeline (network +
+ * disk-cache + decode) populates the memory cache in the background,
+ * and the next document update that references this name resolves
+ * synchronously. Coil dedupes concurrent enqueues for the same
+ * `data`, so calling [loadBitmap] every frame for a missing name
+ * is cheap.
+ *
+ * Note: `BitmapLoader.loadBitmap` is `@NonNull`; the player wraps any
+ * `IOException` in a `RuntimeException` and crashes, so we cannot
+ * signal "miss" by throwing. Returning an empty `InputStream`
+ * decodes to a null bitmap — the player handles that path
+ * gracefully.
+ *
+ * `name` is whatever Coil's mapper accepts as `ImageRequest.data`:
+ * `http(s)://…`, `file://…`, `content://…`, `android.resource://…`,
+ * an absolute file path, etc.
+ *
+ * The player decodes the returned stream with `BitmapFactory.decodeStream`,
+ * so we PNG-encode lossless on the way out. The player's own
+ * decode-result cache means this re-encode runs at most once per
+ * (id, name) pair per document.
+ */
+class CoilBitmapLoader(
+    private val context: Context,
+    private val imageLoader: ImageLoader = SingletonImageLoader.get(context),
+    private val compressFormat: Bitmap.CompressFormat = Bitmap.CompressFormat.PNG,
+    private val compressQuality: Int = 100,
+    private val configure: ImageRequest.Builder.() -> Unit = {},
+) : BitmapLoader {
+
+    override fun loadBitmap(name: String): InputStream {
+        val syncResult = imageLoader.executeBlocking(buildSyncRequest(name))
+        if (syncResult is SuccessResult) {
+            return encode(syncResult.image.toBitmap())
+        }
+        imageLoader.enqueue(buildWarmRequest(name))
+        return ByteArrayInputStream(EMPTY)
+    }
+
+    private fun buildSyncRequest(name: String): ImageRequest =
+        ImageRequest.Builder(context)
+            .data(name)
+            .networkCachePolicy(CachePolicy.DISABLED)
+            .diskCachePolicy(CachePolicy.DISABLED)
+            .apply(configure)
+            .build()
+
+    private fun buildWarmRequest(name: String): ImageRequest =
+        ImageRequest.Builder(context)
+            .data(name)
+            .apply(configure)
+            .build()
+
+    private fun encode(bitmap: Bitmap): InputStream {
+        val out = ByteArrayOutputStream(bitmap.allocationByteCount.coerceAtLeast(1024))
+        bitmap.compress(compressFormat, compressQuality, out)
+        return ByteArrayInputStream(out.toByteArray())
+    }
+
+    private companion object {
+        private val EMPTY = ByteArray(0)
+    }
+}

--- a/rc-image-coil/src/main/kotlin/ee/schimke/ha/rc/image/CoilBitmapLoader.kt
+++ b/rc-image-coil/src/main/kotlin/ee/schimke/ha/rc/image/CoilBitmapLoader.kt
@@ -25,6 +25,28 @@ import java.io.InputStream
  * hit the call goes through coroutine dispatch) and read directly
  * from [ImageLoader.memoryCache] with a key we control.
  *
+ * Why not configure Coil's dispatchers instead — set
+ * `interceptorCoroutineContext` (etc.) to `EmptyCoroutineContext` so
+ * `executeBlocking` runs the engine on the calling thread? Two
+ * reasons:
+ *
+ *  1. `RealImageLoader.execute` builds its `async` with
+ *     `CoroutineStart.DEFAULT` (hardcoded — `BuildersKt.async$default`
+ *     with `start = null`), which schedules through the dispatcher
+ *     in the merged context regardless of what we pass in. Coil
+ *     never starts undispatched, so the calling thread always pays
+ *     for at least one dispatch round-trip.
+ *  2. Coil's dispatcher knobs are per-loader, not per-call. Setting
+ *     them all to direct contexts to make the lookup sync would
+ *     also make [ImageLoader.enqueue] (used for the async warm-up
+ *     below) run on the calling thread — defeating the point.
+ *
+ * Splitting at the [MemoryCache] boundary keeps both invariants:
+ * lookup is a pure `HashMap.get`, and warm-up rides Coil's normal
+ * `enqueue` pipeline (`interceptorCoroutineContext` →
+ * `fetcherCoroutineContext` → `decoderCoroutineContext`, default
+ * `Dispatchers.IO` for fetch).
+ *
  * Coil's engine derives memory-cache keys from the request's data
  * **plus** size, scale, transformations, etc. — the engine-derived
  * key for `data="https://…/x.png"` does **not** equal

--- a/rc-image-coil/src/main/kotlin/ee/schimke/ha/rc/image/CoilBitmapLoader.kt
+++ b/rc-image-coil/src/main/kotlin/ee/schimke/ha/rc/image/CoilBitmapLoader.kt
@@ -3,13 +3,12 @@ package ee.schimke.ha.rc.image
 import android.content.Context
 import android.graphics.Bitmap
 import androidx.compose.remote.player.core.platform.BitmapLoader
+import coil3.BitmapImage
+import coil3.Image
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
-import coil3.executeBlocking
-import coil3.request.CachePolicy
+import coil3.memory.MemoryCache
 import coil3.request.ImageRequest
-import coil3.request.SuccessResult
-import coil3.toBitmap
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
@@ -19,34 +18,38 @@ import java.io.InputStream
  * RemoteCompose player to resolve named-bitmap references
  * (`RemoteHaImageNamed` / `rememberNamedRemoteBitmap(...)`).
  *
- * **Never blocks the caller.** `loadBitmap` is invoked on the player's
- * decode path; we only consult Coil's in-memory cache, so the call is
- * effectively a hash-map lookup. If the bytes are not in memory we
- * return an empty stream (the player decodes that to a null bitmap
- * and keeps the placeholder visible) and enqueue a full async fetch
- * via [ImageLoader.enqueue] — Coil's standard pipeline (network +
- * disk-cache + decode) populates the memory cache in the background,
- * and the next document update that references this name resolves
- * synchronously. Coil dedupes concurrent enqueues for the same
- * `data`, so calling [loadBitmap] every frame for a missing name
- * is cheap.
+ * **Never blocks.** [loadBitmap] runs on the player's decode thread,
+ * so the implementation must be a hash-map lookup, not a coroutine
+ * dispatch. We bypass [ImageLoader.execute] entirely (it spins up an
+ * `async` job on a coroutine scope and `await`s it — even on a memory
+ * hit the call goes through coroutine dispatch) and read directly
+ * from [ImageLoader.memoryCache] with a key we control.
  *
- * Note: `BitmapLoader.loadBitmap` is `@NonNull`; the player wraps any
- * `IOException` in a `RuntimeException` and crashes, so we cannot
- * signal "miss" by throwing. Returning an empty `InputStream`
- * decodes to a null bitmap — the player handles that path
- * gracefully.
+ * Coil's engine derives memory-cache keys from the request's data
+ * **plus** size, scale, transformations, etc. — the engine-derived
+ * key for `data="https://…/x.png"` does **not** equal
+ * `MemoryCache.Key("https://…/x.png")`. To make the direct lookup
+ * agree with what the warm-up writes, both sides use the same
+ * explicit [MemoryCache.Key] via [memoryCacheKeyFor]. Override that
+ * if you want to namespace per-instance.
  *
- * `name` is whatever Coil's mapper accepts as `ImageRequest.data`:
+ * On a miss we:
+ *
+ *  1. Enqueue a full async fetch via [ImageLoader.enqueue] with the
+ *     same explicit memory-cache key. Coil's pipeline (network +
+ *     disk-cache + decode) populates the memory cache in the
+ *     background; concurrent enqueues for the same key are deduped.
+ *  2. Return an empty stream — [BitmapLoader.loadBitmap] is `@NonNull`
+ *     and the player wraps thrown `IOException`s in a
+ *     `RuntimeException`, so we cannot signal "miss" by throwing.
+ *     `BitmapFactory.decodeStream` decodes empty input to a null
+ *     bitmap and the player keeps the placeholder.
+ *
+ * `name` is whatever Coil's mappers accept as `ImageRequest.data`:
  * `http(s)://…`, `file://…`, `content://…`, `android.resource://…`,
  * an absolute file path, etc.
- *
- * The player decodes the returned stream with `BitmapFactory.decodeStream`,
- * so we PNG-encode lossless on the way out. The player's own
- * decode-result cache means this re-encode runs at most once per
- * (id, name) pair per document.
  */
-class CoilBitmapLoader(
+open class CoilBitmapLoader(
     private val context: Context,
     private val imageLoader: ImageLoader = SingletonImageLoader.get(context),
     private val compressFormat: Bitmap.CompressFormat = Bitmap.CompressFormat.PNG,
@@ -54,33 +57,45 @@ class CoilBitmapLoader(
     private val configure: ImageRequest.Builder.() -> Unit = {},
 ) : BitmapLoader {
 
-    override fun loadBitmap(name: String): InputStream {
-        val syncResult = imageLoader.executeBlocking(buildSyncRequest(name))
-        if (syncResult is SuccessResult) {
-            return encode(syncResult.image.toBitmap())
-        }
-        imageLoader.enqueue(buildWarmRequest(name))
+    final override fun loadBitmap(name: String): InputStream {
+        val key = memoryCacheKeyFor(name)
+        val image = imageLoader.memoryCache?.get(key)?.image
+        val bytes = image?.let(::encodeImage)
+        if (bytes != null) return ByteArrayInputStream(bytes)
+        warmUpAsync(name, key)
         return ByteArrayInputStream(EMPTY)
     }
 
-    private fun buildSyncRequest(name: String): ImageRequest =
-        ImageRequest.Builder(context)
-            .data(name)
-            .networkCachePolicy(CachePolicy.DISABLED)
-            .diskCachePolicy(CachePolicy.DISABLED)
-            .apply(configure)
-            .build()
+    /**
+     * Stable key used both for the direct memory-cache lookup and for
+     * the warm-up [ImageRequest.memoryCacheKey], so writes and reads
+     * agree.
+     */
+    protected open fun memoryCacheKeyFor(name: String): MemoryCache.Key = MemoryCache.Key(name)
 
-    private fun buildWarmRequest(name: String): ImageRequest =
-        ImageRequest.Builder(context)
-            .data(name)
-            .apply(configure)
-            .build()
+    /**
+     * Convert the cached [Image] to PNG (or [compressFormat]) bytes,
+     * or `null` if the cached image is not a [BitmapImage] (e.g. a
+     * `ColorImage` placeholder Coil keeps in some configurations).
+     * Override to support additional [Image] subtypes or to swap the
+     * encoder.
+     */
+    protected open fun encodeImage(image: Image): ByteArray? {
+        if (image !is BitmapImage) return null
+        val out = ByteArrayOutputStream(image.bitmap.allocationByteCount.coerceAtLeast(1024))
+        image.bitmap.compress(compressFormat, compressQuality, out)
+        return out.toByteArray()
+    }
 
-    private fun encode(bitmap: Bitmap): InputStream {
-        val out = ByteArrayOutputStream(bitmap.allocationByteCount.coerceAtLeast(1024))
-        bitmap.compress(compressFormat, compressQuality, out)
-        return ByteArrayInputStream(out.toByteArray())
+    /**
+     * Kick off a full Coil fetch in the background. Default uses
+     * [ImageLoader.enqueue] which fires-and-forgets; the populated
+     * memory-cache entry is what [loadBitmap] consults next time.
+     */
+    protected open fun warmUpAsync(name: String, key: MemoryCache.Key) {
+        val request =
+            ImageRequest.Builder(context).data(name).memoryCacheKey(key).apply(configure).build()
+        imageLoader.enqueue(request)
     }
 
     private companion object {

--- a/rc-image-coil/src/test/kotlin/ee/schimke/ha/rc/image/CoilBitmapLoaderTest.kt
+++ b/rc-image-coil/src/test/kotlin/ee/schimke/ha/rc/image/CoilBitmapLoaderTest.kt
@@ -1,0 +1,192 @@
+@file:OptIn(coil3.annotation.ExperimentalCoilApi::class)
+
+package ee.schimke.ha.rc.image
+
+import android.content.ContextWrapper
+import coil3.ComponentRegistry
+import coil3.Image
+import coil3.ImageLoader
+import coil3.disk.DiskCache
+import coil3.memory.MemoryCache
+import coil3.request.Disposable
+import coil3.request.ImageRequest
+import coil3.request.ImageResult
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that the memory-cache hit path is a direct synchronous
+ * lookup — no coroutine dispatch, no thread switch, no calls into
+ * the Coil engine. The point of this loader is that it runs on the
+ * RemoteCompose player's decode thread without ever blocking; if a
+ * future refactor reintroduces `executeBlocking` / `runBlocking` /
+ * `withContext`, this test should fail.
+ */
+class CoilBitmapLoaderTest {
+
+    @Test
+    fun memoryHitReturnsBytesSynchronouslyFromCallingThread() {
+        val name = "https://example.test/icon.png"
+        val cachedImage = StubImage()
+        val cache = RecordingMemoryCache(initial = mapOf(MemoryCache.Key(name) to cachedImage))
+        val loader = StubImageLoader(memCache = cache)
+        val warmUpCalls = mutableListOf<Pair<String, MemoryCache.Key>>()
+        val sentinel = byteArrayOf(7, 8, 9)
+
+        val coil =
+            object : CoilBitmapLoader(context = NULL_CONTEXT, imageLoader = loader) {
+                override fun encodeImage(image: Image): ByteArray? {
+                    return if (image === cachedImage) sentinel else null
+                }
+
+                override fun warmUpAsync(name: String, key: MemoryCache.Key) {
+                    warmUpCalls += name to key
+                }
+            }
+
+        val callingThread = Thread.currentThread()
+        val stream = coil.loadBitmap(name)
+        val bytes = stream.readBytes()
+
+        // Synchronous: the lookup ran on the calling thread (no coroutine
+        // dispatch could have run a get() on a different thread).
+        assertContentEquals(sentinel, bytes)
+        assertEquals(listOf(MemoryCache.Key(name)), cache.getCalls)
+        assertEquals(listOf(callingThread), cache.getThreads)
+        // Hit path does not enqueue.
+        assertTrue(warmUpCalls.isEmpty(), "warm-up should not run on a hit")
+    }
+
+    @Test
+    fun memoryMissReturnsEmptyAndEnqueuesWarmUpWithSameKey() {
+        val name = "https://example.test/missing.png"
+        val cache = RecordingMemoryCache(initial = emptyMap())
+        val loader = StubImageLoader(memCache = cache)
+        val warmUpCalls = mutableListOf<Pair<String, MemoryCache.Key>>()
+
+        val coil =
+            object : CoilBitmapLoader(context = NULL_CONTEXT, imageLoader = loader) {
+                override fun warmUpAsync(name: String, key: MemoryCache.Key) {
+                    warmUpCalls += name to key
+                }
+            }
+
+        val stream = coil.loadBitmap(name)
+        val bytes = stream.readBytes()
+
+        // Empty stream → BitmapFactory.decodeStream → null bitmap → player keeps placeholder.
+        assertEquals(0, bytes.size)
+        // Both the lookup and the warm-up share the same explicit key.
+        assertEquals(listOf(MemoryCache.Key(name)), cache.getCalls)
+        assertEquals(listOf(name to MemoryCache.Key(name)), warmUpCalls)
+    }
+
+    @Test
+    fun nonBitmapCachedImageFallsThroughToWarmUp() {
+        // Coil can hold non-Bitmap Images (e.g. ColorImage). The default
+        // encodeImage returns null for those; the loader should treat that
+        // like a miss rather than crashing.
+        val name = "schemed://x"
+        val nonBitmap = StubImage()
+        val cache = RecordingMemoryCache(initial = mapOf(MemoryCache.Key(name) to nonBitmap))
+        val loader = StubImageLoader(memCache = cache)
+        val warmUpCalls = mutableListOf<Pair<String, MemoryCache.Key>>()
+
+        val coil =
+            object : CoilBitmapLoader(context = NULL_CONTEXT, imageLoader = loader) {
+                override fun warmUpAsync(name: String, key: MemoryCache.Key) {
+                    warmUpCalls += name to key
+                }
+            }
+
+        val stream = coil.loadBitmap(name)
+
+        assertEquals(0, stream.readBytes().size)
+        assertEquals(1, warmUpCalls.size)
+    }
+
+    @Test
+    fun customKeyAlignsLookupAndWarmUp() {
+        val name = "logo"
+        val customKey = MemoryCache.Key("scoped:$name")
+        val cache = RecordingMemoryCache(initial = emptyMap())
+        val loader = StubImageLoader(memCache = cache)
+        val warmUpKeys = mutableListOf<MemoryCache.Key>()
+
+        val coil =
+            object : CoilBitmapLoader(context = NULL_CONTEXT, imageLoader = loader) {
+                override fun memoryCacheKeyFor(name: String): MemoryCache.Key = customKey
+
+                override fun warmUpAsync(name: String, key: MemoryCache.Key) {
+                    warmUpKeys += key
+                }
+            }
+
+        coil.loadBitmap(name)
+
+        // The exact custom key is used on both sides.
+        assertEquals(listOf(customKey), cache.getCalls)
+        assertEquals(listOf(customKey), warmUpKeys)
+    }
+}
+
+private val NULL_CONTEXT = ContextWrapper(null)
+
+private class StubImage : Image {
+    override val size: Long = 0L
+    override val width: Int = 1
+    override val height: Int = 1
+    override val shareable: Boolean = false
+
+    override fun draw(canvas: android.graphics.Canvas) = Unit
+}
+
+private class RecordingMemoryCache(initial: Map<MemoryCache.Key, Image>) : MemoryCache {
+    private val store = initial.mapValues { (_, v) -> MemoryCache.Value(v) }.toMutableMap()
+    val getCalls = mutableListOf<MemoryCache.Key>()
+    val getThreads = mutableListOf<Thread>()
+
+    override val size: Long = 0L
+    override var maxSize: Long = Long.MAX_VALUE
+    override val initialMaxSize: Long = Long.MAX_VALUE
+    override val keys: Set<MemoryCache.Key>
+        get() = store.keys
+
+    override fun get(key: MemoryCache.Key): MemoryCache.Value? {
+        getCalls += key
+        getThreads += Thread.currentThread()
+        return store[key]
+    }
+
+    override fun set(key: MemoryCache.Key, value: MemoryCache.Value) {
+        store[key] = value
+    }
+
+    override fun remove(key: MemoryCache.Key): Boolean = store.remove(key) != null
+
+    override fun trimToSize(size: Long) {}
+
+    override fun clear() = store.clear()
+}
+
+private class StubImageLoader(memCache: MemoryCache) : ImageLoader {
+    override val memoryCache: MemoryCache? = memCache
+    override val diskCache: DiskCache? = null
+    override val defaults: ImageRequest.Defaults
+        get() = unsupported("defaults")
+    override val components: ComponentRegistry
+        get() = unsupported("components")
+
+    override fun enqueue(request: ImageRequest): Disposable = unsupported("enqueue")
+
+    override suspend fun execute(request: ImageRequest): ImageResult = unsupported("execute")
+
+    override fun shutdown() = unsupported("shutdown")
+
+    override fun newBuilder(): ImageLoader.Builder = unsupported("newBuilder")
+
+    private fun unsupported(method: String): Nothing =
+        error("StubImageLoader.$method must not be called from CoilBitmapLoader's hit/miss path")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,6 +29,7 @@ include(
   ":rc-components-ui",
   ":rc-converter",
   ":rc-card-shutter",
+  ":rc-image-coil",
   ":previews",
   ":demo-app",
   ":terrazzo-core",


### PR DESCRIPTION
## Summary
Introduces a non-blocking `CoilBitmapLoader` implementation that enables RemoteCompose to resolve named-bitmap references via Coil's image-loading pipeline. This allows `.rc` documents to reference images by name (e.g., entity URLs) rather than embedding bitmap bytes, reducing document size while keeping images in the host's cache.

## Key Changes

- **New `rc-image-coil` module** with `CoilBitmapLoader`:
  - Implements `BitmapLoader` interface for RemoteCompose player integration
  - Performs synchronous memory-cache lookups on the calling thread (no coroutine dispatch)
  - Falls back to async warm-up via `ImageLoader.enqueue` on cache miss
  - Supports custom memory-cache keys via `memoryCacheKeyFor()` override
  - Handles non-bitmap cached images gracefully by treating them as misses

- **New `RemoteHaImage` composables** in `rc-components`:
  - `RemoteHaImageInline`: Embeds bitmap bytes directly in the document (self-contained, larger payload)
  - `RemoteHaImageNamed`: References images by name, resolved at playback via `BitmapLoader` (smaller payload, requires loader)

- **Image preview samples** in `previews` module:
  - Demonstrates both inline and named image forms
  - Light/dark theme variants
  - Uses programmatically-generated sample bitmaps (no drawable dependencies)

- **Integration updates**:
  - Updated `CardCapture` to accept optional `BitmapLoader` for document playback
  - Added Coil 3.4.0 dependency to version catalog

## Notable Implementation Details

- **Synchronous hit path**: Direct `HashMap.get` on memory cache with no coroutine dispatch, ensuring the decode thread never blocks
- **Aligned keys**: Both cache lookup and warm-up use the same explicit `MemoryCache.Key` to ensure consistency
- **Empty stream on miss**: Returns empty `ByteArrayInputStream` rather than throwing, allowing `BitmapFactory.decodeStream` to return null and the player to show the placeholder
- **Comprehensive test coverage**: `CoilBitmapLoaderTest` verifies synchronous behavior, cache hits/misses, non-bitmap handling, and custom key alignment

https://claude.ai/code/session_01GmG8PxTjr6DTrGkJ9ppJNW