### PR TITLE
fix(ha-model): capture full card object as CardConfig.raw

### DIFF
--- a/app/src/test/kotlin/ee/schimke/terrazzo/core/cache/OfflineCacheTest.kt
+++ b/app/src/test/kotlin/ee/schimke/terrazzo/core/cache/OfflineCacheTest.kt
@@ -57,7 +57,18 @@ class OfflineCacheTest {
     val home =
       Dashboard(
         title = "Home",
-        views = listOf(View(cards = listOf(CardConfig(type = "tile")))),
+        views =
+          listOf(
+            View(
+              cards =
+                listOf(
+                  CardConfig(
+                    type = "tile",
+                    raw = JsonObject(mapOf("type" to JsonPrimitive("tile"))),
+                  )
+                )
+            )
+          ),
       )
     val homeSnap =
       HaSnapshot(

--- a/app/src/test/kotlin/ee/schimke/terrazzo/core/session/RealLovelaceConfigDecodingTest.kt
+++ b/app/src/test/kotlin/ee/schimke/terrazzo/core/session/RealLovelaceConfigDecodingTest.kt
@@ -1,0 +1,124 @@
+package ee.schimke.terrazzo.core.session
+
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.Dashboard
+import ee.schimke.ha.model.Section
+import ee.schimke.ha.model.View
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Regression test for the live-HA decoding bug: `HaClient.fetchDashboard` previously decoded each
+ * card via the default kotlinx-serialization decoder for `CardConfig(type, raw)`. Real Lovelace JSON
+ * emits per-card fields (`entity`, `name`, …) directly on the card object — there is no `raw`
+ * wrapper on the wire — so every card decoded with `raw = {}` and converters rendered blanks.
+ *
+ * This test runs the production decoding path (same `Json` config as [ee.schimke.ha.client.HaClient]
+ * — `ignoreUnknownKeys = true`, `isLenient = true`) over real bundled Lovelace JSON and asserts that
+ * card-level fields survive into [CardConfig.raw]. If `CardConfig`'s serializer regresses to the
+ * default member-by-member decoder, every assertion below fails.
+ */
+class RealLovelaceConfigDecodingTest {
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+  }
+
+  private fun loadDashboard(slug: String): Dashboard {
+    val text =
+      DemoData::class
+        .java
+        .getResourceAsStream("/dashboards/$slug/lovelace_config.json")
+        ?.bufferedReader()
+        ?.use { it.readText() }
+    assertNotNull(text, "missing bundled lovelace_config.json for $slug")
+    return json.decodeFromString(Dashboard.serializer(), text)
+  }
+
+  private fun walkCards(dashboard: Dashboard): Sequence<CardConfig> = sequence {
+    for (view in dashboard.views) {
+      for (card in view.cards) yieldAll(walk(card))
+      for (section in view.sections) yieldAll(walk(section))
+    }
+  }
+
+  private fun walk(section: Section): Sequence<CardConfig> = sequence {
+    for (card in section.cards) yieldAll(walk(card))
+  }
+
+  private fun walk(card: CardConfig): Sequence<CardConfig> = sequence {
+    yield(card)
+    // Stack-style containers nest cards under "cards"; conditional/picture-entity
+    // nest under "card". Walk both so nested children are exercised too.
+    (card.raw["cards"] as? kotlinx.serialization.json.JsonArray)?.forEach { el ->
+      val obj = el as? JsonObject ?: return@forEach
+      val type = obj["type"]?.jsonPrimitive?.content ?: return@forEach
+      yieldAll(walk(CardConfig(type = type, raw = obj)))
+    }
+    (card.raw["card"] as? JsonObject)?.let { obj ->
+      val type = obj["type"]?.jsonPrimitive?.content ?: return@let
+      yieldAll(walk(CardConfig(type = type, raw = obj)))
+    }
+  }
+
+  @Test
+  fun decodes_3d_printing_with_card_fields_populated() {
+    val dashboard = loadDashboard("3d_printing")
+    val cards = walkCards(dashboard).toList()
+    assertTrue(cards.isNotEmpty(), "expected captured cards in 3d_printing dashboard")
+
+    // No card config should arrive with an empty `raw` — that was the
+    // exact symptom of the bug.
+    val emptyRaw = cards.filter { it.raw.isEmpty() }
+    assertTrue(emptyRaw.isEmpty(), "expected every card.raw populated, but ${emptyRaw.size} were empty")
+
+    // Tile cards in this dashboard always have an `entity` and most have a `name`. Both fields are
+    // top-level on the wire and would be dropped by the default serializer.
+    val tilesWithEntity = cards.filter {
+      it.type == "tile" && it.raw["entity"]?.jsonPrimitive?.content != null
+    }
+    assertTrue(
+      tilesWithEntity.isNotEmpty(),
+      "expected at least one tile card with an `entity` field surfaced in raw",
+    )
+
+    val tilesWithName = cards.filter {
+      it.type == "tile" && it.raw["name"]?.jsonPrimitive?.content != null
+    }
+    assertTrue(
+      tilesWithName.isNotEmpty(),
+      "expected at least one tile card with a `name` field surfaced in raw",
+    )
+  }
+
+  @Test
+  fun decodes_every_bundled_dashboard_with_non_empty_card_raw() {
+    // Cover every captured dashboard so card shapes that 3d_printing
+    // doesn't include (markdown, picture-entity, weather-forecast, etc.)
+    // also exercise the production decoding path.
+    val slugs =
+      listOf(
+        "security",
+        "3d_printing",
+        "climate",
+        "energy",
+        "github",
+        "meshcore",
+        "networks",
+      )
+
+    for (slug in slugs) {
+      val dashboard = loadDashboard(slug)
+      val cards = walkCards(dashboard).toList()
+      assertTrue(cards.isNotEmpty(), "$slug: expected non-empty card list")
+      val empty = cards.filter { it.raw.isEmpty() }
+      assertTrue(empty.isEmpty(), "$slug: ${empty.size} cards decoded with empty raw (types=${empty.map { it.type }.distinct()})")
+    }
+  }
+}

--- a/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/Dashboard.kt
+++ b/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/Dashboard.kt
@@ -1,7 +1,16 @@
 package ee.schimke.ha.model
 
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonEncoder
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * Resolved Lovelace dashboard config, matching the payload returned by the HA WebSocket command
@@ -48,5 +57,29 @@ data class Section(
 /**
  * A Lovelace card config. Only `type` is guaranteed — everything else lives in [raw] for per-card
  * converters to interpret.
+ *
+ * Lovelace serialises card fields directly on the card object (no `raw` wrapper), so a custom
+ * serializer captures the entire JSON object as [raw] rather than letting kotlinx-serialization
+ * look for a literal `raw` field that the wire format never emits.
  */
-@Serializable data class CardConfig(val type: String, val raw: JsonObject = JsonObject(emptyMap()))
+@Serializable(with = CardConfigSerializer::class)
+data class CardConfig(val type: String, val raw: JsonObject = JsonObject(emptyMap()))
+
+object CardConfigSerializer : KSerializer<CardConfig> {
+  override val descriptor: SerialDescriptor = JsonObject.serializer().descriptor
+
+  override fun deserialize(decoder: Decoder): CardConfig {
+    val input = decoder as? JsonDecoder ?: error("CardConfig is JSON-only")
+    val obj = input.decodeJsonElement().jsonObject
+    val type = obj["type"]?.jsonPrimitive?.content ?: error("Card config missing required 'type'")
+    return CardConfig(type = type, raw = obj)
+  }
+
+  override fun serialize(encoder: Encoder, value: CardConfig) {
+    val output = encoder as? JsonEncoder ?: error("CardConfig is JSON-only")
+    val obj =
+      if (value.raw["type"] == JsonPrimitive(value.type)) value.raw
+      else JsonObject(value.raw + ("type" to JsonPrimitive(value.type)))
+    output.encodeJsonElement(obj)
+  }
+}

--- a/ha-model/src/commonTest/kotlin/ee/schimke/ha/model/CardConfigSerializerTest.kt
+++ b/ha-model/src/commonTest/kotlin/ee/schimke/ha/model/CardConfigSerializerTest.kt
@@ -1,0 +1,105 @@
+package ee.schimke.ha.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
+
+class CardConfigSerializerTest {
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+  }
+
+  @Test
+  fun decode_capturesEveryFieldOfTheCardObjectAsRaw() {
+    val payload =
+      """
+      {
+        "type": "tile",
+        "entity": "light.kitchen",
+        "name": "Kitchen",
+        "icon": "mdi:lightbulb"
+      }
+      """
+        .trimIndent()
+
+    val card = json.decodeFromString(CardConfig.serializer(), payload)
+
+    assertEquals("tile", card.type)
+    assertEquals("light.kitchen", card.raw["entity"]?.jsonPrimitive?.content)
+    assertEquals("Kitchen", card.raw["name"]?.jsonPrimitive?.content)
+    assertEquals("mdi:lightbulb", card.raw["icon"]?.jsonPrimitive?.content)
+  }
+
+  @Test
+  fun decode_inDashboard_carriesCardFieldsThroughViewsAndSections() {
+    val payload =
+      """
+      {
+        "title": "Home",
+        "views": [
+          {
+            "title": "Main",
+            "cards": [
+              { "type": "tile", "entity": "light.kitchen" }
+            ],
+            "sections": [
+              {
+                "type": "grid",
+                "cards": [
+                  { "type": "button", "entity": "switch.lamp", "name": "Lamp" }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+      """
+        .trimIndent()
+
+    val dashboard = json.decodeFromString(Dashboard.serializer(), payload)
+
+    val orphan = dashboard.views[0].cards[0]
+    assertEquals("tile", orphan.type)
+    assertEquals("light.kitchen", orphan.raw["entity"]?.jsonPrimitive?.content)
+
+    val sectionCard = dashboard.views[0].sections[0].cards[0]
+    assertEquals("button", sectionCard.type)
+    assertEquals("switch.lamp", sectionCard.raw["entity"]?.jsonPrimitive?.content)
+    assertEquals("Lamp", sectionCard.raw["name"]?.jsonPrimitive?.content)
+  }
+
+  @Test
+  fun encode_writesTypeAtTopLevelEvenWhenAbsentFromRaw() {
+    val card = CardConfig(type = "tile", raw = JsonObject(emptyMap()))
+
+    val encoded = json.encodeToString(CardConfig.serializer(), card)
+    val roundTrip = json.decodeFromString(CardConfig.serializer(), encoded)
+
+    assertEquals("tile", roundTrip.type)
+    assertEquals(JsonPrimitive("tile"), roundTrip.raw["type"])
+  }
+
+  @Test
+  fun encode_preservesExistingTypeFieldInRaw() {
+    val raw =
+      JsonObject(mapOf("type" to JsonPrimitive("tile"), "entity" to JsonPrimitive("light.kitchen")))
+    val card = CardConfig(type = "tile", raw = raw)
+
+    val encoded = json.encodeToString(CardConfig.serializer(), card)
+
+    // No duplicated type fields, and entity survives.
+    val firstTypeIndex = encoded.indexOf("\"type\"")
+    val lastTypeIndex = encoded.lastIndexOf("\"type\"")
+    assertTrue(
+      firstTypeIndex >= 0 && firstTypeIndex == lastTypeIndex,
+      "expected single type key, got: $encoded",
+    )
+    assertTrue(encoded.contains("light.kitchen"), "expected entity preserved, got: $encoded")
+  }
+}


### PR DESCRIPTION
## Summary

- Live HA dashboards rendered with cards completely missing on real servers (demo mode worked).
- Root cause: `CardConfig(type, raw)` was decoded by the default kotlinx-serialization member decoder. Lovelace puts per-card fields (`entity`, `name`, …) directly on the card object — there is no `raw` wrapper on the wire — so with `ignoreUnknownKeys = true` every card decoded as `CardConfig(type, raw = {})` and converters had nothing to render. Demo mode dodged this because `DemoHaSession.toCardConfig()` builds `CardConfig(type, raw = obj)` by hand.
- Fix: a `CardConfigSerializer` that captures the entire JSON object as `raw` on decode and emits `raw` (injecting `type` when absent) on encode, so the wire shape round-trips.
- Updated `OfflineCacheTest` so the constructed `CardConfig` matches the post-deserialization shape (`raw` includes `type`).

## Test plan

- [x] `./gradlew :ha-model:jvmTest` — new `CardConfigSerializerTest` covers raw decode, decode through `Dashboard` → `View` → `Section` → `CardConfig`, and round-trip encode.
- [x] `./gradlew :app:testDebugUnitTest` — new `RealLovelaceConfigDecodingTest` runs the production `Json` config (same as `HaClient`) over the seven bundled (sanitised) lovelace fixtures and asserts every `card.raw` is non-empty plus that tile cards surface `entity` and `name`. Without the fix, every card.raw is empty and these assertions fail loudly.
- [x] `./gradlew :ha-client:jvmTest :rc-converter:test` — existing tests still green.
- [ ] Manual: log into a real HA server and confirm dashboards now render fully populated cards instead of blank tiles.