### PR TITLE
feat(widget): capture widget docs with the WIDGETS_V6 profile

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/TerrazzoWidgetProvider.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/TerrazzoWidgetProvider.kt
@@ -2,85 +2,121 @@
 
 package ee.schimke.terrazzo.widget
 
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
 import android.content.Context
+import android.os.Build
+import android.util.Log
+import android.util.TypedValue
+import android.widget.RemoteViews
+import androidx.annotation.RequiresApi
+import androidx.compose.remote.creation.compose.capture.RemoteCreationDisplayInfo
+import androidx.compose.remote.creation.compose.capture.captureSingleRemoteDocument
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
-import androidx.compose.remote.creation.compose.widgets.RemoteComposeWidget
-import androidx.compose.runtime.Composable
-import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.ProvideCardRegistry
 import ee.schimke.ha.rc.RenderChild
+import ee.schimke.ha.rc.cardHeightDp
 import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.components.ProvideHaTheme
 import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.ha.rc.components.haThemeFor
+import ee.schimke.ha.rc.widgetsV6
 import ee.schimke.terrazzo.core.prefs.DarkModePref
 import ee.schimke.terrazzo.core.prefs.ThemePref
 import ee.schimke.terrazzo.core.session.DemoData
-import ee.schimke.terrazzo.core.widget.WidgetStore
 import ee.schimke.terrazzo.terrazzoGraph
 import kotlinx.coroutines.runBlocking
 
 /**
- * Per-card home-screen widget. Extends the RemoteCompose
- * `AppWidgetProvider` scaffolding, which turns our `@Composable
- * Content(context, widgetId)` into `RemoteViews.DrawInstructions` and
- * routes click lambdas back through `onReceive` automatically.
+ * Per-card home-screen widget. Extends [AppWidgetProvider] directly
+ * rather than RemoteCompose's `RemoteComposeWidget` scaffolding so we
+ * can pin the capture to [widgetsV6] — the launcher's RemoteCompose
+ * runtime supports a stricter op set than the embedded AndroidX
+ * player, and `RemoteComposeWidget` hard-codes
+ * `RcPlatformProfiles.ANDROIDX` inside its `RCWidget` capture.
  *
- * One provider class covers all installed Terrazzo widgets — each
- * pinned instance gets a unique `widgetId` that keys into [WidgetStore]
- * to find which HA card this instance should render.
+ * Flow:
+ *   1. Framework or our own broadcast triggers [onUpdate].
+ *   2. For each pinned widget id, look up the [WidgetStore.Entry] and
+ *      headlessly capture the card via [captureSingleRemoteDocument]
+ *      with `profile = widgetsV6`. The composition is wrapped with
+ *      [ProvideCardRegistry] + [ProvideHaTheme] so converters resolve
+ *      the user's theme.
+ *   3. Wrap the bytes in `RemoteViews.DrawInstructions` and publish via
+ *      `AppWidgetManager.updateAppWidget(widgetId, …)`.
  *
- * v1 scope:
- *   - Read the widget's card config + base URL from [WidgetStore]
- *     synchronously at render time.
- *   - Render with an empty snapshot (no cached state yet) — the card
- *     will show defaults until a future background worker writes a
- *     fresh snapshot and calls `updateWidgets(id, lambda)`.
+ * Widgets pinned while the app was in demo mode carry the demo
+ * baseUrl marker; render those against the current [DemoData] snapshot
+ * so values are non-empty. Live-mode widgets use the empty default
+ * until a future background worker writes a fresh snapshot.
  *
- * API floor: VANILLA_ICE_CREAM (Android 15 / API 35) — baked into
- * `RemoteComposeWidget.onUpdate` via `@RequiresApi`. The app's minSdk
- * of 36 already satisfies this.
+ * API floor: VANILLA_ICE_CREAM (Android 15 / API 35) — needed for
+ * `RemoteViews.DrawInstructions`. The app's minSdk of 36 already
+ * satisfies this; the `@RequiresApi` is here only to keep lint quiet.
  */
