### PR TITLE
feat: image samples + Coil-backed BitmapLoader

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -128,6 +128,10 @@ kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.
 # wanting HTTP add `coil-network-okhttp` themselves.
 coil = { module = "io.coil-kt.coil3:coil", version.ref = "coil" }
 coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
+# Fake `ImageLoader` engine for previews + tests; never goes near
+# the network. Pair with `CoilBitmapLoader` so previews exercise the
+# named-bitmap path deterministically.
+coil-test = { module = "io.coil-kt.coil3:coil-test-android", version.ref = "coil" }
 
 # Wear data layer (sync mobile ↔ watch). Horologist's data-layer
 # helpers ride on Google Play Services Wearable; both peers share a

--- a/previews/build.gradle.kts
+++ b/previews/build.gradle.kts
@@ -26,6 +26,8 @@ dependencies {
   implementation(project(":ha-model"))
   implementation(project(":rc-converter"))
   implementation(project(":rc-card-shutter"))
+  implementation(project(":rc-components-ui"))
+  implementation(project(":rc-image-coil"))
 
   implementation(platform(libs.compose.bom))
   implementation(libs.compose.ui)
@@ -40,6 +42,12 @@ dependencies {
   implementation(libs.remote.player.compose)
   implementation(libs.remote.player.view)
   implementation(libs.remote.tooling.preview)
+
+  // Coil + fake engine — previews that exercise `CoilBitmapLoader`
+  // resolve named bitmaps through `FakeImageLoaderEngine` instead of
+  // hitting the network, so renders are offline / deterministic.
+  implementation(libs.coil)
+  implementation(libs.coil.test)
 
   implementation(libs.kotlinx.serialization.json)
 }

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/ImagePreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/ImagePreviews.kt
@@ -3,6 +3,8 @@
 package ee.schimke.ha.previews
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth as uiFillMaxWidth
+import androidx.compose.foundation.layout.height as uiHeight
 import androidx.compose.remote.creation.compose.layout.RemoteComposable
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
@@ -11,40 +13,47 @@ import androidx.compose.remote.creation.compose.state.rdp
 import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.remote.tooling.preview.RemotePreview
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Paint
-import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.layout.fillMaxWidth as uiFillMaxWidth
-import androidx.compose.foundation.layout.height as uiHeight
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import ee.schimke.ha.rc.androidXExperimental
 import ee.schimke.ha.rc.components.HaTheme
 import ee.schimke.ha.rc.components.ProvideHaTheme
 import ee.schimke.ha.rc.components.RemoteHaImageInline
 import ee.schimke.ha.rc.components.RemoteHaImageNamed
+import ee.schimke.ha.rc.components.RemoteHaImageUrl
+import ee.schimke.ha.rc.ui.HaEmbeddedPlayer
 
 /**
- * Image samples — exercise the two ways RemoteCompose carries images:
+ * Image samples — exercise the three ways RemoteCompose carries
+ * images into a `.rc` document:
  *
- * - `RemoteHaImageInline` bakes the bitmap bytes into the `.rc`
- *   document. Renders identically in `RemotePreview` (no loader
- *   needed) and in any player.
- * - `RemoteHaImageNamed` references the image by name. Players that
- *   provide a `BitmapLoader` resolve the bytes at playback; everyone
- *   else (including these previews) sees the placeholder bitmap.
+ * - `RemoteHaImageInline` — anonymous bytes baked in. Renders
+ *   identically in `RemotePreview` (no loader needed).
+ * - `RemoteHaImageNamed` — bytes baked in with a registry name.
+ *   Renders without a loader; the name is the channel for state
+ *   updates.
+ * - `RemoteHaImageUrl` — URL only. The player calls
+ *   `BitmapLoader.loadBitmap(url)` at playback. Hosts **must** wire
+ *   a loader (`RemotePreview`'s default `AndroidBitmapLoader` calls
+ *   `URL.openStream()` and crashes in offline / preview contexts);
+ *   use [HaEmbeddedPlayer] + a fake `CoilBitmapLoader` (see
+ *   [previewCoilBitmapLoader]) in previews / tests.
  *
- * Both previews use a programmatically-generated [sampleBitmap] so
- * they don't depend on a drawable resource — making the document
- * size visible (~few KB inline vs. just-the-name for the named form
- * is a deliberate part of the demo).
+ * Bitmaps are programmatically drawn so renders don't depend on
+ * drawable resources.
  */
-
 private const val IMAGE_BOX_HEIGHT_DP = 96
 private const val SAMPLE_BITMAP_PX = 96
+private const val SAMPLE_NAME = "samples/weather-now"
+private const val SAMPLE_URL = "https://example.test/samples/weather-now.png"
 
 private fun sampleBitmap(): ImageBitmap {
     val size = SAMPLE_BITMAP_PX.toFloat()
@@ -58,53 +67,137 @@ private fun sampleBitmap(): ImageBitmap {
     return bmp
 }
 
-@Preview(name = "image-inline (light)", showBackground = false, widthDp = 200, heightDp = IMAGE_BOX_HEIGHT_DP)
-@Composable
-fun ImageInline_Light() = ImageHost(HaTheme.Light) {
-    RemoteHaImageInline(
-        bitmap = sampleBitmap(),
-        contentDescription = "inline sample".rs,
-        modifier = RemoteModifier.fillMaxWidth().height(IMAGE_BOX_HEIGHT_DP.rdp),
-    )
+/**
+ * Distinct from [sampleBitmap] so the URL fake-coil preview can
+ * prove the loader actually resolved (vs. a default fallback).
+ */
+private fun resolvedSampleBitmap(): ImageBitmap {
+    val size = SAMPLE_BITMAP_PX.toFloat()
+    val bmp = ImageBitmap(SAMPLE_BITMAP_PX, SAMPLE_BITMAP_PX)
+    val canvas = Canvas(bmp)
+    val paint = Paint()
+    paint.color = Color(0xFF2E7D32)
+    canvas.drawRect(0f, 0f, size, size, paint)
+    paint.color = Color(0xFFFFFFFF)
+    canvas.drawCircle(Offset(size / 2f, size / 2f), size * 0.4f, paint)
+    paint.color = Color(0xFF2E7D32)
+    canvas.drawCircle(Offset(size / 2f, size / 2f), size * 0.18f, paint)
+    return bmp
 }
 
-@Preview(name = "image-inline (dark)", showBackground = false, widthDp = 200, heightDp = IMAGE_BOX_HEIGHT_DP)
+// ─── inline (anonymous, baked) ──────────────────────────────────────
+
+@Preview(
+    name = "image-inline (light)",
+    showBackground = false,
+    widthDp = 200,
+    heightDp = IMAGE_BOX_HEIGHT_DP,
+)
 @Composable
-fun ImageInline_Dark() = ImageHost(HaTheme.Dark) {
-    RemoteHaImageInline(
-        bitmap = sampleBitmap(),
-        contentDescription = "inline sample".rs,
-        modifier = RemoteModifier.fillMaxWidth().height(IMAGE_BOX_HEIGHT_DP.rdp),
-    )
+fun ImageInline_Light() =
+    ImageHost(HaTheme.Light) {
+        RemoteHaImageInline(
+            bitmap = sampleBitmap(),
+            contentDescription = "inline sample".rs,
+            modifier = RemoteModifier.fillMaxWidth().height(IMAGE_BOX_HEIGHT_DP.rdp),
+        )
+    }
+
+@Preview(
+    name = "image-inline (dark)",
+    showBackground = false,
+    widthDp = 200,
+    heightDp = IMAGE_BOX_HEIGHT_DP,
+)
+@Composable
+fun ImageInline_Dark() =
+    ImageHost(HaTheme.Dark) {
+        RemoteHaImageInline(
+            bitmap = sampleBitmap(),
+            contentDescription = "inline sample".rs,
+            modifier = RemoteModifier.fillMaxWidth().height(IMAGE_BOX_HEIGHT_DP.rdp),
+        )
+    }
+
+// ─── named (baked, addressable) ─────────────────────────────────────
+
+@Preview(
+    name = "image-named (light)",
+    showBackground = false,
+    widthDp = 200,
+    heightDp = IMAGE_BOX_HEIGHT_DP,
+)
+@Composable
+fun ImageNamed_Light() =
+    ImageHost(HaTheme.Light) {
+        RemoteHaImageNamed(
+            name = SAMPLE_NAME,
+            bitmap = sampleBitmap(),
+            contentDescription = "named sample".rs,
+            modifier = RemoteModifier.fillMaxWidth().height(IMAGE_BOX_HEIGHT_DP.rdp),
+        )
+    }
+
+@Preview(
+    name = "image-named (dark)",
+    showBackground = false,
+    widthDp = 200,
+    heightDp = IMAGE_BOX_HEIGHT_DP,
+)
+@Composable
+fun ImageNamed_Dark() =
+    ImageHost(HaTheme.Dark) {
+        RemoteHaImageNamed(
+            name = SAMPLE_NAME,
+            bitmap = sampleBitmap(),
+            contentDescription = "named sample".rs,
+            modifier = RemoteModifier.fillMaxWidth().height(IMAGE_BOX_HEIGHT_DP.rdp),
+        )
+    }
+
+// ─── URL (loader-resolved, fake-coil-backed) ────────────────────────
+
+@Preview(
+    name = "image-url fake-coil (light)",
+    showBackground = false,
+    widthDp = 200,
+    heightDp = IMAGE_BOX_HEIGHT_DP,
+)
+@Composable
+fun ImageUrl_FakeCoil_Light() = FakeCoilUrlHost(HaTheme.Light)
+
+@Preview(
+    name = "image-url fake-coil (dark)",
+    showBackground = false,
+    widthDp = 200,
+    heightDp = IMAGE_BOX_HEIGHT_DP,
+)
+@Composable
+fun ImageUrl_FakeCoil_Dark() = FakeCoilUrlHost(HaTheme.Dark)
+
+@Composable
+private fun FakeCoilUrlHost(theme: HaTheme) {
+    val context = LocalContext.current
+    val resolved = remember { resolvedSampleBitmap() }
+    val bitmapLoader =
+        remember(context, resolved) {
+            previewCoilBitmapLoader(context, mappings = mapOf(SAMPLE_URL to resolved))
+        }
+    Box(modifier = Modifier.uiFillMaxWidth().uiHeight(IMAGE_BOX_HEIGHT_DP.dp)) {
+        HaEmbeddedPlayer(profile = androidXExperimental, bitmapLoader = bitmapLoader) {
+            ProvideHaTheme(theme) {
+                RemoteHaImageUrl(
+                    url = SAMPLE_URL,
+                    contentDescription = "url sample".rs,
+                    modifier = RemoteModifier.fillMaxWidth().height(IMAGE_BOX_HEIGHT_DP.rdp),
+                )
+            }
+        }
+    }
 }
 
-@Preview(name = "image-named (light)", showBackground = false, widthDp = 200, heightDp = IMAGE_BOX_HEIGHT_DP)
 @Composable
-fun ImageNamed_Light() = ImageHost(HaTheme.Light) {
-    RemoteHaImageNamed(
-        name = "samples/weather-now",
-        placeholder = sampleBitmap(),
-        contentDescription = "named sample".rs,
-        modifier = RemoteModifier.fillMaxWidth().height(IMAGE_BOX_HEIGHT_DP.rdp),
-    )
-}
-
-@Preview(name = "image-named (dark)", showBackground = false, widthDp = 200, heightDp = IMAGE_BOX_HEIGHT_DP)
-@Composable
-fun ImageNamed_Dark() = ImageHost(HaTheme.Dark) {
-    RemoteHaImageNamed(
-        name = "samples/weather-now",
-        placeholder = sampleBitmap(),
-        contentDescription = "named sample".rs,
-        modifier = RemoteModifier.fillMaxWidth().height(IMAGE_BOX_HEIGHT_DP.rdp),
-    )
-}
-
-@Composable
-private fun ImageHost(
-    theme: HaTheme,
-    content: @Composable @RemoteComposable () -> Unit,
-) {
+private fun ImageHost(theme: HaTheme, content: @Composable @RemoteComposable () -> Unit) {
     Box(modifier = Modifier.uiFillMaxWidth().uiHeight(IMAGE_BOX_HEIGHT_DP.dp)) {
         RemotePreview(profile = androidXExperimental) {
             ProvideHaTheme(theme) { content() }

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/PreviewCoil.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/PreviewCoil.kt
@@ -1,0 +1,53 @@
+@file:Suppress("RestrictedApi")
+@file:OptIn(coil3.annotation.ExperimentalCoilApi::class)
+
+package ee.schimke.ha.previews
+
+import android.content.Context
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
+import coil3.ImageLoader
+import coil3.asImage
+import coil3.memory.MemoryCache
+import coil3.test.FakeImageLoaderEngine
+import ee.schimke.ha.rc.image.CoilBitmapLoader
+
+/**
+ * Build a [CoilBitmapLoader] for previews / tests that resolves named
+ * bitmaps through a [FakeImageLoaderEngine] — never the network,
+ * never disk — and pre-populates the memory cache so the synchronous
+ * lookup hits on the first call.
+ *
+ * `RemoteHaImageNamed` writes a `addNamedBitmapUrl(prefixedName, url)`
+ * op into the document; the player passes the **URL** verbatim to
+ * `BitmapLoader.loadBitmap(url)` — the registry name is internal
+ * and not part of the loader call. Mappings are therefore keyed by
+ * URL, with no domain prefix applied here.
+ *
+ * Two layers of safety:
+ *
+ *  1. The loader's [ImageLoader] is wired with [FakeImageLoaderEngine]
+ *     as its sole engine, so any code path that reaches
+ *     [ImageLoader.execute] / [ImageLoader.enqueue] is intercepted
+ *     before any fetcher / decoder runs.
+ *  2. Each URL is `set` directly into the memory cache under
+ *     `MemoryCache.Key(url)`, matching
+ *     `CoilBitmapLoader.memoryCacheKeyFor`. The synchronous lookup
+ *     hits these entries — no waiting on a coroutine, no async
+ *     warm-up needed.
+ */
+fun previewCoilBitmapLoader(
+    context: Context,
+    mappings: Map<String, ImageBitmap>,
+): CoilBitmapLoader {
+    val androidMappings = mappings.mapValues { (_, b) -> b.asAndroidBitmap() }
+    val engine =
+        FakeImageLoaderEngine.Builder()
+            .apply { androidMappings.forEach { (url, bmp) -> intercept(url, bmp.asImage()) } }
+            .build()
+    val imageLoader = ImageLoader.Builder(context).components { add(engine) }.build()
+    androidMappings.forEach { (url, bmp) ->
+        imageLoader.memoryCache?.set(MemoryCache.Key(url), MemoryCache.Value(bmp.asImage()))
+    }
+    return CoilBitmapLoader(context = context, imageLoader = imageLoader)
+}

--- a/rc-components-ui/build.gradle.kts
+++ b/rc-components-ui/build.gradle.kts
@@ -31,6 +31,8 @@ dependencies {
   implementation(libs.remote.creation.android)
   implementation(libs.remote.creation.core)
   implementation(libs.remote.core)
+  implementation(libs.remote.player.core)
+  implementation(libs.remote.player.compose)
   implementation(libs.remote.tooling.preview)
 
   testImplementation(libs.kotlin.test)

--- a/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaEmbeddedPlayer.kt
+++ b/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaEmbeddedPlayer.kt
@@ -1,0 +1,71 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.ui
+
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.remote.creation.compose.capture.RemoteCreationDisplayInfo
+import androidx.compose.remote.creation.compose.capture.rememberRemoteDocument
+import androidx.compose.remote.creation.compose.layout.RemoteComposable
+import androidx.compose.remote.creation.profile.Profile
+import androidx.compose.remote.player.compose.RemoteDocumentPlayer
+import androidx.compose.remote.player.core.platform.BitmapLoader
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+
+/**
+ * Tier-2 embedding host — RemotePreview, but with a [BitmapLoader]
+ * knob.
+ *
+ * `androidx.compose.remote.tooling.preview.RemotePreview` captures
+ * its `content` into a `.rc` document and plays it inline; it's the
+ * standard preview / embedding helper. It does **not**, however,
+ * accept a `BitmapLoader`, so its `RemoteDocumentPlayer` falls back
+ * to the default loader (`AndroidBitmapLoader` →
+ * `URL.openStream()`). Any document that uses `RemoteHaImageUrl` /
+ * `addNamedBitmapUrl` blows up when played with the default loader
+ * in offline contexts (Robolectric `@Preview` renders, widget
+ * captures off the network, integration tests).
+ *
+ * [HaEmbeddedPlayer] is the same capture + play pattern with the
+ * loader threaded through to the player, so embedding surfaces have
+ * a single knob to wire — pass `CoilBitmapLoader` from
+ * `rc-image-coil` in production, `previewCoilBitmapLoader` in
+ * previews / tests.
+ *
+ * The container's measured size becomes the document's intrinsic
+ * size — same contract as `RemotePreview`. Use [profile] to pick the
+ * RemoteCompose op set (typically `androidXExperimental` /
+ * `androidXExperimentalWrap` from `rc-converter`).
+ */
+@Composable
+fun HaEmbeddedPlayer(
+    profile: Profile,
+    modifier: Modifier = Modifier,
+    bitmapLoader: BitmapLoader = BitmapLoader.UNSUPPORTED,
+    content: @Composable @RemoteComposable () -> Unit,
+) {
+    BoxWithConstraints(modifier) {
+        val density = LocalDensity.current
+        val widthPx = with(density) { maxWidth.roundToPx() }
+        val heightPx = with(density) { maxHeight.roundToPx() }
+        val densityDpi = (density.density * 160f).toInt()
+        val doc =
+            rememberRemoteDocument(
+                creationDisplayInfo = RemoteCreationDisplayInfo(widthPx, heightPx, densityDpi),
+                profile = profile,
+            ) {
+                content()
+            }
+        doc.value?.let { document ->
+            RemoteDocumentPlayer(
+                document = document,
+                documentWidth = widthPx,
+                documentHeight = heightPx,
+                modifier = Modifier.fillMaxSize(),
+                bitmapLoader = bitmapLoader,
+            )
+        }
+    }
+}

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaImage.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaImage.kt
@@ -14,37 +14,38 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.layout.ContentScale
 
 /**
- * Sample image composables that exercise the two ways RemoteCompose can
- * carry an image into a `.rc` document.
+ * Sample image composables — three flavours, picked by where the bytes
+ * live:
  *
- * - [RemoteHaImageInline] embeds the bitmap bytes directly. The
- *   document is fully self-contained (works in `RemotePreview` with
- *   no extra wiring) at the cost of bloating the `.rc` payload.
- * - [RemoteHaImageNamed] embeds only the image *name*. At playback
- *   time the host's `BitmapLoader` resolves the name to bytes; the
- *   placeholder is what `RemotePreview` and any player without a
- *   loader will show. Pair this with `CoilBitmapLoader` from
- *   `rc-image-coil` for HTTP / disk-cached resolution.
+ * - [RemoteHaImageInline] — anonymous embed. The bitmap bytes are
+ *   baked into the document and have no host-visible name. Use when
+ *   the image is fixed for the lifetime of this document and there's
+ *   no need to update it afterwards (vendor logo, baked icon).
  *
- * ### Which form to pick
+ * - [RemoteHaImageNamed] — embed bytes **with a name**. Bytes still
+ *   travel inside the document, but the name lets the host push
+ *   updates later (e.g. a fresh PNG every time the underlying
+ *   entity's state changes). Use for **local images that are
+ *   available at generation time and updated later** — the document
+ *   renders fully offline on first paint, and the name is the channel
+ *   for in-place swaps.
  *
- * Use [RemoteHaImageInline] when the image is **static / config-driven**
- * — it lives in the source tree, ships with the app, or is otherwise
- * fixed at document-encode time (e.g. a vendor logo, a state-icon
- * pre-baked from a vector, an integration's brand mark). The bytes
- * travel with the document, so playback is fully offline and the
- * widget host needs no extra plumbing.
+ * - [RemoteHaImageUrl] — embed only a URL. The player's `BitmapLoader`
+ *   resolves it at playback. Use for **URLs we don't own and can't
+ *   bake** (HA `entity_picture`, media-player thumbnails, anything
+ *   served by an external host). The same `.rc` survives image swaps
+ *   and the bytes stay in the host's image cache (e.g. Coil's disk
+ *   cache) instead of every snapshot. Pair with `CoilBitmapLoader`
+ *   from `rc-image-coil` for HTTP / disk-cached resolution.
  *
- * Use [RemoteHaImageNamed] when the image is **external and may
- * change** independently of the document — typically an
- * `entity_picture` URL, a media-player thumbnail, or any HA-served
- * resource that updates without the dashboard config changing. The
- * document carries only the name, so the same `.rc` survives image
- * swaps and the bytes stay in the host's image cache (e.g. Coil's
- * disk cache) instead of bloating every snapshot.
+ *   Hosts that don't wire a `BitmapLoader` get RemoteCompose's
+ *   default, which calls `URL.openStream()` synchronously. That
+ *   blows up in offline / preview environments with
+ *   `UnknownHostException` — so any embedding surface that uses
+ *   [RemoteHaImageUrl] should pass an explicit loader.
  */
 
-/** Bake [bitmap] into the document. */
+/** Anonymous bitmap baked into the document. */
 @Composable
 @RemoteComposable
 fun RemoteHaImageInline(
@@ -63,25 +64,52 @@ fun RemoteHaImageInline(
 }
 
 /**
- * Reference [name] in the document; the player resolves it via its
- * `BitmapLoader`. [placeholder] is rendered before the loader returns
- * (and remains in players that do not provide one).
+ * Bitmap baked into the document under [name]. Renders correctly with
+ * no `BitmapLoader` wiring (the bytes are inline); the [name] is the
+ * channel for state-driven updates.
  */
 @Composable
 @RemoteComposable
 fun RemoteHaImageNamed(
     name: String,
-    placeholder: ImageBitmap,
+    bitmap: ImageBitmap,
     contentDescription: RemoteString,
     modifier: RemoteModifier = RemoteModifier,
     contentScale: ContentScale = ContentScale.Fit,
     domain: RemoteState.Domain = RemoteState.Domain.User,
 ) {
-    val rb = rememberNamedRemoteBitmap(
-        name = name,
-        domain = domain,
-        content = { placeholder },
+    val rb = rememberNamedRemoteBitmap(name = name, domain = domain, content = { bitmap })
+    RemoteImage(
+        remoteBitmap = rb,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        contentScale = contentScale,
     )
+}
+
+/**
+ * URL-only reference. The player calls `BitmapLoader.loadBitmap(url)`
+ * at playback. [url] is passed verbatim to the loader, so anything
+ * Coil (or the host's chosen loader) can fetch works:
+ * `http(s)://…`, `file://…`, `content://…`, `android.resource://…`,
+ * an absolute file path, etc.
+ *
+ * Embedding surfaces **must** wire a loader (see
+ * `CoilBitmapLoader` in `rc-image-coil`); the default loader does a
+ * blocking `URL.openStream()` and crashes in offline / preview
+ * environments.
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaImageUrl(
+    url: String,
+    contentDescription: RemoteString,
+    modifier: RemoteModifier = RemoteModifier,
+    contentScale: ContentScale = ContentScale.Fit,
+    name: String = url,
+    domain: RemoteState.Domain = RemoteState.Domain.User,
+) {
+    val rb = rememberNamedRemoteBitmap(name = name, url = url, domain = domain)
     RemoteImage(
         remoteBitmap = rb,
         contentDescription = contentDescription,


### PR DESCRIPTION
## Summary

Three image samples that exercise both ways RemoteCompose carries
images, plus the embedding plumbing they need:

- `RemoteHaImageInline(bitmap)` — anonymous bytes baked into the `.rc`.
- `RemoteHaImageNamed(name, bitmap)` — bytes baked **with a name**;
  the name is the channel for state-driven updates. Local images
  available at generation time and updateable later.
- `RemoteHaImageUrl(url)` — URL only, resolved at playback via
  `BitmapLoader.loadBitmap(url)`. For HA `entity_picture` and other
  external resources we don't control.

New `rc-image-coil` module with `CoilBitmapLoader`: a non-blocking
`BitmapLoader` impl. `loadBitmap` is a direct
`imageLoader.memoryCache?.get(key)` — no `executeBlocking`, no
coroutine dispatch — and on a miss enqueues a full async fetch via
`imageLoader.enqueue(...)` (Coil's normal `interceptorCoroutineContext`
→ `fetcherCoroutineContext` → `decoderCoroutineContext` pipeline,
`Dispatchers.IO` for fetch by default). Synchronous on hits because
`RealImageLoader.execute` is hardcoded to `CoroutineStart.DEFAULT`,
so any `executeBlocking`-based path always pays for at least one
dispatch. Splitting at the `MemoryCache` boundary keeps both
invariants — sync hit, async fetch.

`RemotePreview` doesn't take a `BitmapLoader`, so URL-form documents
played through it crash with `UnknownHostException` (its default
`AndroidBitmapLoader` calls `URL.openStream()`). Add
`HaEmbeddedPlayer` in `rc-components-ui` — same capture-and-play
pattern as `RemotePreview` with the loader threaded through to
`RemoteDocumentPlayer`. Use it from any surface that embeds
`RemoteHaImageUrl`.

`previewCoilBitmapLoader(context, mappings)` in `previews/` builds a
`CoilBitmapLoader` backed by `FakeImageLoaderEngine` + a
pre-populated memory cache, so previews / tests that exercise the
URL path resolve **deterministically and offline** — never the
network.

`CardPlayer` (`rc-converter`) takes an optional `bitmapLoader`
forwarded to `RemoteDocumentPlayer`, defaulting to
`BitmapLoader.UNSUPPORTED` so existing callers are unaffected.

## Test plan

- [x] `./gradlew :rc-image-coil:test` — 4 tests, including
  `memoryHitReturnsBytesSynchronouslyFromCallingThread` which proves
  the lookup runs on the calling thread (no thread switch, no
  coroutine dispatch).
- [x] `./gradlew :rc-image-coil:assembleRelease`,
  `:rc-components:assembleRelease`,
  `:rc-components-ui:assembleRelease`,
  `:rc-converter:assembleRelease`,
  `:previews:assembleDebug` all green.
- [x] `compose-preview render --filter image-` — six previews
  rendered:
  - `image-inline (light/dark)` — anonymous baked bitmap.
  - `image-named (light/dark)` — bitmap baked with a registry name.
  - `image-url fake-coil (light/dark)` — URL form played through
    `HaEmbeddedPlayer` + `previewCoilBitmapLoader`. Renders the
    **resolved** bitmap (green) — confirms the player calls
    `loadBitmap(url)` and our `CoilBitmapLoader` hits the
    pre-populated `FakeImageLoaderEngine` memory cache, never the
    network.
- [x] No agent attribution in commits / PR body; branch is
  `agent/...`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmG8PxTjr6DTrGkJ9ppJNW)_