### PR TITLE
Add demo mode action handling with cover animations

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardActionDispatcher.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardActionDispatcher.kt
@@ -1,0 +1,132 @@
+package ee.schimke.terrazzo.dashboard
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import ee.schimke.ha.rc.CardDocumentCache
+import ee.schimke.ha.rc.HaActionDispatcher
+import ee.schimke.ha.rc.LocalCardDocumentCache
+import ee.schimke.ha.rc.components.HaAction
+import ee.schimke.terrazzo.core.session.CoverCommand
+import ee.schimke.terrazzo.core.session.DemoData
+import ee.schimke.terrazzo.core.session.DemoHaSession
+import ee.schimke.terrazzo.core.session.HaSession
+import ee.schimke.terrazzo.core.session.demoCoverPositionPercent
+
+/**
+ * Build the [HaActionDispatcher] that backs `LocalHaActionDispatcher`
+ * for the dashboard surface. The dispatcher fans actions out by type:
+ *
+ *   - [HaAction.Url] → `Intent.ACTION_VIEW` (opens a browser)
+ *   - [HaAction.CallService] / [HaAction.Toggle] → demo router for
+ *     [DemoHaSession]; logged-only for live sessions until the live
+ *     client gains a service-call API.
+ *   - [HaAction.Navigate] / [HaAction.MoreInfo] → logged for now —
+ *     these need in-app navigation that the dashboard doesn't expose yet.
+ *
+ * In demo mode the dispatcher also evicts the [CardDocumentCache] so
+ * cards baking state into bytes (e.g. the garage shutter card's
+ * `closedFraction`) re-encode against the new snapshot on the next
+ * dashboard refresh — without that, toggles fire but the visual
+ * doesn't update.
+ */
+@Composable
+fun rememberDashboardActionDispatcher(session: HaSession): HaActionDispatcher {
+    val context = LocalContext.current
+    val cache = LocalCardDocumentCache.current
+    return remember(session, context, cache) {
+        DashboardActionDispatcher(context.applicationContext, session, cache)
+    }
+}
+
+private class DashboardActionDispatcher(
+    private val context: Context,
+    private val session: HaSession,
+    private val cache: CardDocumentCache,
+) : HaActionDispatcher {
+    override fun dispatch(action: HaAction) {
+        when (action) {
+            is HaAction.Url -> launchUrl(action.url)
+            is HaAction.Toggle -> applyDemoToggle(action.entityId)
+            is HaAction.CallService -> applyDemoCallService(action)
+            is HaAction.MoreInfo,
+            is HaAction.Navigate,
+            HaAction.None -> Log.i(TAG, "Action not yet wired: $action")
+        }
+    }
+
+    private fun launchUrl(url: String) {
+        val uri = runCatching { Uri.parse(url) }.getOrNull() ?: run {
+            Log.w(TAG, "Refusing to launch unparseable URL: $url")
+            return
+        }
+        val intent = Intent(Intent.ACTION_VIEW, uri).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        try {
+            context.startActivity(intent)
+        } catch (e: ActivityNotFoundException) {
+            Log.w(TAG, "No activity found to open $url", e)
+        }
+    }
+
+    private fun applyDemoToggle(entityId: String) {
+        val demo = session as? DemoHaSession ?: run {
+            Log.i(TAG, "Toggle for $entityId — live HA service call not implemented yet")
+            return
+        }
+        // Snapshot once so we can read the entity's current state, then
+        // bounce the request through the router.
+        val snapshot = ee.schimke.terrazzo.core.session.DemoData.snapshot(
+            router = demo.actionRouter,
+        )
+        val current = snapshot.states[entityId]?.state ?: return
+        demo.actionRouter.applyToggle(entityId, current)
+        cache.clear()
+    }
+
+    private fun applyDemoCallService(action: HaAction.CallService) {
+        val demo = session as? DemoHaSession ?: run {
+            Log.i(TAG, "CallService ${action.domain}.${action.service} — live not implemented yet")
+            return
+        }
+        val entityId = action.entityId ?: return
+        when (action.domain) {
+            "cover" -> {
+                val command = when (action.service) {
+                    "open_cover" -> CoverCommand.Open
+                    "close_cover" -> CoverCommand.Close
+                    "stop_cover" -> CoverCommand.Stop
+                    else -> return
+                }
+                val snapshot = DemoData.snapshot(router = demo.actionRouter)
+                val position = snapshot.states[entityId]?.demoCoverPositionPercent() ?: 0
+                demo.actionRouter.requestCover(
+                    entityId = entityId,
+                    command = command,
+                    nowMs = System.currentTimeMillis(),
+                    currentPosition = position,
+                )
+                cache.clear()
+            }
+            "homeassistant", "switch", "light", "input_boolean" -> {
+                if (action.service == "toggle" || action.service == "turn_on" || action.service == "turn_off") {
+                    val snapshot = ee.schimke.terrazzo.core.session.DemoData.snapshot(
+                        router = demo.actionRouter,
+                    )
+                    val current = snapshot.states[entityId]?.state ?: return
+                    demo.actionRouter.applyToggle(entityId, current)
+                    cache.clear()
+                }
+            }
+            else -> Log.i(TAG, "Demo router has no handler for ${action.domain}.${action.service}")
+        }
+    }
+
+    companion object {
+        private const val TAG = "DashboardAction"
+    }
+}

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -38,9 +39,12 @@ import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.Dashboard
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.terrazzo.LocalTerrazzoGraph
+import ee.schimke.terrazzo.core.session.DemoHaSession
 import ee.schimke.terrazzo.core.session.HaSession
 import ee.schimke.ha.rc.CachedCardPreview
 import ee.schimke.ha.rc.CardWidthClass
