### PR TITLE
feat(dashboard): wire live HA service calls for non-demo sessions

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardActionDispatcher.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardActionDispatcher.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import ee.schimke.ha.rc.CardDocumentCache
 import ee.schimke.ha.rc.HaActionDispatcher
@@ -17,17 +18,22 @@ import ee.schimke.terrazzo.core.session.DemoData
 import ee.schimke.terrazzo.core.session.DemoHaSession
 import ee.schimke.terrazzo.core.session.HaSession
 import ee.schimke.terrazzo.core.session.demoCoverPositionPercent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 /**
  * Build the [HaActionDispatcher] that backs `LocalHaActionDispatcher`
  * for the dashboard surface. The dispatcher fans actions out by type:
  *
  *   - [HaAction.Url] → `Intent.ACTION_VIEW` (opens a browser)
- *   - [HaAction.CallService] / [HaAction.Toggle] → demo router for
- *     [DemoHaSession]; logged-only for live sessions until the live
- *     client gains a service-call API.
+ *   - [HaAction.Toggle] / [HaAction.CallService] → live `HaSession`
+ *     calls through `call_service` (`homeassistant.toggle` for the
+ *     bare `Toggle` form); demo sessions route through
+ *     [DemoHaSession.actionRouter] so taps are visible without a
+ *     network round-trip.
  *   - [HaAction.Navigate] / [HaAction.MoreInfo] → logged for now —
- *     these need in-app navigation that the dashboard doesn't expose yet.
+ *     these need in-app navigation that the dashboard doesn't expose
+ *     yet.
  *
  * In demo mode the dispatcher also evicts the [CardDocumentCache] so
  * cards baking state into bytes (e.g. the garage shutter card's
@@ -39,8 +45,9 @@ import ee.schimke.terrazzo.core.session.demoCoverPositionPercent
 fun rememberDashboardActionDispatcher(session: HaSession): HaActionDispatcher {
     val context = LocalContext.current
     val cache = LocalCardDocumentCache.current
-    return remember(session, context, cache) {
-        DashboardActionDispatcher(context.applicationContext, session, cache)
+    val scope = rememberCoroutineScope()
+    return remember(session, context, cache, scope) {
+        DashboardActionDispatcher(context.applicationContext, session, cache, scope)
     }
 }
 
@@ -48,12 +55,13 @@ private class DashboardActionDispatcher(
     private val context: Context,
     private val session: HaSession,
     private val cache: CardDocumentCache,
+    private val scope: CoroutineScope,
 ) : HaActionDispatcher {
     override fun dispatch(action: HaAction) {
         when (action) {
             is HaAction.Url -> launchUrl(action.url)
-            is HaAction.Toggle -> applyDemoToggle(action.entityId)
-            is HaAction.CallService -> applyDemoCallService(action)
+            is HaAction.Toggle -> handleToggle(action.entityId)
+            is HaAction.CallService -> handleCallService(action)
             is HaAction.MoreInfo,
             is HaAction.Navigate,
             HaAction.None -> Log.i(TAG, "Action not yet wired: $action")
@@ -73,26 +81,37 @@ private class DashboardActionDispatcher(
         }
     }
 
-    private fun applyDemoToggle(entityId: String) {
-        val demo = session as? DemoHaSession ?: run {
-            Log.i(TAG, "Toggle for $entityId — live HA service call not implemented yet")
-            return
+    private fun handleToggle(entityId: String) {
+        val demo = session as? DemoHaSession
+        if (demo != null) {
+            val current = DemoData.snapshot(router = demo.actionRouter)
+                .states[entityId]?.state
+                ?: return
+            demo.actionRouter.applyToggle(entityId, current)
+            cache.clear()
+        } else {
+            // `homeassistant.toggle` flips on/off across every domain
+            // that supports it, so we don't have to special-case
+            // light vs switch vs input_boolean per entity prefix.
+            launchService(domain = "homeassistant", service = "toggle", entityId = entityId)
         }
-        // Snapshot once so we can read the entity's current state, then
-        // bounce the request through the router.
-        val snapshot = ee.schimke.terrazzo.core.session.DemoData.snapshot(
-            router = demo.actionRouter,
-        )
-        val current = snapshot.states[entityId]?.state ?: return
-        demo.actionRouter.applyToggle(entityId, current)
-        cache.clear()
     }
 
-    private fun applyDemoCallService(action: HaAction.CallService) {
-        val demo = session as? DemoHaSession ?: run {
-            Log.i(TAG, "CallService ${action.domain}.${action.service} — live not implemented yet")
-            return
+    private fun handleCallService(action: HaAction.CallService) {
+        val demo = session as? DemoHaSession
+        if (demo != null) {
+            applyDemoCallService(demo, action)
+        } else {
+            launchService(
+                domain = action.domain,
+                service = action.service,
+                entityId = action.entityId,
+                serviceData = action.serviceData,
+            )
         }
+    }
+
+    private fun applyDemoCallService(demo: DemoHaSession, action: HaAction.CallService) {
         val entityId = action.entityId ?: return
         when (action.domain) {
             "cover" -> {
@@ -113,11 +132,10 @@ private class DashboardActionDispatcher(
                 cache.clear()
             }
             "homeassistant", "switch", "light", "input_boolean" -> {
-                if (action.service == "toggle" || action.service == "turn_on" || action.service == "turn_off") {
-                    val snapshot = ee.schimke.terrazzo.core.session.DemoData.snapshot(
-                        router = demo.actionRouter,
-                    )
-                    val current = snapshot.states[entityId]?.state ?: return
+                if (action.service in TOGGLE_LIKE_SERVICES) {
+                    val current = DemoData.snapshot(router = demo.actionRouter)
+                        .states[entityId]?.state
+                        ?: return
                     demo.actionRouter.applyToggle(entityId, current)
                     cache.clear()
                 }
@@ -126,7 +144,29 @@ private class DashboardActionDispatcher(
         }
     }
 
+    private fun launchService(
+        domain: String,
+        service: String,
+        entityId: String?,
+        serviceData: kotlinx.serialization.json.JsonObject =
+            kotlinx.serialization.json.JsonObject(emptyMap()),
+    ) {
+        scope.launch {
+            runCatching {
+                session.callService(
+                    domain = domain,
+                    service = service,
+                    entityId = entityId,
+                    serviceData = serviceData,
+                )
+            }.onFailure { e ->
+                Log.w(TAG, "call_service $domain.$service failed for $entityId", e)
+            }
+        }
+    }
+
     companion object {
         private const val TAG = "DashboardAction"
+        private val TOGGLE_LIKE_SERVICES = setOf("toggle", "turn_on", "turn_off")
     }
 }

--- a/ha-client/src/commonMain/kotlin/ee/schimke/ha/client/HaClient.kt
+++ b/ha-client/src/commonMain/kotlin/ee/schimke/ha/client/HaClient.kt
@@ -148,6 +148,33 @@ class HaClient(private val config: HaConfig) {
 
   suspend fun snapshot(): HaSnapshot = HaSnapshot(states = fetchStates())
 
+  /**
+   * Call a Home Assistant service (`call_service` WebSocket command).
+   *
+   * Mirrors the shape Lovelace tap actions produce — a `domain.service` targeting an optional
+   * entity, with arbitrary extra data. The dashboard-side `HaActionDispatcher` decodes button taps
+   * into [HaAction.CallService][ee.schimke.ha.rc.components.HaAction.CallService] payloads and
+   * routes them here.
+   *
+   * Returns when HA acknowledges the command. Errors propagate as exceptions out of `awaitCommand`
+   * so callers can surface them.
+   */
+  suspend fun callService(
+    domain: String,
+    service: String,
+    entityId: String? = null,
+    serviceData: JsonObject = JsonObject(emptyMap()),
+  ) {
+    runCommand("call_service") {
+      put("domain", domain)
+      put("service", service)
+      if (serviceData.isNotEmpty()) put("service_data", serviceData)
+      if (entityId != null) {
+        put("target", buildJsonObject { put("entity_id", entityId) })
+      }
+    }
+  }
+
   suspend fun close() {
     receiveJob?.cancel()
     runCatching { session?.close(CloseReason(CloseReason.Codes.NORMAL, "bye")) }

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/HaSession.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/HaSession.kt
@@ -5,6 +5,7 @@ import ee.schimke.ha.client.HaClient
 import ee.schimke.ha.client.HaConfig
 import ee.schimke.ha.model.Dashboard
 import ee.schimke.ha.model.HaSnapshot
+import kotlinx.serialization.json.JsonObject
 
 /**
  * One HA session held for the app's lifetime. A facade over whatever
@@ -27,6 +28,20 @@ interface HaSession {
     suspend fun connect()
     suspend fun listDashboards(): List<DashboardSummary>
     suspend fun loadDashboard(urlPath: String?): Pair<Dashboard, HaSnapshot>
+
+    /**
+     * Fire-and-await an HA service call. The dashboard's
+     * `HaActionDispatcher` invokes this when a Lovelace tap action
+     * decodes to `CallService` / `Toggle`. Default does nothing so
+     * sessions that can't talk to HA (demo, tests) opt out cleanly.
+     */
+    suspend fun callService(
+        domain: String,
+        service: String,
+        entityId: String? = null,
+        serviceData: JsonObject = JsonObject(emptyMap()),
+    ): Unit = Unit
+
     suspend fun close()
 }
 
