### PR TITLE
feat(components): in-document animations for toggle / gauge / arc dial

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/AnimationPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/AnimationPreviews.kt
@@ -1,0 +1,209 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.previews
+
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rf
+import androidx.compose.remote.tooling.preview.RemotePreview
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.LocalPreviewClock
+import ee.schimke.ha.rc.ProvideCardRegistry
+import ee.schimke.ha.rc.RenderChild
+import ee.schimke.ha.rc.androidXExperimental
+import ee.schimke.ha.rc.cards.defaultRegistry
+import ee.schimke.ha.rc.components.HaTheme
+import ee.schimke.ha.rc.components.ProvideHaTheme
+import ee.schimke.ha.rc.components.RemoteHaToggleSwitch
+import ee.schimke.ha.rc.components.RemoteHaToggleSwitchByProgress
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+
+/**
+ * Animation flipbooks for the in-document tweens introduced by
+ * `Animations.kt`.
+ *
+ * Each strip is a `@PreviewParameter` fan-out — one PNG per frame at
+ * evenly spaced progress / value points. Reading the rendered PNGs in
+ * order is the recording: the toggle knob slides, the track colour
+ * cross-fades, the gauge sweep grows, the severity band changes from
+ * red → yellow → green as the value crosses the configured thresholds.
+ *
+ * For each component the file ships:
+ * - **`*_Strip_*`** — frozen frames driven via a by-progress entry
+ *   point (toggle) or distinct entity values (gauge). Deterministic;
+ *   the host builds one `.rc` document per frame.
+ * - **`*_Animated_*`** — a single live document, encoded once. Tapping
+ *   it in an interactive player flips the in-doc state and the player
+ *   tweens between resting frames. The static PNG only shows the
+ *   resting state; this exists so the compose-preview tooling has a
+ *   real animated document to record from.
+ */
+
+private val PreviewActiveAccent = Color(0xFF2196F3)
+private val PreviewInactiveAccent = Color(0xFFB0B0B0)
+private val PreviewNow: ZonedDateTime =
+    ZonedDateTime.of(2026, 5, 5, 10, 8, 0, 0, ZoneOffset.UTC)
+
+// ——— toggle switch ———
+
+/**
+ * Knob-progress fan-out for [RemoteHaToggleSwitchByProgress] —
+ * 0%, 25%, 50%, 75%, 100% of the off→on travel. The intermediate
+ * frames are exactly what the in-doc animation replays at runtime;
+ * the strip is a stop-motion of the same tween.
+ */
+class ToggleProgressFramesProvider : PreviewParameterProvider<Pair<String, Float>> {
+    override val values: Sequence<Pair<String, Float>> = sequenceOf(
+        "0pct" to 0f,
+        "25pct" to 0.25f,
+        "50pct" to 0.5f,
+        "75pct" to 0.75f,
+        "100pct" to 1f,
+    )
+}
+
+@Preview(name = "toggle-anim (light)", showBackground = false, widthDp = 40, heightDp = 24)
+@Composable
+fun Toggle_Animation_Light(
+    @PreviewParameter(ToggleProgressFramesProvider::class) frame: Pair<String, Float>,
+) {
+    RemotePreview(profile = androidXExperimental) {
+        ProvideHaTheme(HaTheme.Light) {
+            RemoteHaToggleSwitchByProgress(
+                progress = frame.second.rf,
+                activeAccent = PreviewActiveAccent.rc,
+                inactiveAccent = PreviewInactiveAccent.rc,
+            )
+        }
+    }
+}
+
+@Preview(name = "toggle-anim (dark)", showBackground = false, widthDp = 40, heightDp = 24)
+@Composable
+fun Toggle_Animation_Dark(
+    @PreviewParameter(ToggleProgressFramesProvider::class) frame: Pair<String, Float>,
+) {
+    RemotePreview(profile = androidXExperimental) {
+        ProvideHaTheme(HaTheme.Dark) {
+            RemoteHaToggleSwitchByProgress(
+                progress = frame.second.rf,
+                activeAccent = PreviewActiveAccent.rc,
+                inactiveAccent = PreviewInactiveAccent.rc,
+            )
+        }
+    }
+}
+
+/**
+ * Live-animated toggle. Encodes one `.rc` document with
+ * `rememberMutableRemoteBoolean` + `animateRemoteFloat`; an
+ * interactive player tweens the knob and colour when the document is
+ * tapped.
+ */
+@Preview(name = "toggle-animated (light)", showBackground = false, widthDp = 40, heightDp = 24)
+@Composable
+fun Toggle_Animated_Light() {
+    RemotePreview(profile = androidXExperimental) {
+        ProvideHaTheme(HaTheme.Light) {
+            RemoteHaToggleSwitch(
+                initiallyOn = false,
+                activeAccent = PreviewActiveAccent.rc,
+                inactiveAccent = PreviewInactiveAccent.rc,
+            )
+        }
+    }
+}
+
+@Preview(name = "toggle-animated (dark)", showBackground = false, widthDp = 40, heightDp = 24)
+@Composable
+fun Toggle_Animated_Dark() {
+    RemotePreview(profile = androidXExperimental) {
+        ProvideHaTheme(HaTheme.Dark) {
+            RemoteHaToggleSwitch(
+                initiallyOn = false,
+                activeAccent = PreviewActiveAccent.rc,
+                inactiveAccent = PreviewInactiveAccent.rc,
+            )
+        }
+    }
+}
+
+// ——— gauge ———
+
+/**
+ * Gauge value fan-out — five frames at 0%, 25%, 50%, 75%, 100%.
+ *
+ * Each frame is a different `.rc` document seeded with a different
+ * battery-percent value. The arc sweep grows; the severity band
+ * (red ≤ 30, yellow ≤ 60, green > 60) transitions exactly as a host
+ * push would, since the `.numeric_state` binding is what
+ * `RemoteHaGauge` already animates between snapshots.
+ */
+class GaugeValueFramesProvider : PreviewParameterProvider<Pair<String, Int>> {
+    override val values: Sequence<Pair<String, Int>> = sequenceOf(
+        "0pct" to 0,
+        "25pct" to 25,
+        "50pct" to 50,
+        "75pct" to 75,
+        "100pct" to 100,
+    )
+}
+
+private fun gaugeFrameSnapshot(value: Int): HaSnapshot = snapshot(
+    state(
+        "sensor.gauge_demo",
+        value.toString(),
+        mapOf(
+            "friendly_name" to "Battery",
+            "unit_of_measurement" to "%",
+            "device_class" to "battery",
+        ),
+    ),
+)
+
+private fun gaugeFrameCardJson(): String =
+    """{"type":"gauge","entity":"sensor.gauge_demo","name":"Battery %",
+       "min":0,"max":100,"severity":{"green":60,"yellow":30,"red":0}}"""
+
+@Composable
+private fun GaugeFrameHost(theme: HaTheme, content: @Composable () -> Unit) {
+    RemotePreview(profile = androidXExperimental) {
+        CompositionLocalProvider(LocalPreviewClock provides PreviewNow) {
+            ProvideCardRegistry(defaultRegistry()) {
+                ProvideHaTheme(theme) { content() }
+            }
+        }
+    }
+}
+
+@Preview(name = "gauge-anim (light)", showBackground = false, widthDp = 187, heightDp = 150)
+@Composable
+fun Gauge_Animation_Light(
+    @PreviewParameter(GaugeValueFramesProvider::class) frame: Pair<String, Int>,
+) = GaugeFrameHost(HaTheme.Light) {
+    RenderChild(
+        card(gaugeFrameCardJson()),
+        gaugeFrameSnapshot(frame.second),
+        RemoteModifier.fillMaxWidth(),
+    )
+}
+
+@Preview(name = "gauge-anim (dark)", showBackground = false, widthDp = 187, heightDp = 150)
+@Composable
+fun Gauge_Animation_Dark(
+    @PreviewParameter(GaugeValueFramesProvider::class) frame: Pair<String, Int>,
+) = GaugeFrameHost(HaTheme.Dark) {
+    RenderChild(
+        card(gaugeFrameCardJson()),
+        gaugeFrameSnapshot(frame.second),
+        RemoteModifier.fillMaxWidth(),
+    )
+}

