### PR TITLE
Bind sparkline samples to live numeric state for smooth updates

### DIFF
--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/LiveValues.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/LiveValues.kt
@@ -77,6 +77,24 @@ object LiveValues {
     }
 
     /**
+     * One sample of an entity's history series ↔ `<entityId>.numeric.<index>`.
+     * Sparkline-style cards bind each captured point individually so the
+     * host can push a sliding window of values without re-encoding the
+     * document. The renderer uses the captured float values to fix the
+     * y-axis range at encode time.
+     */
+    fun numericPoint(entityId: String?, index: Int, initial: Float): RemoteFloat =
+        namedFloat(entityId, "numeric.$index", initial)
+
+    /**
+     * Convenience for a whole history series — one named binding per
+     * index (`<entityId>.numeric.0`, `…1`, `…2`, …). When [entityId] is
+     * null each entry falls back to a constant `RemoteFloat`.
+     */
+    fun numericPoints(entityId: String?, points: List<Float>): List<RemoteFloat> =
+        points.mapIndexed { i, v -> numericPoint(entityId, i, v) }
+
+    /**
      * Generic helper for fields whose binding name doesn't follow the
      * `state` / `is_on` / `attributes.*` convention. The caller picks
      * the suffix; useful for composite labels (e.g. `state_label`,

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaGauge.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaGauge.kt
@@ -45,11 +45,12 @@ import androidx.compose.ui.text.style.TextOverflow
  *      0       100
  * ```
  *
- * The arc sweep representing `(value - min) / (max - min)` is computed
- * at capture time; the host re-encodes when the underlying entity
- * changes. Severity bands tint the value arc green / yellow / red
- * (matching HA's `gauge.severity` config). Alpha08 doesn't expose a
- * RemoteFloat numeric binding to animate the sweep without re-encode.
+ * The arc sweep is derived from the named `<entityId>.numeric_state`
+ * binding (animated through [animateRemoteFloat]) so live value updates
+ * tween without re-encoding. Severity bands tint the value arc green /
+ * yellow / red (matching HA's `gauge.severity` config); the active
+ * band's colour is baked at encode time, so a host re-encodes when the
+ * value crosses a band boundary.
  */
 @Composable
 @RemoteComposable

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaHistoryGraph.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaHistoryGraph.kt
@@ -20,6 +20,7 @@ import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
 import androidx.compose.remote.creation.compose.modifier.height
 import androidx.compose.remote.creation.compose.modifier.padding
 import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.RemoteFloat
 import androidx.compose.remote.creation.compose.state.asRemotePaint
 import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.remote.creation.compose.state.rdp
