### PR TITLE
Use state_int for alarm panel chrome to avoid re-encodes

### DIFF
--- a/addon-server/src/main/kotlin/ee/schimke/ha/addon/routes/StreamRoute.kt
+++ b/addon-server/src/main/kotlin/ee/schimke/ha/addon/routes/StreamRoute.kt
@@ -2,6 +2,7 @@ package ee.schimke.ha.addon.routes
 
 import ee.schimke.ha.addon.bridge.HaEvent
 import ee.schimke.ha.addon.bridge.HaSupervisorBridge
+import ee.schimke.ha.model.alarmStateIntFromRaw
 import io.ktor.server.routing.Routing
 import io.ktor.server.websocket.webSocket
 import io.ktor.websocket.Frame
@@ -62,6 +63,11 @@ fun Routing.streamRoute(bridge: HaSupervisorBridge) {
                   // for everything is harmless — clients
                   // ignore unknown names.
                   put("${state.entityId}.is_on", JsonPrimitive(state.state == "on"))
+                  // Domain-specific int keys (alarm panel, …) so
+                  // `RemoteStateLayout(RemoteInt, …)` chrome can
+                  // flip without a re-encode. Same harmless-extra
+                  // policy as `is_on`.
+                  putStateInt(state.entityId, state.state)
                 },
               )
             }
@@ -128,6 +134,7 @@ private suspend fun handleClientFrame(
             for ((entityId, state) in bindings) {
               put("$entityId.state", JsonPrimitive(state.state))
               put("$entityId.is_on", JsonPrimitive(state.state == "on"))
+              putStateInt(entityId, state.state)
             }
           },
         )
@@ -173,4 +180,23 @@ private suspend fun <T> kotlinx.coroutines.sync.Mutex.withLockReturn(block: () -
   } finally {
     unlock()
   }
+}
+
+/**
+ * Emit `<entityId>.state_int` for entities whose domain has a stable `String → Int` wire mapping
+ * defined in `ha-model`. Clients that don't use the int binding ignore the extra field; clients
+ * that do (alarm-panel, …) flip chrome through `RemoteStateLayout(RemoteInt, …)` without a document
+ * re-encode.
+ */
+private fun kotlinx.serialization.json.JsonObjectBuilder.putStateInt(
+  entityId: String,
+  state: String,
+) {
+  val domain = entityId.substringBefore('.', missingDelimiterValue = "")
+  val intKey =
+    when (domain) {
+      "alarm_control_panel" -> alarmStateIntFromRaw(state)
+      else -> null
+    } ?: return
+  put("$entityId.state_int", JsonPrimitive(intKey))
 }

--- a/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/HaDomainState.kt
+++ b/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/HaDomainState.kt
@@ -214,6 +214,67 @@ val AlarmState.isArmed: Boolean
       this is AlarmState.ArmedVacation ||
       this is AlarmState.ArmedCustomBypass
 