--- a/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaUiModels.kt
+++ b/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaUiModels.kt
@@ -2,10 +2,7 @@
 
 package ee.schimke.ha.rc.ui
 
-import androidx.compose.remote.creation.compose.state.RemoteBoolean
-import androidx.compose.remote.creation.compose.state.RemoteState
 import androidx.compose.remote.creation.compose.state.rc
-import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import ee.schimke.ha.rc.components.HaAction
@@ -93,78 +90,78 @@ data class HaUnsupportedUiData(
 )
 
 // ——— plain → Remote bridges ———
+//
+// Tier-2 data already uses plain Kotlin types (String / Color /
+// Boolean) — Tier-1 [HaToggleAccent] / [HaTileData] / … now do the
+// same since the rc-components refactor in fa24b6d. The wrapper is
+// just a field-by-field copy, with [Color] mapped to its `RemoteColor`
+// `.rc` form.
 
-internal fun HaToggleAccentUi.toRemote(tag: String): HaToggleAccent =
+internal fun HaToggleAccentUi.toRemote(): HaToggleAccent =
     HaToggleAccent(
         activeAccent = activeAccent.rc,
         inactiveAccent = inactiveAccent.rc,
-        isOn = isOn?.let { literalRemoteBoolean("$tag.is_on", it) },
         initiallyOn = isOn ?: false,
+        toggleable = isOn != null,
     )
 
-/**
- * A constant [RemoteBoolean] expressed as a named binding in the
- * [RemoteState.Domain.User] domain. We piggy-back on the named-binding
- * machinery because the alpha09 SDK exposes no public literal-boolean
- * constructor; the name is otherwise unused (Tier-2 callers don't push
- * live updates — that's Tier-1's job).
- */
-private fun literalRemoteBoolean(name: String, value: Boolean): RemoteBoolean =
-    RemoteBoolean.createNamedRemoteBoolean(name, value, RemoteState.Domain.User)
-
-internal fun HaTileUiData.toRemote(tag: String = "tile"): HaTileData =
+internal fun HaTileUiData.toRemote(): HaTileData =
     HaTileData(
-        name = name.rs,
-        state = state.rs,
+        entityId = null,
+        name = name,
+        state = state,
         icon = icon,
-        accent = accent.toRemote(tag),
+        accent = accent.toRemote(),
         tapAction = tapAction,
     )
 
-internal fun HaButtonUiData.toRemote(tag: String = "button"): HaButtonData =
+internal fun HaButtonUiData.toRemote(): HaButtonData =
     HaButtonData(
-        name = name.rs,
+        entityId = null,
+        name = name,
         icon = icon,
-        accent = accent.toRemote(tag),
+        accent = accent.toRemote(),
         showName = showName,
         tapAction = tapAction,
     )
 
-internal fun HaEntityRowUiData.toRemote(tag: String = "row"): HaEntityRowData =
+internal fun HaEntityRowUiData.toRemote(): HaEntityRowData =
     HaEntityRowData(
-        name = name.rs,
-        state = state.rs,
+        entityId = null,
+        name = name,
+        state = state,
         icon = icon,
-        accent = accent.toRemote(tag),
+        accent = accent.toRemote(),
         tapAction = tapAction,
     )
 
-internal fun HaEntitiesUiData.toRemote(tag: String = "entities"): HaEntitiesData =
+internal fun HaEntitiesUiData.toRemote(): HaEntitiesData =
     HaEntitiesData(
-        title = title?.rs,
-        rows = rows.mapIndexed { i, r -> r.toRemote("$tag.$i") },
+        title = title,
+        rows = rows.map { it.toRemote() },
     )
 
-internal fun HaGlanceCellUiData.toRemote(tag: String = "cell"): HaGlanceCellData =
+internal fun HaGlanceCellUiData.toRemote(): HaGlanceCellData =
     HaGlanceCellData(
-        name = name.rs,
-        state = state.rs,
+        entityId = null,
+        name = name,
+        state = state,
         icon = icon,
-        accent = accent.toRemote(tag),
+        accent = accent.toRemote(),
         tapAction = tapAction,
     )
 