@@ -45,10 +46,11 @@ import androidx.compose.ui.text.style.TextOverflow
  *   └─────────────────────────────────────────────┘
  * ```
  *
- * Sparkline is captured from numeric `HistoryPoint`s. Sample values get
- * normalised into the row's drawable rect at capture time; alpha08
- * doesn't expose a numeric `RemoteFloat` binding for live updates, so a
- * host that wants a moving line re-encodes when history changes.
+ * Sparkline is captured from numeric `HistoryPoint`s. Each sample is
+ * bound to `<entityId>.numeric.<index>`, so a host can push a sliding
+ * window of values without re-encoding the document. The y-axis range
+ * is captured from the initial values; samples that drift well outside
+ * that range clip to the canvas (host re-encodes when that happens).
  */
 @Composable
 @RemoteComposable
@@ -122,7 +124,7 @@ private fun Row(row: HaHistoryGraphRow, theme: HaTheme) {
         )
     }
     if (row.points.size >= 2) {
-        Sparkline(row.points, row.accent, theme)
+        Sparkline(row.entityId, row.points, row.accent, theme)
     } else {
         RemoteText(
             text = "No samples".rs,
@@ -134,10 +136,19 @@ private fun Row(row: HaHistoryGraphRow, theme: HaTheme) {
 }
 
 @Composable
-private fun Sparkline(points: List<Float>, accent: Color, theme: HaTheme) {
+private fun Sparkline(entityId: String?, points: List<Float>, accent: Color, theme: HaTheme) {
     val minP = points.min()
     val maxP = points.max()
     val span = (maxP - minP).takeIf { it > 0f } ?: 1f
+
+    // One named RemoteFloat per sample (`<entityId>.numeric.<i>`) so a
+    // host can push the next window of values without re-encoding. The
+    // y-range is fixed at encode time from the initial captured values;
+    // values that drift outside [minP, maxP] still render, just clipped
+    // by the canvas.
+    val bound: List<RemoteFloat> = LiveValues.numericPoints(entityId, points)
+    val minRf = minP.rf
+    val spanRf = span.rf
     RemoteCanvas(modifier = RemoteModifier.fillMaxWidth().height(28.rdp)) {
         val w = width
         val h = height
@@ -169,12 +180,12 @@ private fun Sparkline(points: List<Float>, accent: Color, theme: HaTheme) {
             color = accent.toArgb()
         }.asRemotePaint()
 
-        val n = points.size
+        val n = bound.size
         for (i in 0 until n - 1) {
             val x0 = padX + drawW * (i.toFloat() / (n - 1).toFloat()).rf
             val x1 = padX + drawW * ((i + 1).toFloat() / (n - 1).toFloat()).rf
-            val y0 = padY + drawH * (1f - (points[i] - minP) / span).rf
-            val y1 = padY + drawH * (1f - (points[i + 1] - minP) / span).rf
+            val y0 = padY + drawH * (1f.rf - (bound[i] - minRf) / spanRf)
+            val y1 = padY + drawH * (1f.rf - (bound[i + 1] - minRf) / spanRf)
             drawLine(stroke, RemoteOffset(x0, y0), RemoteOffset(x1, y1))
         }
     }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/GaugeCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/GaugeCardConverter.kt
@@ -19,8 +19,9 @@ import kotlinx.serialization.json.jsonPrimitive
 /**
  * `gauge` card. Maps the entity's numeric state into a half-circle dial
  * with HA's severity bands (`severity.green`/`yellow`/`red` thresholds).
- * Sweep is captured statically — alpha08 doesn't expose a `RemoteFloat`
- * binding, so live updates re-encode.
+ * The sweep is derived from `<entity>.numeric_state` so live value
+ * updates animate without re-encoding; severity-band colours are baked
+ * at encode time and re-encode when the active band changes.
  */
 class GaugeCardConverter : CardConverter {
     override val cardType: String = CardTypes.GAUGE

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/HistoryGraphCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/HistoryGraphCardConverter.kt
@@ -19,12 +19,12 @@ import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * `history-graph` card. Renders one sparkline per entity using the
- * snapshot's `history[entityId]`. The per-row summary text is a named
- * `<entity>.state` binding so the host can refresh it without a
- * re-encode. Numeric points are normalised into the row's drawable rect
- * at capture time; alpha010 still doesn't expose a RemoteFloat list
- * binding, so the sparkline geometry itself is re-encoded when new
- * samples arrive.
+ * snapshot's `history[entityId]`. Per-row summary text is bound to
+ * `<entity>.state`; each sample is bound to `<entity>.numeric.<index>`
+ * so a host can push the next window of values without re-encoding the
+ * document. The y-axis range is fixed at encode time from the captured
+ * samples — values that drift well outside the initial range will clip
+ * to the canvas, in which case the host should re-encode.
  */
 class HistoryGraphCardConverter : CardConverter {
     override val cardType: String = CardTypes.HISTORY_GRAPH


### PR DESCRIPTION
## Summary
Enable live updates to sparkline charts without re-encoding by binding each sample to a named `<entityId>.numeric.<index>` RemoteFloat. This allows hosts to push sliding windows of values that animate smoothly in the UI.

## Key Changes
- **RemoteHaHistoryGraph.kt**: Modified `Sparkline()` to accept `entityId` and bind individual points to named RemoteFloat values via `LiveValues.numericPoints()`. Updated y-axis calculations to use RemoteFloat arithmetic for proper live binding semantics.
- **LiveValues.kt**: Added `numericPoint()` and `numericPoints()` helper functions to create named bindings for history series samples following the `<entityId>.numeric.<index>` convention.
- **Documentation updates**: Clarified in docstrings for `RemoteHaHistoryGraph`, `HistoryGraphCardConverter`, `RemoteHaGauge`, and `GaugeCardConverter` that:
  - Sparkline samples are now individually bound for live updates
  - Y-axis range is fixed at encode time; values outside the range clip to canvas
  - Hosts can push new samples without re-encoding unless values drift significantly outside the initial range

## Implementation Details
- Each sample in the sparkline is now a `RemoteFloat` bound to `<entityId>.numeric.<i>` instead of a static float
- The y-axis normalization range (`minP`, `span`) is captured at encode time and converted to RemoteFloat for use in the drawing calculations
- When `entityId` is null, `numericPoints()` falls back to constant RemoteFloat values, maintaining backward compatibility
- The canvas clipping behavior naturally handles values that drift outside the initial `[minP, maxP]` range

https://claude.ai/code/session_015e5Yy3M6B27XBWX2NgrfnY