+import ee.schimke.ha.rc.LocalCardCaptureEpoch
+import ee.schimke.ha.rc.LocalHaActionDispatcher
 import ee.schimke.ha.rc.ProvideCardRegistry
 import ee.schimke.ha.rc.RenderChild
 import ee.schimke.ha.rc.androidXExperimentalWrap
@@ -104,7 +108,7 @@ fun DashboardViewScreen(
     }
 
     LaunchedEffect(session, urlPath) {
-        // Poll when the session opts in (demo mode does, at ~2s) so
+        // Poll when the session opts in (demo mode does, at ~1s) so
         // values visibly change; a one-shot fetch otherwise.
         while (true) {
             runCatching { session.loadDashboard(urlPath) }
@@ -121,14 +125,42 @@ fun DashboardViewScreen(
         }
     }
 
-    when (val s = state) {
-        DashboardState.Loading -> Box(Modifier.fillMaxSize().padding(contentPadding).padding(24.dp)) {
-            CircularProgressIndicator()
+    // Demo mode: refresh as soon as a tap mutates state so the next
+    // dashboard frame reflects the new override (cover animation,
+    // toggle flip) instead of waiting up to a full poll interval.
+    val demoEpoch: Long = if (session is DemoHaSession) {
+        val epoch by session.actionRouter.epoch.collectAsState()
+        LaunchedEffect(session, urlPath, epoch) {
+            // Skip the seed value (epoch == 0). Subsequent bumps are
+            // user-driven taps and warrant an immediate re-fetch.
+            if (epoch > 0L) {
+                runCatching { session.loadDashboard(urlPath) }
+                    .onSuccess { (dashboard, snapshot) ->
+                        state = DashboardState.Ready(dashboard, snapshot)
+                    }
+            }
         }
-        is DashboardState.Error -> Box(Modifier.fillMaxSize().padding(contentPadding).padding(24.dp)) {
-            Text("Failed: ${s.message}", style = MaterialTheme.typography.bodyMedium)
+        epoch
+    } else {
+        0L
+    }
+
+    val actionDispatcher = rememberDashboardActionDispatcher(session)
+
+    CompositionLocalProvider(
+        LocalHaActionDispatcher provides actionDispatcher,
+        LocalCardCaptureEpoch provides demoEpoch,
+    ) {
+        when (val s = state) {
+            DashboardState.Loading -> Box(Modifier.fillMaxSize().padding(contentPadding).padding(24.dp)) {
+                CircularProgressIndicator()
+            }
+            is DashboardState.Error -> Box(Modifier.fillMaxSize().padding(contentPadding).padding(24.dp)) {
+                Text("Failed: ${s.message}", style = MaterialTheme.typography.bodyMedium)
+            }
+            is DashboardState.Ready ->
+                DashboardList(s.dashboard, s.snapshot, onCardLongPress, contentPadding)
         }
-        is DashboardState.Ready -> DashboardList(s.dashboard, s.snapshot, onCardLongPress, contentPadding)
     }
 }
 
@@ -460,12 +492,17 @@ private fun CardSlot(
 ) {
     val style = LocalThemeStyle.current
     val dark = LocalIsDarkTheme.current
+    val captureEpoch = LocalCardCaptureEpoch.current
     // The document's paint colours are baked at capture; re-encode when
     // theme flips. Snapshot is deliberately NOT in the cache key —
     // entity values flow into the running player by named binding
-    // (see LiveValues in rc-components).
+    // (see LiveValues in rc-components). [captureEpoch] is the
+    // exception: hosts that mutate state out-of-band (demo mode taps)
+    // bump it to force a re-encode on the next composition.
     val haTheme = remember(style, dark) { haThemeFor(style, dark) }
-    val cacheKey = remember(card, style, dark) { CardSlotCacheKey(card, style, dark) }
+    val cacheKey = remember(card, style, dark, captureEpoch) {
+        CardSlotCacheKey(card, style, dark, captureEpoch)
+    }
     Box(
         modifier = modifier
             // Stable semantics tag so uiautomator / Compose tests can
@@ -493,6 +530,7 @@ private data class CardSlotCacheKey(
     val card: CardConfig,
     val style: ThemeStyle,
     val dark: Boolean,
+    val captureEpoch: Long,
 )
 
 /**

--- a/app/src/test/kotlin/ee/schimke/ha/rc/HaActionDispatcherTest.kt
+++ b/app/src/test/kotlin/ee/schimke/ha/rc/HaActionDispatcherTest.kt
@@ -1,0 +1,59 @@
+package ee.schimke.ha.rc
+
+import ee.schimke.ha.rc.components.HaAction
+import ee.schimke.ha.rc.components.toRemoteAction
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.serialization.json.Json
+
+class HaActionDispatcherTest {
+
+    @Test
+    fun decodeHaAction_round_trips_url() {
+        // Round-trip via the same JSON encoder `toRemoteAction()` uses
+        // so we exercise the on-the-wire shape, not just an arbitrary
+        // serializer call.
+        val original = HaAction.Url("https://example.com/x")
+        val payload = Json.encodeToString(HaAction.serializer(), original)
+
+        assertEquals(original, decodeHaAction(payload))
+    }
+
+    @Test
+    fun decodeHaAction_returns_null_for_non_string() {
+        assertNull(decodeHaAction(42))
+        assertNull(decodeHaAction(null))
+    }
+
+    @Test
+    fun decodeHaAction_returns_null_for_garbage_json() {
+        assertNull(decodeHaAction("{not-json"))
+    }
+
+    @Test
+    fun toRemoteAction_payload_is_decodable() {
+        // Wired check: anything emitted by `toRemoteAction` must be
+        // re-readable by the playback side, otherwise dashboards
+        // fire actions the dispatcher silently drops.
+        val callService = HaAction.CallService(domain = "cover", service = "open_cover", entityId = "cover.x")
+        val remote = callService.toRemoteAction()
+        // toRemoteAction packs the JSON in the HostAction's `value`
+        // field; we serialize the same way to assert the contract.
+        val payload = Json.encodeToString(HaAction.serializer(), callService)
+
+        assertEquals(callService, decodeHaAction(payload))
+        // sanity: HostAction was created (non-null) — None returns null.
+        assert(remote != null)
+    }
+
+    @Test
+    fun noop_dispatcher_does_not_throw() {
+        // Smoke: the default dispatcher must accept every variant
+        // without raising — it's the safety net for surfaces that
+        // haven't wired a real handler.
+        NoOpHaActionDispatcher.dispatch(HaAction.Url("x"))
+        NoOpHaActionDispatcher.dispatch(HaAction.Toggle("light.x"))
+        NoOpHaActionDispatcher.dispatch(HaAction.None)
+    }
+}

--- a/app/src/test/kotlin/ee/schimke/terrazzo/core/session/DemoActionRouterTest.kt
+++ b/app/src/test/kotlin/ee/schimke/terrazzo/core/session/DemoActionRouterTest.kt
@@ -1,0 +1,133 @@
+package ee.schimke.terrazzo.core.session
+
+import ee.schimke.ha.model.EntityState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
+
+class DemoActionRouterTest {
+
+    private fun base(id: String, state: String, attrs: Map<String, JsonPrimitive> = emptyMap()) =
+        EntityState(entityId = id, state = state, attributes = JsonObject(attrs))
+
+    @Test
+    fun applyToggle_flips_on_off() {
+        val router = DemoActionRouter()
+        val states = mapOf("light.kitchen" to base("light.kitchen", "off"))
+
+        router.applyToggle("light.kitchen", "off")
+
+        val result = router.snapshotOverrides(states, nowMs = 0L)
+        assertEquals("on", result["light.kitchen"]?.state)
+    }
+
+    @Test
+    fun applyToggle_flips_open_closed() {
+        val router = DemoActionRouter()
+        val states = mapOf("cover.front" to base("cover.front", "open"))
+
+        router.applyToggle("cover.front", "open")
+
+        assertEquals("closed", router.snapshotOverrides(states, nowMs = 0L)["cover.front"]?.state)
+    }
+
+    @Test
+    fun applyToggle_ignores_non_binary_state() {
+        val router = DemoActionRouter()
+        val states = mapOf("sensor.temp" to base("sensor.temp", "21.5"))
+
+        router.applyToggle("sensor.temp", "21.5")
+
+        // Untouched.
+        assertEquals("21.5", router.snapshotOverrides(states, nowMs = 0L)["sensor.temp"]?.state)
+    }
+
+    @Test
+    fun requestCover_open_starts_animation_from_zero() {
+        val router = DemoActionRouter()
+        val states = mapOf("cover.garage" to base("cover.garage", "closed"))
+
+        router.requestCover("cover.garage", CoverCommand.Open, nowMs = 1_000L, currentPosition = 0)
+
+        // 100 ms after start: ~2% open, motion = opening.
+        val mid = router.snapshotOverrides(states, nowMs = 1_100L)["cover.garage"]
+        assertEquals("opening", mid?.state)
+        val pos = mid?.attributes?.get("current_position")?.jsonPrimitive?.content?.toIntOrNull()
+        assertTrue(pos != null && pos in 1..10, "expected partial-open position, got $pos")
+    }
+
+    @Test
+    fun requestCover_eventually_settles_to_open() {
+        val router = DemoActionRouter()
+        val states = mapOf("cover.garage" to base("cover.garage", "closed"))
+
+        router.requestCover("cover.garage", CoverCommand.Open, nowMs = 0L, currentPosition = 0)
+
+        // 6 s in — animation runs to completion (~5 s end-to-end).
+        val terminal = router.snapshotOverrides(states, nowMs = 6_000L)["cover.garage"]
+        assertEquals("open", terminal?.state)
+    }
+
+    @Test
+    fun requestCover_close_flips_state_when_already_at_target() {
+        val router = DemoActionRouter()
+        val states = mapOf("cover.garage" to base("cover.garage", "closed"))
+
+        // Already closed, but request close anyway — should at least
+        // ensure the override settles `closed` so the label is right.
+        router.requestCover("cover.garage", CoverCommand.Close, nowMs = 0L, currentPosition = 0)
+
+        assertEquals("closed", router.snapshotOverrides(states, nowMs = 0L)["cover.garage"]?.state)
+    }
+
+    @Test
+    fun mutations_bump_epoch() {
+        val router = DemoActionRouter()
+        val before = router.epoch.value
+
+        router.applyToggle("light.kitchen", "off")
+        val afterToggle = router.epoch.value
+
+        router.requestCover("cover.x", CoverCommand.Open, nowMs = 0L, currentPosition = 50)
+        val afterCover = router.epoch.value
+
+        assertNotEquals(before, afterToggle)
+        assertNotEquals(afterToggle, afterCover)
+    }
+
+    @Test
+    fun reset_clears_overrides_and_bumps_epoch() {
+        val router = DemoActionRouter()
+        router.applyToggle("light.kitchen", "off")
+        val states = mapOf("light.kitchen" to base("light.kitchen", "off"))
+
+        // Sanity: override took effect.
+        assertEquals("on", router.snapshotOverrides(states, nowMs = 0L)["light.kitchen"]?.state)
+
+        val epochBeforeReset = router.epoch.value
+        router.reset()
+
+        assertEquals("off", router.snapshotOverrides(states, nowMs = 0L)["light.kitchen"]?.state)
+        assertNotEquals(epochBeforeReset, router.epoch.value)
+    }
+
+    @Test
+    fun demoCoverPositionPercent_reads_attribute() {
+        val state = base(
+            "cover.x", "open",
+            attrs = mapOf("current_position" to JsonPrimitive(73)),
+        )
+        assertEquals(73, state.demoCoverPositionPercent())
+    }
+
+    @Test
+    fun demoCoverPositionPercent_falls_back_by_state() {
+        assertEquals(100, base("cover.x", "open").demoCoverPositionPercent())
+        assertEquals(0, base("cover.x", "closed").demoCoverPositionPercent())
+        assertEquals(50, base("cover.x", "opening").demoCoverPositionPercent())
+    }
+}

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/HaAction.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/HaAction.kt
@@ -14,12 +14,16 @@ import kotlinx.serialization.json.JsonObject
  * `src/data/lovelace/config/action.ts`).
  *
  * At render time these get serialized into a single RemoteCompose
- * [HostAction] carrying a JSON payload; the widget-side host intercepts
- * the action via `RemoteDocumentPlayer(onNamedAction = …)` and calls the
- * corresponding HA service / navigates / fires a URL.
+ * [HostAction] carrying a JSON payload; the host intercepts the action
+ * via `RemoteDocumentPlayer(onNamedAction = …)` and calls the
+ * corresponding HA service / navigates / fires a URL. In `:rc-converter`
+ * the playback path (`CachedCardPreview`, `CardPlayer`) wires that
+ * callback to a composition-local `HaActionDispatcher`, so cards
+ * themselves only need to emit actions and the host app supplies one
+ * dispatcher for the whole dashboard.
  *
- * The action name on the wire is always [ACTION_NAME]; the payload is the
- * discriminated-union JSON of the sealed subtype.
+ * The action name on the wire is always [HA_ACTION_NAME]; the payload is
+ * the discriminated-union JSON of the sealed subtype.
  */
 @Serializable
 sealed interface HaAction {
@@ -48,7 +52,11 @@ sealed interface HaAction {
     data object None : HaAction
 }
 
-/** Host-side action name; receive via `RemoteDocumentPlayer(onNamedAction = …)`. */
+/**
+ * Host-side action name. The playback path in `:rc-converter` listens
+ * for `HostAction`s under this name and decodes the JSON payload into
+ * an [HaAction] before forwarding to `LocalHaActionDispatcher`.
+ */
 public const val HA_ACTION_NAME: String = "ha"
 
 private val json = Json { ignoreUnknownKeys = true }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CachedCardPreview.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CachedCardPreview.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalWindowInfo
+import ee.schimke.ha.rc.components.HA_ACTION_NAME
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -69,6 +70,7 @@ fun CachedCardPreview(
 
     val coreDocument = remember(cardDocument) { cardDocument.decode() }
     val windowInfo = LocalWindowInfo.current
+    val dispatcher = LocalHaActionDispatcher.current
 
     Box(modifier = modifier.fillMaxSize()) {
         RemoteDocumentPlayer(
@@ -76,6 +78,11 @@ fun CachedCardPreview(
             documentWidth = windowInfo.containerSize.width,
             documentHeight = windowInfo.containerSize.height,
             modifier = Modifier.fillMaxSize(),
+            onNamedAction = { name, value, _ ->
+                if (name == HA_ACTION_NAME) {
+                    decodeHaAction(value)?.let(dispatcher::dispatch)
+                }
+            },
         )
     }
 }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardCapture.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardCapture.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.components.HA_ACTION_NAME
 import java.io.ByteArrayInputStream
 
 /**
@@ -128,11 +129,17 @@ fun CardPlayer(
         converter.Render(card, snapshot)
     }
     val document = doc.value ?: return
+    val dispatcher = LocalHaActionDispatcher.current
     RemoteDocumentPlayer(
         document = document,
         documentWidth = widthPx,
         documentHeight = heightPx,
         modifier = modifier,
         bitmapLoader = bitmapLoader,
+        onNamedAction = { name, value, _ ->
+            if (name == HA_ACTION_NAME) {
+                decodeHaAction(value)?.let(dispatcher::dispatch)
+            }
+        },
     )
 }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/HaActionDispatcher.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/HaActionDispatcher.kt
@@ -1,0 +1,65 @@
+package ee.schimke.ha.rc
+
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.staticCompositionLocalOf
+import ee.schimke.ha.rc.components.HaAction
+import kotlinx.serialization.json.Json
+
+/**
+ * Receives [HaAction]s the player decoded from a RemoteCompose
+ * `HostAction` named [HA_ACTION_NAME][ee.schimke.ha.rc.components.HA_ACTION_NAME].
+ * Implementations decide what each variant means in the host app
+ * (Intent.ACTION_VIEW for [HaAction.Url], an HA service call for
+ * [HaAction.CallService] / [HaAction.Toggle], in-app navigation for
+ * [HaAction.Navigate]).
+ */
+fun interface HaActionDispatcher {
+    fun dispatch(action: HaAction)
+}
+
+/**
+ * Dispatcher that drops every action on the floor. Used by previews,
+ * tests, and any surface that hasn't wired a real handler — keeps the
+ * playback path side-effect-free until somebody opts in.
+ */
+val NoOpHaActionDispatcher: HaActionDispatcher = HaActionDispatcher { /* no-op */ }
+
+/**
+ * Composition-scoped dispatcher. The dashboard / widget host wraps its
+ * content in a `CompositionLocalProvider(LocalHaActionDispatcher provides …)`
+ * so [CachedCardPreview] and [CardPlayer] can forward decoded actions
+ * without each card having to wire a callback.
+ */
+val LocalHaActionDispatcher = staticCompositionLocalOf { NoOpHaActionDispatcher }
+
+/**
+ * Monotonic stamp that callers fold into per-card cache keys when they
+ * need to bust the document cache out-of-band — e.g. demo mode bumps
+ * this on every router action so cards baking state into bytes
+ * (garage shutter, dial readouts) re-encode against the new snapshot
+ * on the next composition.
+ *
+ * Default is 0L: production cards rely on RemoteCompose named bindings
+ * to reflect new state without re-encoding, so most surfaces never
+ * change this.
+ */
+val LocalCardCaptureEpoch = compositionLocalOf { 0L }
+
+private val haActionJson = Json { ignoreUnknownKeys = true }
+
+/**
+ * Decode a `HostAction(name = "ha", value = …)` payload back into the
+ * typed [HaAction] sealed hierarchy. Returns null if [value] isn't a
+ * JSON string carrying our discriminator (host actions named `"ha"`
+ * always are; this guards against bytes built by something else).
+ *
+ * Public so test surfaces in downstream modules can assert the
+ * encode → decode contract; production callers should usually go
+ * through [LocalHaActionDispatcher] instead.
+ */
+fun decodeHaAction(value: Any?): HaAction? {
+    val text = value as? String ?: return null
+    return runCatching {
+        haActionJson.decodeFromString(HaAction.serializer(), text)
+    }.getOrNull()
+}

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/DemoActionRouter.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/DemoActionRouter.kt
@@ -1,0 +1,168 @@
+package ee.schimke.terrazzo.core.session
+
+import ee.schimke.ha.model.EntityState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
+
+/** Direction of motion requested for a cover entity. */
+enum class CoverCommand { Open, Close, Stop }
+
+/**
+ * Holds in-memory overrides applied on top of the captured demo entity
+ * state so demo-mode taps produce visible behaviour. Toggles flip the
+ * underlying state immediately; cover commands seed an animation that
+ * [snapshotOverrides] resolves to a `current_position` per call (one
+ * percent every [COVER_ANIM_STEP_MS] ms until it lands at the target).
+ *
+ * The router is process-scoped — same lifetime as `DemoData` itself.
+ * Live HA sessions don't use it; they call HA services directly.
+ *
+ * Mutations bump [epoch] so observers can invalidate caches keyed on
+ * "did anything just change". The app uses this to evict the
+ * `CardDocumentCache` so cards baking state into bytes (e.g. the
+ * garage shutter card's `closedFraction`) re-encode after a click.
+ */
+class DemoActionRouter {
+    private val toggleOverrides: MutableMap<String, String> = mutableMapOf()
+    private val coverAnimations: MutableMap<String, CoverAnimation> = mutableMapOf()
+    private val _epoch = MutableStateFlow(0L)
+
+    /** Bumped on every mutation. Composables can `collectAsState` to recompose. */
+    val epoch: StateFlow<Long> = _epoch
+
+    /** Flip a binary entity's state. No-op if [currentState] isn't a known flag. */
+    fun applyToggle(entityId: String, currentState: String) {
+        val flipped = when (currentState.lowercase()) {
+            "on" -> "off"
+            "off" -> "on"
+            "open" -> "closed"
+            "closed" -> "open"
+            else -> return
+        }
+        toggleOverrides[entityId] = flipped
+        bump()
+    }
+
+    /**
+     * Start (or stop) the open/close animation for [entityId]. The
+     * animation is sampled by [snapshotOverrides] so each subsequent
+     * frame fed to the dashboard advances the position; on completion
+     * the cover settles into its terminal `open` / `closed` state.
+     */
+    fun requestCover(entityId: String, command: CoverCommand, nowMs: Long, currentPosition: Int) {
+        when (command) {
+            CoverCommand.Stop -> coverAnimations.remove(entityId)
+            CoverCommand.Open, CoverCommand.Close -> {
+                val target = if (command == CoverCommand.Open) 100 else 0
+                if (currentPosition == target) {
+                    // Already there — settle the override so the state
+                    // label flips even when the position can't advance.
+                    toggleOverrides[entityId] = if (target == 100) "open" else "closed"
+                } else {
+                    coverAnimations[entityId] = CoverAnimation(
+                        startMs = nowMs,
+                        fromPercent = currentPosition.coerceIn(0, 100),
+                        toPercent = target,
+                    )
+                }
+            }
+        }
+        bump()
+    }
+
+    /**
+     * Apply current overrides on top of [base], computed at [nowMs].
+     * Cover animations that have reached their target on this sample
+     * are inlined as the terminal state and the in-memory animation
+     * is dropped.
+     */
+    fun snapshotOverrides(
+        base: Map<String, EntityState>,
+        nowMs: Long,
+    ): Map<String, EntityState> {
+        if (toggleOverrides.isEmpty() && coverAnimations.isEmpty()) return base
+        val result = base.toMutableMap()
+        toggleOverrides.forEach { (id, override) ->
+            result[id] = (result[id] ?: return@forEach).copy(state = override)
+        }
+        val finished = mutableListOf<String>()
+        coverAnimations.forEach { (id, anim) ->
+            val current = result[id] ?: return@forEach
+            val sample = anim.sampleAt(nowMs)
+            result[id] = current.withCoverSample(sample)
+            if (sample.isFinal) finished += id
+        }
+        finished.forEach { id ->
+            val terminal = result[id] ?: return@forEach
+            coverAnimations.remove(id)
+            toggleOverrides[id] = terminal.state
+        }
+        return result
+    }
+
+    /** Drop every override; bumps [epoch] so consumers refresh. */
+    fun reset() {
+        toggleOverrides.clear()
+        coverAnimations.clear()
+        bump()
+    }
+
+    private fun bump() {
+        _epoch.value = _epoch.value + 1
+    }
+
+    private data class CoverAnimation(
+        val startMs: Long,
+        val fromPercent: Int,
+        val toPercent: Int,
+    ) {
+        fun sampleAt(nowMs: Long): CoverSample {
+            val elapsed = (nowMs - startMs).coerceAtLeast(0L)
+            val steps = (elapsed / COVER_ANIM_STEP_MS).toInt()
+            val direction = if (toPercent > fromPercent) 1 else -1
+            val raw = fromPercent + direction * steps
+            val clamped = raw.coerceIn(
+                minOf(fromPercent, toPercent),
+                maxOf(fromPercent, toPercent),
+            )
+            val isFinal = clamped == toPercent
+            val state = when {
+                isFinal && toPercent == 100 -> "open"
+                isFinal && toPercent == 0 -> "closed"
+                direction > 0 -> "opening"
+                else -> "closing"
+            }
+            return CoverSample(state = state, position = clamped, isFinal = isFinal)
+        }
+    }
+
+    private data class CoverSample(val state: String, val position: Int, val isFinal: Boolean)
+
+    private fun EntityState.withCoverSample(sample: CoverSample): EntityState {
+        val attrs = attributes.toMutableMap()
+        attrs["current_position"] = JsonPrimitive(sample.position)
+        return copy(state = sample.state, attributes = JsonObject(attrs))
+    }
+
+    private companion object {
+        /** Per-percent step duration (≈5 s end-to-end at 50 ms). */
+        const val COVER_ANIM_STEP_MS: Long = 50L
+    }
+}
+
+/**
+ * Read the cover position the dashboard last saw, defaulting by-state
+ * when the integration doesn't expose `current_position`. Visible to
+ * dispatchers so they can seed animations from the latest sample
+ * rather than always starting from 0/100.
+ */
+fun EntityState.demoCoverPositionPercent(): Int =
+    attributes["current_position"]?.jsonPrimitive?.content?.toIntOrNull()
+        ?: when (state) {
+            "open" -> 100
+            "closed" -> 0
+            else -> 50
+        }

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/DemoHaSession.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/DemoHaSession.kt
@@ -26,17 +26,29 @@ import kotlinx.serialization.json.jsonPrimitive
  */
 class DemoHaSession(
     private val clock: () -> Long = System::currentTimeMillis,
+    /**
+     * Demo-mode action sink. Defaults to the process-scoped router so
+     * pinned widgets (which build their own [DemoHaSession]) share the
+     * same overrides as the foreground dashboard. Tests pass an
+     * isolated instance.
+     */
+    val actionRouter: DemoActionRouter = DemoData.actionRouter,
 ) : HaSession {
     override val baseUrl: String = DemoData.BASE_URL
 
-    /** Once a minute. The demo entities drift on a per-minute cadence so
-     *  the user sees values change without burning battery. */
-    override val refreshIntervalMillis: Long = 60_000L
+    /**
+     * Refresh every second so demo-mode taps produce visible motion —
+     * cover animations sample at a sub-second cadence, and a one-second
+     * dashboard refresh keeps the UI on the leading edge of that
+     * without burning battery (the active surface is one user-driven
+     * screen, not a background widget).
+     */
+    override val refreshIntervalMillis: Long = 1_000L
 
     override suspend fun connect() = Unit
     override suspend fun listDashboards(): List<DashboardSummary> = DemoData.dashboards
     override suspend fun loadDashboard(urlPath: String?): Pair<Dashboard, HaSnapshot> =
-        DemoData.dashboard(urlPath) to DemoData.snapshot(clock())
+        DemoData.dashboard(urlPath) to DemoData.snapshot(clock(), actionRouter)
     override suspend fun close() = Unit
 }
 
@@ -57,6 +69,13 @@ object DemoData {
     const val BASE_URL: String = "demo://terrazzo"
 
     fun isDemo(baseUrl: String?): Boolean = baseUrl == BASE_URL
+
+    /**
+     * Process-scoped router shared by every [DemoHaSession] (foreground
+     * dashboards and pinned widgets) so an action fired on one surface
+     * is visible on the others.
+     */
+    val actionRouter: DemoActionRouter = DemoActionRouter()
 
     private val json = Json { ignoreUnknownKeys = true; isLenient = true }
 
@@ -96,9 +115,13 @@ object DemoData {
             ?: cachedDashboards[BOARDS.first().slug]!!
     }
 
-    fun snapshot(nowMs: Long = System.currentTimeMillis()): HaSnapshot {
+    fun snapshot(
+        nowMs: Long = System.currentTimeMillis(),
+        router: DemoActionRouter = actionRouter,
+    ): HaSnapshot {
         val drifted = baseStates.mapValues { (id, st) -> drift(id, st, nowMs) }
-        return HaSnapshot(states = drifted)
+        val withOverrides = router.snapshotOverrides(drifted, nowMs)
+        return HaSnapshot(states = withOverrides)
     }
 
     private fun urlPathToSlug(urlPath: String?): String {


### PR DESCRIPTION
## Summary
Implement action dispatching for demo mode, enabling interactive toggles and cover animations on the dashboard. When users tap buttons in demo mode, the UI now reflects state changes immediately without waiting for the next poll cycle.

## Key Changes

- **DemoActionRouter**: New class that manages in-memory state overrides for demo mode
  - Handles binary toggles (on/off, open/closed) with immediate state flips
  - Implements smooth cover animations that sample position per frame over ~5 seconds
  - Bumps an `epoch` StateFlow on mutations so observers can invalidate caches
  - Automatically settles animations to terminal states when complete

- **HaActionDispatcher**: New composition-local interface for handling decoded HA actions
  - Abstracts action dispatch so cards don't need direct callbacks
  - Supports URL launches, service calls, toggles, and navigation (partial)
  - Includes a no-op default for previews and tests

- **DashboardActionDispatcher**: Concrete implementation wired to the dashboard
  - Routes URL actions to `Intent.ACTION_VIEW`
  - Dispatches toggles and cover commands to the demo router
  - Clears the CardDocumentCache after mutations so cards re-encode against new state
  - Logs unimplemented actions (live HA service calls, navigation)

- **Demo mode integration**:
  - `DemoHaSession` now accepts an `actionRouter` parameter (defaults to process-scoped singleton)
  - Reduced refresh interval from 60s to 1s to keep UI responsive to animations
  - Dashboard screen listens to router epoch changes and re-fetches immediately on mutations
  - Composition locals (`LocalHaActionDispatcher`, `LocalCardCaptureEpoch`) wire dispatcher and epoch through the card tree

- **Action encoding/decoding**:
  - `decodeHaAction()` deserializes HA action payloads from RemoteCompose `HostAction` callbacks
  - Updated `HaAction` documentation to clarify the encode → dispatch → decode flow
  - `CachedCardPreview` and `CardPlayer` now wire the dispatcher callback

## Notable Details

- Cover animations use a 50ms step cadence (~1% per frame) for smooth motion
- Animations are sampled on-demand by `snapshotOverrides()`, allowing frame-perfect positioning
- The router is process-scoped so pinned widgets and foreground dashboards share the same overrides
- Tests verify toggle flips, cover motion, epoch bumping, and state fallbacks

https://claude.ai/code/session_017dqzrpdimNzcQVcDqzEA85