-internal fun HaGlanceUiData.toRemote(tag: String = "glance"): HaGlanceData =
+internal fun HaGlanceUiData.toRemote(): HaGlanceData =
     HaGlanceData(
-        title = title?.rs,
-        cells = cells.mapIndexed { i, c -> c.toRemote("$tag.$i") },
+        title = title,
+        cells = cells.map { it.toRemote() },
     )
 
 internal fun HaMarkdownUiData.toRemote(): HaMarkdownData =
-    HaMarkdownData(title = title?.rs, lines = lines.map { it.rs })
+    HaMarkdownData(title = title, lines = lines)
 
 internal fun HaHeadingUiData.toRemote(): HaHeadingData =
-    HaHeadingData(title = title.rs, style = style)
+    HaHeadingData(title = title, style = style)
 
 internal fun HaUnsupportedUiData.toRemote(): HaUnsupportedData =
-    HaUnsupportedData(cardType = cardType.rs)
+    HaUnsupportedData(cardType = cardType)

--- a/rc-components-ui/src/test/kotlin/ee/schimke/ha/rc/ui/HaUiModelsTest.kt
+++ b/rc-components-ui/src/test/kotlin/ee/schimke/ha/rc/ui/HaUiModelsTest.kt
@@ -8,8 +8,8 @@ import androidx.compose.ui.graphics.Color
 import ee.schimke.ha.rc.components.HaAction
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * The plain→Remote conversion is the only Tier-2 surface that's
@@ -31,15 +31,15 @@ class HaUiModelsTest {
         isOn = null,
     )
 