+/**
+ * Stable `String → Int` key for [AlarmState], used by `RemoteStateLayout(RemoteInt, …)` so the
+ * alarm-panel chrome (icon, accent, label) flips on data alone — the host pushes
+ * `<entityId>.state_int` and the player picks the matching variant without a re-encode.
+ *
+ * Keys are part of the wire contract between host and `.rc` document; once published they MUST NOT
+ * be reordered or removed. Append new states with a new key.
+ */
+object AlarmStateInt {
+  const val Disarmed: Int = 0
+  const val ArmedHome: Int = 1
+  const val ArmedAway: Int = 2
+  const val ArmedNight: Int = 3
+  const val ArmedVacation: Int = 4
+  const val ArmedCustomBypass: Int = 5
+  const val Triggered: Int = 6
+  const val Pending: Int = 7
+  const val Arming: Int = 8
+  const val Disarming: Int = 9
+  const val Unavailable: Int = 10
+
+  /** Catch-all for states the wire contract doesn't recognise yet. */
+  const val Unknown: Int = 11
+
+  /** All keys in declaration order — pass to `RemoteStateLayout` as the enumerated states. */
+  val All: IntArray =
+    intArrayOf(
+      Disarmed,
+      ArmedHome,
+      ArmedAway,
+      ArmedNight,
+      ArmedVacation,
+      ArmedCustomBypass,
+      Triggered,
+      Pending,
+      Arming,
+      Disarming,
+      Unavailable,
+      Unknown,
+    )
+}
+
+fun AlarmState.intKey(): Int =
+  when (this) {
+    is AlarmState.Disarmed -> AlarmStateInt.Disarmed
+    is AlarmState.ArmedHome -> AlarmStateInt.ArmedHome
+    is AlarmState.ArmedAway -> AlarmStateInt.ArmedAway
+    is AlarmState.ArmedNight -> AlarmStateInt.ArmedNight
+    is AlarmState.ArmedVacation -> AlarmStateInt.ArmedVacation
+    is AlarmState.ArmedCustomBypass -> AlarmStateInt.ArmedCustomBypass
+    is AlarmState.Triggered -> AlarmStateInt.Triggered
+    is AlarmState.Pending -> AlarmStateInt.Pending
+    is AlarmState.Arming -> AlarmStateInt.Arming
+    is AlarmState.Disarming -> AlarmStateInt.Disarming
+    is AlarmState.Unavailable -> AlarmStateInt.Unavailable
+    is AlarmState.Unknown -> AlarmStateInt.Unknown
+  }
+
+/** Parse a raw HA alarm-panel state string straight into the int wire key. */
+fun alarmStateIntFromRaw(raw: String): Int = AlarmState.parse(raw).intKey()
+
 sealed interface VacuumState {
   data object Cleaning : VacuumState
 

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/LiveValues.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/LiveValues.kt
@@ -4,9 +4,11 @@ package ee.schimke.ha.rc.components
 
 import androidx.compose.remote.creation.compose.state.RemoteBoolean
 import androidx.compose.remote.creation.compose.state.RemoteFloat
-import androidx.compose.remote.creation.compose.state.RemoteString
+import androidx.compose.remote.creation.compose.state.RemoteInt
 import androidx.compose.remote.creation.compose.state.RemoteState
+import androidx.compose.remote.creation.compose.state.RemoteString
 import androidx.compose.remote.creation.compose.state.rf
+import androidx.compose.remote.creation.compose.state.ri
 import androidx.compose.remote.creation.compose.state.rs
 
 /**
@@ -37,6 +39,32 @@ object LiveValues {
     /** Entity primary state ↔ `<entityId>.state`. */
     fun state(entityId: String?, initial: String): RemoteString =
         named(entityId, "state", initial)
+
+    /**
+     * Entity primary state as an integer key ↔ `<entityId>.state_int`. The
+     * caller picks a stable `String → Int` mapping for the relevant HA
+     * domain (alarm-panel, climate hvac_mode, …); the host pushes the
+     * matching int when the entity changes and `RemoteStateLayout(RemoteInt,
+     * …)` flips the variant without a re-encode. When [entityId] is null
+     * the helper falls back to a constant.
+     */
+    fun intState(entityId: String?, initial: Int): RemoteInt =
+        namedInt(entityId, "state_int", initial)
+
+    /**
+     * Generic integer host binding. The caller picks the suffix; useful
+     * for any enum-shaped state that isn't the primary `state` (e.g.
+     * mode indices). When [entityId] is null the helper falls back to
+     * a constant.
+     */
+    fun namedInt(entityId: String?, suffix: String, initial: Int): RemoteInt {
+        if (entityId == null) return initial.ri
+        return RemoteInt.createNamedRemoteInt(
+            name(entityId, suffix),
+            initial,
+            RemoteState.Domain.User,
+        )
+    }
 
     /** Entity active flag ↔ `<entityId>.is_on`. */
     fun isOn(entityId: String?, initial: Boolean): RemoteBoolean? {

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
@@ -373,17 +373,43 @@ data class HaStatisticsGraphData(
     val stacked: Boolean = false,
 )
 
-/** `alarm-panel` card model — title, status badge, ARM AWAY/HOME
- *  buttons (variants depend on `states:` config), code-input field +
- *  numeric keypad. */
+/**
+ * `alarm-panel` card model — title, status chrome (label + icon + accent
+ * border), ARM AWAY/HOME buttons (variants depend on `states:` config),
+ * code-input field + numeric keypad.
+ *
+ * The status chrome is keyed by [initialStateInt] and rendered through
+ * `RemoteStateLayout(RemoteInt, …)` so the host can flip
+ * (icon, accent, label) by pushing a new `<entityId>.state_int` — no
+ * document re-encode. [statuses] enumerates one variant per known state
+ * key on the wire (`AlarmStateInt.*` in `ha-model`); the converter is
+ * responsible for supplying every key the host might ever push,
+ * including the catch-all `Unknown` index.
+ */
 data class HaAlarmPanelData(
     val entityId: String?,
     val title: String,
-    val state: String,
-    val accent: Color,
-    val statusIcon: ImageVector,
+    val initialStateInt: Int,
+    val statuses: List<HaAlarmStatus>,
     val actions: List<HaAlarmAction>,
     val showKeypad: Boolean,
+) {
+    init {
+        require(statuses.isNotEmpty()) { "HaAlarmPanelData.statuses must not be empty" }
+        require(statuses.distinctBy { it.stateKey }.size == statuses.size) {
+            "HaAlarmPanelData.statuses must have distinct stateKey values"
+        }
+    }
+}
+
+/** One status variant rendered for a specific `state_int` key — the
+ *  triplet (icon, accent, label) that the alarm panel chrome flips
+ *  through at playback. */
+data class HaAlarmStatus(
+    val stateKey: Int,
+    val label: String,
+    val accent: Color,
+    val icon: ImageVector,
 )
 
 /** One ARM button on the alarm panel — label + the call-service action

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaAlarmPanel.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaAlarmPanel.kt
@@ -8,6 +8,7 @@ import androidx.compose.remote.creation.compose.layout.RemoteBox
 import androidx.compose.remote.creation.compose.layout.RemoteColumn
 import androidx.compose.remote.creation.compose.layout.RemoteComposable
 import androidx.compose.remote.creation.compose.layout.RemoteRow
+import androidx.compose.remote.creation.compose.layout.RemoteStateLayout
 import androidx.compose.remote.creation.compose.layout.RemoteText
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.background
@@ -41,6 +42,12 @@ import androidx.wear.compose.remote.material3.RemoteIcon
 @RemoteComposable
 fun RemoteHaAlarmPanel(data: HaAlarmPanelData, modifier: RemoteModifier = RemoteModifier) {
     val theme = haTheme()
+    val statusByKey = data.statuses.associateBy { it.stateKey }
+    val initialStatus = statusByKey[data.initialStateInt] ?: data.statuses.first()
+    // Keypad accent stays tied to the initial state — keypad chrome is
+    // permanent at capture time, the live binding only swaps the status
+    // chrome above.
+    val keypadAccent = initialStatus.accent
     RemoteBox(
         modifier = modifier
             .fillMaxWidth()
@@ -50,44 +57,7 @@ fun RemoteHaAlarmPanel(data: HaAlarmPanelData, modifier: RemoteModifier = Remote
             .padding(horizontal = 14.rdp, vertical = 12.rdp),
     ) {
         RemoteColumn(verticalArrangement = RemoteArrangement.spacedBy(10.rdp)) {
-            RemoteRow(
-                modifier = RemoteModifier.fillMaxWidth(),
-                verticalAlignment = RemoteAlignment.CenterVertically,
-                horizontalArrangement = RemoteArrangement.SpaceBetween,
-            ) {
-                RemoteColumn {
-                    RemoteText(
-                        text = data.title.rs,
-                        color = theme.primaryText.rc,
-                        fontSize = 16.rsp,
-                        fontWeight = FontWeight.Medium,
-                        style = RemoteTextStyle.Default,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    RemoteText(
-                        text = LiveValues.state(data.entityId, data.state),
-                        color = data.accent.rc,
-                        fontSize = 12.rsp,
-                        style = RemoteTextStyle.Default,
-                        maxLines = 1,
-                    )
-                }
-                RemoteBox(
-                    modifier = RemoteModifier
-                        .size(40.rdp)
-                        .clip(RemoteCircleShape)
-                        .border(2.rdp, data.accent.rc, RemoteCircleShape),
-                    contentAlignment = RemoteAlignment.Center,
-                ) {
-                    RemoteIcon(
-                        imageVector = data.statusIcon,
-                        contentDescription = data.state.rs,
-                        modifier = RemoteModifier.size(22.rdp),
-                        tint = data.accent.rc,
-                    )
-                }
-            }
+            StatusRow(data, statusByKey, initialStatus, theme)
 
             // ARM AWAY / ARM HOME / DISARM buttons.
             if (data.actions.isNotEmpty()) {
@@ -101,7 +71,60 @@ fun RemoteHaAlarmPanel(data: HaAlarmPanelData, modifier: RemoteModifier = Remote
                 }
             }
 
-            if (data.showKeypad) Keypad(data.accent, theme)
+            if (data.showKeypad) Keypad(keypadAccent, theme)
+        }
+    }
+}
+
+@Composable
+@RemoteComposable
+private fun StatusRow(
+    data: HaAlarmPanelData,
+    statusByKey: Map<Int, HaAlarmStatus>,
+    initialStatus: HaAlarmStatus,
+    theme: HaTheme,
+) {
+    val keys = data.statuses.map { it.stateKey }.toIntArray()
+    val stateInt = LiveValues.intState(data.entityId, data.initialStateInt)
+    RemoteStateLayout(stateInt, *keys) { key ->
+        val status = statusByKey[key] ?: initialStatus
+        RemoteRow(
+            modifier = RemoteModifier.fillMaxWidth(),
+            verticalAlignment = RemoteAlignment.CenterVertically,
+            horizontalArrangement = RemoteArrangement.SpaceBetween,
+        ) {
+            RemoteColumn {
+                RemoteText(
+                    text = data.title.rs,
+                    color = theme.primaryText.rc,
+                    fontSize = 16.rsp,
+                    fontWeight = FontWeight.Medium,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                RemoteText(
+                    text = status.label.rs,
+                    color = status.accent.rc,
+                    fontSize = 12.rsp,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                )
+            }
+            RemoteBox(
+                modifier = RemoteModifier
+                    .size(40.rdp)
+                    .clip(RemoteCircleShape)
+                    .border(2.rdp, status.accent.rc, RemoteCircleShape),
+                contentAlignment = RemoteAlignment.Center,
+            ) {
+                RemoteIcon(
+                    imageVector = status.icon,
+                    contentDescription = status.label.rs,
+                    modifier = RemoteModifier.size(22.rdp),
+                    tint = status.accent.rc,
+                )
+            }
         }
     }
 }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/AlarmPanelCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/AlarmPanelCardConverter.kt
@@ -9,13 +9,16 @@ import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import ee.schimke.ha.model.AlarmStateInt
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.model.alarmStateIntFromRaw
 import ee.schimke.ha.rc.CardConverter
 import ee.schimke.ha.rc.components.HaAction
 import ee.schimke.ha.rc.components.HaAlarmAction
 import ee.schimke.ha.rc.components.HaAlarmPanelData
+import ee.schimke.ha.rc.components.HaAlarmStatus
 import ee.schimke.ha.rc.components.RemoteHaAlarmPanel
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -70,9 +73,8 @@ class AlarmPanelCardConverter : CardConverter {
             HaAlarmPanelData(
                 entityId = entityId,
                 title = title,
-                state = formatState(state),
-                accent = stateAccent(state),
-                statusIcon = stateIcon(state),
+                initialStateInt = alarmStateIntFromRaw(state),
+                statuses = AlarmStatuses,
                 actions = actions,
                 showKeypad =
                     card.raw["show_keypad"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: true,
@@ -82,14 +84,42 @@ class AlarmPanelCardConverter : CardConverter {
     }
 }
 
-private fun stateAccent(state: String): Color = when (state) {
-    "armed_away", "armed_home", "armed_night", "armed_vacation", "armed_custom_bypass" ->
-        Color(0xFF43A047)
-    "disarmed" -> Color(0xFF43A047)
-    "pending", "arming" -> Color(0xFFFFA000)
-    "triggered" -> Color(0xFFE53935)
-    else -> Color(0xFF757575)
-}
+private val AccentArmed = Color(0xFF43A047)
+private val AccentPending = Color(0xFFFFA000)
+private val AccentTriggered = Color(0xFFE53935)
+private val AccentNeutral = Color(0xFF757575)
+
+private fun status(key: Int, label: String, accent: Color, icon: ImageVector): HaAlarmStatus =
+    HaAlarmStatus(stateKey = key, label = label, accent = accent, icon = icon)
+
+/**
+ * One [HaAlarmStatus] per wire key in [AlarmStateInt]. The list is the
+ * complete set of variants the alarm-panel chrome can flip through at
+ * playback — the host pushes any of these int keys and the
+ * `RemoteStateLayout` swaps to the matching variant without a
+ * re-encode. Order mirrors [AlarmStateInt.All] so keys stay aligned
+ * with the wire contract.
+ */
+private val AlarmStatuses: List<HaAlarmStatus> =
+    listOf(
+        status(AlarmStateInt.Disarmed, "Disarmed", AccentArmed, Icons.Filled.LockOpen),
+        status(AlarmStateInt.ArmedHome, "Armed home", AccentArmed, Icons.Filled.Shield),
+        status(AlarmStateInt.ArmedAway, "Armed away", AccentArmed, Icons.Filled.Shield),
+        status(AlarmStateInt.ArmedNight, "Armed night", AccentArmed, Icons.Filled.Shield),
+        status(AlarmStateInt.ArmedVacation, "Armed vacation", AccentArmed, Icons.Filled.Shield),
+        status(
+            AlarmStateInt.ArmedCustomBypass,
+            "Armed custom bypass",
+            AccentArmed,
+            Icons.Filled.Shield,
+        ),
+        status(AlarmStateInt.Triggered, "Triggered", AccentTriggered, Icons.Filled.Warning),
+        status(AlarmStateInt.Pending, "Pending", AccentPending, Icons.Filled.Lock),
+        status(AlarmStateInt.Arming, "Arming", AccentPending, Icons.Filled.Lock),
+        status(AlarmStateInt.Disarming, "Disarming", AccentPending, Icons.Filled.Lock),
+        status(AlarmStateInt.Unavailable, "Unavailable", AccentNeutral, Icons.Filled.Lock),
+        status(AlarmStateInt.Unknown, "Unknown", AccentNeutral, Icons.Filled.Lock),
+    )
 
 private fun armAccent(suffix: String): Color = when (suffix) {
     "arm_away" -> Color(0xFF1565C0)
@@ -98,13 +128,3 @@ private fun armAccent(suffix: String): Color = when (suffix) {
     "disarm" -> Color(0xFFE53935)
     else -> Color(0xFF1565C0)
 }
-
-private fun stateIcon(state: String): ImageVector = when (state) {
-    "disarmed" -> Icons.Filled.LockOpen
-    "triggered" -> Icons.Filled.Warning
-    "armed_away", "armed_home", "armed_night", "armed_vacation", "armed_custom_bypass" -> Icons.Filled.Shield
-    else -> Icons.Filled.Lock
-}
-
-private fun formatState(s: String): String =
-    s.replace('_', ' ').replaceFirstChar { it.uppercaseChar() }


### PR DESCRIPTION
## Summary
Refactor the alarm panel card to use integer state keys (`state_int`) for rendering status chrome (icon, accent, label), enabling the host to flip these UI elements without requiring document re-encodes. This leverages `RemoteStateLayout` to swap between pre-defined status variants based on integer keys pushed from the server.

## Key Changes

- **Alarm state integer mapping** (`ha-model`):
  - Added `AlarmStateInt` object with stable integer keys for all alarm states (Disarmed, ArmedHome, ArmedAway, etc.)
  - Added `AlarmState.intKey()` function to convert sealed class instances to wire keys
  - Added `alarmStateIntFromRaw()` helper to parse raw HA state strings directly to int keys

- **Alarm panel data model** (`rc-components`):
  - Replaced `state: String`, `accent: Color`, `statusIcon: ImageVector` with `initialStateInt: Int` and `statuses: List<HaAlarmStatus>`
  - Added new `HaAlarmStatus` data class to represent one status variant (stateKey, label, accent, icon)
  - Added validation to ensure statuses are non-empty and have distinct state keys

- **Alarm panel UI** (`rc-components`):
  - Extracted status display into new `StatusRow()` composable wrapped in `RemoteStateLayout(RemoteInt, ...)`
  - Status chrome now flips based on live `state_int` binding without re-encoding
  - Keypad accent remains tied to initial state (captured at document creation time)

- **Converter** (`rc-converter`):
  - Replaced dynamic state formatting with pre-defined `AlarmStatuses` list
  - Removed `stateAccent()`, `stateIcon()`, and `formatState()` functions
  - Now passes `initialStateInt` and complete status list to data model

- **Live bindings** (`rc-components`):
  - Added `LiveValues.intState()` and `LiveValues.namedInt()` for integer state bindings
  - Supports domain-specific int keys (alarm panel, climate modes, etc.)

- **Server streaming** (`addon-server`):
  - Added `putStateInt()` helper to emit `<entityId>.state_int` for domains with wire mappings
  - Currently supports `alarm_control_panel` domain; extensible for other domains
  - Extra fields are harmless for clients that don't use them

## Implementation Details

The status list order mirrors `AlarmStateInt.All` to keep wire keys aligned with the contract. The converter is responsible for supplying every possible state key the host might push, including the catch-all `Unknown` index. This design allows the host to update alarm state without re-encoding the entire document—only the integer key changes, and `RemoteStateLayout` handles the UI swap.

https://claude.ai/code/session_01SUW479kDqabMBeymxE9ZDY