### PR TITLE
feat(theme): apply M3 surface elevation + section grouping to rich palettes

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -16,8 +16,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -47,6 +49,7 @@ import ee.schimke.ha.rc.androidXExperimentalWrap
 import ee.schimke.ha.rc.cardHeightDp
 import ee.schimke.ha.rc.cardWidthClass
 import ee.schimke.ha.rc.cards.defaultRegistry
+import ee.schimke.ha.rc.components.HaTheme
 import ee.schimke.ha.rc.components.ProvideHaTheme
 import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.ha.rc.components.haThemeFor
@@ -159,6 +162,13 @@ private fun DashboardList(
     // be capped to a single-column max.
     val constrainColumn = !sideBySide && cfg.maxContentWidth != Dp.Unspecified
 
+    val style = LocalThemeStyle.current
+    val dark = LocalIsDarkTheme.current
+    // Same haTheme each card resolves; computed once here so the
+    // section-group surface upstairs and the per-card paint downstairs
+    // are derived from a single source.
+    val haTheme = remember(style, dark) { haThemeFor(style, dark) }
+
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.TopCenter,
@@ -181,9 +191,39 @@ private fun DashboardList(
                     sideBySide = sideBySide,
                     sectionColumns = sectionColumns,
                     useGridLayout = useGridLayout,
+                    haTheme = haTheme,
                     onLongPress = onCardLongPress,
                 )
             }
+        }
+    }
+}
+
+/**
+ * Wraps a `type: sections` group in a Material 3 surface tinted with
+ * [HaTheme.sectionBackground]. Themes that opt into the M3 elevation
+ * stack (`Material3`, `Mushroom`, `Kiosk`) set this distinct from
+ * `dashboardBackground`, so each section reads as a grouped container.
+ * Flat themes (`TerrazzoHome`, `Minimalist`) set it equal to
+ * `dashboardBackground`, so the wrap renders as a no-op and preserves
+ * the single-surface HA / matt8707 look.
+ */
+@Composable
+private fun SectionGroupSurface(
+    haTheme: HaTheme,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Surface(
+        color = haTheme.sectionBackground,
+        shape = RoundedCornerShape(20.dp),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            content()
         }
     }
 }
