### PR TITLE
feat(rc-components): basic markdown parser for markdown card

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,9 @@ coil = "3.4.0"
 # Formatting
 ktfmt-gradle = "0.26.0"
 
+# Markdown parsing (KMP, by JetBrains — used by IntelliJ)
+jetbrains-markdown = "0.7.3"
+
 # Wear data layer + Proto DataStore + Horologist
 horologist = "0.8.3-alpha"
 play-services-wearable = "20.0.1"
@@ -157,6 +160,8 @@ junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 mockserver-netty = { module = "org.mock-server:mockserver-netty", version.ref = "mockserver" }
 mockserver-client-java = { module = "org.mock-server:mockserver-client-java", version.ref = "mockserver" }
+
+jetbrains-markdown = { module = "org.jetbrains:markdown", version.ref = "jetbrains-markdown" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaUiModels.kt
+++ b/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaUiModels.kt
@@ -17,6 +17,7 @@ import ee.schimke.ha.rc.components.HaMarkdownData
 import ee.schimke.ha.rc.components.HaTileData
 import ee.schimke.ha.rc.components.HaToggleAccent
 import ee.schimke.ha.rc.components.HaUnsupportedData
+import ee.schimke.ha.rc.components.Markdown
 
 /**
  * Tier-2 mirror of [HaToggleAccent] expressed in plain Compose types.
@@ -158,7 +159,7 @@ internal fun HaGlanceUiData.toRemote(): HaGlanceData =
     )
 
 internal fun HaMarkdownUiData.toRemote(): HaMarkdownData =
-    HaMarkdownData(title = title, lines = lines)
+    HaMarkdownData(title = title, blocks = Markdown.parse(lines.joinToString("\n")))
 
 internal fun HaHeadingUiData.toRemote(): HaHeadingData =
     HaHeadingData(title = title, style = style)

--- a/rc-components/build.gradle.kts
+++ b/rc-components/build.gradle.kts
@@ -34,4 +34,5 @@ dependencies {
   implementation(libs.kotlinx.serialization.json)
 
   testImplementation(libs.kotlin.test)
+  testImplementation(libs.kotlin.test.junit)
 }

--- a/rc-components/build.gradle.kts
+++ b/rc-components/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
   implementation(libs.remote.material3)
 
   implementation(libs.kotlinx.serialization.json)
+  implementation(libs.jetbrains.markdown)
 
   testImplementation(libs.kotlin.test)
   testImplementation(libs.kotlin.test.junit)

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Markdown.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Markdown.kt
@@ -1,8 +1,17 @@
 package ee.schimke.ha.rc.components
 
+import org.intellij.markdown.MarkdownElementTypes
+import org.intellij.markdown.MarkdownTokenTypes
+import org.intellij.markdown.ast.ASTNode
+import org.intellij.markdown.ast.getTextInNode
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import org.intellij.markdown.flavours.gfm.GFMTokenTypes
+import org.intellij.markdown.parser.MarkdownParser
+
 /**
  * Block-level markdown element. Inline syntax (links, images, emphasis,
- * code spans) has already been stripped to plain text.
+ * code spans) has already been collapsed to plain text — RemoteText
+ * applies one style per node.
  */
 data class MarkdownBlock(
     val kind: Kind,
@@ -13,78 +22,131 @@ data class MarkdownBlock(
 }
 
 /**
- * Tiny line-oriented Markdown parser. Recognises headings, unordered
- * bullets and horizontal rules; everything else becomes a paragraph.
- * Inline emphasis, links, images and code spans collapse to plain text
- * — the renderer applies one style per block, which is the most
- * RemoteText can express today.
+ * Markdown → block list using JetBrains' multiplatform parser. The
+ * parser is responsible for block boundaries (CommonMark + GFM
+ * extensions); we walk the AST and emit one [MarkdownBlock] per
+ * top-level block, dropping inline markup so each block can be
+ * rendered with a single text style.
  */
 object Markdown {
+    private val flavour = GFMFlavourDescriptor()
+
     fun parse(source: String): List<MarkdownBlock> {
+        if (source.isBlank()) return emptyList()
+        val tree = MarkdownParser(flavour).buildMarkdownTreeFromString(source)
         val out = mutableListOf<MarkdownBlock>()
-        var inFence = false
-        for (raw in source.split('\n')) {
-            val line = raw.trim()
-            if (FENCE.matches(line)) {
-                inFence = !inFence
-                continue
-            }
-            if (inFence) {
-                if (line.isNotEmpty()) out += MarkdownBlock(MarkdownBlock.Kind.Paragraph, line)
-                continue
-            }
-            if (line.isEmpty()) continue
-            if (DIVIDER.matches(line)) {
-                out += MarkdownBlock(MarkdownBlock.Kind.Divider, "")
-                continue
-            }
-            HEADING.matchEntire(line)?.let { m ->
-                val level = m.groupValues[1].length.coerceAtMost(6)
-                val text = stripInline(m.groupValues[2])
-                if (text.isNotEmpty()) {
-                    out += MarkdownBlock(MarkdownBlock.Kind.Heading, text, level)
-                }
-                return@let
-            } ?: BULLET.matchEntire(line)?.let { m ->
-                val text = stripInline(m.groupValues[1])
-                if (text.isNotEmpty()) {
-                    out += MarkdownBlock(MarkdownBlock.Kind.Bullet, text)
-                }
-            } ?: run {
-                val text = stripInline(line)
-                if (text.isNotEmpty()) {
-                    out += MarkdownBlock(MarkdownBlock.Kind.Paragraph, text)
-                }
-            }
-        }
+        visit(tree, source, out)
         return out
     }
 
-    private val HEADING = Regex("""^(#{1,6})\s*(.*?)\s*#*\s*$""")
-    private val BULLET = Regex("""^[-*+]\s+(.*)$""")
-    private val DIVIDER = Regex("""^(?:-{3,}|\*{3,}|_{3,})$""")
-    private val FENCE = Regex("""^(?:`{3,}|~{3,}).*$""")
-
-    private val IMAGE = Regex("""!\[[^\]]*]\([^)]*\)""")
-    private val LINK = Regex("""\[([^\]]*)]\([^)]*\)""")
-    private val BOLD_STAR = Regex("""\*\*([^*]+)\*\*""")
-    private val BOLD_UNDER = Regex("""__([^_]+)__""")
-    private val STRIKE = Regex("""~~([^~]+)~~""")
-    private val ITALIC_STAR = Regex("""\*([^*\s][^*]*?)\*""")
-    private val ITALIC_UNDER = Regex("""(?<![A-Za-z0-9_])_([^_\s][^_]*?)_(?![A-Za-z0-9_])""")
-    private val CODE = Regex("""`([^`]+)`""")
-
-    /** Strip inline markdown markers, leaving the visible text. */
-    fun stripInline(input: String): String {
-        var s = input
-        s = IMAGE.replace(s, "")
-        s = LINK.replace(s) { it.groupValues[1] }
-        s = CODE.replace(s) { it.groupValues[1] }
-        s = STRIKE.replace(s) { it.groupValues[1] }
-        s = BOLD_STAR.replace(s) { it.groupValues[1] }
-        s = BOLD_UNDER.replace(s) { it.groupValues[1] }
-        s = ITALIC_STAR.replace(s) { it.groupValues[1] }
-        s = ITALIC_UNDER.replace(s) { it.groupValues[1] }
-        return s.trim()
+    private fun visit(node: ASTNode, src: String, out: MutableList<MarkdownBlock>) {
+        when (node.type) {
+            MarkdownElementTypes.ATX_1 -> heading(node, src, 1, out)
+            MarkdownElementTypes.ATX_2 -> heading(node, src, 2, out)
+            MarkdownElementTypes.ATX_3 -> heading(node, src, 3, out)
+            MarkdownElementTypes.ATX_4 -> heading(node, src, 4, out)
+            MarkdownElementTypes.ATX_5 -> heading(node, src, 5, out)
+            MarkdownElementTypes.ATX_6 -> heading(node, src, 6, out)
+            MarkdownElementTypes.SETEXT_1 -> heading(node, src, 1, out)
+            MarkdownElementTypes.SETEXT_2 -> heading(node, src, 2, out)
+            MarkdownElementTypes.PARAGRAPH -> {
+                val text = visibleText(node, src)
+                if (text.isNotEmpty()) out += MarkdownBlock(MarkdownBlock.Kind.Paragraph, text)
+            }
+            MarkdownElementTypes.UNORDERED_LIST,
+            MarkdownElementTypes.ORDERED_LIST -> {
+                for (item in node.children) {
+                    if (item.type == MarkdownElementTypes.LIST_ITEM) {
+                        val text = visibleText(item, src)
+                        if (text.isNotEmpty()) out += MarkdownBlock(MarkdownBlock.Kind.Bullet, text)
+                    }
+                }
+            }
+            MarkdownTokenTypes.HORIZONTAL_RULE -> out += MarkdownBlock(MarkdownBlock.Kind.Divider, "")
+            MarkdownElementTypes.CODE_FENCE,
+            MarkdownElementTypes.CODE_BLOCK -> {
+                node.getTextInNode(src).toString().lineSequence()
+                    .map { it.trim() }
+                    .filter { it.isNotEmpty() && !it.startsWith("```") && !it.startsWith("~~~") }
+                    .forEach { out += MarkdownBlock(MarkdownBlock.Kind.Paragraph, it) }
+            }
+            MarkdownElementTypes.BLOCK_QUOTE -> node.children.forEach { visit(it, src, out) }
+            else -> if (node.children.isNotEmpty()) {
+                node.children.forEach { visit(it, src, out) }
+            }
+        }
     }
+
+    private fun heading(node: ASTNode, src: String, level: Int, out: MutableList<MarkdownBlock>) {
+        val text = visibleText(node, src)
+        if (text.isNotEmpty()) {
+            out += MarkdownBlock(MarkdownBlock.Kind.Heading, text, level)
+        }
+    }
+
+    /** Concatenate visible inline text, dropping images and link URLs. */
+    private fun visibleText(node: ASTNode, src: String): String {
+        val sb = StringBuilder()
+        appendVisible(node, src, sb)
+        return sb.toString().replace(WHITESPACE, " ").trim()
+    }
+
+    private fun appendVisible(node: ASTNode, src: String, sb: StringBuilder) {
+        when (node.type) {
+            MarkdownElementTypes.IMAGE -> return
+            MarkdownElementTypes.AUTOLINK -> {
+                sb.append(
+                    node.getTextInNode(src).toString().trim().removePrefix("<").removeSuffix(">"),
+                )
+                return
+            }
+            MarkdownElementTypes.INLINE_LINK,
+            MarkdownElementTypes.FULL_REFERENCE_LINK,
+            MarkdownElementTypes.SHORT_REFERENCE_LINK -> {
+                node.children
+                    .firstOrNull { it.type == MarkdownElementTypes.LINK_TEXT }
+                    ?.let { linkText ->
+                        for (c in linkText.children) {
+                            if (c.type != MarkdownTokenTypes.LBRACKET &&
+                                c.type != MarkdownTokenTypes.RBRACKET) {
+                                appendVisible(c, src, sb)
+                            }
+                        }
+                    }
+                return
+            }
+        }
+        if (node.children.isEmpty()) {
+            when (node.type) {
+                MarkdownTokenTypes.EOL,
+                MarkdownTokenTypes.HARD_LINE_BREAK -> sb.append(' ')
+                in MARKUP_TOKENS -> Unit
+                else -> sb.append(node.getTextInNode(src))
+            }
+        } else {
+            node.children.forEach { appendVisible(it, src, sb) }
+        }
+    }
+
+    private val WHITESPACE = Regex("\\s+")
+
+    private val MARKUP_TOKENS = setOf(
+        MarkdownTokenTypes.EMPH,
+        MarkdownTokenTypes.BACKTICK,
+        MarkdownTokenTypes.ESCAPED_BACKTICKS,
+        MarkdownTokenTypes.LBRACKET,
+        MarkdownTokenTypes.RBRACKET,
+        MarkdownTokenTypes.LPAREN,
+        MarkdownTokenTypes.RPAREN,
+        MarkdownTokenTypes.LT,
+        MarkdownTokenTypes.GT,
+        MarkdownTokenTypes.EXCLAMATION_MARK,
+        MarkdownTokenTypes.ATX_HEADER,
+        MarkdownTokenTypes.SETEXT_1,
+        MarkdownTokenTypes.SETEXT_2,
+        MarkdownTokenTypes.LIST_BULLET,
+        MarkdownTokenTypes.LIST_NUMBER,
+        MarkdownTokenTypes.BLOCK_QUOTE,
+        GFMTokenTypes.TILDE,
+    )
 }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Markdown.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Markdown.kt
@@ -1,0 +1,90 @@
+package ee.schimke.ha.rc.components
+
+/**
+ * Block-level markdown element. Inline syntax (links, images, emphasis,
+ * code spans) has already been stripped to plain text.
+ */
+data class MarkdownBlock(
+    val kind: Kind,
+    val text: String,
+    val level: Int = 0,
+) {
+    enum class Kind { Heading, Paragraph, Bullet, Divider }
+}
+
+/**
+ * Tiny line-oriented Markdown parser. Recognises headings, unordered
+ * bullets and horizontal rules; everything else becomes a paragraph.
+ * Inline emphasis, links, images and code spans collapse to plain text
+ * — the renderer applies one style per block, which is the most
+ * RemoteText can express today.
+ */
+object Markdown {
+    fun parse(source: String): List<MarkdownBlock> {
+        val out = mutableListOf<MarkdownBlock>()
+        var inFence = false
+        for (raw in source.split('\n')) {
+            val line = raw.trim()
+            if (FENCE.matches(line)) {
+                inFence = !inFence
+                continue
+            }
+            if (inFence) {
+                if (line.isNotEmpty()) out += MarkdownBlock(MarkdownBlock.Kind.Paragraph, line)
+                continue
+            }
+            if (line.isEmpty()) continue
+            if (DIVIDER.matches(line)) {
+                out += MarkdownBlock(MarkdownBlock.Kind.Divider, "")
+                continue
+            }
+            HEADING.matchEntire(line)?.let { m ->
+                val level = m.groupValues[1].length.coerceAtMost(6)
+                val text = stripInline(m.groupValues[2])
+                if (text.isNotEmpty()) {
+                    out += MarkdownBlock(MarkdownBlock.Kind.Heading, text, level)
+                }
+                return@let
+            } ?: BULLET.matchEntire(line)?.let { m ->
+                val text = stripInline(m.groupValues[1])
+                if (text.isNotEmpty()) {
+                    out += MarkdownBlock(MarkdownBlock.Kind.Bullet, text)
+                }
+            } ?: run {
+                val text = stripInline(line)
+                if (text.isNotEmpty()) {
+                    out += MarkdownBlock(MarkdownBlock.Kind.Paragraph, text)
+                }
+            }
+        }
+        return out
+    }
+
+    private val HEADING = Regex("""^(#{1,6})\s*(.*?)\s*#*\s*$""")
+    private val BULLET = Regex("""^[-*+]\s+(.*)$""")
+    private val DIVIDER = Regex("""^(?:-{3,}|\*{3,}|_{3,})$""")
+    private val FENCE = Regex("""^(?:`{3,}|~{3,}).*$""")
+
+    private val IMAGE = Regex("""!\[[^\]]*]\([^)]*\)""")
+    private val LINK = Regex("""\[([^\]]*)]\([^)]*\)""")
+    private val BOLD_STAR = Regex("""\*\*([^*]+)\*\*""")
+    private val BOLD_UNDER = Regex("""__([^_]+)__""")
+    private val STRIKE = Regex("""~~([^~]+)~~""")
+    private val ITALIC_STAR = Regex("""\*([^*\s][^*]*?)\*""")
+    private val ITALIC_UNDER = Regex("""(?<![A-Za-z0-9_])_([^_\s][^_]*?)_(?![A-Za-z0-9_])""")
+    private val CODE = Regex("""`([^`]+)`""")
+
+    /** Strip inline markdown markers, leaving the visible text. */
+    fun stripInline(input: String): String {
+        var s = input
+        s = IMAGE.replace(s, "")
+        s = LINK.replace(s) { it.groupValues[1] }
+        s = CODE.replace(s) { it.groupValues[1] }
+        s = STRIKE.replace(s) { it.groupValues[1] }
+        s = BOLD_STAR.replace(s) { it.groupValues[1] }
+        s = BOLD_UNDER.replace(s) { it.groupValues[1] }
+        s = ITALIC_STAR.replace(s) { it.groupValues[1] }
+        s = ITALIC_UNDER.replace(s) { it.groupValues[1] }
+        return s.trim()
+    }
+}

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
@@ -92,7 +92,7 @@ data class HaGlanceCellData(
 data class HaGlanceData(val title: String?, val cells: List<HaGlanceCellData>)
 
 /** Markdown card. */
-data class HaMarkdownData(val title: String?, val lines: List<String>)
+data class HaMarkdownData(val title: String?, val blocks: List<MarkdownBlock>)
 
 /** Heading card. */
 data class HaHeadingData(val title: String, val style: HaHeadingStyle = HaHeadingStyle.Title)

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaMarkdown.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaMarkdown.kt
@@ -11,6 +11,7 @@ import androidx.compose.remote.creation.compose.modifier.background
 import androidx.compose.remote.creation.compose.modifier.border
 import androidx.compose.remote.creation.compose.modifier.clip
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.modifier.height
 import androidx.compose.remote.creation.compose.modifier.padding
 import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
 import androidx.compose.remote.creation.compose.state.rc
@@ -22,9 +23,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.font.FontWeight
 
 /**
- * HA `markdown` card — renders plain text lines inside the card chrome.
- * A small subset of Markdown (heading `#`, bold `**`) could be parsed
- * later; today we keep it readable without re-implementing a parser.
+ * HA `markdown` card — renders parsed markdown blocks inside the card
+ * chrome. Headings, bullets and paragraphs each pick a block-level
+ * style; inline syntax was stripped during parsing because RemoteText
+ * applies one style per node.
  */
 @Composable
 @RemoteComposable
@@ -49,13 +51,49 @@ fun RemoteHaMarkdown(data: HaMarkdownData, modifier: RemoteModifier = RemoteModi
                 )
                 RemoteBox(modifier = RemoteModifier.padding(top = 4.rdp))
             }
-            data.lines.forEach { line ->
-                RemoteText(
-                    text = line.rs,
-                    color = theme.primaryText.rc,
-                    fontSize = 13.rsp,
-                    style = RemoteTextStyle.Default,
-                )
+            data.blocks.forEach { block ->
+                when (block.kind) {
+                    MarkdownBlock.Kind.Heading -> {
+                        val size = when (block.level) {
+                            1 -> 16
+                            2 -> 15
+                            3 -> 14
+                            else -> 13
+                        }
+                        RemoteText(
+                            text = block.text.rs,
+                            color = theme.primaryText.rc,
+                            fontSize = size.rsp,
+                            fontWeight = FontWeight.SemiBold,
+                            style = RemoteTextStyle.Default,
+                        )
+                    }
+                    MarkdownBlock.Kind.Bullet -> {
+                        RemoteText(
+                            text = "• ${block.text}".rs,
+                            color = theme.primaryText.rc,
+                            fontSize = 13.rsp,
+                            style = RemoteTextStyle.Default,
+                        )
+                    }
+                    MarkdownBlock.Kind.Divider -> {
+                        RemoteBox(
+                            modifier = RemoteModifier
+                                .padding(vertical = 4.rdp)
+                                .fillMaxWidth()
+                                .height(1.rdp)
+                                .background(theme.divider.rc),
+                        )
+                    }
+                    MarkdownBlock.Kind.Paragraph -> {
+                        RemoteText(
+                            text = block.text.rs,
+                            color = theme.primaryText.rc,
+                            fontSize = 13.rsp,
+                            style = RemoteTextStyle.Default,
+                        )
+                    }
+                }
             }
         }
     }

--- a/rc-components/src/test/kotlin/ee/schimke/ha/rc/components/MarkdownTest.kt
+++ b/rc-components/src/test/kotlin/ee/schimke/ha/rc/components/MarkdownTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertTrue
 class MarkdownTest {
     @Test
     fun headingsByLevel() {
-        val blocks = Markdown.parse("# H1\n## H2\n### H3\n#### H4")
+        val blocks = Markdown.parse("# H1\n\n## H2\n\n### H3\n\n#### H4")
         assertEquals(4, blocks.size)
         assertEquals(MarkdownBlock.Kind.Heading, blocks[0].kind)
         assertEquals(1, blocks[0].level)
@@ -18,8 +18,19 @@ class MarkdownTest {
     }
 
     @Test
+    fun setextHeadings() {
+        val blocks = Markdown.parse("Big heading\n===\n\nMedium\n---")
+        assertEquals(2, blocks.size)
+        assertEquals(MarkdownBlock.Kind.Heading, blocks[0].kind)
+        assertEquals(1, blocks[0].level)
+        assertEquals("Big heading", blocks[0].text)
+        assertEquals(2, blocks[1].level)
+        assertEquals("Medium", blocks[1].text)
+    }
+
+    @Test
     fun bulletList() {
-        val blocks = Markdown.parse("- one\n* two\n+ three")
+        val blocks = Markdown.parse("- one\n- two\n- three")
         assertEquals(3, blocks.size)
         assertTrue(blocks.all { it.kind == MarkdownBlock.Kind.Bullet })
         assertEquals("one", blocks[0].text)
@@ -28,10 +39,20 @@ class MarkdownTest {
     }
 
     @Test
+    fun orderedList() {
+        val blocks = Markdown.parse("1. first\n2. second")
+        assertEquals(2, blocks.size)
+        assertTrue(blocks.all { it.kind == MarkdownBlock.Kind.Bullet })
+        assertEquals("first", blocks[0].text)
+    }
+
+    @Test
     fun divider() {
-        val blocks = Markdown.parse("above\n---\nbelow")
+        val blocks = Markdown.parse("above\n\n---\n\nbelow")
         assertEquals(3, blocks.size)
+        assertEquals("above", blocks[0].text)
         assertEquals(MarkdownBlock.Kind.Divider, blocks[1].kind)
+        assertEquals("below", blocks[2].text)
     }
 
     @Test
@@ -43,9 +64,15 @@ class MarkdownTest {
 
     @Test
     fun imagesAreDropped() {
-        assertEquals("", Markdown.stripInline("![alt](x.png)"))
-        // Linked image: outer link's label is the image itself, which
-        // collapses to empty after image stripping → no block emitted.
+        val blocks = Markdown.parse("alt text ![pic](x.png) trailing")
+        assertEquals(1, blocks.size)
+        assertEquals("alt text trailing", blocks[0].text)
+    }
+
+    @Test
+    fun linkedImageCollapsesToEmpty() {
+        // Outer link's label is the image itself; image is dropped, leaving
+        // no visible text → no block emitted.
         val blocks =
             Markdown.parse("[![ci](https://img/badge.svg)](https://ci.example/run)")
         assertTrue(blocks.isEmpty(), "expected no block, got $blocks")
@@ -53,22 +80,22 @@ class MarkdownTest {
 
     @Test
     fun emphasisIsStripped() {
-        assertEquals("bold", Markdown.stripInline("**bold**"))
-        assertEquals("bold", Markdown.stripInline("__bold__"))
-        assertEquals("italic", Markdown.stripInline("*italic*"))
-        assertEquals("italic", Markdown.stripInline("_italic_"))
-        assertEquals("strike", Markdown.stripInline("~~strike~~"))
-        assertEquals("code", Markdown.stripInline("`code`"))
+        assertEquals("bold", Markdown.parse("**bold**").single().text)
+        assertEquals("bold", Markdown.parse("__bold__").single().text)
+        assertEquals("italic", Markdown.parse("*italic*").single().text)
+        assertEquals("italic", Markdown.parse("_italic_").single().text)
+        assertEquals("strike", Markdown.parse("~~strike~~").single().text)
+        assertEquals("code", Markdown.parse("`code`").single().text)
     }
 
     @Test
     fun underscoreInsideWordIsKept() {
-        assertEquals("snake_case_name", Markdown.stripInline("snake_case_name"))
+        assertEquals("snake_case_name", Markdown.parse("snake_case_name").single().text)
     }
 
     @Test
     fun fencedCodeBlocksAreFlattened() {
-        val blocks = Markdown.parse("before\n```\ncode line\n```\nafter")
+        val blocks = Markdown.parse("before\n\n```\ncode line\n```\n\nafter")
         assertEquals(3, blocks.size)
         assertEquals("before", blocks[0].text)
         assertEquals("code line", blocks[1].text)
@@ -84,11 +111,22 @@ class MarkdownTest {
     }
 
     @Test
+    fun blockquoteIsFlattened() {
+        val blocks = Markdown.parse("> quoted line")
+        assertEquals(1, blocks.size)
+        assertEquals(MarkdownBlock.Kind.Paragraph, blocks[0].kind)
+        assertEquals("quoted line", blocks[0].text)
+    }
+
+    @Test
     fun realWorldReadme() {
         val src = """
             ## meshcore-mobile
+
             [meshcore-mobile](https://github.com/yschimke/meshcore-mobile)
+
             _Mobile companion for MeshCore_
+
             [![ci](https://img/badge.svg)](https://ci/url)
         """.trimIndent()
         val blocks = Markdown.parse(src)

--- a/rc-components/src/test/kotlin/ee/schimke/ha/rc/components/MarkdownTest.kt
+++ b/rc-components/src/test/kotlin/ee/schimke/ha/rc/components/MarkdownTest.kt
@@ -1,0 +1,102 @@
+package ee.schimke.ha.rc.components
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MarkdownTest {
+    @Test
+    fun headingsByLevel() {
+        val blocks = Markdown.parse("# H1\n## H2\n### H3\n#### H4")
+        assertEquals(4, blocks.size)
+        assertEquals(MarkdownBlock.Kind.Heading, blocks[0].kind)
+        assertEquals(1, blocks[0].level)
+        assertEquals("H1", blocks[0].text)
+        assertEquals(2, blocks[1].level)
+        assertEquals(3, blocks[2].level)
+        assertEquals(4, blocks[3].level)
+    }
+
+    @Test
+    fun bulletList() {
+        val blocks = Markdown.parse("- one\n* two\n+ three")
+        assertEquals(3, blocks.size)
+        assertTrue(blocks.all { it.kind == MarkdownBlock.Kind.Bullet })
+        assertEquals("one", blocks[0].text)
+        assertEquals("two", blocks[1].text)
+        assertEquals("three", blocks[2].text)
+    }
+
+    @Test
+    fun divider() {
+        val blocks = Markdown.parse("above\n---\nbelow")
+        assertEquals(3, blocks.size)
+        assertEquals(MarkdownBlock.Kind.Divider, blocks[1].kind)
+    }
+
+    @Test
+    fun linksKeepLabelDropUrl() {
+        val blocks = Markdown.parse("see [meshcore-mobile](https://example.com/x)")
+        assertEquals(1, blocks.size)
+        assertEquals("see meshcore-mobile", blocks[0].text)
+    }
+
+    @Test
+    fun imagesAreDropped() {
+        assertEquals("", Markdown.stripInline("![alt](x.png)"))
+        // Linked image: outer link's label is the image itself, which
+        // collapses to empty after image stripping → no block emitted.
+        val blocks =
+            Markdown.parse("[![ci](https://img/badge.svg)](https://ci.example/run)")
+        assertTrue(blocks.isEmpty(), "expected no block, got $blocks")
+    }
+
+    @Test
+    fun emphasisIsStripped() {
+        assertEquals("bold", Markdown.stripInline("**bold**"))
+        assertEquals("bold", Markdown.stripInline("__bold__"))
+        assertEquals("italic", Markdown.stripInline("*italic*"))
+        assertEquals("italic", Markdown.stripInline("_italic_"))
+        assertEquals("strike", Markdown.stripInline("~~strike~~"))
+        assertEquals("code", Markdown.stripInline("`code`"))
+    }
+
+    @Test
+    fun underscoreInsideWordIsKept() {
+        assertEquals("snake_case_name", Markdown.stripInline("snake_case_name"))
+    }
+
+    @Test
+    fun fencedCodeBlocksAreFlattened() {
+        val blocks = Markdown.parse("before\n```\ncode line\n```\nafter")
+        assertEquals(3, blocks.size)
+        assertEquals("before", blocks[0].text)
+        assertEquals("code line", blocks[1].text)
+        assertEquals("after", blocks[2].text)
+    }
+
+    @Test
+    fun blankAndOrphanHashAreSkipped() {
+        val blocks = Markdown.parse("\n##\n   \nhello\n")
+        assertEquals(1, blocks.size)
+        assertEquals("hello", blocks[0].text)
+        assertEquals(MarkdownBlock.Kind.Paragraph, blocks[0].kind)
+    }
+
+    @Test
+    fun realWorldReadme() {
+        val src = """
+            ## meshcore-mobile
+            [meshcore-mobile](https://github.com/yschimke/meshcore-mobile)
+            _Mobile companion for MeshCore_
+            [![ci](https://img/badge.svg)](https://ci/url)
+        """.trimIndent()
+        val blocks = Markdown.parse(src)
+        // heading + link + italic-line + (linked image collapses to empty → dropped)
+        assertEquals(3, blocks.size)
+        assertEquals(MarkdownBlock.Kind.Heading, blocks[0].kind)
+        assertEquals("meshcore-mobile", blocks[0].text)
+        assertEquals("meshcore-mobile", blocks[1].text)
+        assertEquals("Mobile companion for MeshCore", blocks[2].text)
+    }
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/MarkdownCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/MarkdownCardConverter.kt
@@ -7,6 +7,7 @@ import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.CardConverter
 import ee.schimke.ha.rc.components.HaMarkdownData
+import ee.schimke.ha.rc.components.Markdown
 import ee.schimke.ha.rc.components.RemoteHaMarkdown
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -26,7 +27,7 @@ class MarkdownCardConverter : CardConverter {
     override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
         val title = card.raw["title"]?.jsonPrimitive?.content
         val content = card.raw["content"]?.jsonPrimitive?.content ?: ""
-        val lines = content.split('\n').filter { it.isNotBlank() }
-        RemoteHaMarkdown(HaMarkdownData(title = title, lines = lines), modifier = modifier)
+        val blocks = Markdown.parse(content)
+        RemoteHaMarkdown(HaMarkdownData(title = title, blocks = blocks), modifier = modifier)
     }
 }


### PR DESCRIPTION
The HA `markdown` card was rendering raw markdown source (heading
hashes, link/image syntax, emphasis markers). Add a tiny line-based
parser that recognises headings, bullets and horizontal rules, strips
inline emphasis, links, images and code spans, and feeds the result to
RemoteHaMarkdown which now picks a block-level style per element.