### PR TITLE
feat(components): drive RemoteHaToggleSwitch from a host RemoteBoolean

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/AnimationPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/AnimationPreviews.kt
@@ -4,6 +4,7 @@ package ee.schimke.ha.previews
 
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.state.RemoteBoolean
 import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.remote.creation.compose.state.rf
 import androidx.compose.remote.tooling.preview.RemotePreview
@@ -103,10 +104,11 @@ fun Toggle_Animation_Dark(
 }
 
 /**
- * Live-animated toggle. Encodes one `.rc` document with
- * `rememberMutableRemoteBoolean` + `animateRemoteFloat`; an
- * interactive player tweens the knob and colour when the document is
- * tapped.
+ * Public-entry-point smoke preview. The document encodes
+ * `animateRemoteFloat` over the `isOn`-derived progress, so a host
+ * writing back to a named `RemoteBoolean` would tween the knob and
+ * colour live. Here `isOn` is a constant `RemoteBoolean(false)`, so
+ * the static PNG just shows the resting off-state.
  */
 @Preview(name = "toggle-animated (light)", showBackground = false, widthDp = 40, heightDp = 24)
 @Composable
@@ -114,7 +116,7 @@ fun Toggle_Animated_Light() {
     RemotePreview(profile = androidXExperimental) {
         ProvideHaTheme(HaTheme.Light) {
             RemoteHaToggleSwitch(
-                initiallyOn = false,
+                isOn = RemoteBoolean(false),
                 activeAccent = PreviewActiveAccent.rc,
                 inactiveAccent = PreviewInactiveAccent.rc,
             )
@@ -128,7 +130,7 @@ fun Toggle_Animated_Dark() {
     RemotePreview(profile = androidXExperimental) {
         ProvideHaTheme(HaTheme.Dark) {
             RemoteHaToggleSwitch(
-                initiallyOn = false,
+                isOn = RemoteBoolean(false),
                 activeAccent = PreviewActiveAccent.rc,
                 inactiveAccent = PreviewInactiveAccent.rc,
             )

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/ToggleSwitchPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/ToggleSwitchPreviews.kt
@@ -2,6 +2,7 @@
 
 package ee.schimke.ha.previews
 
+import androidx.compose.remote.creation.compose.state.RemoteBoolean
 import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.remote.creation.compose.state.rf
 import androidx.compose.remote.tooling.preview.RemotePreview
@@ -21,9 +22,10 @@ import ee.schimke.ha.rc.components.RemoteHaToggleSwitchByProgress
  *   directly with literal RemoteFloats (0 / 0.5 / 1.0) — these prove the
  *   visual works for any constant progress.
  * - `ToggleInitial_*` uses the public [RemoteHaToggleSwitch] entry
- *   point. Currently STATIC: the host-side `Boolean` picks one of the
- *   two literal RemoteFloats; the document never animates between them.
- *   See `docs/bugs/rc-alpha08-select-derived-float-layout.md` for why.
+ *   point with a constant `RemoteBoolean`. Currently STATIC: the
+ *   constant picks one of the two literal RemoteFloats; the document
+ *   never animates between them. See
+ *   `docs/bugs/rc-alpha08-select-derived-float-layout.md` for why.
  */
 
 private val PreviewActiveAccent = Color(0xFF2196F3)
@@ -74,7 +76,7 @@ fun ToggleByProgress_On() = SwitchHost(HaTheme.Light) {
 @Composable
 fun ToggleInitial_Off() = SwitchHost(HaTheme.Light) {
     RemoteHaToggleSwitch(
-        initiallyOn = false,
+        isOn = RemoteBoolean(false),
         activeAccent = PreviewActiveAccent.rc,
         inactiveAccent = PreviewInactiveAccent.rc,
     )
@@ -84,7 +86,7 @@ fun ToggleInitial_Off() = SwitchHost(HaTheme.Light) {
 @Composable
 fun ToggleInitial_On() = SwitchHost(HaTheme.Light) {
     RemoteHaToggleSwitch(
-        initiallyOn = true,
+        isOn = RemoteBoolean(true),
         activeAccent = PreviewActiveAccent.rc,
         inactiveAccent = PreviewInactiveAccent.rc,
     )
@@ -94,7 +96,7 @@ fun ToggleInitial_On() = SwitchHost(HaTheme.Light) {
 @Composable
 fun ToggleInitial_On_Dark() = SwitchHost(HaTheme.Dark) {
     RemoteHaToggleSwitch(
-        initiallyOn = true,
+        isOn = RemoteBoolean(true),
         activeAccent = PreviewActiveAccent.rc,
         inactiveAccent = PreviewInactiveAccent.rc,
     )

--- a/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaToggleSwitch.kt
+++ b/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaToggleSwitch.kt
@@ -2,6 +2,7 @@
 
 package ee.schimke.ha.rc.ui
 
+import androidx.compose.remote.creation.compose.state.RemoteBoolean
 import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -11,8 +12,11 @@ import ee.schimke.ha.rc.components.RemoteHaToggleSwitch
 
 /**
  * Compose-UI Tier-2 wrapper around [RemoteHaToggleSwitch] — pill-shape
- * switch with a knob position keyed on [initiallyOn]. See the Tier-1
- * doc for the alpha09 layout caveat.
+ * switch with a knob position keyed on [initiallyOn]. The Tier-2 entry
+ * doesn't expose RemoteCompose state, so the boolean is wrapped as a
+ * constant `RemoteBoolean`; tapping fires the host action but does not
+ * flip the visual locally. See the Tier-1 doc for the alpha09 layout
+ * caveat.
  */
 @Composable
 fun HaToggleSwitch(
@@ -24,7 +28,7 @@ fun HaToggleSwitch(
 ) {
     HaUiHost(modifier) {
         RemoteHaToggleSwitch(
-            initiallyOn = initiallyOn,
+            isOn = RemoteBoolean(initiallyOn),
             activeAccent = activeAccent.rc,
             inactiveAccent = inactiveAccent.rc,
             tapAction = tapAction,

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaArea.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaArea.kt
@@ -19,6 +19,7 @@ import androidx.compose.remote.creation.compose.modifier.padding
 import androidx.compose.remote.creation.compose.modifier.size
 import androidx.compose.remote.creation.compose.shapes.RemoteCircleShape
 import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.RemoteColor
 import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.remote.creation.compose.state.rdp
 import androidx.compose.remote.creation.compose.state.rf
@@ -105,8 +106,20 @@ private fun ActionChip(action: HaAreaAction, theme: HaTheme) {
     val click = action.tapAction.toRemoteAction()
         ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
     val accent = action.accent.rc
-    val bg = if (action.initiallyActive) accent.copy(alpha = accent.alpha * 0.18f.rf)
-    else theme.divider.rc.copy(alpha = theme.divider.rc.alpha * 0.4f.rf)
+    val activeBg: RemoteColor = accent.copy(alpha = accent.alpha * 0.18f.rf)
+    val inactiveBg: RemoteColor = theme.divider.rc.copy(alpha = theme.divider.rc.alpha * 0.4f.rf)
+    val activeTint: RemoteColor = accent
+    val inactiveTint: RemoteColor = theme.secondaryText.rc
+
+    // Live `<entityId>.is_on` binding so the host can flip the chip's
+    // active styling without a re-encode. Falls back to the seed value
+    // when entityId is null (preview).
+    val isActive = LiveValues.isOn(action.entityId, action.initiallyActive)
+    val bg: RemoteColor = isActive?.select(activeBg, inactiveBg)
+        ?: if (action.initiallyActive) activeBg else inactiveBg
+    val tint: RemoteColor = isActive?.select(activeTint, inactiveTint)
+        ?: if (action.initiallyActive) activeTint else inactiveTint
+
     RemoteBox(
         modifier = RemoteModifier.then(click)
             .size(40.rdp)
@@ -118,7 +131,7 @@ private fun ActionChip(action: HaAreaAction, theme: HaTheme) {
             imageVector = action.icon,
             contentDescription = "action".rs,
             modifier = RemoteModifier.size(20.rdp),
-            tint = if (action.initiallyActive) accent else theme.secondaryText.rc,
+            tint = tint,
         )
     }
 }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaEntityRow.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaEntityRow.kt
@@ -3,8 +3,6 @@
 package ee.schimke.ha.rc.components
 
 import androidx.compose.remote.creation.compose.action.Action
-import androidx.compose.remote.creation.compose.action.CombinedAction
-import androidx.compose.remote.creation.compose.action.ValueChange
 import androidx.compose.remote.creation.compose.layout.RemoteAlignment
 import androidx.compose.remote.creation.compose.layout.RemoteArrangement
 import androidx.compose.remote.creation.compose.layout.RemoteBox
@@ -21,11 +19,11 @@ import androidx.compose.remote.creation.compose.modifier.padding
 import androidx.compose.remote.creation.compose.modifier.size
 import androidx.compose.remote.creation.compose.shapes.RemoteCircleShape
 import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.RemoteBoolean
 import androidx.compose.remote.creation.compose.state.RemoteColor
 import androidx.compose.remote.creation.compose.state.RemoteFloat
 import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.remote.creation.compose.state.rdp
-import androidx.compose.remote.creation.compose.state.rememberMutableRemoteBoolean
 import androidx.compose.remote.creation.compose.state.rf
 import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.remote.creation.compose.state.rsp
@@ -85,7 +83,7 @@ fun RemoteHaEntityRow(data: HaEntityRowData, modifier: RemoteModifier = RemoteMo
         }
         if (isOnBinding != null) {
             RemoteHaToggleSwitch(
-                initiallyOn = data.accent.initiallyOn,
+                isOn = isOnBinding,
                 activeAccent = data.accent.activeAccent,
                 inactiveAccent = data.accent.inactiveAccent,
                 tapAction = data.tapAction,
@@ -121,48 +119,45 @@ private const val ToggleDurationSeconds = 0.20f
 /**
  * Pill-shaped toggle switch — animates between off / on.
  *
- * 1. `rememberMutableRemoteBoolean` creates document-local state seeded
- *    from [initiallyOn].
- * 2. A `ValueChange` toggles that state on click; the player evaluates
- *    the write declaratively, no re-encoding required.
- * 3. The boolean drives a `select`-derived `RemoteFloat` progress in
+ * 1. [isOn] is the live `RemoteBoolean` for the entity (typically
+ *    `<entityId>.is_on` from [LiveValues.isOn]). The host pushes by
+ *    name; the document re-renders without re-encoding.
+ * 2. The boolean drives a `select`-derived `RemoteFloat` progress in
  *    `[0, 1]`, wrapped in [animateRemoteFloat] so successive flips
  *    tween instead of snapping.
- * 4. The track color tweens between [inactiveAccent] and [activeAccent]
+ * 3. The track color tweens between [inactiveAccent] and [activeAccent]
  *    via the alpha010 [tween] color helper.
- * 5. The knob position is the same animated `progress` mapped through
+ * 4. The knob position is the same animated `progress` mapped through
  *    `toRemoteDp()` and applied as `Modifier.offset` — avoids the
  *    weight()-on-derived-RemoteFloat issue that bit alpha08
  *    (b/504893436).
  *
  * @param tapAction Emitted as a `HostAction` so the runtime can call
- *   HA's service. The optimistic in-document flip happens regardless;
- *   the host is responsible for rolling state back if the service call
- *   fails.
+ *   HA's service. There is no in-document optimistic flip — the visual
+ *   only changes once the host writes the new value back to [isOn].
+ *   (We may layer optimistic updates on top later.)
  */
 @Composable
 @RemoteComposable
 fun RemoteHaToggleSwitch(
-    initiallyOn: Boolean,
+    isOn: RemoteBoolean,
     activeAccent: RemoteColor,
     inactiveAccent: RemoteColor,
     modifier: RemoteModifier = RemoteModifier,
     tapAction: HaAction = HaAction.None,
 ) {
-    val localIsOn = rememberMutableRemoteBoolean(initiallyOn)
-    val target: RemoteFloat = localIsOn.select(1f.rf, 0f.rf)
+    val target: RemoteFloat = isOn.select(1f.rf, 0f.rf)
     val progress: RemoteFloat = animateRemoteFloat(target, ToggleDurationSeconds)
 
-    val toggle: Action = ValueChange(localIsOn, localIsOn.not())
     val host: Action? = tapAction.toRemoteAction()
-    val click: Action = if (host != null) CombinedAction(toggle, host) else toggle
+    val clickable = if (host != null) RemoteModifier.clickable(host) else RemoteModifier
 
     RemoteHaToggleSwitchByProgress(
         progress = progress,
         activeAccent = activeAccent,
         inactiveAccent = inactiveAccent,
         modifier = modifier,
-        clickable = RemoteModifier.clickable(click),
+        clickable = clickable,
     )
 }
 

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaPicture.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaPicture.kt
@@ -20,6 +20,7 @@ import androidx.compose.remote.creation.compose.modifier.padding
 import androidx.compose.remote.creation.compose.modifier.size
 import androidx.compose.remote.creation.compose.shapes.RemoteCircleShape
 import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.RemoteColor
 import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.remote.creation.compose.state.rdp
 import androidx.compose.remote.creation.compose.state.rf
@@ -162,21 +163,30 @@ private fun Cell(cell: HaPictureGlanceCell, theme: HaTheme) {
     val click = cell.tapAction.toRemoteAction()
         ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
     val accent = cell.accent.rc
+    val activeBg: RemoteColor = accent.copy(alpha = accent.alpha * 0.18f.rf)
+    val inactiveBg: RemoteColor = theme.divider.rc.copy(alpha = theme.divider.rc.alpha * 0.5f.rf)
+
+    // Live `<entityId>.is_on` so the host can flip the cell styling
+    // without a re-encode; falls back to the authoring-time seed when
+    // entityId is null (preview).
+    val isActive = LiveValues.isOn(cell.entityId, cell.initiallyActive)
+    val bg: RemoteColor = isActive?.select(activeBg, inactiveBg)
+        ?: if (cell.initiallyActive) activeBg else inactiveBg
+    val tint: RemoteColor = isActive?.select(accent, theme.secondaryText.rc)
+        ?: if (cell.initiallyActive) accent else theme.secondaryText.rc
+
     RemoteBox(
         modifier = RemoteModifier.then(click)
             .size(32.rdp)
             .clip(RemoteCircleShape)
-            .background(
-                if (cell.initiallyActive) accent.copy(alpha = accent.alpha * 0.18f.rf)
-                else theme.divider.rc.copy(alpha = theme.divider.rc.alpha * 0.5f.rf),
-            ),
+            .background(bg),
         contentAlignment = RemoteAlignment.Center,
     ) {
         RemoteIcon(
             imageVector = cell.icon,
             contentDescription = cell.label.rs,
             modifier = RemoteModifier.size(18.rdp),
-            tint = if (cell.initiallyActive) accent else theme.secondaryText.rc,
+            tint = tint,
         )
     }
 }
@@ -262,21 +272,30 @@ private fun Element(
             val click = element.tapAction.toRemoteAction()
                 ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
             val accent = element.accent.rc
+            val activeBg: RemoteColor = accent.copy(alpha = accent.alpha * 0.18f.rf)
+            val inactiveBg: RemoteColor =
+                theme.divider.rc.copy(alpha = theme.divider.rc.alpha * 0.5f.rf)
+
+            // Live `<entityId>.is_on` so the host can flip the element
+            // styling without a re-encode.
+            val isActive = LiveValues.isOn(element.entityId, element.initiallyActive)
+            val bg: RemoteColor = isActive?.select(activeBg, inactiveBg)
+                ?: if (element.initiallyActive) activeBg else inactiveBg
+            val tint: RemoteColor = isActive?.select(accent, theme.secondaryText.rc)
+                ?: if (element.initiallyActive) accent else theme.secondaryText.rc
+
             RemoteBox(
                 modifier = modifier.then(click)
                     .size(28.rdp)
                     .clip(RemoteCircleShape)
-                    .background(
-                        if (element.initiallyActive) accent.copy(alpha = accent.alpha * 0.18f.rf)
-                        else theme.divider.rc.copy(alpha = theme.divider.rc.alpha * 0.5f.rf),
-                    ),
+                    .background(bg),
                 contentAlignment = RemoteAlignment.Center,
             ) {
                 RemoteIcon(
                     imageVector = element.icon,
                     contentDescription = "element".rs,
                     modifier = RemoteModifier.size(16.rdp),
-                    tint = if (element.initiallyActive) accent else theme.secondaryText.rc,
+                    tint = tint,
                 )
             }
         }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaToggleButton.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaToggleButton.kt
@@ -2,9 +2,6 @@
 
 package ee.schimke.ha.rc.components
 
-import androidx.compose.remote.creation.compose.action.Action
-import androidx.compose.remote.creation.compose.action.CombinedAction
-import androidx.compose.remote.creation.compose.action.ValueChange
 import androidx.compose.remote.creation.compose.layout.RemoteAlignment
 import androidx.compose.remote.creation.compose.layout.RemoteBox
 import androidx.compose.remote.creation.compose.layout.RemoteColumn
@@ -24,7 +21,6 @@ import androidx.compose.remote.creation.compose.state.RemoteFloat
 import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.remote.creation.compose.state.rdp
 import androidx.compose.remote.creation.compose.state.rf
-import androidx.compose.remote.creation.compose.state.rememberMutableRemoteBoolean
 import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.remote.creation.compose.state.rsp
 import androidx.compose.remote.creation.compose.state.tween
@@ -37,54 +33,45 @@ import androidx.wear.compose.remote.material3.RemoteIcon
 /**
  * A toggleable variant of [RemoteHaButton].
  *
- * Mirrors the RemoteCompose SDK demo pattern (androidx-main
- * `compose/remote/integration-tests/demos/.../ClickableDemo.kt`):
+ * The accent color tracks the entity's live `<entityId>.is_on` binding
+ * (built from [HaButtonData.accent.initiallyOn] as the authoring-time
+ * seed). On click we emit the configured [HaAction] — usually a
+ * [HaAction.Toggle] [HostAction] — and the host writes the new value
+ * back to the same binding. There is no in-document optimistic flip;
+ * see `RemoteHaToggleSwitch` for the same model.
  *
- * 1. `rememberMutableRemoteBoolean` creates local state *inside* the
- *    `.rc` document.
- * 2. A `ValueChange` action toggles that state on click — the player
- *    evaluates the write declaratively; no re-encoding needed.
- * 3. The accent color is bound to the same state via
- *    `isOn.select(active, inactive)` so the chip flip is instantaneous.
- * 4. [data.tapAction] still emits a `HostAction` alongside the local
- *    flip, so the host app can call HA's real service
- *    (`light.toggle`, `switch.toggle`, …) in response.
- *
- * If the host's service call fails, the host is responsible for
- * rolling back the optimistic state — it can do that by writing back
- * to the same binding.
- *
- * For non-toggleable entities pass [HaButtonData.accent.isOn] = null
- * and use the plain [RemoteHaButton] instead; this component expects
- * the optimistic model.
+ * For non-toggleable entities pass [HaToggleAccent.toggleable] = false
+ * (or use the plain [RemoteHaButton]); without a live boolean the
+ * accent stays on [activeAccent] unconditionally.
  */
 @Composable
 @RemoteComposable
 fun RemoteHaToggleButton(data: HaButtonData, modifier: RemoteModifier = RemoteModifier) {
     val theme = haTheme()
 
-    // Optimistic in-doc state — seeded from the snapshot. The host
-    // updates this same state when HA pushes a new entity state;
-    // addressed by the in-document id of the MutableRemoteBoolean.
-    val localIsOn = rememberMutableRemoteBoolean(data.accent.initiallyOn)
+    // Live host binding for the entity's on/off state. Seeded from the
+    // snapshot; the host pushes updates by name (`<entityId>.is_on`).
+    val isOnBinding =
+        if (data.accent.toggleable) LiveValues.isOn(data.entityId, data.accent.initiallyOn) else null
 
-    // Build the click action(s): optimistic flip + optional host action.
-    // alpha09's `clickable` takes a single Action — combine via CombinedAction.
-    val toggle: Action = ValueChange(localIsOn, localIsOn.not())
-    val host: Action? = data.tapAction.toRemoteAction()
-    val click: Action = if (host != null) CombinedAction(toggle, host) else toggle
-    val clickable = RemoteModifier.clickable(click)
+    // Click action is just the configured host action. No local state
+    // flip — the accent updates when the host writes back to is_on.
+    val clickable = data.tapAction.toRemoteAction()
+        ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
 
-    // Tween the accent between inactive ↔ active so the icon halo and
-    // tint cross-fade instead of snapping. The progress source is the
-    // optimistic in-doc boolean; on a click ValueChange flips it and
-    // `animateRemoteFloat` provides the smoothing.
-    val accentProgress: RemoteFloat = animateRemoteFloat(
-        localIsOn.select(1f.rf, 0f.rf),
-        durationSeconds = 0.20f,
-    )
-    val accent: RemoteColor =
+    // Tween the accent between inactive ↔ active so a host writeback
+    // crossfades the icon halo and tint instead of snapping. Falls back
+    // to the active accent unconditionally when there's no live binding
+    // (preview / non-toggleable / null entityId).
+    val accent: RemoteColor = if (isOnBinding != null) {
+        val accentProgress: RemoteFloat = animateRemoteFloat(
+            isOnBinding.select(1f.rf, 0f.rf),
+            durationSeconds = 0.20f,
+        )
         tween(data.accent.inactiveAccent, data.accent.activeAccent, accentProgress)
+    } else {
+        data.accent.activeAccent
+    }
 
     // Wrap-content by default so grid / horizontal-stack can pack
     // multiple buttons per row. Standalone callers wanting a


### PR DESCRIPTION
Replace the in-document `MutableRemoteBoolean` + `ValueChange` flip with
a `RemoteBoolean` parameter — the entity row passes the live
`<entityId>.is_on` binding from `LiveValues.isOn(...)`, and the host is
the only writer. Tap now emits just the configured `HaAction` (typically
a `HostAction` calling HA's service); there is no local optimistic flip.
We may layer optimism back on later.

The Tier-2 `HaToggleSwitch` wrapper still takes a plain `Boolean` and
constructs a constant `RemoteBoolean` internally, so non-document
callers keep their current API.