@@ -44,5 +59,11 @@ class LiveHaSession(
         val snapshot = client.snapshot()
         return dashboard to snapshot
     }
+    override suspend fun callService(
+        domain: String,
+        service: String,
+        entityId: String?,
+        serviceData: JsonObject,
+    ) = client.callService(domain, service, entityId, serviceData)
     override suspend fun close() = client.close()
 }


### PR DESCRIPTION
## Summary

- Adds `HaClient.callService(domain, service, entityId, serviceData)` — emits the `call_service` WebSocket command in the same shape Lovelace tap actions produce.
- Surfaces `callService` on `HaSession` with a default no-op so demo / test sessions opt out cleanly; `LiveHaSession` delegates to the underlying client.
- `DashboardActionDispatcher` now branches on session type: demo sessions use the in-memory router as before; live sessions fire `session.callService(...)` from a `rememberCoroutineScope`. The bare `HaAction.Toggle(entityId)` form routes to `homeassistant.toggle` so it works across light / switch / input_boolean without per-domain dispatch. Failures log at WARN and don't block the dispatch path.

Follow-up to #131, which only wired demo-mode taps.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest`
- [x] `./gradlew :ha-client:jvmTest`
- [x] `./gradlew ktfmtCheck`
- [ ] Manual: tap a tile bound to a switch on a live HA dashboard and confirm the entity flips on the HA side.
- [ ] Manual: tap the garage open / close buttons on a live dashboard and confirm `cover.open_cover` / `cover.close_cover` reach HA.

---
_Generated by [Claude Code](https://claude.ai/code/session_017dqzrpdimNzcQVcDqzEA85)_