### PR TITLE
chore: clean up stale naturalHeightDp docs after wrap-adaptive sizing

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -59,7 +59,6 @@ import ee.schimke.ha.rc.LocalRcDebugBorders
 import ee.schimke.ha.rc.ProvideCardRegistry
 import ee.schimke.ha.rc.RenderChild
 import ee.schimke.ha.rc.androidXExperimentalWrap
-import ee.schimke.ha.rc.cardHeightDp
 import ee.schimke.ha.rc.cardWidthClass
 import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.cards.shutter.withEnhancedShutter
@@ -485,8 +484,9 @@ private fun SectionRow(
  * is the Grid layout policy itself, not a different cell renderer.
  *
  * Implicit row tracks default to `GridTrackSize.Auto`, so each row
- * sizes to its tallest section (cards inside still report fixed
- * heights via `cardHeightDp`).
+ * sizes to its tallest section. Cards inside a section size
+ * themselves to their document's intrinsic content height via
+ * `WrapAdaptiveRemoteDocumentPlayer` (called from `CachedCardPreview`).
  */
 @OptIn(ExperimentalGridApi::class)
 @Composable

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/DashboardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/DashboardPreviews.kt
@@ -41,9 +41,10 @@ import ee.schimke.ha.rc.components.ProvideHaTheme
  * dashboard at mobile (411 dp wide) and tablet (800 dp wide) and look
  * at the resulting PNGs side-by-side.
  *
- * Card heights come from each converter's `naturalHeightDp(card,
- * snapshot)`, so vertical-stack / grid / sections cards size
- * themselves correctly. The whole dashboard renders inside one
+ * Card heights flow from each document's intrinsic content via
+ * `WrapAdaptiveRemoteDocumentPlayer` (used by `CachedCardPreview`), so
+ * vertical-stack / grid / sections cards size themselves to whatever
+ * they actually drew. The whole dashboard renders inside one
  * `verticalScroll` so previews longer than the canvas crop instead of
  * clipping silently.
  *

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CachedCardPreview.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CachedCardPreview.kt
@@ -49,25 +49,25 @@ import kotlinx.coroutines.runBlocking
  *      entities the card consumes (`entity:` / `entities:`, including
  *      nested cards in stack / conditional / picture-elements).
  *   2. Captures the player's [StateUpdater] via
- *      `RemoteDocumentPlayer(init = ...)`.
+ *      `WrapAdaptiveRemoteDocumentPlayer(init = ...)`.
  *   3. On every [snapshot] change, computes the bindings via
  *      [cardSnapshotBindings] and writes only those that actually
  *      changed since the last push (`<id>.state`, `<id>.is_on`).
  *
  * Sizing model: the captured document is authored with the
  * wrap-friendly measure path (FEATURE_PAINT_MEASURE = 0, baked by
- * `androidXExperimentalWrap`). With
- * [RemoteComposePlayerFlags.shouldPlayerWrapContentSize] flipped to
- * `true` (done idempotently below), the player applies
- * `wrapContentSize()` to itself — but in alpha010 the
- * `RemoteComposeView` still lays out at its authored canvas size when
- * the parent constraint is unbounded, so a fully wrap-content host
- * (no `Modifier.height(...)`) does not yet shrink to the document's
- * intrinsic content. End-to-end adaptive wrap therefore needs an
- * EXACTLY constraint somewhere up the chain — the dashboard pins
- * `Modifier.height(naturalHeightDp.dp)` and the player conforms to
- * that, ignoring the document's authored canvas. See
- * `SizingExperimentPreviews` for the matrix that documents this.
+ * `androidXExperimentalWrap`). Playback goes through
+ * [WrapAdaptiveRemoteDocumentPlayer], which warms up the
+ * `RemoteComposePlayer`'s paint context with one off-screen draw at
+ * the parent's max constraints, then re-measures. This unblocks the
+ * alpha010 wrap-h bug (the `RemoteComposeView` skips the document's
+ * measure pass until paint context is set, causing a
+ * `Modifier.fillMaxWidth()`-only host to balloon to the authored
+ * canvas height) — see
+ * https://github.com/yschimke/homeassistant-remotecompose/issues/153.
+ * Callers can therefore size the slot via [modifier] alone:
+ * `fillMaxWidth()` for adaptive height, or `Modifier.height(...) /
+ * .size(...)` for an EXACTLY constraint that pins the slot.
  */
 @OptIn(ExperimentalRemotePlayerApi::class)
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardConverter.kt
@@ -41,9 +41,14 @@ interface CardConverter {
 
     /**
      * Preferred rendered height in dp when this card fills its parent
-     * width. Callers that need to pin a slot size (e.g. a dashboard
-     * grid of per-card RemoteCompose players, or a widget preview)
-     * read this instead of re-deriving it.
+     * width. **Hint only**: dashboard slots no longer pin to this — the
+     * RemoteCompose document's intrinsic content height drives the
+     * Compose layout via `WrapAdaptiveRemoteDocumentPlayer`. The hint
+     * is still consumed by hosts that need an explicit pixel size up
+     * front: bitmap captures for Glance widgets
+     * (`TerrazzoWidgetProvider`, `MonitoringService`), the widget
+     * install preview (`WidgetInstallSheet`), and the sizing
+     * experiment previews (slack/tight slot variants).
      *
      * The default is a catch-all; each converter should override with
      * a value that matches its HA reference capture. If a card's

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/LocalCardRegistry.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/LocalCardRegistry.kt
@@ -53,9 +53,11 @@ fun RenderChild(
 }
 
 /**
- * Host-side lookup of a card's preferred rendered height in dp.
- * Callers pinning a container size (dashboard grid cell, widget
- * preview frame) use this instead of hand-rolling a per-type table.
+ * Host-side lookup of a card's preferred rendered height in dp. The
+ * dashboard does **not** call this — its slots size to the document's
+ * intrinsic content via `WrapAdaptiveRemoteDocumentPlayer`. The hint
+ * is consumed by hosts that need a fixed pixel size up front:
+ * Glance widget bitmap captures and the widget install preview.
  * Unknown card types fall back to the unsupported-placeholder
  * converter's height; failing that, 160.
  */


### PR DESCRIPTION
## Summary

Follow-up to #154. After moving the dashboard to `WrapAdaptiveRemoteDocumentPlayer` (slots size to the document's intrinsic content height), several KDocs and one import still described the old `naturalHeightDp`-pinning model.

`naturalHeightDp` itself stays on the `CardConverter` interface — Glance widget bitmap captures (`TerrazzoWidgetProvider`, `MonitoringService`), the widget install preview (`WidgetInstallSheet`), and the slack/tight slot variants in `SizingExperimentPreviews` still need an explicit pixel size up front. The cleanup is doc/comment-only:

- **`CachedCardPreview` KDoc** — replace the alpha010-workaround paragraph (which described pinning the slot to `Modifier.height(naturalHeightDp.dp)`) with a description of the wrap-adaptive playback path.
- **`CardConverter.naturalHeightDp` KDoc** — mark as a hint and enumerate the remaining production callers.
- **`CardRegistry.cardHeightDp` KDoc** — same.
- **`DashboardViewScreen`** — drop the unused `cardHeightDp` import and update the `SectionGrid` comment that referenced it.
- **`DashboardPreviews`** — update the file-level KDoc to reference intrinsic content sizing.

No behaviour change.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin :rc-converter:testDebugUnitTest :previews:compileDebugKotlin` — passes
- [x] `./gradlew ktfmtCheck` — passes (run automatically by the pre-commit hook)
- [x] No production code paths changed; only KDoc, an unused import removal, and one comment edit.

Refs: #154, #153

---
_Generated by [Claude Code](https://claude.ai/code/session_01Py9Gm4cFucpZuwC9goRY8V)_