### PR TITLE
Add document caching and live bindings for card rendering

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -34,12 +34,12 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
-import androidx.compose.remote.tooling.preview.RemotePreview
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.Dashboard
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.terrazzo.LocalTerrazzoGraph
 import ee.schimke.terrazzo.core.session.HaSession
+import ee.schimke.ha.rc.CachedCardPreview
 import ee.schimke.ha.rc.CardWidthClass
 import ee.schimke.ha.rc.ProvideCardRegistry
 import ee.schimke.ha.rc.RenderChild
@@ -48,6 +48,7 @@ import ee.schimke.ha.rc.cardHeightDp
 import ee.schimke.ha.rc.cardWidthClass
 import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.components.ProvideHaTheme
+import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.ha.rc.components.haThemeFor
 import ee.schimke.terrazzo.LocalTerrazzoGraph
 import ee.schimke.terrazzo.ui.LayoutConfig
@@ -459,10 +460,12 @@ private fun CardSlot(
 ) {
     val style = LocalThemeStyle.current
     val dark = LocalIsDarkTheme.current
-    // Re-capture the `.rc` document when the user switches theme — the
-    // document's colours are baked at capture, so we key the
-    // `RemotePreview` on the style+dark pair.
+    // The document's paint colours are baked at capture; re-encode when
+    // theme flips. Snapshot is deliberately NOT in the cache key —
+    // entity values flow into the running player by named binding
+    // (see LiveBindings).
     val haTheme = remember(style, dark) { haThemeFor(style, dark) }
+    val cacheKey = remember(card, style, dark) { CardSlotCacheKey(card, style, dark) }
     Box(
         modifier = modifier
             // Stable semantics tag so uiautomator / Compose tests can
@@ -472,11 +475,11 @@ private fun CardSlot(
                 contentDescription = "dashboard-card:${card.type}"
             }
             // longPressBeforeChild — listens on the Initial pass so it
-            // fires even though RemotePreview's pointer-input consumes
+            // fires even though the player's pointer-input consumes
             // events on the Main pass for in-document click regions.
             .longPressBeforeChild { onLongPress(card) },
     ) {
-        RemotePreview(profile = androidXExperimentalWrap) {
+        CachedCardPreview(cacheKey = cacheKey, profile = androidXExperimentalWrap) {
             ProvideCardRegistry(registry) {
                 ProvideHaTheme(haTheme) {
                     RenderChild(card, snapshot, RemoteModifier.fillMaxWidth())
@@ -485,6 +488,12 @@ private fun CardSlot(
         }
     }
 }
+
+private data class CardSlotCacheKey(
+    val card: CardConfig,
+    val style: ThemeStyle,
+    val dark: Boolean,
+)
 
 /**
  * One emitted dashboard row in the LazyColumn. Either a single

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
@@ -298,7 +298,7 @@ data class HaArcDialData(
     val centerLabel: RemoteString,
     /** Smaller secondary readout under the centre label (e.g. "↑ 22 °C"). */
     val supportingLabel: RemoteString?,
-    val modeChip: RemoteString?,
+    val modeChip: HaModeChip?,
     val accent: Color,
     val showSteppers: Boolean,
     val centerIcon: ImageVector?,
@@ -306,6 +306,33 @@ data class HaArcDialData(
     val incrementAction: HaAction = HaAction.None,
     val decrementAction: HaAction = HaAction.None,
 )
+
+/**
+ * The small mode chip rendered above the centre label of an arc dial /
+ * tile. Modelled as a sum so the component can route discrete states
+ * through `RemoteStateLayout` (no re-encode when the mode flips) while
+ * still accepting plain named-string bindings for free-form values.
+ */
+sealed interface HaModeChip {
+    /**
+     * A pre-formatted [RemoteString], typically built from a named
+     * binding (`LiveBindings.state` / `.attribute`). The player can
+     * still update the text live; what it cannot do is switch between
+     * structurally different variants.
+     */
+    data class Static(val label: RemoteString) : HaModeChip
+
+    /**
+     * Two label variants picked at playback time by [isOn]. Routed
+     * through `RemoteStateLayout(RemoteBoolean)` so a host flipping the
+     * boolean toggles the visible label without touching the document.
+     */
+    data class Toggle(
+        val isOn: RemoteBoolean,
+        val onLabel: String,
+        val offLabel: String,
+    ) : HaModeChip
+}
 
 /** `clock` card model. The default render uses
  *  `RemoteTimeDefaults.defaultTimeString` so the time text auto-ticks

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaArcDial.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaArcDial.kt
@@ -15,6 +15,7 @@ import androidx.compose.remote.creation.compose.layout.RemoteComposable
 import androidx.compose.remote.creation.compose.layout.RemoteOffset
 import androidx.compose.remote.creation.compose.layout.RemoteRow
 import androidx.compose.remote.creation.compose.layout.RemoteSize
+import androidx.compose.remote.creation.compose.layout.RemoteStateLayout
 import androidx.compose.remote.creation.compose.layout.RemoteText
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.background
@@ -26,6 +27,7 @@ import androidx.compose.remote.creation.compose.modifier.padding
 import androidx.compose.remote.creation.compose.modifier.size
 import androidx.compose.remote.creation.compose.shapes.RemoteCircleShape
 import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.RemoteString
 import androidx.compose.remote.creation.compose.state.asRemotePaint
 import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.remote.creation.compose.state.rdp
@@ -117,16 +119,7 @@ private fun DialBody(data: HaArcDialData, theme: HaTheme) {
                     tint = data.accent.rc,
                 )
             }
-            if (data.modeChip != null) {
-                RemoteText(
-                    text = data.modeChip,
-                    color = data.accent.rc,
-                    fontSize = 12.rsp,
-                    fontWeight = FontWeight.Medium,
-                    style = RemoteTextStyle.Default,
-                    maxLines = 1,
-                )
-            }
+            ModeChip(data.modeChip, data.accent)
             RemoteText(
                 text = data.centerLabel,
                 color = theme.primaryText.rc,
@@ -147,6 +140,31 @@ private fun DialBody(data: HaArcDialData, theme: HaTheme) {
             }
         }
     }
+}
+
+@Composable
+@RemoteComposable
+private fun ModeChip(chip: HaModeChip?, accent: Color) {
+    if (chip == null) return
+    when (chip) {
+        is HaModeChip.Static -> ChipText(chip.label, accent)
+        is HaModeChip.Toggle -> RemoteStateLayout(chip.isOn) { on ->
+            ChipText((if (on) chip.onLabel else chip.offLabel).rs, accent)
+        }
+    }
+}
+
+@Composable
+@RemoteComposable
+private fun ChipText(text: RemoteString, accent: Color) {
+    RemoteText(
+        text = text,
+        color = accent.rc,
+        fontSize = 12.rsp,
+        fontWeight = FontWeight.Medium,
+        style = RemoteTextStyle.Default,
+        maxLines = 1,
+    )
 }
 
 @Composable

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CachedCardPreview.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CachedCardPreview.kt
@@ -1,0 +1,77 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc
+
+import androidx.annotation.RestrictTo
+import androidx.compose.foundation.layout.Box
+import androidx.compose.remote.creation.compose.capture.captureSingleRemoteDocument
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.profile.Profile
+import androidx.compose.remote.creation.profile.RcPlatformProfiles
+import androidx.compose.remote.player.compose.RemoteDocumentPlayer
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Cached counterpart to upstream
+ * `androidx.compose.remote.tooling.preview.RemotePreview`.
+ *
+ * The difference that matters: this version keys the captured `.rc`
+ * bytes on a caller-supplied [cacheKey] and stores hits in
+ * [LocalCardDocumentCache]. Two calls with the same key skip the
+ * encode entirely and play the cached bytes — even across Activity
+ * recreation, because the cache is process-scoped.
+ *
+ * Cache-key contract: include everything that bakes into the document
+ * (the card YAML, theme colours / dark flag, profile), and nothing
+ * that the host can update by named binding (entity state, attributes,
+ * `is_on`). Snapshot data is read by [content] on capture but must
+ * NOT be part of the key — `LiveBindings.state` / `.attribute` /
+ * `.isOn` are exactly the seam through which a running player gets
+ * fresh data without re-encoding.
+ *
+ * Sizing follows upstream `RemotePreview`: the captured document
+ * carries its natural size in the header, and the player measures via
+ * `RemoteComposePlayerFlags.shouldPlayerWrapContentSize` (on by
+ * default), so callers size the slot via [modifier] and don't have to
+ * thread pixels through.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Composable
+fun CachedCardPreview(
+    cacheKey: Any,
+    profile: Profile = RcPlatformProfiles.ANDROIDX,
+    modifier: Modifier = Modifier,
+    content: @RemoteComposable @Composable () -> Unit,
+) {
+    val context = LocalContext.current
+    val cache = LocalCardDocumentCache.current
+
+    val cardDocument =
+        remember(cacheKey) {
+            cache.get(cacheKey)
+                ?: runBlocking {
+                        val captured =
+                            captureSingleRemoteDocument(
+                                context = context,
+                                profile = profile,
+                                content = content,
+                            )
+                        CardDocument(bytes = captured.bytes, widthPx = 0, heightPx = 0)
+                    }
+                    .also { cache.put(cacheKey, it) }
+        }
+
+    val coreDocument = remember(cardDocument) { cardDocument.decode() }
+
+    Box(modifier = modifier) {
+        RemoteDocumentPlayer(
+            document = coreDocument,
+            documentWidth = cardDocument.widthPx,
+            documentHeight = cardDocument.heightPx,
+        )
+    }
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardCapture.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardCapture.kt
@@ -43,8 +43,15 @@ data class CardDocument(
 
 /**
  * Headless capture path — produces a [CardDocument] without any visible
- * surface. This is what a widget worker calls: the HA snapshot changed, so
- * re-encode the card's bytes and push to the app instance / Glance session.
+ * surface. This is what a widget worker calls: the dashboard YAML
+ * changed (or the slot is freshly seeded), re-encode the card's bytes
+ * and push to the app instance / Glance session.
+ *
+ * Consults [cache] before encoding: the snapshot is allowed to change
+ * without forcing a re-encode, since named-binding writes from the
+ * host carry value updates. Pass [forceRefresh] = true to bypass the
+ * cache (e.g. when the YAML just changed but the cache key is hard
+ * to evict surgically).
  *
  * alpha09 collapses the public/V2 capture functions into a single
  * `captureSingleRemoteDocument` which is itself `@RestrictTo(LIBRARY_GROUP)`
@@ -61,17 +68,35 @@ suspend fun captureCardDocument(
     registry: CardRegistry,
     card: CardConfig,
     snapshot: HaSnapshot,
+    cache: CardDocumentCache = defaultCardDocumentCache,
+    forceRefresh: Boolean = false,
 ): CardDocument {
     val converter = registry.get(card.type)
         ?: error("No converter registered for card type='${card.type}'")
+    val cacheKey = HeadlessCardCacheKey(card, widthPx, heightPx, densityDpi)
+    if (!forceRefresh) cache.get(cacheKey)?.let { return it }
     val captured = captureSingleRemoteDocument(
         context = context,
         creationDisplayInfo = RemoteCreationDisplayInfo(widthPx, heightPx, densityDpi),
     ) {
         converter.Render(card, snapshot)
     }
-    return CardDocument(captured.bytes, widthPx, heightPx)
+    return CardDocument(captured.bytes, widthPx, heightPx).also { cache.put(cacheKey, it) }
 }
+
+/**
+ * Default cache key for the headless capture path. Includes the size
+ * inputs because the encoded document bakes them into its header and
+ * recomputing layout for a different slot size produces different
+ * bytes. Theme isn't part of the key today: widget capture uses the
+ * default theme; if widgets gain a theme picker, extend this key.
+ */
+private data class HeadlessCardCacheKey(
+    val card: CardConfig,
+    val widthPx: Int,
+    val heightPx: Int,
+    val densityDpi: Int,
+)
 
 /**
  * In-composition capture — for previews and in-app playback. Encodes once

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardDocumentCache.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardDocumentCache.kt
@@ -1,0 +1,57 @@
+package ee.schimke.ha.rc
+
+import androidx.collection.LruCache
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * Process-scoped store of encoded `.rc` byte buffers, keyed by an
+ * opaque caller-supplied key.
+ *
+ * Encoding a card runs the full converter composition + serialization
+ * pass. Once the document is captured, swapping its named-binding
+ * values (sensor state, mode chip, …) is the player's job — the
+ * document bytes don't move. So the cache key must contain only inputs
+ * that change the *shape* of the document: the YAML for the card, the
+ * theme colours that get baked into paints, the profile, and (for the
+ * headless capture path used by widgets) the target pixel size.
+ *
+ * Snapshot data deliberately is NOT part of the key. A fresh
+ * `HaSnapshot` produces the same document bytes; the host pushes new
+ * values into the running player by name instead of re-encoding.
+ *
+ * Lifetime is process-scoped — survives Activity recreation, drops on
+ * process death. That matches the immediate goal: a cold-start
+ * back-stack pop shouldn't pay for an encode.
+ */
+interface CardDocumentCache {
+    fun get(key: Any): CardDocument?
+    fun put(key: Any, document: CardDocument)
+    fun clear()
+}
+
+/** Default in-memory bounded LRU. */
+class InMemoryCardDocumentCache(maxEntries: Int = 64) : CardDocumentCache {
+    private val cache = LruCache<Any, CardDocument>(maxEntries)
+
+    override fun get(key: Any): CardDocument? = cache.get(key)
+
+    override fun put(key: Any, document: CardDocument) {
+        cache.put(key, document)
+    }
+
+    override fun clear() {
+        cache.evictAll()
+    }
+}
+
+/**
+ * Composition-scoped binding. Tests / previews can override; production
+ * uses [defaultCardDocumentCache].
+ */
+val LocalCardDocumentCache = staticCompositionLocalOf<CardDocumentCache> { defaultCardDocumentCache }
+
+/**
+ * Singleton instance reachable from non-Compose call sites (the
+ * widget-worker headless capture path uses it without a Composition).
+ */
+val defaultCardDocumentCache: CardDocumentCache by lazy { InMemoryCardDocumentCache() }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/LiveBindings.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/LiveBindings.kt
@@ -57,4 +57,21 @@ object LiveBindings {
             RemoteState.Domain.User,
         )
     }
+
+    /**
+     * Named binding for an entity attribute (e.g. `hvac_action`,
+     * `brightness`, `media_title`). The host pushes new values keyed by
+     * `<entity_id>.attributes.<attr>`.
+     *
+     * Returns a static [RemoteString] when [entity] is null so previews
+     * and unmatched-entity cards still render, with no host wiring.
+     */
+    fun attribute(entity: EntityState?, attribute: String, formatted: String): RemoteString {
+        val entityId = entity?.entityId ?: return formatted.rs
+        return RemoteString.createNamedRemoteString(
+            name(entityId, "attributes.$attribute"),
+            formatted,
+            RemoteState.Domain.User,
+        )
+    }
 }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/AlarmPanelCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/AlarmPanelCardConverter.kt
@@ -14,6 +14,7 @@ import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.LiveBindings
 import ee.schimke.ha.rc.components.HaAction
 import ee.schimke.ha.rc.components.HaAlarmAction
 import ee.schimke.ha.rc.components.HaAlarmPanelData
@@ -66,7 +67,7 @@ class AlarmPanelCardConverter : CardConverter {
         RemoteHaAlarmPanel(
             HaAlarmPanelData(
                 title = title.rs,
-                state = formatState(state).rs,
+                state = LiveBindings.state(entity, formatState(state)),
                 accent = stateAccent(state),
                 statusIcon = stateIcon(state),
                 actions = actions,

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/AreaCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/AreaCardConverter.kt
@@ -16,6 +16,7 @@ import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.LiveBindings
 import ee.schimke.ha.rc.components.HaAction
 import ee.schimke.ha.rc.components.HaAreaAction
 import ee.schimke.ha.rc.components.HaAreaCardData
@@ -58,10 +59,14 @@ class AreaCardConverter : CardConverter {
             val deviceClass = entity.attributes["device_class"]?.jsonPrimitive?.content
             val unit = entity.attributes["unit_of_measurement"]?.jsonPrimitive?.content
             when (deviceClass) {
-                "temperature" -> HaAreaStat(Icons.Filled.Thermostat,
-                    "${entity.state}${unit ?: " °C"}".rs)
-                "humidity", "moisture" -> HaAreaStat(Icons.Filled.WaterDrop,
-                    "${entity.state}${unit ?: " %"}".rs)
+                "temperature" -> HaAreaStat(
+                    Icons.Filled.Thermostat,
+                    LiveBindings.state(entity, "${entity.state}${unit ?: " °C"}"),
+                )
+                "humidity", "moisture" -> HaAreaStat(
+                    Icons.Filled.WaterDrop,
+                    LiveBindings.state(entity, "${entity.state}${unit ?: " %"}"),
+                )
                 else -> null
             }
         }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/BambuLabCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/BambuLabCardConverter.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.font.FontWeight
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.LiveBindings
 import ee.schimke.ha.rc.components.LocalHaTheme
 import ee.schimke.ha.rc.formatState
 import kotlinx.serialization.json.jsonPrimitive
@@ -106,7 +107,7 @@ open class BambuLabCardConverter(
                         style = RemoteTextStyle.Default,
                     )
                     RemoteText(
-                        text = state.rs,
+                        text = LiveBindings.state(entity, state),
                         color = theme.secondaryText.rc,
                         fontSize = 13.rsp,
                         style = RemoteTextStyle.Default,

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/HistoryGraphCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/HistoryGraphCardConverter.kt
@@ -9,6 +9,7 @@ import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.model.HistoryPoint
 import ee.schimke.ha.rc.CardConverter
 import ee.schimke.ha.rc.HaStateColor
+import ee.schimke.ha.rc.LiveBindings
 import ee.schimke.ha.rc.components.HaHistoryGraphData
 import ee.schimke.ha.rc.components.HaHistoryGraphRow
 import ee.schimke.ha.rc.components.RemoteHaHistoryGraph
@@ -20,9 +21,12 @@ import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * `history-graph` card. Renders one sparkline per entity using the
- * snapshot's `history[entityId]`. Numeric points are normalised into
- * the row's drawable rect at capture time; alpha08 doesn't expose a
- * RemoteFloat numeric binding, so live updates re-encode.
+ * snapshot's `history[entityId]`. The per-row summary text is a named
+ * `<entity>.state` binding so the host can refresh it without a
+ * re-encode. Numeric points are normalised into the row's drawable rect
+ * at capture time; alpha010 still doesn't expose a RemoteFloat list
+ * binding, so the sparkline geometry itself is re-encoded when new
+ * samples arrive.
  */
 class HistoryGraphCardConverter : CardConverter {
     override val cardType: String = CardTypes.HISTORY_GRAPH
@@ -47,7 +51,7 @@ class HistoryGraphCardConverter : CardConverter {
             val numeric = history.mapNotNull { it.state.toFloatOrNull() }
             HaHistoryGraphRow(
                 name = name.rs,
-                summary = summarise(history).rs,
+                summary = LiveBindings.state(entity, summarise(history)),
                 accent = HaStateColor.activeFor(entity),
                 points = numeric,
             )

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/HumidifierCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/HumidifierCardConverter.kt
@@ -8,8 +8,10 @@ import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.LiveBindings
 import ee.schimke.ha.rc.components.HaAction
 import ee.schimke.ha.rc.components.HaArcDialData
+import ee.schimke.ha.rc.components.HaModeChip
 import ee.schimke.ha.rc.components.RemoteHaArcDial
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -63,9 +65,11 @@ class HumidifierCardConverter : CardConverter {
                 name = name.rs,
                 valueFraction = valueFraction.coerceIn(0f, 1f),
                 targetFraction = targetFraction?.coerceIn(0f, 1f),
-                centerLabel = centerLabel.rs,
-                supportingLabel = supportingLabel?.rs,
-                modeChip = modeChip.rs,
+                centerLabel = LiveBindings.attribute(entity, "current_humidity_label", centerLabel),
+                supportingLabel = supportingLabel?.let {
+                    LiveBindings.attribute(entity, "humidity_label", it)
+                },
+                modeChip = HaModeChip.Static(LiveBindings.attribute(entity, "action_label", modeChip)),
                 accent = Color(0xFF00ACC1),
                 showSteppers = target != null,
                 centerIcon = null,

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/LightCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/LightCardConverter.kt
@@ -10,8 +10,10 @@ import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.LiveBindings
 import ee.schimke.ha.rc.components.HaAction
 import ee.schimke.ha.rc.components.HaArcDialData
+import ee.schimke.ha.rc.components.HaModeChip
 import ee.schimke.ha.rc.components.RemoteHaArcDial
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -42,7 +44,14 @@ class LightCardConverter : CardConverter {
         val brightness = attrs["brightness"]?.jsonPrimitive?.content?.toFloatOrNull()
         val fraction = if (isOn) (brightness ?: 255f) / 255f else 0f
         val accent = if (isOn) Color(0xFFFFBE3E) else Color(0xFFB0B0B0)
-        val centerLabel = if (isOn) "${(fraction * 100f).toInt()}%" else "Off"
+        val centerLabel = LiveBindings.attribute(
+            entity,
+            "brightness_pct",
+            if (isOn) "${(fraction * 100f).toInt()}%" else "Off",
+        )
+        val modeChip = LiveBindings.isOn(entity)?.let { isOnBinding ->
+            HaModeChip.Toggle(isOnBinding, onLabel = "On", offLabel = "Off")
+        } ?: HaModeChip.Static((if (isOn) "On" else "Off").rs)
 
         val tap = entityId?.let { HaAction.Toggle(it) } ?: HaAction.None
         val (inc, dec) = brightnessSteppers(entityId, isOn, brightness)
@@ -52,9 +61,9 @@ class LightCardConverter : CardConverter {
                 name = name.rs,
                 valueFraction = fraction,
                 targetFraction = null,
-                centerLabel = centerLabel.rs,
+                centerLabel = centerLabel,
                 supportingLabel = null,
-                modeChip = (if (isOn) "On" else "Off").rs,
+                modeChip = modeChip,
                 accent = accent,
                 showSteppers = isOn,
                 centerIcon = Icons.Filled.Lightbulb,

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/MediaControlCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/MediaControlCardConverter.kt
@@ -8,6 +8,7 @@ import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.LiveBindings
 import ee.schimke.ha.rc.components.HaAction
 import ee.schimke.ha.rc.components.HaMediaControlData
 import ee.schimke.ha.rc.components.RemoteHaMediaControl
@@ -52,8 +53,8 @@ class MediaControlCardConverter : CardConverter {
         RemoteHaMediaControl(
             HaMediaControlData(
                 playerName = playerName.rs,
-                title = title.rs,
-                artist = artist?.rs,
+                title = LiveBindings.attribute(entity, "media_title", title),
+                artist = artist?.let { LiveBindings.attribute(entity, "media_artist", it) },
                 accent = accent,
                 isPlaying = isPlaying,
                 positionFraction = fraction,

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/SensorCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/SensorCardConverter.kt
@@ -8,6 +8,7 @@ import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.CardConverter
 import ee.schimke.ha.rc.HaStateColor
+import ee.schimke.ha.rc.LiveBindings
 import ee.schimke.ha.rc.components.HaSensorCardData
 import ee.schimke.ha.rc.components.RemoteHaSensorCard
 import ee.schimke.ha.rc.formatState
@@ -38,7 +39,7 @@ class SensorCardConverter : CardConverter {
         RemoteHaSensorCard(
             HaSensorCardData(
                 name = name.rs,
-                valueLabel = formatState(entity).rs,
+                valueLabel = LiveBindings.state(entity, formatState(entity)),
                 accent = HaStateColor.activeFor(entity),
                 points = numeric,
                 rangeLabel = "Last ${hours}h".rs,

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/StatisticCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/StatisticCardConverter.kt
@@ -8,6 +8,7 @@ import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.CardConverter
 import ee.schimke.ha.rc.HaStateColor
+import ee.schimke.ha.rc.LiveBindings
 import ee.schimke.ha.rc.components.HaStatisticCardData
 import ee.schimke.ha.rc.components.RemoteHaStatisticCard
 import kotlinx.serialization.json.jsonPrimitive
@@ -63,7 +64,7 @@ class StatisticCardConverter : CardConverter {
         RemoteHaStatisticCard(
             HaStatisticCardData(
                 name = name.rs,
-                valueLabel = valueLabel.rs,
+                valueLabel = LiveBindings.state(entity, valueLabel),
                 unit = unit?.rs,
                 periodLabel = period?.rs,
                 accent = HaStateColor.activeFor(entity),

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ThermostatCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ThermostatCardConverter.kt
@@ -9,8 +9,10 @@ import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.EntityState
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.LiveBindings
 import ee.schimke.ha.rc.components.HaAction
 import ee.schimke.ha.rc.components.HaArcDialData
+import ee.schimke.ha.rc.components.HaModeChip
 import ee.schimke.ha.rc.components.RemoteHaArcDial
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -67,14 +69,20 @@ class ThermostatCardConverter : CardConverter {
 
         val (incAction, decAction) = stepperActions(entity, target, step) ?: (HaAction.None to HaAction.None)
 
+        val liveCenterLabel = LiveBindings.attribute(entity, "current_temperature_label", centerLabel)
+        val liveSupportingLabel = supportingLabel?.let {
+            LiveBindings.attribute(entity, "temperature_label", it)
+        }
+        val liveModeChip = HaModeChip.Static(LiveBindings.attribute(entity, "hvac_action_label", modeChip))
+
         RemoteHaArcDial(
             HaArcDialData(
                 name = name.rs,
                 valueFraction = valueFraction.coerceIn(0f, 1f),
                 targetFraction = targetFraction?.coerceIn(0f, 1f),
-                centerLabel = centerLabel.rs,
-                supportingLabel = supportingLabel?.rs,
-                modeChip = modeChip.rs,
+                centerLabel = liveCenterLabel,
+                supportingLabel = liveSupportingLabel,
+                modeChip = liveModeChip,
                 accent = accent,
                 showSteppers = target != null,
                 centerIcon = null,

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/WeatherForecastCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/WeatherForecastCardConverter.kt
@@ -17,6 +17,7 @@ import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.LiveBindings
 import ee.schimke.ha.rc.components.HaWeatherDay
 import ee.schimke.ha.rc.components.HaWeatherForecastData
 import ee.schimke.ha.rc.components.RemoteHaWeatherForecast
@@ -73,8 +74,8 @@ class WeatherForecastCardConverter : CardConverter {
         RemoteHaWeatherForecast(
             HaWeatherForecastData(
                 name = name.rs,
-                condition = formatCondition(condition).rs,
-                temperature = temperature.rs,
+                condition = LiveBindings.state(entity, formatCondition(condition)),
+                temperature = LiveBindings.attribute(entity, "temperature_label", temperature),
                 supportingLine = null,
                 icon = weatherIcon(condition),
                 days = days,


### PR DESCRIPTION
## Summary
This PR introduces a caching layer for encoded remote card documents and expands the live binding system to support dynamic updates without re-encoding. These changes enable more efficient card rendering in dashboards and widgets by separating static document structure (cached) from dynamic entity state (updated via named bindings).

## Key Changes

### Document Caching Infrastructure
- **New `CardDocumentCache` interface** with `InMemoryCardDocumentCache` implementation using LRU eviction (64 entries by default)
- **`CachedCardPreview` composable** replaces `RemotePreview` in dashboard rendering, caching encoded `.rc` bytes keyed by card config + theme
- **Headless capture caching** in `captureCardDocument()` for widget workers, with optional `forceRefresh` to bypass cache when YAML changes
- Cache survives Activity recreation (process-scoped) but drops on process death

### Live Bindings Expansion
- **New `LiveBindings.attribute()`** method for entity attributes (e.g., `brightness_pct`, `hvac_action`, `media_title`)
- Existing `LiveBindings.state()` and `LiveBindings.isOn()` now used throughout converters for dynamic updates
- Named bindings allow host to push fresh values without re-encoding the document

### Mode Chip Refactoring
- **New `HaModeChip` sealed interface** with two variants:
  - `Static`: Pre-formatted text from named bindings (e.g., sensor readings)
  - `Toggle`: Two-state label variants routed through `RemoteStateLayout` for boolean toggles
- Extracted `ModeChip()` and `ChipText()` composables in `RemoteHaArcDial` for cleaner structure
- Light card now uses `Toggle` variant for on/off labels; thermostat/humidifier use `Static` with attribute bindings

### Converter Updates
All card converters updated to use live bindings for dynamic content:
- **LightCardConverter**: brightness percentage and on/off mode via bindings
- **ThermostatCardConverter**: temperature labels and HVAC action via attribute bindings
- **HumidifierCardConverter**: humidity and action labels via attribute bindings
- **AreaCardConverter**: temperature/humidity sensor readings via state bindings
- **HistoryGraphCardConverter**: per-row summary text via state bindings
- **MediaControlCardConverter, WeatherForecastCardConverter, AlarmPanelCardConverter, SensorCardConverter, StatisticCardConverter**: various state/attribute bindings for live updates

## Implementation Details

**Cache Key Strategy**: Document cache keys include card config, theme style, and dark mode flag—everything that affects encoded bytes. Snapshot data is deliberately excluded so entity state changes flow through named bindings without cache invalidation.

**Headless Capture**: Widget workers can now cache documents by size/density, avoiding re-encodes when only snapshot values change. The `HeadlessCardCacheKey` includes pixel dimensions since they're baked into the document header.

**Composition-Scoped Override**: `LocalCardDocumentCache` allows tests and previews to inject custom cache implementations while production uses the singleton `defaultCardDocumentCache`.

https://claude.ai/code/session_01X9LPkgLbNyL6n4ZViaFLjT