### PR TITLE
feat(widget): bump widget capture to WIDGETS_V7 profile

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/TerrazzoWidgetProvider.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/TerrazzoWidgetProvider.kt
@@ -23,7 +23,7 @@ import ee.schimke.ha.rc.cards.shutter.withEnhancedShutter
 import ee.schimke.ha.rc.components.ProvideHaTheme
 import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.ha.rc.components.haThemeFor
-import ee.schimke.ha.rc.widgetsV6
+import ee.schimke.ha.rc.widgetsProfile
 import ee.schimke.terrazzo.core.prefs.DarkModePref
 import ee.schimke.terrazzo.core.prefs.ThemePref
 import ee.schimke.terrazzo.core.session.DemoData
@@ -33,7 +33,7 @@ import kotlinx.coroutines.runBlocking
 /**
  * Per-card home-screen widget. Extends [AppWidgetProvider] directly
  * rather than RemoteCompose's `RemoteComposeWidget` scaffolding so we
- * can pin the capture to [widgetsV6] — the launcher's RemoteCompose
+ * can pin the capture to [widgetsProfile] — the launcher's RemoteCompose
  * runtime supports a stricter op set than the embedded AndroidX
  * player, and `RemoteComposeWidget` hard-codes
  * `RcPlatformProfiles.ANDROIDX` inside its `RCWidget` capture.
@@ -42,7 +42,7 @@ import kotlinx.coroutines.runBlocking
  *   1. Framework or our own broadcast triggers [onUpdate].
  *   2. For each pinned widget id, look up the [WidgetStore.Entry] and
  *      headlessly capture the card via [captureSingleRemoteDocument]
- *      with `profile = widgetsV6`. The composition is wrapped with
+ *      with `profile = widgetsProfile`. The composition is wrapped with
  *      [ProvideCardRegistry] + [ProvideHaTheme] so converters resolve
  *      the user's theme.
  *   3. Wrap the bytes in `RemoteViews.DrawInstructions` and publish via
@@ -98,7 +98,7 @@ class TerrazzoWidgetProvider : AppWidgetProvider() {
                 captureSingleRemoteDocument(
                     context = context,
                     creationDisplayInfo = RemoteCreationDisplayInfo(widthPx, heightPx, densityDpi),
-                    profile = widgetsV6,
+                    profile = widgetsProfile,
                 ) {
                     ProvideCardRegistry(registry) {
                         ProvideHaTheme(haTheme) {
@@ -108,7 +108,7 @@ class TerrazzoWidgetProvider : AppWidgetProvider() {
                 }
             }
         }.getOrElse {
-            // WIDGETS_V6 rejects ops outside the launcher's vocabulary —
+            // The widgets profile rejects ops outside the launcher's vocabulary —
             // log and skip rather than crashing the host process.
             Log.w(TAG, "widgets-profile capture failed for id=$widgetId type=${entry.card.type}", it)
             return

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstallSheet.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstallSheet.kt
@@ -36,14 +36,14 @@ import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.cards.shutter.withEnhancedShutter
 import ee.schimke.ha.rc.components.HaTheme
 import ee.schimke.ha.rc.components.ProvideHaTheme
-import ee.schimke.ha.rc.widgetsV6
+import ee.schimke.ha.rc.widgetsProfile
 import ee.schimke.terrazzo.LocalTerrazzoGraph
 import ee.schimke.terrazzo.core.widget.WidgetStore
 
 /**
  * Bottom sheet shown when the user long-presses a card. Live preview
  * on top (rendered through `CachedCardPreview` with the same
- * [widgetsV6] profile the home screen widget uses, so what you see is
+ * [widgetsProfile] profile the home screen widget uses, so what you see is
  * what gets installed), then an "Add to Home Screen" button that calls
  * `requestPinAppWidget`.
  *
@@ -96,8 +96,8 @@ fun WidgetInstallSheet(
                 modifier = Modifier.fillMaxWidth().height(heightDp.dp),
             ) {
                 CachedCardPreview(
-                    cacheKey = WidgetPreviewCacheKey(card, HaTheme.Light, widgetsV6),
-                    profile = widgetsV6,
+                    cacheKey = WidgetPreviewCacheKey(card, HaTheme.Light, widgetsProfile),
+                    profile = widgetsProfile,
                     card = card,
                     snapshot = snapshot,
                 ) {
@@ -146,7 +146,7 @@ fun WidgetInstallSheet(
  * re-encode (see `CachedCardPreview` for the binding push). Profile
  * is part of the key so the same card cached for the dashboard
  * (AndroidX-experimental) doesn't collide with the widget capture
- * (V6).
+ * (V7).
  */
 private data class WidgetPreviewCacheKey(
     val card: CardConfig,

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WidgetProfile.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WidgetProfile.kt
@@ -15,14 +15,14 @@ import androidx.compose.remote.creation.profile.RcPlatformProfiles
  * widgets profile up-front keeps the bytes within the launcher's
  * vocabulary.
  *
- * Today: alpha010 ships [RcPlatformProfiles.WIDGETS_V6] (Glance widgets
- * on Baklava, document API level 6, no operation-profile bits — only
- * the common-baseline ops are valid). Cards that lean on AndroidX-only
- * ops (`FlowLayout`, etc.) will fail to capture under this profile —
+ * Today: alpha010 ships [RcPlatformProfiles.WIDGETS_V7] (document API
+ * level 7, `RcProfiles.PROFILE_WIDGETS` bit) — the newer of the two
+ * available widget profiles. Cards that lean on AndroidX-only ops
+ * (`FlowLayout`, etc.) will fail to capture under this profile —
  * expected. The compatible card subset is what's installable as a
  * widget; the dashboard / preview path keeps using `androidXExperimental`.
  *
- * `WIDGETS_V6` is `@RestrictTo(LIBRARY_GROUP)`; aliasing it here keeps
+ * `WIDGETS_V7` is `@RestrictTo(LIBRARY_GROUP)`; aliasing it here keeps
  * the suppression scoped to a single file.
  */
-val widgetsV6: Profile = RcPlatformProfiles.WIDGETS_V6
+val widgetsProfile: Profile = RcPlatformProfiles.WIDGETS_V7


### PR DESCRIPTION
## Summary
- Switch widget capture from `RcPlatformProfiles.WIDGETS_V6` to `WIDGETS_V7` (document API level 7, `PROFILE_WIDGETS` bit) — wider op vocabulary than V6's bare baseline, so more cards survive the capture.
- Rename the alias from `widgetsV6` to `widgetsProfile` so future Vn bumps stay scoped to a single file.

## Test plan
- [ ] `./gradlew ktfmtCheck` (passes locally)
- [ ] `./gradlew :app:compileDebugKotlin :rc-converter:compileDebugKotlin` (passes locally)
- [ ] Pin a widget on device, confirm it renders (no `widgets-profile capture failed` warnings in logcat for cards that worked under V6)
- [ ] Open the install bottom sheet for a widget-compatible card, confirm the live preview updates as snapshot data changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4Mcwbd1uhVJF4AocLQ8xM)_