-class TerrazzoWidgetProvider : RemoteComposeWidget(useCompose = true) {
+class TerrazzoWidgetProvider : AppWidgetProvider() {
 
-    @Composable
-    override fun Content(context: Context, widgetId: Int) {
-        val entry = remember(context, widgetId) { loadEntry(context, widgetId) }
-        if (entry == null) {
-            // Not configured yet — nothing to draw. Happens momentarily
-            // between pin + first config write. The widget will update
-            // again once the app calls updateAppWidget().
-            return
-        }
-        // Widgets pinned while the app was in demo mode carry the demo
-        // baseUrl marker; render those against the current demo
-        // snapshot so values are non-empty. Live-mode widgets keep the
-        // empty default — they'll be refreshed by a future background
-        // worker once we wire snapshot caching.
-        val snapshot = if (DemoData.isDemo(entry.baseUrl)) DemoData.snapshot() else EMPTY_SNAPSHOT
-        val (style, dark) = remember(context, widgetId) { loadThemeChoice(context) }
-        val haTheme = remember(style, dark) { haThemeFor(style, dark) }
-        val registry = defaultRegistry()
-        ProvideCardRegistry(registry) {
-            ProvideHaTheme(haTheme) {
-                RenderChild(entry.card, snapshot, RemoteModifier.fillMaxWidth())
-            }
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+    ) {
+        super.onUpdate(context, appWidgetManager, appWidgetIds)
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) return
+        for (id in appWidgetIds) {
+            renderAndPublish(context, appWidgetManager, id)
         }
     }
 
-    private fun loadEntry(context: Context, widgetId: Int): WidgetStore.Entry? =
-        runBlocking { context.terrazzoGraph().widgetStore.get(widgetId) }
+    @RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+    private fun renderAndPublish(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        widgetId: Int,
+    ) {
+        val entry = runBlocking { context.terrazzoGraph().widgetStore.get(widgetId) }
+        if (entry == null) {
+            // Pin in flight, or the entry was evicted. The framework
+            // will call onUpdate again once the install receiver writes
+            // the row.
+            return
+        }
+        val snapshot = if (DemoData.isDemo(entry.baseUrl)) DemoData.snapshot() else EMPTY_SNAPSHOT
+        val (style, dark) = loadThemeChoice(context)
+        val haTheme = haThemeFor(style, dark)
+        val registry = defaultRegistry()
 
-    /**
-     * Resolve the user's theme + dark-mode preference synchronously at
-     * render time. The widget has no Compose theme scope upstream —
-     * each `updateAppWidget` call captures a fresh `.rc` document, so
-     * changing the preference regenerates the widget on the next
-     * refresh (see `TerrazzoApp`'s settings screen, which triggers a
-     * broadcast refresh when the user picks a new theme).
-     */
+        val widthPx = dpToPx(context, WIDGET_WIDTH_DP)
+        val heightPx = dpToPx(context, registry.cardHeightDp(entry.card, snapshot))
+        val densityDpi = context.resources.configuration.densityDpi
+
+        val captured = runCatching {
+            runBlocking {
+                captureSingleRemoteDocument(
+                    context = context,
+                    creationDisplayInfo = RemoteCreationDisplayInfo(widthPx, heightPx, densityDpi),
+                    profile = widgetsV6,
+                ) {
+                    ProvideCardRegistry(registry) {
+                        ProvideHaTheme(haTheme) {
+                            RenderChild(entry.card, snapshot, RemoteModifier.fillMaxWidth())
+                        }
+                    }
+                }
+            }
+        }.getOrElse {
+            // WIDGETS_V6 rejects ops outside the launcher's vocabulary —
+            // log and skip rather than crashing the host process.
+            Log.w(TAG, "widgets-profile capture failed for id=$widgetId type=${entry.card.type}", it)
+            return
+        }
+
+        val instructions = RemoteViews.DrawInstructions.Builder(listOf(captured.bytes)).build()
+        appWidgetManager.updateAppWidget(widgetId, RemoteViews(instructions))
+    }
+
     private fun loadThemeChoice(context: Context): Pair<ThemeStyle, Boolean> = runBlocking {
         val prefs = context.terrazzoGraph().preferencesStore
         val style = prefs.themeStyleNow().toStyle()
@@ -104,14 +140,16 @@ class TerrazzoWidgetProvider : RemoteComposeWidget(useCompose = true) {
         ThemePref.TerrazzoKiosk -> ThemeStyle.TerrazzoKiosk
     }
 
+    private fun dpToPx(context: Context, dp: Int): Int =
+        TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            dp.toFloat(),
+            context.resources.displayMetrics,
+        ).toInt()
+
     private companion object {
         val EMPTY_SNAPSHOT = HaSnapshot()
+        const val WIDGET_WIDTH_DP = 320
+        const val TAG = "TerrazzoWidgetProvider"
     }
 }
-
-// Non-composable `remember` alias — the RemoteComposeWidget capture
-// runs inside a Compose composition, but we want a plain memoization
-// keyed to a pair of inputs. Implemented via androidx.compose.runtime.
-@Composable
-private fun <T> remember(key1: Any?, key2: Any?, calculation: () -> T): T =
-    androidx.compose.runtime.remember(key1, key2, calculation)

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstallSheet.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstallSheet.kt
@@ -26,24 +26,32 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth as rcFillMaxWidth
-import androidx.compose.remote.tooling.preview.RemotePreview
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CachedCardPreview
 import ee.schimke.ha.rc.ProvideCardRegistry
 import ee.schimke.ha.rc.RenderChild
-import ee.schimke.ha.rc.androidXExperimental
 import ee.schimke.ha.rc.cardHeightDp
 import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.components.HaTheme
 import ee.schimke.ha.rc.components.ProvideHaTheme
+import ee.schimke.ha.rc.widgetsV6
 import ee.schimke.terrazzo.LocalTerrazzoGraph
 import ee.schimke.terrazzo.core.widget.WidgetStore
 
 /**
  * Bottom sheet shown when the user long-presses a card. Live preview
- * on top (rendered through the exact same `RemotePreview` the home
- * screen widget uses — so what you see is what gets installed), then
- * an "Add to Home Screen" button that calls `requestPinAppWidget`.
+ * on top (rendered through `CachedCardPreview` with the same
+ * [widgetsV6] profile the home screen widget uses, so what you see is
+ * what gets installed), then an "Add to Home Screen" button that calls
+ * `requestPinAppWidget`.
+ *
+ * `CachedCardPreview` (vs. `RemotePreview`) buys two things here:
+ *   - It pushes named-binding writes into the running player whenever
+ *     [snapshot] changes, so the preview tracks live entity state
+ *     instead of freezing on the first frame.
+ *   - It captures once per `(card, theme, profile)` and keeps playing,
+ *     so opening the sheet repeatedly for the same card is cheap.
  *
  * Install cap: disable the button once five widgets are already
  * installed. The cap-check number comes live from [WidgetStore] so
@@ -86,7 +94,12 @@ fun WidgetInstallSheet(
             Box(
                 modifier = Modifier.fillMaxWidth().height(heightDp.dp),
             ) {
-                RemotePreview(profile = androidXExperimental) {
+                CachedCardPreview(
+                    cacheKey = WidgetPreviewCacheKey(card, HaTheme.Light, widgetsV6),
+                    profile = widgetsV6,
+                    card = card,
+                    snapshot = snapshot,
+                ) {
                     ProvideCardRegistry(registry) {
                         ProvideHaTheme(HaTheme.Light) {
                             RenderChild(card, snapshot, RemoteModifier.rcFillMaxWidth())
@@ -124,3 +137,18 @@ fun WidgetInstallSheet(
         }
     }
 }
+
+/**
+ * Cache key for the install-sheet preview. Mirrors the dashboard's
+ * `CardSlotCacheKey` shape — snapshot is deliberately omitted so live
+ * entity changes flow through named bindings instead of forcing a
+ * re-encode (see `CachedCardPreview` for the binding push). Profile
+ * is part of the key so the same card cached for the dashboard
+ * (AndroidX-experimental) doesn't collide with the widget capture
+ * (V6).
+ */
+private data class WidgetPreviewCacheKey(
+    val card: CardConfig,
+    val theme: HaTheme,
+    val profile: Any,
+)

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardCapture.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardCapture.kt
@@ -9,6 +9,8 @@ import androidx.compose.remote.core.RemoteComposeBuffer
 import androidx.compose.remote.creation.compose.capture.RemoteCreationDisplayInfo
 import androidx.compose.remote.creation.compose.capture.captureSingleRemoteDocument
 import androidx.compose.remote.creation.compose.capture.rememberRemoteDocument
+import androidx.compose.remote.creation.profile.Profile
+import androidx.compose.remote.creation.profile.RcPlatformProfiles
 import androidx.compose.remote.player.compose.RemoteDocumentPlayer
 import androidx.compose.remote.player.core.platform.BitmapLoader
 import androidx.compose.runtime.Composable
@@ -72,14 +74,16 @@ suspend fun captureCardDocument(
     snapshot: HaSnapshot,
     cache: CardDocumentCache = defaultCardDocumentCache,
     forceRefresh: Boolean = false,
+    profile: Profile = RcPlatformProfiles.ANDROIDX,
 ): CardDocument {
     val converter = registry.get(card.type)
         ?: error("No converter registered for card type='${card.type}'")
-    val cacheKey = HeadlessCardCacheKey(card, widthPx, heightPx, densityDpi)
+    val cacheKey = HeadlessCardCacheKey(card, widthPx, heightPx, densityDpi, profile)
     if (!forceRefresh) cache.get(cacheKey)?.let { return it }
     val captured = captureSingleRemoteDocument(
         context = context,
         creationDisplayInfo = RemoteCreationDisplayInfo(widthPx, heightPx, densityDpi),
+        profile = profile,
     ) {
         converter.Render(card, snapshot)
     }
@@ -90,14 +94,17 @@ suspend fun captureCardDocument(
  * Default cache key for the headless capture path. Includes the size
  * inputs because the encoded document bakes them into its header and
  * recomputing layout for a different slot size produces different
- * bytes. Theme isn't part of the key today: widget capture uses the
- * default theme; if widgets gain a theme picker, extend this key.
+ * bytes, plus [profile] so the widget (Glance / launcher) and embedded
+ * AndroidX captures don't clobber each other in [defaultCardDocumentCache].
+ * Theme isn't part of the key today: widget capture uses the default
+ * theme; if widgets gain a theme picker, extend this key.
  */
 private data class HeadlessCardCacheKey(
     val card: CardConfig,
     val widthPx: Int,
     val heightPx: Int,
     val densityDpi: Int,
+    val profile: Profile,
 )
 
 /**

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WidgetProfile.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WidgetProfile.kt
@@ -1,0 +1,28 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc
+
+import androidx.compose.remote.creation.profile.Profile
+import androidx.compose.remote.creation.profile.RcPlatformProfiles
+
+/**
+ * Profile used when capturing the `.rc` document that ships to the
+ * launcher as a pinned widget (or to the notification system as a
+ * `CustomBigContentView`). Both surfaces hand the bytes to
+ * `RemoteViews.DrawInstructions`, which is interpreted by the
+ * platform's RemoteCompose runtime — that runtime supports a stricter
+ * op set than the embedded AndroidX player, so capturing with the
+ * widgets profile up-front keeps the bytes within the launcher's
+ * vocabulary.
+ *
+ * Today: alpha010 ships [RcPlatformProfiles.WIDGETS_V6] (Glance widgets
+ * on Baklava, document API level 6, no operation-profile bits — only
+ * the common-baseline ops are valid). Cards that lean on AndroidX-only
+ * ops (`FlowLayout`, etc.) will fail to capture under this profile —
+ * expected. The compatible card subset is what's installable as a
+ * widget; the dashboard / preview path keeps using `androidXExperimental`.
+ *
+ * `WIDGETS_V6` is `@RestrictTo(LIBRARY_GROUP)`; aliasing it here keeps
+ * the suppression scoped to a single file.
+ */
+val widgetsV6: Profile = RcPlatformProfiles.WIDGETS_V6


### PR DESCRIPTION
The launcher's RemoteCompose runtime supports a stricter op set than
the embedded AndroidX player, so the bytes shipped via
RemoteViews.DrawInstructions need to be authored against the widgets
profile up-front. Capturing with RcPlatformProfiles.ANDROIDX (the
default that RemoteComposeWidget hard-codes inside RCWidget) means a
card that compiles can still hit unsupported ops at playback.

Changes:
- Add a profile parameter to captureCardDocument and include it in the
  cache key so the dashboard's androidXExperimentalWrap captures don't
  collide with widget captures of the same card/size.
- Replace TerrazzoWidgetProvider's RemoteComposeWidget base with a
  direct AppWidgetProvider implementation that captures via
  captureSingleRemoteDocument(profile = widgetsV6) and publishes
  RemoteViews.DrawInstructions itself. Logs and skips when V6 rejects
  a card rather than crashing the host.
- Route WidgetInstallSheet through CachedCardPreview with the same
  widgetsV6 profile so the bottom-sheet preview matches what gets
  installed AND, more importantly, picks up live snapshot updates
  through CachedCardPreview's named-binding push (RemotePreview's
  remember{} froze the preview on the first frame).