@@ -208,6 +248,7 @@ private fun LazyListScope.renderView(
     sideBySide: Boolean,
     sectionColumns: Int,
     useGridLayout: Boolean,
+    haTheme: HaTheme,
     onLongPress: (CardConfig) -> Unit,
 ) {
     val viewKey = "v$viewIndex"
@@ -226,23 +267,24 @@ private fun LazyListScope.renderView(
     if (view.sections.isEmpty()) return
 
     if (!sideBySide) {
+        // Single-column: each section becomes a single LazyColumn item
+        // wrapped in [SectionGroupSurface] so the title + its cards
+        // render as one grouped material container. Cards inside are
+        // rendered eagerly (a section is a small handful of cards;
+        // laziness still applies across sections).
         view.sections.forEachIndexed { sectionIndex, section ->
             val sectionKey = "$viewKey-s$sectionIndex"
-            section.title?.let { title ->
-                item(key = "$sectionKey-title") { SectionHeading(title) }
+            item(key = sectionKey) {
+                SectionGroupSurface(haTheme) {
+                    section.title?.let { title -> SectionHeading(title) }
+                    val rows = packAndChunk(section.cards, cfg.compactCardsPerRow) { c ->
+                        registry.cardWidthClass(c, snapshot)
+                    }
+                    rows.forEach { row ->
+                        CardRow(row, snapshot, registry, onLongPress)
+                    }
+                }
             }
-            cardRows(
-                keyPrefix = "$sectionKey",
-                cards = section.cards,
-                snapshot = snapshot,
-                registry = registry,
-                // Within a single-column section, keep the same
-                // packing rule the orphan path uses — small buttons
-                // pair up so a "lights" cluster stays usable on
-                // narrow screens.
-                compactPerRow = cfg.compactCardsPerRow,
-                onLongPress = onLongPress,
-            )
         }
     } else if (useGridLayout) {
         item(key = "$viewKey-grid") {
@@ -251,6 +293,7 @@ private fun LazyListScope.renderView(
                 columns = sectionColumns,
                 snapshot = snapshot,
                 registry = registry,
+                haTheme = haTheme,
                 onLongPress = onLongPress,
             )
         }
@@ -262,6 +305,7 @@ private fun LazyListScope.renderView(
                     columns = sectionColumns,
                     snapshot = snapshot,
                     registry = registry,
+                    haTheme = haTheme,
                     onLongPress = onLongPress,
                 )
             }
@@ -295,6 +339,7 @@ private fun SectionRow(
     columns: Int,
     snapshot: HaSnapshot,
     registry: ee.schimke.ha.rc.CardRegistry,
+    haTheme: HaTheme,
     onLongPress: (CardConfig) -> Unit,
 ) {
     Row(
@@ -307,6 +352,7 @@ private fun SectionRow(
                 section = section,
                 snapshot = snapshot,
                 registry = registry,
+                haTheme = haTheme,
                 onLongPress = onLongPress,
                 modifier = Modifier.weight(1f),
             )
@@ -339,6 +385,7 @@ private fun SectionGrid(
     columns: Int,
     snapshot: HaSnapshot,
     registry: ee.schimke.ha.rc.CardRegistry,
+    haTheme: HaTheme,
     onLongPress: (CardConfig) -> Unit,
 ) {
     Grid(
@@ -353,6 +400,7 @@ private fun SectionGrid(
                 section = section,
                 snapshot = snapshot,
                 registry = registry,
+                haTheme = haTheme,
                 onLongPress = onLongPress,
                 modifier = Modifier.gridItem(),
             )
@@ -365,13 +413,11 @@ private fun SectionColumn(
     section: SectionLayout,
     snapshot: HaSnapshot,
     registry: ee.schimke.ha.rc.CardRegistry,
+    haTheme: HaTheme,
     onLongPress: (CardConfig) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
+    SectionGroupSurface(haTheme = haTheme, modifier = modifier) {
         section.title?.let { SectionHeading(it) }
         section.cards.forEach { card ->
             val heightDp = remember(card, snapshot) { registry.cardHeightDp(card, snapshot) }

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/DashboardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/DashboardPreviews.kt
@@ -215,15 +215,31 @@ private fun SectionsView(view: View, snapshot: HaSnapshot) {
 
 @Composable
 private fun SectionBlock(section: Section, snapshot: HaSnapshot) {
-    if (section.title != null) {
-        Box(modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)) {
-            androidx.compose.material3.Text(
-                text = section.title!!,
-                style = androidx.compose.material3.MaterialTheme.typography.labelLarge,
-            )
+    // Wrap the title + cards in a Surface tinted with
+    // `HaTheme.Light.sectionBackground` so M3-elevation themes (Mushroom,
+    // Kiosk, Material3) get a visible group. For these flat-HA previews
+    // `sectionBackground == dashboardBackground`, so the wrap is a no-op
+    // and the HA-reference pixel diff is unaffected.
+    androidx.compose.material3.Surface(
+        color = HaTheme.Light.sectionBackground,
+        shape = androidx.compose.foundation.shape.RoundedCornerShape(16.dp),
+        modifier = Modifier.uiFillMaxWidth().padding(horizontal = 4.dp),
+    ) {
+        androidx.compose.foundation.layout.Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(vertical = 4.dp),
+        ) {
+            if (section.title != null) {
+                Box(modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp)) {
+                    androidx.compose.material3.Text(
+                        text = section.title!!,
+                        style = androidx.compose.material3.MaterialTheme.typography.labelLarge,
+                    )
+                }
+            }
+            section.cards.forEach { card -> CardSlot(card, snapshot) }
         }
     }
-    section.cards.forEach { card -> CardSlot(card, snapshot) }
 }
 
 /** Greedy pack — append each section to the shortest column. Keeps

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/ThemePreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/ThemePreviews.kt
@@ -3,10 +3,12 @@
 package ee.schimke.ha.previews
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth as uiFillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -37,68 +39,71 @@ import ee.schimke.ha.rc.components.terrazzoTypographyFor
 
 /**
  * Palette showcases — one preview per (ThemeStyle, darkMode) pair. Each
- * renders:
+ * renders, top-to-bottom:
  *
- *  1. A titled header panel using `MaterialTheme.typography.titleLarge`
- *     in `primary` — shows the chosen Google Font pairing.
- *  2. A sample of the Material 3 token swatches (primary, secondary,
- *     surface, surfaceVariant, outline) so the palette's derived scheme
- *     is legible at a glance.
- *  3. A real HA tile card rendered via `RemotePreview` + `haThemeFor`,
- *     so the HA-card palette that drives pinned widgets is included in
- *     the same frame.
- *
- * Canvas width is 360 dp (phone-compact Android width); height is tall
- * enough to fit all three bands with breathing room.
+ *  1. A titled header using `MaterialTheme.typography.titleLarge` in
+ *     `primary` — shows the chosen Google Font pairing.
+ *  2. The Material 3 key-role swatches (primary / primaryContainer /
+ *     secondary / tertiary / surfaceVariant / outline).
+ *  3. The full M3 surface-elevation strip (`surface` →
+ *     `surfaceContainerLowest` → `…Low` → `…` → `…High` → `…Highest`)
+ *     so the elevation hierarchy `haThemeFor` reads from is visible at
+ *     a glance — it's the lever that breaks the "everything is one
+ *     colour" feel called out in the issue.
+ *  4. A two-card stack rendered on the dashboard layer: an HA tile and
+ *     an HA entities row, hosted via `RemotePreview` under
+ *     `haThemeFor`. Because cards now sit on `surfaceContainerLow` and
+ *     the dashboard sits on `surface`, the tinted lift is real, not
+ *     mocked.
  */
 
 // ——— Material 3 defaults ———
 
-@Preview(name = "theme: Material3 (light)", widthDp = 360, heightDp = 340, showBackground = false)
+@Preview(name = "theme: Material3 (light)", widthDp = 360, heightDp = 480, showBackground = false)
 @Composable
 fun Theme_Material3_Light() = ThemeShowcase(ThemeStyle.Material3, darkTheme = false)
 
-@Preview(name = "theme: Material3 (dark)", widthDp = 360, heightDp = 340, showBackground = false)
+@Preview(name = "theme: Material3 (dark)", widthDp = 360, heightDp = 480, showBackground = false)
 @Composable
 fun Theme_Material3_Dark() = ThemeShowcase(ThemeStyle.Material3, darkTheme = true)
 
 // ——— Terrazzo Home (HA blue + Roboto Flex/Inter) ———
 
-@Preview(name = "theme: Home (light)", widthDp = 360, heightDp = 340, showBackground = false)
+@Preview(name = "theme: Home (light)", widthDp = 360, heightDp = 480, showBackground = false)
 @Composable
 fun Theme_Home_Light() = ThemeShowcase(ThemeStyle.TerrazzoHome, darkTheme = false)
 
-@Preview(name = "theme: Home (dark)", widthDp = 360, heightDp = 340, showBackground = false)
+@Preview(name = "theme: Home (dark)", widthDp = 360, heightDp = 480, showBackground = false)
 @Composable
 fun Theme_Home_Dark() = ThemeShowcase(ThemeStyle.TerrazzoHome, darkTheme = true)
 
 // ——— Terrazzo Mushroom (salmon + Figtree) ———
 
-@Preview(name = "theme: Mushroom (light)", widthDp = 360, heightDp = 340, showBackground = false)
+@Preview(name = "theme: Mushroom (light)", widthDp = 360, heightDp = 480, showBackground = false)
 @Composable
 fun Theme_Mushroom_Light() = ThemeShowcase(ThemeStyle.TerrazzoMushroom, darkTheme = false)
 
-@Preview(name = "theme: Mushroom (dark)", widthDp = 360, heightDp = 340, showBackground = false)
+@Preview(name = "theme: Mushroom (dark)", widthDp = 360, heightDp = 480, showBackground = false)
 @Composable
 fun Theme_Mushroom_Dark() = ThemeShowcase(ThemeStyle.TerrazzoMushroom, darkTheme = true)
 
 // ——— Terrazzo Minimalist (slate + IBM Plex Sans) ———
 
-@Preview(name = "theme: Minimalist (light)", widthDp = 360, heightDp = 340, showBackground = false)
+@Preview(name = "theme: Minimalist (light)", widthDp = 360, heightDp = 480, showBackground = false)
 @Composable
 fun Theme_Minimalist_Light() = ThemeShowcase(ThemeStyle.TerrazzoMinimalist, darkTheme = false)
 
-@Preview(name = "theme: Minimalist (dark)", widthDp = 360, heightDp = 340, showBackground = false)
+@Preview(name = "theme: Minimalist (dark)", widthDp = 360, heightDp = 480, showBackground = false)
 @Composable
 fun Theme_Minimalist_Dark() = ThemeShowcase(ThemeStyle.TerrazzoMinimalist, darkTheme = true)
 
 // ——— Terrazzo Kiosk (teal + Atkinson Hyperlegible, dark-only context) ———
 
-@Preview(name = "theme: Kiosk (light)", widthDp = 360, heightDp = 340, showBackground = false)
+@Preview(name = "theme: Kiosk (light)", widthDp = 360, heightDp = 480, showBackground = false)
 @Composable
 fun Theme_Kiosk_Light() = ThemeShowcase(ThemeStyle.TerrazzoKiosk, darkTheme = false)
 
-@Preview(name = "theme: Kiosk (dark)", widthDp = 360, heightDp = 340, showBackground = false)
+@Preview(name = "theme: Kiosk (dark)", widthDp = 360, heightDp = 480, showBackground = false)
 @Composable
 fun Theme_Kiosk_Dark() = ThemeShowcase(ThemeStyle.TerrazzoKiosk, darkTheme = true)
 
@@ -109,7 +114,9 @@ private fun ThemeShowcase(style: ThemeStyle, darkTheme: Boolean) {
     val haTheme: HaTheme = haThemeFor(style, darkTheme)
 
     MaterialTheme(colorScheme = colors, typography = typography) {
-        Surface(color = colors.background) {
+        // Page is `dashboardBackground` so the surface-stack labels read
+        // against the same neutral the cards sit on.
+        Surface(color = haTheme.dashboardBackground) {
             Column(
                 modifier = Modifier.uiFillMaxWidth().padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -127,46 +134,83 @@ private fun ThemeShowcase(style: ThemeStyle, darkTheme: Boolean) {
                     )
                 }
 
-                // M3 swatch row
+                // Key M3 role swatches.
                 Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                     Swatch("P", colors.primary, colors.onPrimary)
                     Swatch("PC", colors.primaryContainer, colors.onPrimaryContainer)
                     Swatch("S", colors.secondary, colors.onSecondary)
                     Swatch("T", colors.tertiary, colors.onTertiary)
-                    Swatch("Su", colors.surfaceVariant, colors.onSurfaceVariant)
+                    Swatch("Sv", colors.surfaceVariant, colors.onSurfaceVariant)
                     Swatch("O", colors.outline, colors.onSurface)
                 }
 
-                // Typography sample on a card
-                Surface(
-                    color = colors.surface,
-                    contentColor = colors.onSurface,
-                    shape = RoundedCornerShape(12.dp),
-                    modifier = Modifier.uiFillMaxWidth(),
-                ) {
-                    Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                        Text("Living room", style = MaterialTheme.typography.titleMedium)
-                        Text("21.5°C · humidity 48%", style = MaterialTheme.typography.bodyMedium, color = colors.onSurfaceVariant)
-                        Text("Updated 2 min ago", style = MaterialTheme.typography.labelSmall, color = colors.onSurfaceVariant)
-                    }
+                // M3 surface elevation strip. Bands left-to-right are
+                // `surface` plus the five `surfaceContainer*` tokens.
+                // For elevated themes (Material3 / Mushroom / Kiosk) the
+                // outline highlights `Cn` (section group) and `Hi`
+                // (card) — the two tokens `haThemeFor` reads from for
+                // those palettes. Flat themes (Home / Minimalist) ignore
+                // these and use `surface` as cardBackground, so the
+                // highlight is informational.
+                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    SurfaceBand("surface", colors.surface, colors.onSurface)
+                    SurfaceBand("Lo-", colors.surfaceContainerLowest, colors.onSurface)
+                    SurfaceBand("Lo", colors.surfaceContainerLow, colors.onSurface)
+                    SurfaceBand("Cn", colors.surfaceContainer, colors.onSurface, highlight = true)
+                    SurfaceBand("Hi", colors.surfaceContainerHigh, colors.onSurface, highlight = true)
+                    SurfaceBand("Hi+", colors.surfaceContainerHighest, colors.onSurface)
                 }
 
-                // Real HA tile card under the derived HaTheme
-                Box(
+                // Two HA cards stacked inside a section-group surface
+                // (`sectionBackground`), itself sitting on the dashboard
+                // layer (`dashboardBackground`). For Material3 / Mushroom
+                // / Kiosk the three layers read as three distinct tints;
+                // for Home / Minimalist `sectionBackground` equals
+                // `dashboardBackground`, so the wrap reads as a no-op
+                // and the flat HA / matt8707 look is preserved.
+                Column(
                     modifier = Modifier
                         .uiFillMaxWidth()
-                        .height(48.dp)
-                        .clip(RoundedCornerShape(12.dp))
-                        .background(haTheme.cardBackground),
+                        .clip(RoundedCornerShape(20.dp))
+                        .background(haTheme.sectionBackground)
+                        .padding(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    RemotePreview(profile = androidXExperimental) {
-                        ProvideCardRegistry(defaultRegistry()) {
-                            ProvideHaTheme(haTheme) {
-                                RenderChild(
-                                    card("""{"type":"tile","entity":"sensor.living_room"}"""),
-                                    Fixtures.livingRoomTemp,
-                                    RemoteModifier.fillMaxWidth(),
-                                )
+                    Box(
+                        modifier = Modifier
+                            .uiFillMaxWidth()
+                            .height(56.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(haTheme.cardBackground),
+                    ) {
+                        RemotePreview(profile = androidXExperimental) {
+                            ProvideCardRegistry(defaultRegistry()) {
+                                ProvideHaTheme(haTheme) {
+                                    RenderChild(
+                                        card("""{"type":"tile","entity":"sensor.living_room"}"""),
+                                        Fixtures.livingRoomTemp,
+                                        RemoteModifier.fillMaxWidth(),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    Box(
+                        modifier = Modifier
+                            .uiFillMaxWidth()
+                            .height(96.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(haTheme.cardBackground),
+                    ) {
+                        RemotePreview(profile = androidXExperimental) {
+                            ProvideCardRegistry(defaultRegistry()) {
+                                ProvideHaTheme(haTheme) {
+                                    RenderChild(
+                                        card("""{"type":"tile","entity":"light.kitchen"}"""),
+                                        Fixtures.kitchenLight,
+                                        RemoteModifier.fillMaxWidth(),
+                                    )
+                                }
                             }
                         }
                     }
@@ -189,6 +233,28 @@ private fun Swatch(label: String, color: Color, onColor: Color) {
             style = MaterialTheme.typography.labelSmall,
             color = onColor,
             modifier = Modifier.padding(4.dp),
+        )
+    }
+}
+
+@Composable
+private fun RowScope.SurfaceBand(
+    label: String,
+    color: Color,
+    onColor: Color,
+    highlight: Boolean = false,
+) {
+    val shape = RoundedCornerShape(6.dp)
+    val outline = MaterialTheme.colorScheme.outline
+    val base = Modifier.weight(1f).height(32.dp).clip(shape).background(color)
+    Box(
+        modifier = if (highlight) base.border(1.dp, outline, shape) else base,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = onColor,
+            modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp),
         )
     }
 }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/HaTheme.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/HaTheme.kt
@@ -20,6 +20,19 @@ import androidx.compose.ui.graphics.Color
 data class HaTheme(
     val cardBackground: Color,
     val dashboardBackground: Color,
+    /**
+     * Background of a `type: sections` group container. Cards within the
+     * section sit on [cardBackground] above this layer — three-layer
+     * stack is `dashboardBackground` → `sectionBackground` → `cardBackground`.
+     *
+     * Set equal to [dashboardBackground] to opt out of the group surface
+     * (a `Surface(color = sectionBackground)` wrap then renders as a
+     * no-op). The flat themes — `TerrazzoHome` (HA blue) and
+     * `TerrazzoMinimalist` (matt8707) — opt out, since their identity is
+     * a single uniform surface; the elevated themes (`Material3`,
+     * `TerrazzoMushroom`, `TerrazzoKiosk`) opt in.
+     */
+    val sectionBackground: Color,
     val primaryText: Color,
     val secondaryText: Color,
     val divider: Color,
@@ -35,6 +48,7 @@ data class HaTheme(
         val Light = HaTheme(
             cardBackground = Color(0xFFFFFFFF),
             dashboardBackground = Color(0xFFFAFAFA),
+            sectionBackground = Color(0xFFFAFAFA),
             primaryText = Color(0xFF141414),
             secondaryText = Color(0xFF8F8F8F),
             divider = Color(0xFFE0E0E0),
@@ -48,6 +62,7 @@ data class HaTheme(
         val Dark = HaTheme(
             cardBackground = Color(0xFF1C1C1C),
             dashboardBackground = Color(0xFF111111),
+            sectionBackground = Color(0xFF111111),
             primaryText = Color(0xFFE1E1E1),
             secondaryText = Color(0xFF878787),
             divider = Color(0xFF333333),
@@ -60,40 +75,61 @@ data class HaTheme(
 }
 
 /**
- * Derive an [HaTheme] for a given [style] and [darkTheme] flag. Each
- * Terrazzo palette maps the Material 3 `ColorScheme` (built from
- * [terrazzoColorScheme]) onto the HA-card role layer so cards render in
- * the selected palette automatically:
+ * Derive an [HaTheme] for a given [style] and [darkTheme] flag.
  *
- * - `surface` ↦ `cardBackground`
- * - `background` ↦ `dashboardBackground`
- * - `onSurface` ↦ `primaryText`
- * - `onSurfaceVariant` ↦ `secondaryText`
- * - `outline` ↦ `divider`
- * - `secondary` ↦ `placeholderAccent`
- * - `secondaryContainer` ↦ `placeholderBackground`
+ * The mapping branches by palette identity:
  *
- * [ThemeStyle.Material3] is special-cased: the M3 defaults have a
- * lilac primary that doesn't match any HA palette, so we fall back to
- * the HA-sampled Light/Dark snapshots rather than let `colorScheme()`
- * leak purple containers into the dashboard.
+ *  - **`Material3`, `TerrazzoMushroom`, `TerrazzoKiosk`** — the "rich"
+ *    palettes. Map onto Material 3's surface-elevation tokens for a
+ *    three-layer stack: the page sits on `surface`, sections group their
+ *    cards on `surfaceContainer`, and cards themselves sit on
+ *    `surfaceContainerHigh`. Picture/unsupported/completed accents come
+ *    from `primary`/`primaryContainer` so the palette's hero colour
+ *    carries through, and dividers use the softer `outlineVariant`
+ *    decorative role.
+ *
+ *  - **`TerrazzoHome`, `TerrazzoMinimalist`** — the "flat" palettes.
+ *    Their brief is a single uniform surface (HA's stock blue dashboard
+ *    and the matt8707 minimalist look respectively), so they keep the
+ *    pre-existing flat mapping: cards on `surface`, dashboard on
+ *    `background`, divider on `outline`, accents from
+ *    `secondary`/`secondaryContainer`. `sectionBackground` is set equal
+ *    to `dashboardBackground` so the dashboard's section-group
+ *    `Surface` wrap renders as a no-op for these two themes.
  */
 fun haThemeFor(style: ThemeStyle, darkTheme: Boolean): HaTheme {
-    if (style == ThemeStyle.Material3) {
-        return if (darkTheme) HaTheme.Dark else HaTheme.Light
-    }
     val m3 = terrazzoColorScheme(style, darkTheme)
-    return HaTheme(
-        cardBackground = m3.surface,
-        dashboardBackground = m3.background,
-        primaryText = m3.onSurface,
-        secondaryText = m3.onSurfaceVariant,
-        divider = m3.outline,
-        placeholderAccent = m3.secondary,
-        placeholderBackground = m3.secondaryContainer,
-        unknownAccent = m3.onSurfaceVariant,
-        isDark = darkTheme,
-    )
+    return when (style) {
+        ThemeStyle.TerrazzoHome,
+        ThemeStyle.TerrazzoMinimalist ->
+            HaTheme(
+                cardBackground = m3.surface,
+                dashboardBackground = m3.background,
+                sectionBackground = m3.background,
+                primaryText = m3.onSurface,
+                secondaryText = m3.onSurfaceVariant,
+                divider = m3.outline,
+                placeholderAccent = m3.secondary,
+                placeholderBackground = m3.secondaryContainer,
+                unknownAccent = m3.onSurfaceVariant,
+                isDark = darkTheme,
+            )
+        ThemeStyle.Material3,
+        ThemeStyle.TerrazzoMushroom,
+        ThemeStyle.TerrazzoKiosk ->
+            HaTheme(
+                cardBackground = m3.surfaceContainerHigh,
+                dashboardBackground = m3.surface,
+                sectionBackground = m3.surfaceContainer,
+                primaryText = m3.onSurface,
+                secondaryText = m3.onSurfaceVariant,
+                divider = m3.outlineVariant,
+                placeholderAccent = m3.primary,
+                placeholderBackground = m3.primaryContainer,
+                unknownAccent = m3.onSurfaceVariant,
+                isDark = darkTheme,
+            )
+    }
 }
 
 val LocalHaTheme = staticCompositionLocalOf { HaTheme.Light }


### PR DESCRIPTION
Rework `haThemeFor` to map the Material 3 colour scheme onto the HA-card
role layer following the surface-elevation guidance, and add a new
`sectionBackground` token so dashboards can wrap each `type: sections`
group in its own tinted Surface.

The mapping now branches by palette identity:

- `Material3`, `TerrazzoMushroom`, `TerrazzoKiosk` opt into the M3
  three-layer stack: `surface` for the page, `surfaceContainer` for the
  section group, `surfaceContainerHigh` for the cards. Dividers move to
  `outlineVariant` (softer decorative role) and `placeholder*` tokens
  pull from `primary` / `primaryContainer` so the palette's hero colour
  carries through the picture / unsupported / completed-todo glyphs.
  Cards now lift off the dashboard with a visible tinted layer instead
  of disappearing into a near-uniform surface.

- `TerrazzoHome` and `TerrazzoMinimalist` keep the prior flat mapping —
  cards on `surface`, dashboard on `background`, accents from
  `secondary` / `secondaryContainer`. `sectionBackground` is set equal
  to `dashboardBackground`, so the new section-group `Surface` wrap
  renders as a no-op for these two themes and the HA-blue / matt8707
  single-surface look is preserved.

Wire the section-group surface through `DashboardViewScreen` for all
three layout paths (single-column, side-by-side row, experimental
grid), and through the static `DashboardPreviews` host. Single-column
sections collapse into a single `LazyColumn` item per section so the
title and its cards share the wrap; laziness still applies across
sections.

Update `ThemePreviews` to render the surface-elevation strip and a
two-card section group on the dashboard background, so the three-layer
stack is visible side-by-side with the Material 3 swatch row. Bump
preview height to 480 dp to fit.