### PR TITLE
Push live entity state updates to cached card previews

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -562,7 +562,12 @@ private fun CardSlot(
             // events on the Main pass for in-document click regions.
             .longPressBeforeChild { onLongPress(card) },
     ) {
-        CachedCardPreview(cacheKey = cacheKey, profile = androidXExperimentalWrap) {
+        CachedCardPreview(
+            cacheKey = cacheKey,
+            profile = androidXExperimentalWrap,
+            card = card,
+            snapshot = snapshot,
+        ) {
             ProvideCardRegistry(registry) {
                 ProvideHaTheme(haTheme) {
                     RenderChild(card, snapshot, RemoteModifier.fillMaxWidth())

--- a/rc-converter/build.gradle.kts
+++ b/rc-converter/build.gradle.kts
@@ -37,4 +37,5 @@ dependencies {
   implementation(libs.remote.material3)
 
   testImplementation(libs.kotlin.test)
+  testImplementation(libs.kotlin.test.junit)
 }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CachedCardPreview.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CachedCardPreview.kt
@@ -10,11 +10,16 @@ import androidx.compose.remote.creation.compose.layout.RemoteComposable
 import androidx.compose.remote.creation.profile.Profile
 import androidx.compose.remote.creation.profile.RcPlatformProfiles
 import androidx.compose.remote.player.compose.RemoteDocumentPlayer
+import androidx.compose.remote.player.core.state.StateUpdater
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalWindowInfo
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.components.HA_ACTION_NAME
 import kotlinx.coroutines.runBlocking
 
@@ -36,6 +41,21 @@ import kotlinx.coroutines.runBlocking
  * `.isOn` (in rc-components) are exactly the seam through which a
  * running player gets fresh data without re-encoding.
  *
+ * **Live snapshot push.** When [card] and [snapshot] are supplied,
+ * the running player is fed named-binding writes for the entities
+ * the card references each time [snapshot] changes. This covers the
+ * regression introduced by document caching: without it, the document
+ * is encoded once per `(card, theme)` and no value updates ever reach
+ * the player. The push:
+ *   1. Walks `card.raw` once with [cardEntityIds] to enumerate the
+ *      entities the card consumes (`entity:` / `entities:`, including
+ *      nested cards in stack / conditional / picture-elements).
+ *   2. Captures the player's [StateUpdater] via
+ *      `RemoteDocumentPlayer(init = ...)`.
+ *   3. On every [snapshot] change, computes the bindings via
+ *      [cardSnapshotBindings] and writes only those that actually
+ *      changed since the last push (`<id>.state`, `<id>.is_on`).
+ *
  * Sizing follows upstream `RemotePreview`: the captured document
  * carries its natural size in the header, and the player measures via
  * `RemoteComposePlayerFlags.shouldPlayerWrapContentSize` (on by
@@ -48,6 +68,8 @@ fun CachedCardPreview(
     cacheKey: Any,
     profile: Profile = RcPlatformProfiles.ANDROIDX,
     modifier: Modifier = Modifier,
+    card: CardConfig? = null,
+    snapshot: HaSnapshot? = null,
     content: @RemoteComposable @Composable () -> Unit,
 ) {
     val context = LocalContext.current
@@ -72,17 +94,66 @@ fun CachedCardPreview(
     val windowInfo = LocalWindowInfo.current
     val dispatcher = LocalHaActionDispatcher.current
 
+    val entityIds = remember(card) { card?.let { cardEntityIds(it) }.orEmpty() }
+    // The handle survives recomposition but is replaced if the player
+    // is torn down and rebuilt (cache invalidation, theme flip).
+    val updaterHolder = remember { mutableStateOf<StateUpdater?>(null) }
+    // Tracks the last value we pushed for each binding so a redundant
+    // snapshot recompose doesn't re-issue identical writes. Reset when
+    // [cacheKey] changes — the new document carries its own initial
+    // bake, and we want the next push to be unconditional.
+    val pushed = remember(cacheKey) { HashMap<String, Any?>() }
+
+    if (card != null && snapshot != null && entityIds.isNotEmpty()) {
+        LaunchedEffect(updaterHolder.value, snapshot) {
+            val updater = updaterHolder.value ?: return@LaunchedEffect
+            pushSnapshotBindings(updater, entityIds, snapshot, pushed)
+        }
+    }
+
     Box(modifier = modifier.fillMaxSize()) {
         RemoteDocumentPlayer(
             document = coreDocument,
             documentWidth = windowInfo.containerSize.width,
             documentHeight = windowInfo.containerSize.height,
             modifier = Modifier.fillMaxSize(),
+            init = { player -> updaterHolder.value = player.stateUpdater },
             onNamedAction = { name, value, _ ->
                 if (name == HA_ACTION_NAME) {
                     decodeHaAction(value)?.let(dispatcher::dispatch)
                 }
             },
         )
+    }
+}
+
+/**
+ * Push the diff between the previous push (tracked in [pushed]) and
+ * the current [snapshot] for the named bindings of [entityIds] into
+ * [updater]. Catches per-binding failures so a single unknown name
+ * doesn't take down the whole push (the player rejects writes for
+ * names not declared in the document).
+ *
+ * Boolean bindings are pushed as ints — `LiveValues.isOn` creates a
+ * `RemoteBoolean` which alpha010 stores internally as a `RemoteInt`
+ * (0/1), and the player only exposes `setUserLocalInt` for that
+ * channel.
+ */
+private fun pushSnapshotBindings(
+    updater: StateUpdater,
+    entityIds: Set<String>,
+    snapshot: HaSnapshot,
+    pushed: MutableMap<String, Any?>,
+) {
+    val bindings = cardSnapshotBindings(entityIds, snapshot)
+    for ((name, value) in bindings.strings) {
+        if (pushed[name] == value) continue
+        runCatching { updater.setUserLocalString(name, value) }
+            .onSuccess { pushed[name] = value }
+    }
+    for ((name, value) in bindings.booleans) {
+        if (pushed[name] == value) continue
+        runCatching { updater.setUserLocalInt(name, if (value) 1 else 0) }
+            .onSuccess { pushed[name] = value }
     }
 }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardEntities.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardEntities.kt
@@ -1,0 +1,94 @@
+package ee.schimke.ha.rc
+
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.HaSnapshot
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+/**
+ * Recursively walks a Lovelace card's raw config to discover the
+ * `entity_id`s the card consumes, so a host can push named-binding
+ * updates only for what the card actually reads.
+ *
+ * Recognises the two HA-standard fields:
+ *   - `entity:` — string value, single entity.
+ *   - `entities:` — array of strings, or array of objects each with an
+ *     `entity:` key.
+ *
+ * Walks into nested `JsonObject` / `JsonArray` so stack / grid /
+ * conditional / picture-elements / entity-filter cards expose the
+ * entities of every nested card. Conservative: an unknown key with an
+ * entity-id-shaped value is NOT picked up; only the documented
+ * Lovelace shape. Values without a `domain.id` dot are skipped to
+ * avoid catching `name:`-shaped strings that happen to be in an
+ * `entity` field.
+ */
+fun cardEntityIds(card: CardConfig): Set<String> {
+    val out = LinkedHashSet<String>()
+    collectEntityIds(card.raw, out)
+    return out
+}
+
+private fun collectEntityIds(element: JsonElement, out: MutableSet<String>) {
+    when (element) {
+        is JsonObject -> {
+            for ((key, value) in element) {
+                when {
+                    key == "entity" && value is JsonPrimitive -> addEntityId(value, out)
+                    key == "entities" && value is JsonArray -> {
+                        for (entry in value) {
+                            when (entry) {
+                                is JsonPrimitive -> addEntityId(entry, out)
+                                is JsonObject -> collectEntityIds(entry, out)
+                                else -> {}
+                            }
+                        }
+                    }
+                    else -> collectEntityIds(value, out)
+                }
+            }
+        }
+        is JsonArray -> element.forEach { collectEntityIds(it, out) }
+        else -> {}
+    }
+}
+
+private fun addEntityId(value: JsonPrimitive, out: MutableSet<String>) {
+    val id = value.contentOrNull ?: return
+    if (id.contains('.')) out.add(id)
+}
+
+/**
+ * Named bindings for one card's [entityIds] under the current
+ * [snapshot]. Mirrors the `addon-server` `/v1/stream` push shape
+ * (see `StreamRoute.kt`): for each entity id present in the snapshot,
+ * `<id>.state` (string) and `<id>.is_on` (bool) — the same names
+ * `LiveValues` bakes into the document at capture time.
+ *
+ * Used by `CachedCardPreview` to push live updates into the running
+ * player without re-encoding. Entities missing from the snapshot are
+ * skipped: there's no defined "absent" value, and the document keeps
+ * its initial bake until the entity reappears.
+ */
+data class CardSnapshotBindings(
+    val strings: Map<String, String>,
+    val booleans: Map<String, Boolean>,
+)
+
+fun cardSnapshotBindings(
+    entityIds: Set<String>,
+    snapshot: HaSnapshot,
+): CardSnapshotBindings {
+    if (entityIds.isEmpty()) return CardSnapshotBindings(emptyMap(), emptyMap())
+    val strings = LinkedHashMap<String, String>(entityIds.size)
+    val booleans = LinkedHashMap<String, Boolean>(entityIds.size)
+    for (id in entityIds) {
+        val state = snapshot.states[id] ?: continue
+        strings["$id.state"] = state.state
+        booleans["$id.is_on"] = state.state == "on"
+    }
+    return CardSnapshotBindings(strings, booleans)
+}

--- a/rc-converter/src/test/kotlin/ee/schimke/ha/rc/CardEntitiesTest.kt
+++ b/rc-converter/src/test/kotlin/ee/schimke/ha/rc/CardEntitiesTest.kt
@@ -1,0 +1,123 @@
+package ee.schimke.ha.rc
+
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.EntityState
+import ee.schimke.ha.model.HaSnapshot
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CardEntitiesTest {
+
+    private fun rawConfig(json: String): JsonObject =
+        Json.parseToJsonElement(json) as JsonObject
+
+    private fun card(json: String, type: String = "tile"): CardConfig =
+        CardConfig(type = type, raw = rawConfig(json))
+
+    @Test
+    fun singleEntityField() {
+        val ids = cardEntityIds(card("""{"entity":"light.kitchen"}"""))
+        assertEquals(setOf("light.kitchen"), ids)
+    }
+
+    @Test
+    fun ignoresEntityFieldWithoutDomain() {
+        // `entity: foo` (no `.`) is HA-illegal; skip rather than emit.
+        val ids = cardEntityIds(card("""{"entity":"name-not-an-id"}"""))
+        assertTrue(ids.isEmpty())
+    }
+
+    @Test
+    fun entitiesArrayOfStrings() {
+        val ids = cardEntityIds(card(
+            """{"entities":["sensor.temp","sensor.humidity"]}""",
+            type = "history-graph",
+        ))
+        assertEquals(setOf("sensor.temp", "sensor.humidity"), ids)
+    }
+
+    @Test
+    fun entitiesArrayOfObjects() {
+        val ids = cardEntityIds(card(
+            """{"entities":[{"entity":"light.bed","name":"Bed"},
+                            {"entity":"switch.fan"}]}""",
+            type = "entities",
+        ))
+        assertEquals(setOf("light.bed", "switch.fan"), ids)
+    }
+
+    @Test
+    fun nestedConditionalAndStack() {
+        // `conditional` wraps `card`, `vertical-stack` wraps `cards`;
+        // both should be walked so the inner entity surfaces.
+        val ids = cardEntityIds(card(
+            """{
+              "conditions":[{"entity":"binary_sensor.door","state":"on"}],
+              "card":{
+                "type":"vertical-stack",
+                "cards":[
+                  {"type":"tile","entity":"light.kitchen"},
+                  {"type":"sensor","entity":"sensor.temp"}
+                ]
+              }
+            }""",
+            type = "conditional",
+        ))
+        assertEquals(
+            setOf("binary_sensor.door", "light.kitchen", "sensor.temp"),
+            ids,
+        )
+    }
+
+    @Test
+    fun snapshotBindingsForKnownEntities() {
+        val snapshot = HaSnapshot(states = mapOf(
+            "light.kitchen" to EntityState("light.kitchen", "on"),
+            "sensor.temp"   to EntityState("sensor.temp",   "21.4"),
+        ))
+        val bindings = cardSnapshotBindings(
+            setOf("light.kitchen", "sensor.temp"),
+            snapshot,
+        )
+        assertEquals(
+            mapOf(
+                "light.kitchen.state" to "on",
+                "sensor.temp.state"   to "21.4",
+            ),
+            bindings.strings,
+        )
+        assertEquals(
+            mapOf(
+                "light.kitchen.is_on" to true,
+                "sensor.temp.is_on"   to false,
+            ),
+            bindings.booleans,
+        )
+    }
+
+    @Test
+    fun snapshotBindingsSkipMissingEntities() {
+        // Card references entities the snapshot doesn't carry yet
+        // (e.g. cold-start, or HA hasn't reported them). Skip rather
+        // than push an empty string — the document keeps its bake.
+        val snapshot = HaSnapshot(states = mapOf(
+            "light.kitchen" to EntityState("light.kitchen", "on"),
+        ))
+        val bindings = cardSnapshotBindings(
+            setOf("light.kitchen", "sensor.missing"),
+            snapshot,
+        )
+        assertEquals(setOf("light.kitchen.state"), bindings.strings.keys)
+        assertEquals(setOf("light.kitchen.is_on"), bindings.booleans.keys)
+    }
+
+    @Test
+    fun emptyEntitySetReturnsEmptyBindings() {
+        val bindings = cardSnapshotBindings(emptySet(), HaSnapshot())
+        assertTrue(bindings.strings.isEmpty())
+        assertTrue(bindings.booleans.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
Implement live snapshot binding updates for cached Lovelace card previews. This fixes a regression where document caching prevented value updates from reaching the player without re-encoding.

## Key Changes
- **New `CardEntities.kt` module**: Adds two core functions:
  - `cardEntityIds()`: Recursively walks a card's raw JSON config to discover all entity IDs the card consumes (via `entity:` and `entities:` fields), including nested cards in stacks, conditionals, and picture-elements
  - `cardSnapshotBindings()`: Converts a set of entity IDs and a snapshot into named bindings (`<id>.state` string and `<id>.is_on` boolean) for entities present in the snapshot

- **Enhanced `CachedCardPreview` composable**:
  - Accepts optional `card` and `snapshot` parameters
  - Captures the player's `StateUpdater` via the `init` callback
  - Uses `LaunchedEffect` to push binding updates whenever the snapshot changes
  - Tracks previously-pushed values to avoid redundant writes
  - Resets tracking when cache key changes (document re-encoded)

- **Integration in `DashboardViewScreen`**: Passes `card` and `snapshot` to `CachedCardPreview` to enable live updates

- **Test coverage**: Comprehensive test suite covering entity ID extraction (single/array/nested), snapshot binding generation, and edge cases (missing entities, empty sets)

## Implementation Details
- Entity ID extraction is conservative: only recognizes documented Lovelace fields (`entity:`, `entities:`) and validates IDs contain a domain dot to avoid false positives
- Missing entities are skipped gracefully—no "absent" value is defined, and the document retains its initial bake until the entity reappears
- Boolean bindings are pushed as integers (0/1) to match the player's internal representation
- Per-binding failures are caught to prevent a single unknown name from breaking the entire push

https://claude.ai/code/session_01PjtTYUwFtTjZhHu5u6JDPH