### PR TITLE
fix(rc): size CachedCardPreview to its slot so cards render

### DIFF
--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CachedCardPreview.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CachedCardPreview.kt
@@ -4,6 +4,7 @@ package ee.schimke.ha.rc
 
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.remote.creation.compose.capture.captureSingleRemoteDocument
 import androidx.compose.remote.creation.compose.layout.RemoteComposable
 import androidx.compose.remote.creation.profile.Profile
@@ -13,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalWindowInfo
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -66,12 +68,14 @@ fun CachedCardPreview(
         }
 
     val coreDocument = remember(cardDocument) { cardDocument.decode() }
+    val windowInfo = LocalWindowInfo.current
 
-    Box(modifier = modifier) {
+    Box(modifier = modifier.fillMaxSize()) {
         RemoteDocumentPlayer(
             document = coreDocument,
-            documentWidth = cardDocument.widthPx,
-            documentHeight = cardDocument.heightPx,
+            documentWidth = windowInfo.containerSize.width,
+            documentHeight = windowInfo.containerSize.height,
+            modifier = Modifier.fillMaxSize(),
         )
     }
 }


### PR DESCRIPTION
## Summary
- `CachedCardPreview` (added in #124) wrapped `RemoteDocumentPlayer` in a `Box` that took the caller's `modifier` (defaulting to plain `Modifier` with no size) and passed `documentWidth=0`/`documentHeight=0` to the player. `DashboardViewScreen.CardSlot` doesn't supply a modifier, so every card collapsed to 0×0 and the dashboard body went blank under the TopAppBar.
- Match upstream `RemotePreview` / `RemoteDocPreview`: `fillMaxSize` on both the wrapping `Box` and the player, and use `LocalWindowInfo.containerSize` for document dimensions.

## Test plan
- [x] Demo mode → GitHub dashboard now renders cards (heading, history-graph, markdown, tile cluster) on emulator
- [ ] Verify on physical device
- [ ] Verify other dashboards (Climate, Energy, etc.) still render