### PR TITLE
feat(app): register enhanced-shutter card converter

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -96,6 +96,7 @@ dependencies {
   implementation(project(":ha-client"))
   implementation(project(":rc-converter"))
   implementation(project(":rc-components"))
+  implementation(project(":rc-card-shutter"))
   implementation(project(":terrazzo-core"))
 
   implementation(platform(libs.compose.bom))

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -53,6 +53,7 @@ import ee.schimke.ha.rc.androidXExperimentalWrap
 import ee.schimke.ha.rc.cardHeightDp
 import ee.schimke.ha.rc.cardWidthClass
 import ee.schimke.ha.rc.cards.defaultRegistry
+import ee.schimke.ha.rc.cards.shutter.withEnhancedShutter
 import ee.schimke.ha.rc.components.HaTheme
 import ee.schimke.ha.rc.components.ProvideHaTheme
 import ee.schimke.ha.rc.components.ThemeStyle
@@ -180,7 +181,7 @@ private fun DashboardList(
     onCardLongPress: (CardConfig) -> Unit,
     contentPadding: PaddingValues,
 ) {
-    val registry = remember { defaultRegistry() }
+    val registry = remember { defaultRegistry().withEnhancedShutter() }
     val layout = remember(dashboard) { buildDashboardLayout(dashboard) }
     val cfg = rememberLayoutConfig()
     val useGridLayout by LocalTerrazzoGraph.current

--- a/app/src/main/kotlin/ee/schimke/terrazzo/monitor/MonitoringService.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/monitor/MonitoringService.kt
@@ -23,6 +23,7 @@ import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.rc.cardHeightDp
 import ee.schimke.ha.rc.captureCardDocument
 import ee.schimke.ha.rc.cards.defaultRegistry
+import ee.schimke.ha.rc.cards.shutter.withEnhancedShutter
 import ee.schimke.terrazzo.MainActivity
 import ee.schimke.terrazzo.core.session.DemoData
 import ee.schimke.terrazzo.widget.TerrazzoWidgetProvider
@@ -110,14 +111,15 @@ class MonitoringService : Service() {
         val snapshot = DemoData.snapshot()
         val density = resources.configuration.densityDpi
         val widthPx = dpToPx(NOTIFICATION_WIDTH_DP)
-        val heightPx = dpToPx(defaultRegistry().cardHeightDp(card, snapshot))
+        val registry = defaultRegistry().withEnhancedShutter()
+        val heightPx = dpToPx(registry.cardHeightDp(card, snapshot))
 
         val doc = captureCardDocument(
             context = this,
             widthPx = widthPx,
             heightPx = heightPx,
             densityDpi = density,
-            registry = defaultRegistry(),
+            registry = registry,
             card = card,
             snapshot = snapshot,
         )

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/TerrazzoWidgetProvider.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/TerrazzoWidgetProvider.kt
@@ -19,6 +19,7 @@ import ee.schimke.ha.rc.ProvideCardRegistry
 import ee.schimke.ha.rc.RenderChild
 import ee.schimke.ha.rc.cardHeightDp
 import ee.schimke.ha.rc.cards.defaultRegistry
+import ee.schimke.ha.rc.cards.shutter.withEnhancedShutter
 import ee.schimke.ha.rc.components.ProvideHaTheme
 import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.ha.rc.components.haThemeFor
@@ -86,7 +87,7 @@ class TerrazzoWidgetProvider : AppWidgetProvider() {
         val snapshot = if (DemoData.isDemo(entry.baseUrl)) DemoData.snapshot() else EMPTY_SNAPSHOT
         val (style, dark) = loadThemeChoice(context)
         val haTheme = haThemeFor(style, dark)
-        val registry = defaultRegistry()
+        val registry = defaultRegistry().withEnhancedShutter()
 
         val widthPx = dpToPx(context, WIDGET_WIDTH_DP)
         val heightPx = dpToPx(context, registry.cardHeightDp(entry.card, snapshot))

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstallSheet.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstallSheet.kt
@@ -33,6 +33,7 @@ import ee.schimke.ha.rc.ProvideCardRegistry
 import ee.schimke.ha.rc.RenderChild
 import ee.schimke.ha.rc.cardHeightDp
 import ee.schimke.ha.rc.cards.defaultRegistry
+import ee.schimke.ha.rc.cards.shutter.withEnhancedShutter
 import ee.schimke.ha.rc.components.HaTheme
 import ee.schimke.ha.rc.components.ProvideHaTheme
 import ee.schimke.ha.rc.widgetsV6
@@ -69,7 +70,7 @@ fun WidgetInstallSheet(
     val context = LocalContext.current
     val installer = remember { WidgetInstaller(context.applicationContext) }
     val store = LocalTerrazzoGraph.current.widgetStore
-    val registry = remember { defaultRegistry() }
+    val registry = remember { defaultRegistry().withEnhancedShutter() }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     var installedCount by remember { mutableIntStateOf(0) }


### PR DESCRIPTION
The release :app module depended only on :rc-converter / :rc-components
and built its registry with a bare defaultRegistry(), so dashboards,
widgets, and the monitor service rendered custom:enhanced-shutter-card
as "Not yet supported". The demo-app already wired it up via
withEnhancedShutter(); mirror that here.