-    @Test fun toggleAccent_isOn_yields_named_remote_boolean() {
-        val remote = accentOn.toRemote("tile.kitchen")
-        assertNotNull(remote.isOn, "isOn should round-trip into a RemoteBoolean")
+    @Test fun toggleAccent_isOn_marks_toggleable_and_seeds_initial_state() {
+        val remote = accentOn.toRemote()
+        assertTrue(remote.toggleable, "isOn != null implies toggleable")
         assertEquals(true, remote.initiallyOn)
     }
 
-    @Test fun toggleAccent_readonly_drops_remote_boolean() {
-        val remote = accentReadOnly.toRemote("tile.sensor")
-        assertNull(remote.isOn, "read-only entity must not carry a RemoteBoolean")
+    @Test fun toggleAccent_readonly_drops_toggleable_flag() {
+        val remote = accentReadOnly.toRemote()
+        assertFalse(remote.toggleable, "isOn = null must produce a non-toggleable accent")
         assertEquals(false, remote.initiallyOn)
     }
 
@@ -52,14 +52,13 @@ class HaUiModelsTest {
             tapAction = HaAction.Toggle("light.kitchen"),
         )
         val remote = ui.toRemote()
+        assertEquals(ui.name, remote.name)
+        assertEquals(ui.state, remote.state)
         assertEquals(ui.icon, remote.icon)
         assertEquals(ui.tapAction, remote.tapAction)
     }
 
-    @Test fun entities_uiData_assigns_unique_tags_per_row() {
-        // Same accent reference on every row — if the conversion shared
-        // a name across rows the named-binding would collide; the
-        // per-index suffix makes each row's binding unique.
+    @Test fun entities_uiData_carries_each_row_through() {
         val ui = HaEntitiesUiData(
             title = "Living Room",
             rows = List(3) {
@@ -71,11 +70,11 @@ class HaUiModelsTest {
                 )
             },
         )
-        val remote = ui.toRemote("entities.living")
+        val remote = ui.toRemote()
         assertEquals(3, remote.rows.size)
-        // Three non-null bindings — the tags differ; the API doesn't
-        // expose the binding name string for a direct assert, but the
-        // count + non-null is enough to lock the contract in.
-        remote.rows.forEach { row -> assertNotNull(row.accent.isOn) }
+        remote.rows.forEachIndexed { i, row ->
+            assertEquals("Lamp $i", row.name)
+            assertTrue(row.accent.toggleable)
+        }
     }
 }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Animations.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Animations.kt
@@ -1,0 +1,57 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.remote.core.operations.utilities.easing.FloatAnimation
+import androidx.compose.remote.creation.compose.state.AnimatedRemoteFloat
+import androidx.compose.remote.creation.compose.state.CUBIC_ACCELERATE
+import androidx.compose.remote.creation.compose.state.CUBIC_ANTICIPATE
+import androidx.compose.remote.creation.compose.state.CUBIC_DECELERATE
+import androidx.compose.remote.creation.compose.state.CUBIC_LINEAR
+import androidx.compose.remote.creation.compose.state.CUBIC_OVERSHOOT
+import androidx.compose.remote.creation.compose.state.CUBIC_STANDARD
+import androidx.compose.remote.creation.compose.state.EASE_OUT_BOUNCE
+import androidx.compose.remote.creation.compose.state.EASE_OUT_ELASTIC
+import androidx.compose.remote.creation.compose.state.RemoteFloat
+
+/**
+ * Easing curve identifiers (mirrored from RemoteCompose's `RemoteFloat.kt`).
+ * The encoded `.rc` document carries the easing type id; the player
+ * evaluates the curve at playback time.
+ */
+object RcEasing {
+    const val Standard: Int = CUBIC_STANDARD
+    const val Accelerate: Int = CUBIC_ACCELERATE
+    const val Decelerate: Int = CUBIC_DECELERATE
+    const val Linear: Int = CUBIC_LINEAR
+    const val Anticipate: Int = CUBIC_ANTICIPATE
+    const val Overshoot: Int = CUBIC_OVERSHOOT
+    const val Bounce: Int = EASE_OUT_BOUNCE
+    const val Elastic: Int = EASE_OUT_ELASTIC
+}
+
+/**
+ * Wrap [input] in an [AnimatedRemoteFloat] so the player tweens between
+ * successive values whenever the document state behind [input]
+ * changes (typically via `RemoteBoolean.select(1f.rf, 0f.rf)` or a
+ * `MutableRemoteFloat` write).
+ *
+ * The encoded animation spec is a 5-tuple
+ * `(duration, easingType, customCurve, wrap, offset)` — we only ever
+ * need the first two, so the rest stay at their defaults.
+ *
+ * @param durationSeconds tween duration in seconds (player real time).
+ * @param easing easing curve id from [RcEasing].
+ */
+fun animateRemoteFloat(
+    input: RemoteFloat,
+    durationSeconds: Float = 0.20f,
+    easing: Int = RcEasing.Standard,
+): RemoteFloat = AnimatedRemoteFloat(
+    input,
+    // Pack only the duration + easing; pass NaN for wrap / offset so
+    // the packed array omits those slots (`packToFloatArray` skips NaN
+    // entries; passing 0f would inject zero values the player would
+    // try to apply as a wrap-around / phase offset).
+    FloatAnimation.packToFloatArray(durationSeconds, easing, null, Float.NaN, Float.NaN),
+)

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/LiveValues.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/LiveValues.kt
@@ -3,8 +3,10 @@
 package ee.schimke.ha.rc.components
 
 import androidx.compose.remote.creation.compose.state.RemoteBoolean
+import androidx.compose.remote.creation.compose.state.RemoteFloat
 import androidx.compose.remote.creation.compose.state.RemoteString
 import androidx.compose.remote.creation.compose.state.RemoteState
+import androidx.compose.remote.creation.compose.state.rf
 import androidx.compose.remote.creation.compose.state.rs
 
 /**
@@ -49,6 +51,30 @@ object LiveValues {
     /** Entity attribute ↔ `<entityId>.attributes.<attribute>`. */
     fun attribute(entityId: String?, attribute: String, initial: String): RemoteString =
         named(entityId, "attributes.$attribute", initial)
+
+    /**
+     * Entity numeric state ↔ `<entityId>.numeric_state` — the parsed
+     * `Float` form of the primary state, used by gauges / arcs that
+     * tween value changes via [AnimatedRemoteFloat]. The host pushes
+     * each new value by name; the player tweens between them.
+     */
+    fun numericState(entityId: String?, initial: Float): RemoteFloat =
+        namedFloat(entityId, "numeric_state", initial)
+
+    /**
+     * Generic numeric host binding for components that need to react to
+     * value updates without a re-encode (`valueFraction`,
+     * `targetFraction`, etc.). The caller picks the suffix; the host
+     * pushes by `<entityId>.<suffix>`.
+     */
+    fun namedFloat(entityId: String?, suffix: String, initial: Float): RemoteFloat {
+        if (entityId == null) return initial.rf
+        return RemoteFloat.createNamedRemoteFloat(
+            name(entityId, suffix),
+            initial,
+            RemoteState.Domain.User,
+        )
+    }
 
     /**
      * Generic helper for fields whose binding name doesn't follow the

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaArcDial.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaArcDial.kt
@@ -183,8 +183,23 @@ private fun ChipText(text: RemoteString, accent: Color) {
 
 @Composable
 private fun ArcCanvas(data: HaArcDialData, theme: HaTheme) {
+    // Live host binding for the value & (optional) target fraction —
+    // wrapped in `animateRemoteFloat` so any state push from the host
+    // tweens the sweep/marker over [DialAnimationSeconds] instead of
+    // snapping. Constant when entityId is null (preview).
     val v = data.valueFraction.coerceIn(0f, 1f)
-    val sweep = 270f * v
+    val rawValueFraction = LiveValues.namedFloat(data.entityId, "value_fraction", v)
+    val animatedValueFraction = animateRemoteFloat(rawValueFraction, DialAnimationSeconds)
+    val animatedSweep = animatedValueFraction * 270f.rf
+
+    val target = data.targetFraction
+    val rawTargetFraction = if (target != null) {
+        LiveValues.namedFloat(data.entityId, "target_fraction", target.coerceIn(0f, 1f))
+    } else null
+    val animatedTargetFraction = rawTargetFraction
+        ?.let { animateRemoteFloat(it, DialAnimationSeconds) }
+    val animatedMarkerAngle = animatedTargetFraction?.let { 135f.rf + it * 270f.rf }
+
     RemoteCanvas(modifier = RemoteModifier.size(180.rdp)) {
         val w = width
         val h = height
@@ -202,20 +217,16 @@ private fun ArcCanvas(data: HaArcDialData, theme: HaTheme) {
         }.asRemotePaint()
         drawArc(track, 135f.rf, 270f.rf, false, topLeft, arcSize)
 
-        if (sweep > 0.5f) {
-            val fill = AndroidPaint().apply {
-                isAntiAlias = true
-                style = AndroidPaint.Style.STROKE
-                strokeWidth = 12f
-                strokeCap = AndroidPaint.Cap.ROUND
-                color = data.accent.toArgb()
-            }.asRemotePaint()
-            drawArc(fill, 135f.rf, sweep.rf, false, topLeft, arcSize)
-        }
+        val fill = AndroidPaint().apply {
+            isAntiAlias = true
+            style = AndroidPaint.Style.STROKE
+            strokeWidth = 12f
+            strokeCap = AndroidPaint.Cap.ROUND
+            color = data.accent.toArgb()
+        }.asRemotePaint()
+        drawArc(fill, 135f.rf, animatedSweep, false, topLeft, arcSize)
 
-        val target = data.targetFraction
-        if (target != null) {
-            val markerAngle = 135f + 270f * target.coerceIn(0f, 1f)
+        if (animatedMarkerAngle != null) {
             val marker = AndroidPaint().apply {
                 isAntiAlias = true
                 style = AndroidPaint.Style.STROKE
@@ -223,10 +234,12 @@ private fun ArcCanvas(data: HaArcDialData, theme: HaTheme) {
                 strokeCap = AndroidPaint.Cap.ROUND
                 color = theme.primaryText.toArgb()
             }.asRemotePaint()
-            drawArc(marker, markerAngle.rf, 0.1f.rf, false, topLeft, arcSize)
+            drawArc(marker, animatedMarkerAngle, 0.1f.rf, false, topLeft, arcSize)
         }
     }
 }
+
+private const val DialAnimationSeconds = 0.45f
 
 @Composable
 private fun Steppers(

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaEntityRow.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaEntityRow.kt
@@ -29,7 +29,7 @@ import androidx.compose.remote.creation.compose.state.rememberMutableRemoteBoole
 import androidx.compose.remote.creation.compose.state.rf
 import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.remote.creation.compose.state.rsp
-import androidx.compose.remote.creation.compose.state.toRemoteDp
+import androidx.compose.remote.creation.compose.state.asRemoteDp
 import androidx.compose.remote.creation.compose.state.tween
 import androidx.compose.remote.creation.compose.text.RemoteTextStyle
 import androidx.compose.runtime.Composable
@@ -174,13 +174,21 @@ fun RemoteHaToggleSwitch(
  * own progress directly.
  *
  * Track color: `tween(inactiveAccent, activeAccent, progress)`.
- * Knob position: derived `start` padding — `(KnobInset + progress *
- * KnobTravelDp).toRemoteDp()`. Modifier.offset(x: RemoteDp) only
- * applies a constant fraction of a non-literal RemoteFloat-derived
- * RemoteDp (alpha010 — verified empirically: 14 dp of intended travel
- * collapsed to ~2 dp), so the position is folded into start padding
- * instead. The padding API consumes RemoteFloat-derived RemoteDp
- * values correctly and produces the full travel.
+ * Knob position: derived `start` padding —
+ * `(KnobInsetDp + progress * KnobTravelDp).asRemoteDp()`. Use
+ * `asRemoteDp` (the documented public converter — see
+ * [RemoteCompose docs][rc]) and not the `toRemoteDp()` cousin: the
+ * latter divides the input by display density (it expects px input and
+ * returns dp), so feeding it a dp-scaled float silently scales the
+ * travel down by `1 / density` (~38 % at 2.625) and the knob barely
+ * moves. `asRemoteDp` wraps the float as-dp directly.
+ *
+ * `Modifier.offset(x: RemoteDp)` is not used here — see commit
+ * f1832a9: `offset` with a RemoteFloat-derived RemoteDp visibly
+ * collapsed the travel even when scaling was correct, so the position
+ * is folded into start padding instead.
+ *
+ * [rc]: https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/remote/remote-creation-compose/src/main/java/androidx/compose/remote/creation/compose/state/RemoteDp.kt
  */
 @Composable
 @RemoteComposable
@@ -193,7 +201,7 @@ fun RemoteHaToggleSwitchByProgress(
 ) {
     val trackColor: RemoteColor = tween(inactiveAccent, activeAccent, progress)
     val startPaddingDp =
-        (KnobInsetDp.rf + progress * KnobTravelDp.rf).toRemoteDp()
+        (KnobInsetDp.rf + progress * KnobTravelDp.rf).asRemoteDp()
 
     RemoteBox(
         modifier = modifier

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaEntityRow.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaEntityRow.kt
@@ -2,6 +2,9 @@
 
 package ee.schimke.ha.rc.components
 
+import androidx.compose.remote.creation.compose.action.Action
+import androidx.compose.remote.creation.compose.action.CombinedAction
+import androidx.compose.remote.creation.compose.action.ValueChange
 import androidx.compose.remote.creation.compose.layout.RemoteAlignment
 import androidx.compose.remote.creation.compose.layout.RemoteArrangement
 import androidx.compose.remote.creation.compose.layout.RemoteBox
@@ -12,20 +15,22 @@ import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.background
 import androidx.compose.remote.creation.compose.modifier.clickable
 import androidx.compose.remote.creation.compose.modifier.clip
-import androidx.compose.remote.creation.compose.modifier.fillMaxHeight
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.offset
 import androidx.compose.remote.creation.compose.modifier.padding
 import androidx.compose.remote.creation.compose.modifier.size
 import androidx.compose.remote.creation.compose.shapes.RemoteCircleShape
 import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
 import androidx.compose.remote.creation.compose.state.RemoteColor
 import androidx.compose.remote.creation.compose.state.RemoteFloat
-import androidx.compose.remote.creation.compose.state.lerp
 import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.remote.creation.compose.state.rememberMutableRemoteBoolean
 import androidx.compose.remote.creation.compose.state.rf
 import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.state.toRemoteDp
+import androidx.compose.remote.creation.compose.state.tween
 import androidx.compose.remote.creation.compose.text.RemoteTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
@@ -104,32 +109,35 @@ fun RemoteHaEntityRow(data: HaEntityRowData, modifier: RemoteModifier = RemoteMo
 private val TrackWidth = 36.rdp
 private val TrackHeight = 22.rdp
 private val KnobSize = 16.rdp
+private val KnobInset = 3.rdp
+
+/** Distance the knob travels in dp between off and on. */
+private const val KnobTravelDp = 36f - 16f - 2f * 3f // = 14f
+
+/** Animation timings. */
+private const val ToggleDurationSeconds = 0.20f
 
 /**
- * Pill-shaped toggle switch.
+ * Pill-shaped toggle switch — animates between off / on.
  *
- * STATIC for now — the visual reflects [initiallyOn] at document-build
- * time. The click only emits the host action; it does NOT flip the
- * visual in-document. To re-render after a service call, the host has
- * to re-encode the document.
- *
- * Why this is a downgrade from the androidx-main `ClickableDemo`
- * pattern: see [docs/bugs/rc-alpha08-select-derived-float-layout.md]
- * (filed as b/504893436). Briefly, in alpha08 a `RemoteFloat` derived from
- * `RemoteBoolean.select(1f.rf, 0f.rf)` (or any non-constant source like
- * `animateRemoteFloat`) cannot be consumed by `RemoteRowScope.weight`
- * or by `lerp(...)` inside a `Modifier.background` without breaking the
- * surrounding layout — the rounded clip is dropped and the inner
- * content disappears. Until that's fixed, the boolean has to live on
- * the host side; the document only ever sees a literal `0f.rf` / `1f.rf`.
- *
- * Once the bug is fixed, restore: `rememberMutableRemoteBoolean` +
- * `ValueChange(localIsOn, localIsOn.not())` + `animateRemoteFloat`
- * driving `RemoteHaToggleSwitchByProgress`.
+ * 1. `rememberMutableRemoteBoolean` creates document-local state seeded
+ *    from [initiallyOn].
+ * 2. A `ValueChange` toggles that state on click; the player evaluates
+ *    the write declaratively, no re-encoding required.
+ * 3. The boolean drives a `select`-derived `RemoteFloat` progress in
+ *    `[0, 1]`, wrapped in [animateRemoteFloat] so successive flips
+ *    tween instead of snapping.
+ * 4. The track color tweens between [inactiveAccent] and [activeAccent]
+ *    via the alpha010 [tween] color helper.
+ * 5. The knob position is the same animated `progress` mapped through
+ *    `toRemoteDp()` and applied as `Modifier.offset` — avoids the
+ *    weight()-on-derived-RemoteFloat issue that bit alpha08
+ *    (b/504893436).
  *
  * @param tapAction Emitted as a `HostAction` so the runtime can call
- *   HA's service. The host is responsible for re-encoding the document
- *   on the next state push.
+ *   HA's service. The optimistic in-document flip happens regardless;
+ *   the host is responsible for rolling state back if the service call
+ *   fails.
  */
 @Composable
 @RemoteComposable
@@ -140,32 +148,32 @@ fun RemoteHaToggleSwitch(
     modifier: RemoteModifier = RemoteModifier,
     tapAction: HaAction = HaAction.None,
 ) {
-    val progress: RemoteFloat = if (initiallyOn) 1f.rf else 0f.rf
-    val host = tapAction.toRemoteAction()
-    val click: RemoteModifier =
-        if (host != null) RemoteModifier.clickable(host) else RemoteModifier
+    val localIsOn = rememberMutableRemoteBoolean(initiallyOn)
+    val target: RemoteFloat = localIsOn.select(1f.rf, 0f.rf)
+    val progress: RemoteFloat = animateRemoteFloat(target, ToggleDurationSeconds)
+
+    val toggle: Action = ValueChange(localIsOn, localIsOn.not())
+    val host: Action? = tapAction.toRemoteAction()
+    val click: Action = if (host != null) CombinedAction(toggle, host) else toggle
 
     RemoteHaToggleSwitchByProgress(
         progress = progress,
         activeAccent = activeAccent,
         inactiveAccent = inactiveAccent,
         modifier = modifier,
-        clickable = click,
+        clickable = RemoteModifier.clickable(click),
     )
 }
 
 /**
  * Progress-driven variant — deterministic layout for any
- * [RemoteFloat] `progress` in `[0, 1]`. Exposed so previews can
- * freeze the switch at 0 / 0.5 / 1 and verify the knob position.
+ * [RemoteFloat] `progress` in `[0, 1]`. Exposed so previews can freeze
+ * the switch at 0 / 0.5 / 1, and so callers (driving an externally
+ * animated source like a host-bound RemoteBoolean) can supply their
+ * own progress directly.
  *
- * Layout: a `RemoteRow` with two weighted spacers around the knob.
- * left.weight = progress, right.weight = 1 − progress. Avoids
- * needing a dynamic `RemoteDp(RemoteFloat)` (that constructor is
- * internal in alpha08).
- *
- * Track color tweens per-channel between [inactiveAccent] and
- * [activeAccent] via `lerp`.
+ * Track color: `tween(inactiveAccent, activeAccent, progress)`.
+ * Knob position: `Modifier.offset(x = (progress * KnobTravelDp).toRemoteDp())`.
  */
 @Composable
 @RemoteComposable
@@ -176,15 +184,9 @@ fun RemoteHaToggleSwitchByProgress(
     modifier: RemoteModifier = RemoteModifier,
     clickable: RemoteModifier = RemoteModifier,
 ) {
-    val trackColor = lerpRemoteColor(inactiveAccent, activeAccent, progress)
-    val rightWeight: RemoteFloat = 1f.rf - progress
+    val trackColor: RemoteColor = tween(inactiveAccent, activeAccent, progress)
+    val knobOffsetX = (progress * KnobTravelDp.rf).toRemoteDp()
 
-    // Outer Box pins the size — inside an entity row, a Row with weighted
-    // children would otherwise claim all available horizontal space, since
-    // alpha08's `.size()` on a Row doesn't override the weight-driven
-    // fillMax behavior. Box gives a hard size; the inner Row fills that.
-    // `clickable` is composed last so it doesn't shadow the visual
-    // modifiers (size/clip/background) in alpha08's modifier chain.
     RemoteBox(
         modifier = modifier
             .size(width = TrackWidth, height = TrackHeight)
@@ -192,33 +194,13 @@ fun RemoteHaToggleSwitchByProgress(
             .background(trackColor)
             .then(clickable),
     ) {
-        RemoteRow(
+        RemoteBox(
             modifier = RemoteModifier
-                .fillMaxWidth()
-                .fillMaxHeight()
-                .padding(horizontal = 2.rdp, vertical = 2.rdp),
-            verticalAlignment = RemoteAlignment.CenterVertically,
-        ) {
-            RemoteBox(modifier = RemoteModifier.weight(progress).fillMaxHeight())
-            RemoteBox(
-                modifier = RemoteModifier
-                    .size(KnobSize)
-                    .clip(RemoteCircleShape)
-                    .background(Color.White.rc),
-            )
-            RemoteBox(modifier = RemoteModifier.weight(rightWeight).fillMaxHeight())
-        }
+                .padding(start = KnobInset, top = KnobInset)
+                .offset(x = knobOffsetX, y = 0.rdp)
+                .size(KnobSize)
+                .clip(RemoteCircleShape)
+                .background(Color.White.rc),
+        )
     }
-}
-
-/**
- * Per-channel linear interpolation between two [RemoteColor]s. Pure
- * RemoteFloat math so the player can tween at playback time.
- */
-private fun lerpRemoteColor(from: RemoteColor, to: RemoteColor, t: RemoteFloat): RemoteColor {
-    val a = lerp(from.alpha, to.alpha, t)
-    val r = lerp(from.red, to.red, t)
-    val g = lerp(from.green, to.green, t)
-    val b = lerp(from.blue, to.blue, t)
-    return RemoteColor(a, r, g, b)
 }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaEntityRow.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaEntityRow.kt
@@ -109,10 +109,11 @@ fun RemoteHaEntityRow(data: HaEntityRowData, modifier: RemoteModifier = RemoteMo
 private val TrackWidth = 36.rdp
 private val TrackHeight = 22.rdp
 private val KnobSize = 16.rdp
-private val KnobInset = 3.rdp
+private const val KnobInsetDp = 3f
+private val KnobInset = KnobInsetDp.toInt().rdp
 
 /** Distance the knob travels in dp between off and on. */
-private const val KnobTravelDp = 36f - 16f - 2f * 3f // = 14f
+private const val KnobTravelDp = 36f - 16f - 2f * KnobInsetDp // = 14f
 
 /** Animation timings. */
 private const val ToggleDurationSeconds = 0.20f
@@ -173,7 +174,13 @@ fun RemoteHaToggleSwitch(
  * own progress directly.
  *
  * Track color: `tween(inactiveAccent, activeAccent, progress)`.
- * Knob position: `Modifier.offset(x = (progress * KnobTravelDp).toRemoteDp())`.
+ * Knob position: derived `start` padding — `(KnobInset + progress *
+ * KnobTravelDp).toRemoteDp()`. Modifier.offset(x: RemoteDp) only
+ * applies a constant fraction of a non-literal RemoteFloat-derived
+ * RemoteDp (alpha010 — verified empirically: 14 dp of intended travel
+ * collapsed to ~2 dp), so the position is folded into start padding
+ * instead. The padding API consumes RemoteFloat-derived RemoteDp
+ * values correctly and produces the full travel.
  */
 @Composable
 @RemoteComposable
@@ -185,7 +192,8 @@ fun RemoteHaToggleSwitchByProgress(
     clickable: RemoteModifier = RemoteModifier,
 ) {
     val trackColor: RemoteColor = tween(inactiveAccent, activeAccent, progress)
-    val knobOffsetX = (progress * KnobTravelDp.rf).toRemoteDp()
+    val startPaddingDp =
+        (KnobInsetDp.rf + progress * KnobTravelDp.rf).toRemoteDp()
 
     RemoteBox(
         modifier = modifier
@@ -196,8 +204,7 @@ fun RemoteHaToggleSwitchByProgress(
     ) {
         RemoteBox(
             modifier = RemoteModifier
-                .padding(start = KnobInset, top = KnobInset)
-                .offset(x = knobOffsetX, y = 0.rdp)
+                .padding(start = startPaddingDp, top = KnobInset)
                 .size(KnobSize)
                 .clip(RemoteCircleShape)
                 .background(Color.White.rc),

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaGauge.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaGauge.kt
@@ -21,6 +21,7 @@ import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
 import androidx.compose.remote.creation.compose.modifier.height
 import androidx.compose.remote.creation.compose.modifier.padding
 import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.RemoteFloat
 import androidx.compose.remote.creation.compose.state.asRemotePaint
 import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.remote.creation.compose.state.rdp
@@ -61,8 +62,20 @@ fun RemoteHaGauge(
         ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
 
     val span = (data.max - data.min).coerceAtLeast(0.0001)
-    val fraction = ((data.value - data.min) / span).coerceIn(0.0, 1.0).toFloat()
-    val sweep = (180f * fraction)
+
+    // Live numeric value from the entity binding, animated so each host
+    // update tweens between successive values instead of snapping. When
+    // there's no entityId we get a constant RemoteFloat — animation is
+    // a no-op since the input never changes.
+    val rawValue: RemoteFloat = LiveValues.numericState(data.entityId, data.value.toFloat())
+    val animatedValue: RemoteFloat = animateRemoteFloat(
+        rawValue,
+        durationSeconds = GaugeAnimationSeconds,
+        easing = RcEasing.Standard,
+    )
+    val animatedFraction: RemoteFloat =
+        (animatedValue - data.min.toFloat().rf) / span.toFloat().rf
+    val animatedSweep: RemoteFloat = animatedFraction * 180f.rf
 
     val severityColor = when (data.severity) {
         HaGaugeSeverity.None -> Color(0xFF03A9F4)
@@ -106,16 +119,14 @@ fun RemoteHaGauge(
                 }.asRemotePaint()
                 drawArc(track, 180f.rf, 180f.rf, false, topLeft, arcSize)
 
-                if (sweep > 0.5f) {
-                    val value = AndroidPaint().apply {
-                        isAntiAlias = true
-                        style = AndroidPaint.Style.STROKE
-                        strokeWidth = 10f
-                        strokeCap = AndroidPaint.Cap.ROUND
-                        color = severityColor.toArgb()
-                    }.asRemotePaint()
-                    drawArc(value, 180f.rf, sweep.rf, false, topLeft, arcSize)
-                }
+                val value = AndroidPaint().apply {
+                    isAntiAlias = true
+                    style = AndroidPaint.Style.STROKE
+                    strokeWidth = 10f
+                    strokeCap = AndroidPaint.Cap.ROUND
+                    color = severityColor.toArgb()
+                }.asRemotePaint()
+                drawArc(value, 180f.rf, animatedSweep, false, topLeft, arcSize)
             }
 
             RemoteText(
@@ -148,6 +159,8 @@ fun RemoteHaGauge(
         }
     }
 }
+
+private const val GaugeAnimationSeconds = 0.45f
 
 private fun formatRange(d: Double): String =
     if (d == d.toLong().toDouble()) d.toLong().toString() else "%.1f".format(d)

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaToggleButton.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaToggleButton.kt
@@ -20,12 +20,14 @@ import androidx.compose.remote.creation.compose.modifier.size
 import androidx.compose.remote.creation.compose.shapes.RemoteCircleShape
 import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
 import androidx.compose.remote.creation.compose.state.RemoteColor
+import androidx.compose.remote.creation.compose.state.RemoteFloat
 import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.remote.creation.compose.state.rdp
 import androidx.compose.remote.creation.compose.state.rf
 import androidx.compose.remote.creation.compose.state.rememberMutableRemoteBoolean
 import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.remote.creation.compose.state.rsp
+import androidx.compose.remote.creation.compose.state.tween
 import androidx.compose.remote.creation.compose.text.RemoteTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.font.FontWeight
@@ -73,7 +75,16 @@ fun RemoteHaToggleButton(data: HaButtonData, modifier: RemoteModifier = RemoteMo
     val click: Action = if (host != null) CombinedAction(toggle, host) else toggle
     val clickable = RemoteModifier.clickable(click)
 
-    val accent: RemoteColor = localIsOn.select(data.accent.activeAccent, data.accent.inactiveAccent)
+    // Tween the accent between inactive ↔ active so the icon halo and
+    // tint cross-fade instead of snapping. The progress source is the
+    // optimistic in-doc boolean; on a click ValueChange flips it and
+    // `animateRemoteFloat` provides the smoothing.
+    val accentProgress: RemoteFloat = animateRemoteFloat(
+        localIsOn.select(1f.rf, 0f.rf),
+        durationSeconds = 0.20f,
+    )
+    val accent: RemoteColor =
+        tween(data.accent.inactiveAccent, data.accent.activeAccent, accentProgress)
 
     // Wrap-content by default so grid / horizontal-stack can pack
     // multiple buttons per row. Standalone callers wanting a


### PR DESCRIPTION
## Summary

Wraps the host-bound numeric and boolean state of every "moving" component
in `AnimatedRemoteFloat` so successive state pushes tween at playback time
instead of snapping. Replaces the alpha08 host-side workarounds documented
in `docs/bugs/rc-alpha08-select-derived-float-layout.md` — alpha010 ships
`tween(RemoteColor, RemoteColor, RemoteFloat)`, leveraged here.

- **Toggle switch** — `rememberMutableRemoteBoolean` + `ValueChange`
  flips state on click; the boolean drives an animated progress.
  Track colour cross-fades via `tween(...)`. Knob position is folded
  into `Modifier.padding(start = (inset + progress *
  travel).asRemoteDp())` — `Modifier.offset(x: RemoteDp)` collapsed
  the travel; `RemoteFloat.toRemoteDp()` divides by display density
  (treats the input as px); only the dp-direct
  `RemoteFloat.asRemoteDp()` plus a derived start padding produces
  the full sweep.
- **Toggle button accent** — same progress source replaces the
  instantaneous `select(activeAccent, inactiveAccent)` with a colour
  tween.
- **Gauge** — `LiveValues.numericState(entityId, …)` exposes the entity
  value as a named `RemoteFloat`; the sweep is computed from that and
  wrapped in `AnimatedRemoteFloat`. Host pushes by name now tween.
- **Arc dial** — `value_fraction` and `target_fraction` go through the
  same path, so thermostat / humidifier dials animate the target marker
  and fill arc smoothly.

New helpers:

- `rc-components/.../Animations.kt` — `animateRemoteFloat(input,
  durationSeconds, easing)` plus `RcEasing` constants
  (Standard / Accelerate / Decelerate / Bounce / Elastic / …). Packs
  the spec via `FloatAnimation.packToFloatArray(...)`, NaN'ing
  wrap/offset so the player doesn't apply a phantom phase shift.
- `LiveValues.numericState` / `LiveValues.namedFloat` for components
  that need a host-bound `RemoteFloat` alongside the existing string /
  boolean bindings.
- `previews/.../AnimationPreviews.kt` flipbooks: `Toggle_Animation_*`
  and `Gauge_Animation_*` fan out via `@PreviewParameter` over five
  evenly-spaced frames; each frame becomes one PNG, so reading them
  in order is the recording. `Toggle_Animated_*` ships a single live
  document for the compose-preview tooling to capture interactively.

Drive-by: `rc-components-ui/HaUiModels.kt` (and its test) stopped
compiling on `main` after the simple-types refactor in fa24b6d — the
bridge still wrapped `String` with `.rs` and passed an `isOn`
parameter that no longer existed. Replaced with the field-by-field
copy that matches the current shape; tests assert `toggleable` /
`initiallyOn` instead of the removed `isOn` `RemoteBoolean`.

## Animation flipbooks

Frames published via `compose-preview publish-images` to the
`compose-preview/animate-card-components` branch (commit `2d26b4d`).

### Toggle switch

Knob slides via `Modifier.padding(start = (inset + progress *
travel).asRemoteDp())`; track colour cross-fades via
`tween(inactiveAccent, activeAccent, progress)`. Click flips the
in-doc boolean; `animateRemoteFloat` smooths the boolean-derived
progress over ~200 ms.

#### Light

| 0 % | 25 % | 50 % | 75 % | 100 % |
|---|---|---|---|---|
| ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/toggle-light-0pct.png) | ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/toggle-light-25pct.png) | ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/toggle-light-50pct.png) | ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/toggle-light-75pct.png) | ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/toggle-light-100pct.png) |

#### Dark

| 0 % | 25 % | 50 % | 75 % | 100 % |
|---|---|---|---|---|
| ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/toggle-dark-0pct.png) | ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/toggle-dark-25pct.png) | ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/toggle-dark-50pct.png) | ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/toggle-dark-75pct.png) | ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/toggle-dark-100pct.png) |

#### Live document (one `.rc`, click to toggle)

| Light | Dark |
|---|---|
| ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/toggle-light-animated.png) | ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/toggle-dark-animated.png) |

