### PR TITLE
fix: handle hardware bitmaps in CoilBitmapLoader cache hits

### DIFF
--- a/rc-image-coil/src/main/kotlin/ee/schimke/ha/rc/image/CoilBitmapLoader.kt
+++ b/rc-image-coil/src/main/kotlin/ee/schimke/ha/rc/image/CoilBitmapLoader.kt
@@ -9,6 +9,7 @@ import coil3.ImageLoader
 import coil3.SingletonImageLoader
 import coil3.memory.MemoryCache
 import coil3.request.ImageRequest
+import coil3.request.allowHardware
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
@@ -101,11 +102,29 @@ open class CoilBitmapLoader(
      * `ColorImage` placeholder Coil keeps in some configurations).
      * Override to support additional [Image] subtypes or to swap the
      * encoder.
+     *
+     * Hardware bitmaps ([Bitmap.Config.HARDWARE], API 26+) are GPU
+     * textures with no CPU-side pixel data — `Bitmap.compress` on
+     * them returns `false` or throws `IllegalStateException`
+     * depending on the device, which would crash playback on a
+     * cache hit. Coil 3 stores hardware bitmaps in the memory cache
+     * by default whenever the device supports it. We can't assume
+     * the host's [imageLoader] was built with `allowHardware(false)`
+     * (it's typically a shared singleton), so copy to a software
+     * config before encoding. Our own [warmUpAsync] disables
+     * hardware bitmaps to avoid this copy on the common path.
      */
     protected open fun encodeImage(image: Image): ByteArray? {
         if (image !is BitmapImage) return null
-        val out = ByteArrayOutputStream(image.bitmap.allocationByteCount.coerceAtLeast(1024))
-        image.bitmap.compress(compressFormat, compressQuality, out)
+        val source = image.bitmap
+        val encodable =
+            if (source.config == Bitmap.Config.HARDWARE) {
+                source.copy(Bitmap.Config.ARGB_8888, /* isMutable = */ false) ?: return null
+            } else {
+                source
+            }
+        val out = ByteArrayOutputStream(encodable.allocationByteCount.coerceAtLeast(1024))
+        encodable.compress(compressFormat, compressQuality, out)
         return out.toByteArray()
     }
 
@@ -113,10 +132,21 @@ open class CoilBitmapLoader(
      * Kick off a full Coil fetch in the background. Default uses
      * [ImageLoader.enqueue] which fires-and-forgets; the populated
      * memory-cache entry is what [loadBitmap] consults next time.
+     *
+     * `allowHardware(false)` is set so the cached `Bitmap` is a
+     * software config we can [Bitmap.compress] directly — see
+     * [encodeImage]. Callers' [configure] block runs after, so a
+     * caller that explicitly wants hardware bitmaps can re-enable
+     * them (and accept the copy in [encodeImage]).
      */
     protected open fun warmUpAsync(name: String, key: MemoryCache.Key) {
         val request =
-            ImageRequest.Builder(context).data(name).memoryCacheKey(key).apply(configure).build()
+            ImageRequest.Builder(context)
+                .data(name)
+                .memoryCacheKey(key)
+                .allowHardware(false)
+                .apply(configure)
+                .build()
         imageLoader.enqueue(request)
     }
 


### PR DESCRIPTION
## Summary

Address review feedback on #125: `CoilBitmapLoader.encodeImage`
re-encodes Coil memory-cache entries by calling `Bitmap.compress`
directly. On API 26+ Coil can cache `Bitmap.Config.HARDWARE`
bitmaps (GPU textures with no CPU-side pixel data), and
`Bitmap.compress` on those returns `false` or throws
`IllegalStateException` depending on the device. A normal cache hit
for a `RemoteHaImageUrl` would therefore crash playback the second
time the player called `loadBitmap` for that URL.

Two changes:

- **`encodeImage`** — check `bitmap.config == HARDWARE` and copy to
  `ARGB_8888` before compressing. Runs on any cached bitmap
  regardless of where it came from; we can't assume the host's
  `imageLoader` was built with `allowHardware(false)` (it's
  typically a shared singleton).

- **`warmUpAsync`** — set `allowHardware(false)` on the request it
  enqueues. The bitmap Coil writes to its memory cache for our
  warm-up is therefore a software config, and the common path
  through `encodeImage` skips the copy. Callers' `configure` block
  runs after, so anyone who explicitly wants hardware bitmaps can
  re-enable them and accept the copy.

## Test plan

- [x] `./gradlew :rc-image-coil:test :rc-image-coil:assembleRelease
      ktfmtCheck` — green. Existing tests still cover the lookup
      path; they override `warmUpAsync`, so they didn't exercise the
      new `allowHardware(false)` line, but the fix itself is small
      and the alternative (Robolectric to construct real
      `ImageRequest` / `Bitmap` instances) felt heavier than
      warranted for the diff.
- [x] No agent attribution in commits / PR body; branch is `agent/...`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmG8PxTjr6DTrGkJ9ppJNW)_