### PR TITLE
fix(theme): drop vertical padding from section-group surface

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -252,7 +252,7 @@ private fun SectionGroupSurface(
         modifier = modifier.fillMaxWidth(),
     ) {
         Column(
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
+            modifier = Modifier.padding(horizontal = 8.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             content()

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/DashboardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/DashboardPreviews.kt
@@ -227,7 +227,6 @@ private fun SectionBlock(section: Section, snapshot: HaSnapshot) {
     ) {
         androidx.compose.foundation.layout.Column(
             verticalArrangement = Arrangement.spacedBy(8.dp),
-            modifier = Modifier.padding(vertical = 4.dp),
         ) {
             if (section.title != null) {
                 Box(modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp)) {

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/UnsupportedCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/UnsupportedCardConverter.kt
@@ -19,6 +19,12 @@ class UnsupportedCardConverter(
 ) : CardConverter {
     override val cardType: String = declaredType ?: UNSUPPORTED_CARD_TYPE
 
+    // Icon (24) + 8 gap + "Not yet supported" (14sp) + card type (12sp)
+    // + 12 padding top/bottom ≈ 88 dp; round to 96 to give descenders
+    // room. The 160 dp default left ~70 dp of empty space below the
+    // placeholder content in every dashboard slot.
+    override fun naturalHeightDp(card: CardConfig, snapshot: HaSnapshot): Int = 96
+
     @Composable
     override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
         RemoteHaUnsupported(HaUnsupportedData(cardType = card.type), modifier = modifier)


### PR DESCRIPTION
Each section-group Surface introduced 8 dp top + 8 dp bottom of internal
padding on top of the LazyColumn's existing 12 dp spacedBy, so every
section landed ~16 dp lower than before and the gap below the last card
in a section grew to 28 dp. Drop the inner Column's vertical padding so
the LazyColumn gap is the only inter-section spacing; the Surface tint
still groups the cards visually because its tinted pixels show through
the spacedBy gap. Apply the same trim to the standalone DashboardPreviews
SectionBlock for consistency.