### PR TITLE
fix(test): point LongPressInstallTest at first captured demo board

### DIFF
--- a/app/src/androidTest/kotlin/ee/schimke/terrazzo/dashboard/LongPressInstallTest.kt
+++ b/app/src/androidTest/kotlin/ee/schimke/terrazzo/dashboard/LongPressInstallTest.kt
@@ -72,11 +72,11 @@ class LongPressInstallTest {
 
     @Test
     fun longPressOnDashboardCard_opensInstallSheet() {
-        // The DashboardPickerScreen lists at least one dashboard;
-        // the demo session's default is "Home". Tapping it opens
-        // the dashboard view.
-        val pickerEntry = device.wait(Until.findObject(By.text("Home")), 10_000)
-        assertNotNull("dashboard picker did not list 'Home' within 10s", pickerEntry)
+        // The DashboardPickerScreen lists the seven captured demo
+        // dashboards (see `DemoData.BOARDS`); the first entry is
+        // "Security". Tapping it opens the dashboard view.
+        val pickerEntry = device.wait(Until.findObject(By.text("Security")), 10_000)
+        assertNotNull("dashboard picker did not list 'Security' within 10s", pickerEntry)
         pickerEntry!!.click()
 
         val card = waitForFirstCard()


### PR DESCRIPTION
## Summary

- `LongPressInstallTest` failed with `dashboard picker did not list 'Home' within 10s`.
- Root cause is unrelated to the recent serializer fix: demo mode replaced the synthetic "Home" board with the seven captured Lovelace dashboards in #98, but this androidTest still searched for a "Home" picker entry that no longer exists.
- Point the test at "Security" — the first entry in `DemoData.BOARDS` — so the picker → dashboard view → long-press flow runs end-to-end again.

## Test plan

- [ ] `./gradlew :app:connectedDebugAndroidTest --tests "ee.schimke.terrazzo.dashboard.LongPressInstallTest"` on an emulator (API 35+ for the RC widget min-sdk).