### Gauge

Each frame is a separate `.rc` document seeded with a different
battery-percent value. Severity band crosses red ≤ 30 → yellow ≤ 60 →
green > 60. Host pushes to `<entityId>.numeric_state` tween between
successive values via `AnimatedRemoteFloat`; reading the row
left-to-right mirrors the trajectory the player walks at runtime.

#### Light

| 0 % | 25 % | 50 % | 75 % | 100 % |
|---|---|---|---|---|
| ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/gauge-light-0pct.png) | ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/gauge-light-25pct.png) | ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/gauge-light-50pct.png) | ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/gauge-light-75pct.png) | ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/gauge-light-100pct.png) |

#### Dark

| 0 % | 25 % | 50 % | 75 % | 100 % |
|---|---|---|---|---|
| ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/gauge-dark-0pct.png) | ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/gauge-dark-25pct.png) | ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/gauge-dark-50pct.png) | ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/gauge-dark-75pct.png) | ![](https://raw.githubusercontent.com/yschimke/homeassistant-remotecompose/2d26b4d39da19049c903d482178ab7fe0e4df260/gauge-dark-100pct.png) |

## Test plan

- [x] `./gradlew :rc-components:compileDebugKotlin` clean
- [x] `./gradlew :rc-components-ui:test :rc-components:test` pass
- [x] `./gradlew ktfmtCheck` passes
- [x] `./gradlew :previews:renderAllPreviews` produces all 22 animation
      frames + the existing thermostat / gauge previews
- [x] Pixel-measured the toggle knob centre across the 5 progress
      frames: 28 → 37 → 47 → 56 → 65 px on the 105 px-wide canvas
      (= ~37 px sweep, matching 14 dp × 2.625 density). At progress=1
      the knob right edge sits flush with the pill's right inset.
- [ ] Render the animated documents in an interactive `RemoteCompose`
      player (out of scope here — the static PNG only shows the
      resting state).
