### PR TITLE
feat(wearsync): add proto schema for pinned sections and widget slots

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -50,6 +50,7 @@ import ee.schimke.terrazzo.dashboard.DashboardListState
 import ee.schimke.terrazzo.dashboard.DashboardPickerScreen
 import ee.schimke.terrazzo.dashboard.DashboardSwitcher
 import ee.schimke.terrazzo.dashboard.DashboardViewScreen
+import ee.schimke.terrazzo.dashboard.ManagePinnedScreen
 import ee.schimke.terrazzo.dashboard.TopBarOverflowMenu
 import ee.schimke.terrazzo.dashboard.rememberDashboardListState
 import ee.schimke.terrazzo.discovery.DiscoveryScreen
@@ -194,7 +195,7 @@ private fun UnauthenticatedScreen(
     }
 }
 
-private enum class AppScreen { Dashboards, Settings, Widgets, SyncDiagnostics }
+private enum class AppScreen { Dashboards, Settings, Widgets, Pinned, SyncDiagnostics }
 
 @Composable
 private fun AuthenticatedShell(
@@ -221,6 +222,7 @@ private fun AuthenticatedShell(
             initialDashboard = initialDashboard,
             onOpenSettings = { screen = AppScreen.Settings },
             onOpenWidgets = { screen = AppScreen.Widgets },
+            onOpenPinned = { screen = AppScreen.Pinned },
             onSignOut = onSignOut,
         )
         AppScreen.Settings -> SettingsScreen(
@@ -231,6 +233,9 @@ private fun AuthenticatedShell(
             onOpenSyncDiagnostics = { screen = AppScreen.SyncDiagnostics },
         )
         AppScreen.Widgets -> WidgetsScreen(
+            onBack = { screen = AppScreen.Dashboards },
+        )
+        AppScreen.Pinned -> ManagePinnedScreen(
             onBack = { screen = AppScreen.Dashboards },
         )
         AppScreen.SyncDiagnostics -> {
@@ -256,6 +261,7 @@ private fun DashboardsRoot(
     initialDashboard: String?,
     onOpenSettings: () -> Unit,
     onOpenWidgets: () -> Unit,
+    onOpenPinned: () -> Unit,
     onSignOut: () -> Unit,
 ) {
     val graph = LocalTerrazzoGraph.current
@@ -298,6 +304,7 @@ private fun DashboardsRoot(
                     TopBarOverflowMenu(
                         onOpenSettings = onOpenSettings,
                         onOpenWidgets = onOpenWidgets,
+                        onOpenPinned = onOpenPinned,
                         onSignOut = onSignOut,
                     )
                 },
@@ -341,6 +348,7 @@ private fun DashboardsRoot(
     installPending?.let { (card, snapshot) ->
         WidgetInstallSheet(
             baseUrl = session.baseUrl,
+            dashboardUrlPath = openedValue.takeIf { it != DASHBOARD_UNSET } ?: "",
             card = card,
             snapshot = snapshot,
             onDismiss = { installPending = null },

--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -55,6 +55,7 @@ import ee.schimke.terrazzo.dashboard.TopBarOverflowMenu
 import ee.schimke.terrazzo.dashboard.rememberDashboardListState
 import ee.schimke.terrazzo.discovery.DiscoveryScreen
 import ee.schimke.terrazzo.monitor.MonitoringService
+import ee.schimke.terrazzo.wearsync.WearWidgetsScreen
 import ee.schimke.terrazzo.widget.WidgetInstallSheet
 import ee.schimke.terrazzo.widget.WidgetRefreshScheduler
 import ee.schimke.terrazzo.widget.WidgetsScreen
@@ -195,7 +196,7 @@ private fun UnauthenticatedScreen(
     }
 }
 
-private enum class AppScreen { Dashboards, Settings, Widgets, Pinned, SyncDiagnostics }
+private enum class AppScreen { Dashboards, Settings, Widgets, Pinned, WearWidgets, SyncDiagnostics }
 
 @Composable
 private fun AuthenticatedShell(
@@ -223,6 +224,7 @@ private fun AuthenticatedShell(
             onOpenSettings = { screen = AppScreen.Settings },
             onOpenWidgets = { screen = AppScreen.Widgets },
             onOpenPinned = { screen = AppScreen.Pinned },
+            onOpenWearWidgets = { screen = AppScreen.WearWidgets },
             onSignOut = onSignOut,
         )
         AppScreen.Settings -> SettingsScreen(
@@ -236,6 +238,9 @@ private fun AuthenticatedShell(
             onBack = { screen = AppScreen.Dashboards },
         )
         AppScreen.Pinned -> ManagePinnedScreen(
+            onBack = { screen = AppScreen.Dashboards },
+        )
+        AppScreen.WearWidgets -> WearWidgetsScreen(
             onBack = { screen = AppScreen.Dashboards },
         )
         AppScreen.SyncDiagnostics -> {
@@ -262,11 +267,17 @@ private fun DashboardsRoot(
     onOpenSettings: () -> Unit,
     onOpenWidgets: () -> Unit,
     onOpenPinned: () -> Unit,
+    onOpenWearWidgets: () -> Unit,
     onSignOut: () -> Unit,
 ) {
     val graph = LocalTerrazzoGraph.current
     val scope = rememberCoroutineScope()
     val dashboards by rememberDashboardListState(session)
+    val context = LocalContext.current
+    val app = remember(context) { context.applicationContext as TerrazzoApplication }
+    val wearWidgetsSupported by app.wearCapabilityProbe
+        .stateFlow(scope)
+        .collectAsState()
 
     var opened by rememberSaveable {
         mutableStateOf(initialDashboardToOpened(initialDashboard))
@@ -305,6 +316,7 @@ private fun DashboardsRoot(
                         onOpenSettings = onOpenSettings,
                         onOpenWidgets = onOpenWidgets,
                         onOpenPinned = onOpenPinned,
+                        onOpenWearWidgets = if (wearWidgetsSupported) onOpenWearWidgets else null,
                         onSignOut = onSignOut,
                     )
                 },

--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApplication.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApplication.kt
@@ -45,7 +45,7 @@ class TerrazzoApplication : Application() {
         wearSync.start(
             scope = ProcessLifecycleOwner.get().lifecycleScope,
             prefs = graph.preferencesStore,
-            widgetStore = graph.widgetStore,
+            pinStore = graph.pinStore,
         )
     }
 

--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApplication.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApplication.kt
@@ -33,6 +33,9 @@ class TerrazzoApplication : Application() {
     val wearSync: MobileWearSyncManager by lazy {
         MobileWearSyncManager(applicationContext, syncStats)
     }
+    val wearCapabilityProbe: ee.schimke.terrazzo.wearsync.WearCapabilityProbe by lazy {
+        ee.schimke.terrazzo.wearsync.WearCapabilityProbe(applicationContext)
+    }
 
     override fun onCreate() {
         super.onCreate()
@@ -46,6 +49,7 @@ class TerrazzoApplication : Application() {
             scope = ProcessLifecycleOwner.get().lifecycleScope,
             prefs = graph.preferencesStore,
             pinStore = graph.pinStore,
+            slotsStore = graph.wearWidgetSlotsStore,
         )
     }
 

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardLayout.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardLayout.kt
@@ -29,6 +29,13 @@ data class DashboardLayout(val views: List<ViewLayout>) {
 
 data class ViewLayout(
     val title: String?,
+    /**
+     * Lovelace's [ee.schimke.ha.model.View.path] — the optional view
+     * slug. Used as part of the stable key for pinned sections so that
+     * reordering views in HA doesn't silently invalidate pins (the path
+     * is the only sort-stable handle a view exposes).
+     */
+    val viewPath: String,
     val orphanCards: List<CardConfig>,
     val sections: List<SectionLayout>,
 )
@@ -48,9 +55,10 @@ data class SectionLayout(
  */
 fun buildDashboardLayout(dashboard: Dashboard): DashboardLayout =
     DashboardLayout(
-        views = dashboard.views.map { view ->
+        views = dashboard.views.mapIndexed { viewIndex, view ->
             ViewLayout(
                 title = view.title,
+                viewPath = view.path?.takeIf { it.isNotEmpty() } ?: "view-$viewIndex",
                 orphanCards = view.cards,
                 sections = view.sections.map { section ->
                     SectionLayout(title = section.title, cards = section.cards)

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -21,8 +21,11 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.PushPin
+import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -35,6 +38,7 @@ import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -48,6 +52,9 @@ import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.Dashboard
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.terrazzo.LocalTerrazzoGraph
+import ee.schimke.terrazzo.core.pin.MobilePinnedSection
+import ee.schimke.terrazzo.core.pin.PinStore
+import ee.schimke.terrazzo.core.pin.PinnedCardData
 import ee.schimke.terrazzo.core.session.DemoHaSession
 import ee.schimke.terrazzo.core.session.HaSession
 import ee.schimke.ha.rc.CachedCardPreview
@@ -71,6 +78,13 @@ import ee.schimke.terrazzo.ui.LocalIsDarkTheme
 import ee.schimke.terrazzo.ui.LocalThemeStyle
 import ee.schimke.terrazzo.ui.rememberLayoutConfig
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * Renders every top-level card in a dashboard as an independent `.rc`
@@ -170,7 +184,14 @@ fun DashboardViewScreen(
                 Text("Failed: ${s.message}", style = MaterialTheme.typography.bodyMedium)
             }
             is DashboardState.Ready ->
-                DashboardList(s.dashboard, s.snapshot, onCardLongPress, contentPadding)
+                DashboardList(
+                    dashboard = s.dashboard,
+                    snapshot = s.snapshot,
+                    baseUrl = session.baseUrl,
+                    dashboardUrlPath = urlPath ?: "",
+                    onCardLongPress = onCardLongPress,
+                    contentPadding = contentPadding,
+                )
         }
     }
 }
@@ -185,12 +206,16 @@ private sealed interface DashboardState {
 private fun DashboardList(
     dashboard: Dashboard,
     snapshot: HaSnapshot,
+    baseUrl: String,
+    dashboardUrlPath: String,
     onCardLongPress: (CardConfig) -> Unit,
     contentPadding: PaddingValues,
 ) {
     val registry = remember { defaultRegistry().withEnhancedShutter() }
     val layout = remember(dashboard) { buildDashboardLayout(dashboard) }
     val cfg = rememberLayoutConfig()
+    val pinStore = LocalTerrazzoGraph.current.pinStore
+    val pinScope = rememberCoroutineScope()
     val useGridLayout by LocalTerrazzoGraph.current
         .preferencesStore.experimentalGridLayout.collectAsState(initial = false)
     val collapsedMode by LocalTerrazzoGraph.current
@@ -259,6 +284,13 @@ private fun DashboardList(
                             if (expandedSectionByView[viewIndex] == sectionIndex) null else sectionIndex
                     },
                     onLongPress = onCardLongPress,
+                    pinContext = SectionPinContext(
+                        baseUrl = baseUrl,
+                        dashboardUrlPath = dashboardUrlPath,
+                        viewPath = view.viewPath,
+                        pinStore = pinStore,
+                        onPinAction = { action -> pinScope.launch { action() } },
+                    ),
                 )
             }
         }
@@ -319,6 +351,7 @@ private fun LazyListScope.renderView(
     expandedSectionIndex: Int?,
     onToggleSection: (Int) -> Unit,
     onLongPress: (CardConfig) -> Unit,
+    pinContext: SectionPinContext,
 ) {
     val viewKey = "v$viewIndex"
 
@@ -349,12 +382,15 @@ private fun LazyListScope.renderView(
             val expanded = !collapsible || expandedSectionIndex == sectionIndex
             item(key = sectionKey) {
                 SectionGroupSurface(haTheme) {
-                    section.title?.let { title ->
-                        SectionHeading(
-                            title = title,
+                    if (section.title != null) {
+                        PinnableSectionHeading(
+                            title = section.title,
                             collapsible = collapsible,
                             expanded = expanded,
                             onClick = { onToggleSection(sectionIndex) },
+                            pinContext = pinContext,
+                            sectionIndex = sectionIndex,
+                            section = section,
                         )
                     }
                     if (expanded) {
@@ -377,6 +413,7 @@ private fun LazyListScope.renderView(
                 registry = registry,
                 haTheme = haTheme,
                 onLongPress = onLongPress,
+                pinContext = pinContext,
             )
         }
     } else {
@@ -384,11 +421,13 @@ private fun LazyListScope.renderView(
             item(key = "$viewKey-srow$rowIndex") {
                 SectionRow(
                     sections = sectionRow,
+                    sectionIndexOffset = rowIndex * sectionColumns,
                     columns = sectionColumns,
                     snapshot = snapshot,
                     registry = registry,
                     haTheme = haTheme,
                     onLongPress = onLongPress,
+                    pinContext = pinContext,
                 )
             }
         }
@@ -407,6 +446,7 @@ private fun SectionHeading(
     collapsible: Boolean = false,
     expanded: Boolean = true,
     onClick: () -> Unit = {},
+    trailing: @Composable (() -> Unit)? = null,
 ) {
     val rowModifier = Modifier
         .fillMaxWidth()
@@ -429,8 +469,112 @@ private fun SectionHeading(
                 tint = MaterialTheme.colorScheme.onSurface,
             )
         }
+        trailing?.invoke()
     }
 }
+
+/**
+ * Context plumbed from [DashboardList] down through every section
+ * renderer. Carries enough to compute a stable pin key
+ * ([PinStore.sectionKey]) and to dispatch pin/unpin coroutines.
+ */
+private data class SectionPinContext(
+    val baseUrl: String,
+    val dashboardUrlPath: String,
+    val viewPath: String,
+    val pinStore: PinStore,
+    val onPinAction: (suspend () -> Unit) -> Unit,
+)
+
+/**
+ * [SectionHeading] plus a pin/unpin toggle. Stable key derives from
+ * the section's position in the dashboard so the same section keeps
+ * the same key across cold launches; unpin → re-pin is a no-op for
+ * downstream slot references.
+ */
+@Composable
+private fun PinnableSectionHeading(
+    title: String,
+    pinContext: SectionPinContext,
+    sectionIndex: Int,
+    section: SectionLayout,
+    collapsible: Boolean = false,
+    expanded: Boolean = true,
+    onClick: () -> Unit = {},
+) {
+    val key = remember(pinContext, sectionIndex) {
+        PinStore.sectionKey(
+            baseUrl = pinContext.baseUrl,
+            dashboardUrlPath = pinContext.dashboardUrlPath,
+            viewPath = pinContext.viewPath,
+            sectionIndex = sectionIndex,
+        )
+    }
+    val isPinned by pinContext.pinStore.isSectionPinned(key).collectAsState(initial = false)
+    SectionHeading(
+        title = title,
+        collapsible = collapsible,
+        expanded = expanded,
+        onClick = onClick,
+        trailing = {
+            IconButton(
+                onClick = {
+                    pinContext.onPinAction {
+                        if (isPinned) {
+                            pinContext.pinStore.unpinSection(key)
+                        } else {
+                            pinContext.pinStore.pinSection(
+                                MobilePinnedSection(
+                                    key = key,
+                                    baseUrl = pinContext.baseUrl,
+                                    dashboardUrlPath = pinContext.dashboardUrlPath,
+                                    viewPath = pinContext.viewPath,
+                                    sectionIndex = sectionIndex,
+                                    title = title,
+                                    cards = section.cards.map { it.toPinnedData() },
+                                )
+                            )
+                        }
+                    }
+                },
+            ) {
+                Icon(
+                    imageVector = if (isPinned) Icons.Filled.PushPin else Icons.Outlined.PushPin,
+                    contentDescription = if (isPinned) "Unpin section from Wear" else "Pin section to Wear",
+                    tint = MaterialTheme.colorScheme.onSurface,
+                )
+            }
+        },
+    )
+}
+
+/**
+ * Capture a [CardConfig] into the pin store's neutral [PinnedCardData]
+ * shape. Title and primary entity are pulled from the same JSON keys
+ * `MobileWearSyncManager.toSummary` uses so the wear-side rendering is
+ * consistent with what the live publish path produces.
+ */
+internal fun CardConfig.toPinnedData(): PinnedCardData {
+    val raw = this.raw
+    val title = raw["title"]?.jsonPrimitive?.contentOrNull
+        ?: raw["heading"]?.jsonPrimitive?.contentOrNull
+        ?: raw["name"]?.jsonPrimitive?.contentOrNull
+        ?: this.type
+    val primary = raw["entity"]?.jsonPrimitive?.contentOrNull
+        ?: raw["entities"]?.jsonArray?.firstOrNull()?.let {
+            (it as? JsonPrimitive)?.contentOrNull
+                ?: (it as? JsonObject)?.get("entity")?.jsonPrimitive?.contentOrNull
+        }
+        ?: ""
+    return PinnedCardData(
+        type = this.type,
+        title = title,
+        primaryEntity = primary,
+        rawJson = pinJson.encodeToString(JsonObject.serializer(), raw),
+    )
+}
+
+private val pinJson = Json { ignoreUnknownKeys = true }
 
 /**
  * One row of [columns] section-columns laid out side-by-side. Cards
@@ -444,24 +588,28 @@ private fun SectionHeading(
 @Composable
 private fun SectionRow(
     sections: List<SectionLayout>,
+    sectionIndexOffset: Int,
     columns: Int,
     snapshot: HaSnapshot,
     registry: ee.schimke.ha.rc.CardRegistry,
     haTheme: HaTheme,
     onLongPress: (CardConfig) -> Unit,
+    pinContext: SectionPinContext,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         verticalAlignment = Alignment.Top,
     ) {
-        sections.forEach { section ->
+        sections.forEachIndexed { offset, section ->
             SectionColumn(
                 section = section,
+                sectionIndex = sectionIndexOffset + offset,
                 snapshot = snapshot,
                 registry = registry,
                 haTheme = haTheme,
                 onLongPress = onLongPress,
+                pinContext = pinContext,
                 modifier = Modifier.weight(1f),
             )
         }
@@ -495,6 +643,7 @@ private fun SectionGrid(
     registry: ee.schimke.ha.rc.CardRegistry,
     haTheme: HaTheme,
     onLongPress: (CardConfig) -> Unit,
+    pinContext: SectionPinContext,
 ) {
     Grid(
         modifier = Modifier.fillMaxWidth(),
@@ -503,13 +652,15 @@ private fun SectionGrid(
             gap(row = 16.dp, column = 16.dp)
         },
     ) {
-        sections.forEach { section ->
+        sections.forEachIndexed { sectionIndex, section ->
             SectionColumn(
                 section = section,
+                sectionIndex = sectionIndex,
                 snapshot = snapshot,
                 registry = registry,
                 haTheme = haTheme,
                 onLongPress = onLongPress,
+                pinContext = pinContext,
                 modifier = Modifier.gridItem(),
             )
         }
@@ -519,14 +670,23 @@ private fun SectionGrid(
 @Composable
 private fun SectionColumn(
     section: SectionLayout,
+    sectionIndex: Int,
     snapshot: HaSnapshot,
     registry: ee.schimke.ha.rc.CardRegistry,
     haTheme: HaTheme,
     onLongPress: (CardConfig) -> Unit,
+    pinContext: SectionPinContext,
     modifier: Modifier = Modifier,
 ) {
     SectionGroupSurface(haTheme = haTheme, modifier = modifier) {
-        section.title?.let { SectionHeading(it) }
+        section.title?.let {
+            PinnableSectionHeading(
+                title = it,
+                pinContext = pinContext,
+                sectionIndex = sectionIndex,
+                section = section,
+            )
+        }
         section.cards.forEach { card ->
             val heightDp = remember(card, snapshot) { registry.cardHeightDp(card, snapshot) }
             CardSlot(

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/ManagePinnedScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/ManagePinnedScreen.kt
@@ -1,0 +1,192 @@
+package ee.schimke.terrazzo.dashboard
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import ee.schimke.terrazzo.LocalTerrazzoGraph
+import ee.schimke.terrazzo.core.pin.MobilePinnedCard
+import ee.schimke.terrazzo.core.pin.MobilePinnedSection
+import kotlinx.coroutines.launch
+
+/**
+ * Manages the user's Wear pin set: lists every pinned card and pinned
+ * section in their unified ordering, lets the user reorder via up/down
+ * arrows (drag handles are a polish follow-up), and lets them unpin.
+ *
+ * Cards and sections share a single ordered list — the position here
+ * is the position the watch's top-level nav will render. New pins land
+ * at the tail; the user reshuffles from this screen.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ManagePinnedScreen(onBack: () -> Unit) {
+    val pinStore = LocalTerrazzoGraph.current.pinStore
+    val scope = rememberCoroutineScope()
+    val cards by pinStore.cards.collectAsState(initial = emptyList())
+    val sections by pinStore.sections.collectAsState(initial = emptyList())
+
+    val items: List<PinRowItem> = remember(cards, sections) {
+        buildList {
+            cards.forEach { add(PinRowItem.Card(it)) }
+            sections.forEach { add(PinRowItem.Section(it)) }
+        }.sortedBy { it.orderIndex }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Manage pinned") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        contentWindowInsets = WindowInsets.safeDrawing,
+    ) { padding ->
+        if (items.isEmpty()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text("No pins yet", style = MaterialTheme.typography.titleMedium)
+                Text(
+                    "Pin sections from a dashboard's section heading or pin cards from " +
+                        "the long-press sheet. Pinned items become Wear nav destinations.",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+            return@Scaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp),
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            items(items, key = { it.key }) { item ->
+                val index = items.indexOfFirst { it.key == item.key }
+                PinRow(
+                    item = item,
+                    canMoveUp = index > 0,
+                    canMoveDown = index >= 0 && index < items.lastIndex,
+                    onMoveUp = {
+                        scope.launch {
+                            val reordered = items.toMutableList()
+                                .apply { add(index - 1, removeAt(index)) }
+                                .map { it.key }
+                            pinStore.reorder(reordered)
+                        }
+                    },
+                    onMoveDown = {
+                        scope.launch {
+                            val reordered = items.toMutableList()
+                                .apply { add(index + 1, removeAt(index)) }
+                                .map { it.key }
+                            pinStore.reorder(reordered)
+                        }
+                    },
+                    onUnpin = {
+                        scope.launch {
+                            when (item) {
+                                is PinRowItem.Card -> pinStore.unpinCard(item.key)
+                                is PinRowItem.Section -> pinStore.unpinSection(item.key)
+                            }
+                        }
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PinRow(
+    item: PinRowItem,
+    canMoveUp: Boolean,
+    canMoveDown: Boolean,
+    onMoveUp: () -> Unit,
+    onMoveDown: () -> Unit,
+    onUnpin: () -> Unit,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 16.dp, end = 4.dp, top = 8.dp, bottom = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(item.title, style = MaterialTheme.typography.titleSmall)
+                Text(item.subtitle, style = MaterialTheme.typography.bodySmall)
+            }
+            IconButton(onClick = onMoveUp, enabled = canMoveUp) {
+                Icon(Icons.Filled.ArrowUpward, contentDescription = "Move up")
+            }
+            IconButton(onClick = onMoveDown, enabled = canMoveDown) {
+                Icon(Icons.Filled.ArrowDownward, contentDescription = "Move down")
+            }
+            IconButton(onClick = onUnpin) {
+                Icon(Icons.Filled.Close, contentDescription = "Unpin")
+            }
+        }
+    }
+}
+
+private sealed interface PinRowItem {
+    val key: String
+    val orderIndex: Int
+    val title: String
+    val subtitle: String
+
+    data class Card(val card: MobilePinnedCard) : PinRowItem {
+        override val key: String get() = card.key
+        override val orderIndex: Int get() = card.orderIndex
+        override val title: String get() = card.card.title.ifEmpty { card.card.type }
+        override val subtitle: String
+            get() = "Card · ${card.dashboardUrlPath.ifEmpty { "default dashboard" }}"
+    }
+
+    data class Section(val section: MobilePinnedSection) : PinRowItem {
+        override val key: String get() = section.key
+        override val orderIndex: Int get() = section.orderIndex
+        override val title: String get() = section.title.ifEmpty { "Untitled section" }
+        override val subtitle: String
+            get() = "Section · ${section.dashboardUrlPath.ifEmpty { "default dashboard" }} (${section.cards.size} cards)"
+    }
+}

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/TopBarOverflowMenu.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/TopBarOverflowMenu.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.setValue
 fun TopBarOverflowMenu(
     onOpenSettings: () -> Unit,
     onOpenWidgets: () -> Unit,
+    onOpenPinned: () -> Unit,
     onSignOut: () -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -42,6 +43,10 @@ fun TopBarOverflowMenu(
         DropdownMenuItem(
             text = { Text("Manage widgets") },
             onClick = { expanded = false; onOpenWidgets() },
+        )
+        DropdownMenuItem(
+            text = { Text("Manage pinned") },
+            onClick = { expanded = false; onOpenPinned() },
         )
         DropdownMenuItem(
             text = { Text("Sign out") },

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/TopBarOverflowMenu.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/TopBarOverflowMenu.kt
@@ -26,6 +26,7 @@ fun TopBarOverflowMenu(
     onOpenSettings: () -> Unit,
     onOpenWidgets: () -> Unit,
     onOpenPinned: () -> Unit,
+    onOpenWearWidgets: (() -> Unit)?,
     onSignOut: () -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -48,6 +49,13 @@ fun TopBarOverflowMenu(
             text = { Text("Manage pinned") },
             onClick = { expanded = false; onOpenPinned() },
         )
+        // Hidden unless a paired Wear node has reported widget support.
+        if (onOpenWearWidgets != null) {
+            DropdownMenuItem(
+                text = { Text("Wear widgets") },
+                onClick = { expanded = false; onOpenWearWidgets() },
+            )
+        }
         DropdownMenuItem(
             text = { Text("Sign out") },
             onClick = { expanded = false; onSignOut() },

--- a/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
@@ -21,6 +21,7 @@ import ee.schimke.terrazzo.core.cache.OfflineCache
 import ee.schimke.terrazzo.core.di.HaSessionFactory
 import ee.schimke.terrazzo.core.di.TerrazzoGraph
 import ee.schimke.terrazzo.core.pin.PinStore
+import ee.schimke.terrazzo.core.pin.WearWidgetSlotsStore
 import ee.schimke.terrazzo.core.prefs.DarkModePref
 import ee.schimke.terrazzo.core.prefs.PreferencesStore
 import ee.schimke.terrazzo.core.session.DemoHaSession
@@ -88,6 +89,7 @@ private fun rememberPreviewGraph(): TerrazzoGraph {
             override val offlineCache: OfflineCache = OfflineCache(context)
             override val preferencesStore: PreferencesStore = PreferencesStore(context)
             override val pinStore: PinStore = PinStore(context)
+            override val wearWidgetSlotsStore: WearWidgetSlotsStore = WearWidgetSlotsStore(context)
             override val widgetStore: WidgetStore
                 get() = error("widgetStore not wired in previews")
             override val tokenVault: TokenVault

--- a/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
@@ -20,6 +20,7 @@ import ee.schimke.terrazzo.core.auth.TokenVault
 import ee.schimke.terrazzo.core.cache.OfflineCache
 import ee.schimke.terrazzo.core.di.HaSessionFactory
 import ee.schimke.terrazzo.core.di.TerrazzoGraph
+import ee.schimke.terrazzo.core.pin.PinStore
 import ee.schimke.terrazzo.core.prefs.DarkModePref
 import ee.schimke.terrazzo.core.prefs.PreferencesStore
 import ee.schimke.terrazzo.core.session.DemoHaSession
@@ -86,6 +87,7 @@ private fun rememberPreviewGraph(): TerrazzoGraph {
         object : TerrazzoGraph {
             override val offlineCache: OfflineCache = OfflineCache(context)
             override val preferencesStore: PreferencesStore = PreferencesStore(context)
+            override val pinStore: PinStore = PinStore(context)
             override val widgetStore: WidgetStore
                 get() = error("widgetStore not wired in previews")
             override val tokenVault: TokenVault

--- a/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/MobileWearSyncManager.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/MobileWearSyncManager.kt
@@ -14,6 +14,8 @@ import ee.schimke.terrazzo.core.pin.MobilePinnedCard
 import ee.schimke.terrazzo.core.pin.MobilePinnedSection
 import ee.schimke.terrazzo.core.pin.PinStore
 import ee.schimke.terrazzo.core.pin.PinnedCardData
+import ee.schimke.terrazzo.core.pin.WearWidgetSlot
+import ee.schimke.terrazzo.core.pin.WearWidgetSlotsStore
 import ee.schimke.terrazzo.core.prefs.PreferencesStore
 import ee.schimke.terrazzo.core.session.HaSession
 import ee.schimke.terrazzo.wearsync.proto.CardSummary
@@ -30,6 +32,7 @@ import ee.schimke.terrazzo.wearsync.proto.WearLease
 import ee.schimke.terrazzo.wearsync.proto.WearSettings
 import ee.schimke.terrazzo.wearsync.proto.WearSyncPaths
 import ee.schimke.terrazzo.wearsync.proto.WearWidgetSlots
+import ee.schimke.terrazzo.wearsync.proto.WidgetSlot
 import ee.schimke.terrazzo.wearsync.proto.decodeProto
 import ee.schimke.terrazzo.wearsync.proto.encodeProto
 import kotlinx.coroutines.CoroutineScope
@@ -124,6 +127,7 @@ class MobileWearSyncManager(
         scope: CoroutineScope,
         prefs: PreferencesStore,
         pinStore: PinStore,
+        slotsStore: WearWidgetSlotsStore,
     ) {
         managerScope = scope
         messageClient.addListener(leaseListener)
@@ -160,6 +164,15 @@ class MobileWearSyncManager(
                 .collect { writeDataItem(WearSyncPaths.SECTIONS, encodeProto(it)) }
         }
 
+        // Wear-widget slots → /wear/slots. Empty assignments survive
+        // the wire so the watch can disable matching widget providers.
+        scope.launch {
+            slotsStore.slots
+                .map { it.toProto() }
+                .distinctUntilChanged()
+                .collect { writeDataItem(WearSyncPaths.SLOTS, encodeProto(it)) }
+        }
+
         // Session snapshot pump. Re-driven on every session change so the
         // demo session and live session each get their own loop. The
         // streaming-vs-batched decision now keys off the unified pin set
@@ -184,14 +197,6 @@ class MobileWearSyncManager(
         streamJob?.cancel()
     }
 
-    /**
-     * Publish the user's wear-widget slot assignments. Slots with an
-     * empty [ee.schimke.terrazzo.wearsync.proto.WidgetSlot.cardKey] tell
-     * the watch to disable the corresponding widget provider component.
-     */
-    suspend fun publishSlots(slots: WearWidgetSlots) {
-        writeDataItem(WearSyncPaths.SLOTS, encodeProto(slots))
-    }
 
     /**
      * Wear → phone path. Ephemeral message delivered if wear-side
@@ -336,6 +341,13 @@ private fun List<MobilePinnedCard>.toProto(): PinnedCardSet =
                 orderIndex = entry.orderIndex,
             )
         },
+        updatedAtMs = System.currentTimeMillis(),
+    )
+
+@JvmName("slotsToProto")
+private fun List<WearWidgetSlot>.toProto(): WearWidgetSlots =
+    WearWidgetSlots(
+        slots = this.map { WidgetSlot(slotIndex = it.slotIndex, cardKey = it.cardKey) },
         updatedAtMs = System.currentTimeMillis(),
     )
 

--- a/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/MobileWearSyncManager.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/MobileWearSyncManager.kt
@@ -10,9 +10,12 @@ import com.google.android.gms.wearable.Wearable
 import com.google.android.horologist.data.WearDataLayerRegistry
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.EntityState
+import ee.schimke.terrazzo.core.pin.MobilePinnedCard
+import ee.schimke.terrazzo.core.pin.MobilePinnedSection
+import ee.schimke.terrazzo.core.pin.PinStore
+import ee.schimke.terrazzo.core.pin.PinnedCardData
 import ee.schimke.terrazzo.core.prefs.PreferencesStore
 import ee.schimke.terrazzo.core.session.HaSession
-import ee.schimke.terrazzo.core.widget.WidgetStore
 import ee.schimke.terrazzo.wearsync.proto.CardSummary
 import ee.schimke.terrazzo.wearsync.proto.DashboardData
 import ee.schimke.terrazzo.wearsync.proto.EntityDelta
@@ -20,6 +23,7 @@ import ee.schimke.terrazzo.wearsync.proto.EntityValue
 import ee.schimke.terrazzo.wearsync.proto.LiveValues
 import ee.schimke.terrazzo.wearsync.proto.PinnedCard
 import ee.schimke.terrazzo.wearsync.proto.PinnedCardSet
+import ee.schimke.terrazzo.wearsync.proto.PinnedSection
 import ee.schimke.terrazzo.wearsync.proto.PinnedSectionSet
 import ee.schimke.terrazzo.wearsync.proto.StreamUpdate
 import ee.schimke.terrazzo.wearsync.proto.WearLease
@@ -56,7 +60,8 @@ import kotlinx.serialization.json.jsonPrimitive
  *  - The current snapshot → `/wear/values` (DataStore-style at the wall
  *    refresh interval) **or** `/wear/stream` (MessageClient ephemeral
  *    deltas) when wear holds an active lease
- *  - [WidgetStore.installed] → `/wear/pinned`
+ *  - [PinStore.cards] → `/wear/pinned`
+ *  - [PinStore.sections] → `/wear/sections`
  *
  * Lease is tracked via MessageClient frames at `/wear/lease`: as long as
  * a recent lease arrived (or pinned cards exist) the manager streams
@@ -118,7 +123,7 @@ class MobileWearSyncManager(
     fun start(
         scope: CoroutineScope,
         prefs: PreferencesStore,
-        widgetStore: WidgetStore,
+        pinStore: PinStore,
     ) {
         managerScope = scope
         messageClient.addListener(leaseListener)
@@ -136,34 +141,39 @@ class MobileWearSyncManager(
                 .collect { writeDataItem(WearSyncPaths.SETTINGS, encodeProto(it)) }
         }
 
-        // Pinned widgets → /wear/pinned.
+        // Pinned cards → /wear/pinned. Source switched from
+        // WidgetStore (phone home-screen widgets) to the new PinStore so
+        // the watch's top-level nav reflects the user's explicit Wear
+        // pins, decoupled from the phone widget set.
         scope.launch {
-            widgetStore.installed
-                .map { entries ->
-                    PinnedCardSet(
-                        cards = entries.map { entry ->
-                            PinnedCard(
-                                baseUrl = entry.baseUrl,
-                                card = entry.card.toSummary(),
-                            )
-                        },
-                        updatedAtMs = System.currentTimeMillis(),
-                    )
-                }
+            pinStore.cards
+                .map { it.toProto() }
                 .distinctUntilChanged()
                 .collect { writeDataItem(WearSyncPaths.PINNED, encodeProto(it)) }
         }
 
-        // Session snapshot pump. Re-driven on every session change so the
-        // demo session and live session each get their own loop.
+        // Pinned sections → /wear/sections.
         scope.launch {
-            combine(sessionState, widgetStore.installed) { s, pinned -> s to pinned }
-                .collectLatest { (session, pinned) ->
+            pinStore.sections
+                .map { it.toProto() }
+                .distinctUntilChanged()
+                .collect { writeDataItem(WearSyncPaths.SECTIONS, encodeProto(it)) }
+        }
+
+        // Session snapshot pump. Re-driven on every session change so the
+        // demo session and live session each get their own loop. The
+        // streaming-vs-batched decision now keys off the unified pin set
+        // (cards + sections); any pin keeps the live stream warm.
+        scope.launch {
+            combine(sessionState, pinStore.cards, pinStore.sections) { s, cards, sections ->
+                Triple(s, cards.isNotEmpty() || sections.isNotEmpty(), Unit)
+            }
+                .collectLatest { (session, hasPinned, _) ->
                     streamJob?.cancel()
                     streamJob = null
                     if (session == null) return@collectLatest
                     publishDashboards(session)
-                    streamJob = scope.launch { sessionPump(session, pinned.isNotEmpty()) }
+                    streamJob = scope.launch { sessionPump(session, hasPinned) }
                 }
         }
     }
@@ -172,15 +182,6 @@ class MobileWearSyncManager(
     fun stop() {
         runCatching { messageClient.removeListener(leaseListener) }
         streamJob?.cancel()
-    }
-
-    /**
-     * Publish the user's pinned-section set to the watch. Called by the
-     * mobile pin store whenever the section pins change. Safe to call
-     * before any wear node is connected — DataItem writes are queued.
-     */
-    suspend fun publishSections(set: PinnedSectionSet) {
-        writeDataItem(WearSyncPaths.SECTIONS, encodeProto(set))
     }
 
     /**
@@ -318,6 +319,51 @@ private fun CardConfig.toSummary(states: Map<String, EntityState> = emptyMap()):
 }
 
 private val json = Json { ignoreUnknownKeys = true }
+
+/**
+ * Convert the mobile pin store's pinned-card list into the proto wire
+ * shape the watch consumes. Captured fields flow through unchanged —
+ * the pin store is the source of truth for title / primary entity at
+ * the time of pinning.
+ */
+private fun List<MobilePinnedCard>.toProto(): PinnedCardSet =
+    PinnedCardSet(
+        cards = this.sortedBy { it.orderIndex }.map { entry ->
+            PinnedCard(
+                baseUrl = entry.baseUrl,
+                card = entry.card.toProto(),
+                cardKey = entry.key,
+                orderIndex = entry.orderIndex,
+            )
+        },
+        updatedAtMs = System.currentTimeMillis(),
+    )
+
+@JvmName("sectionsToProto")
+private fun List<MobilePinnedSection>.toProto(): PinnedSectionSet =
+    PinnedSectionSet(
+        sections = this.sortedBy { it.orderIndex }.map { entry ->
+            PinnedSection(
+                baseUrl = entry.baseUrl,
+                dashboardUrlPath = entry.dashboardUrlPath,
+                viewPath = entry.viewPath,
+                sectionIndex = entry.sectionIndex,
+                title = entry.title,
+                cards = entry.cards.map { it.toProto() },
+                sectionKey = entry.key,
+                orderIndex = entry.orderIndex,
+            )
+        },
+        updatedAtMs = System.currentTimeMillis(),
+    )
+
+private fun PinnedCardData.toProto(): CardSummary =
+    CardSummary(
+        type = this.type,
+        title = this.title,
+        primaryEntityId = this.primaryEntity,
+        rawJson = this.rawJson,
+    )
 
 private suspend fun <T> com.google.android.gms.tasks.Task<T>.await(): T =
     kotlinx.coroutines.suspendCancellableCoroutine { cont ->

--- a/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/MobileWearSyncManager.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/MobileWearSyncManager.kt
@@ -20,10 +20,12 @@ import ee.schimke.terrazzo.wearsync.proto.EntityValue
 import ee.schimke.terrazzo.wearsync.proto.LiveValues
 import ee.schimke.terrazzo.wearsync.proto.PinnedCard
 import ee.schimke.terrazzo.wearsync.proto.PinnedCardSet
+import ee.schimke.terrazzo.wearsync.proto.PinnedSectionSet
 import ee.schimke.terrazzo.wearsync.proto.StreamUpdate
 import ee.schimke.terrazzo.wearsync.proto.WearLease
 import ee.schimke.terrazzo.wearsync.proto.WearSettings
 import ee.schimke.terrazzo.wearsync.proto.WearSyncPaths
+import ee.schimke.terrazzo.wearsync.proto.WearWidgetSlots
 import ee.schimke.terrazzo.wearsync.proto.decodeProto
 import ee.schimke.terrazzo.wearsync.proto.encodeProto
 import kotlinx.coroutines.CoroutineScope
@@ -170,6 +172,24 @@ class MobileWearSyncManager(
     fun stop() {
         runCatching { messageClient.removeListener(leaseListener) }
         streamJob?.cancel()
+    }
+
+    /**
+     * Publish the user's pinned-section set to the watch. Called by the
+     * mobile pin store whenever the section pins change. Safe to call
+     * before any wear node is connected — DataItem writes are queued.
+     */
+    suspend fun publishSections(set: PinnedSectionSet) {
+        writeDataItem(WearSyncPaths.SECTIONS, encodeProto(set))
+    }
+
+    /**
+     * Publish the user's wear-widget slot assignments. Slots with an
+     * empty [ee.schimke.terrazzo.wearsync.proto.WidgetSlot.cardKey] tell
+     * the watch to disable the corresponding widget provider component.
+     */
+    suspend fun publishSlots(slots: WearWidgetSlots) {
+        writeDataItem(WearSyncPaths.SLOTS, encodeProto(slots))
     }
 
     /**

--- a/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/WearCapabilityProbe.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/WearCapabilityProbe.kt
@@ -1,0 +1,83 @@
+package ee.schimke.terrazzo.wearsync
+
+import android.content.Context
+import android.util.Log
+import com.google.android.gms.wearable.CapabilityClient
+import com.google.android.gms.wearable.CapabilityInfo
+import com.google.android.gms.wearable.Wearable
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * Phone-side probe that reports whether any paired Wear node has
+ * declared the wear-widgets capability — i.e. the watch is running
+ * Wear OS 6+ where the Terrazzo wear app advertises widget support.
+ *
+ * The capability `terrazzo_wear_widgets` is added at runtime by the
+ * watch (see `WearSyncRepository.start`) when its OS version supports
+ * Wear widgets. Phone uses [CapabilityClient.getCapability] +
+ * the [CapabilityClient.OnCapabilityChangedListener] to track updates
+ * without polling.
+ */
+class WearCapabilityProbe(context: Context) {
+
+    private val capabilityClient: CapabilityClient = Wearable.getCapabilityClient(context)
+
+    /**
+     * Cold flow that emits the latest "any reachable node supports
+     * wear widgets" boolean. Re-subscribes to the capability listener
+     * on each collector. Most consumers should hand this to
+     * [stateIn] via [stateFlow].
+     */
+    val supportsWearWidgets: Flow<Boolean> = callbackFlow {
+        val listener = CapabilityClient.OnCapabilityChangedListener { info ->
+            trySend(info.nodes.isNotEmpty())
+        }
+        capabilityClient.addListener(listener, CAPABILITY)
+        // Seed with the current state — addListener doesn't replay.
+        runCatching {
+            capabilityClient
+                .getCapability(CAPABILITY, CapabilityClient.FILTER_REACHABLE)
+                .addOnSuccessListener { info: CapabilityInfo ->
+                    trySend(info.nodes.isNotEmpty())
+                }
+                .addOnFailureListener { error ->
+                    Log.w(TAG, "getCapability failed", error)
+                    trySend(false)
+                }
+        }.onFailure {
+            Log.w(TAG, "capability probe init failed", it)
+            trySend(false)
+        }
+        awaitClose { runCatching { capabilityClient.removeListener(listener) } }
+    }
+        .map { it }
+        .distinctUntilChanged()
+
+    /**
+     * Hot [StateFlow] form of [supportsWearWidgets]. Pass an app-scoped
+     * [CoroutineScope] so the probe stays alive across UI rebinds. The
+     * initial value is `false` until the first capability fetch
+     * arrives.
+     */
+    fun stateFlow(scope: CoroutineScope): StateFlow<Boolean> =
+        supportsWearWidgets.stateIn(scope, SharingStarted.Eagerly, false)
+
+    companion object {
+        /**
+         * Capability name advertised by the wear app on Wear OS 6+
+         * (Android 16, API 36+) where the new Wear Widgets framework
+         * is available. Mirrored in `WearSyncRepository.start`.
+         */
+        const val CAPABILITY: String = "terrazzo_wear_widgets"
+
+        private const val TAG = "WearCapability"
+    }
+}

--- a/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/WearWidgetsScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/WearWidgetsScreen.kt
@@ -1,0 +1,178 @@
+package ee.schimke.terrazzo.wearsync
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Card
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import ee.schimke.terrazzo.LocalTerrazzoGraph
+import ee.schimke.terrazzo.core.pin.MobilePinnedCard
+import ee.schimke.terrazzo.core.pin.WearWidgetSlot
+import kotlinx.coroutines.launch
+
+/**
+ * Mobile screen for configuring the 5 wear-widget slots. Each slot
+ * holds a reference to a pinned card (by [MobilePinnedCard.key]); the
+ * watch enables one widget provider per assigned slot, and the system
+ * widget picker on the watch only surfaces the enabled ones.
+ *
+ * This screen is reachable from the dashboard top-bar overflow menu —
+ * but only when [WearCapabilityProbe] reports that a paired Wear
+ * node advertises widget support. The menu entry is hidden otherwise,
+ * so this screen always has a meaningful effect when the user gets to
+ * it.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WearWidgetsScreen(onBack: () -> Unit) {
+    val pinStore = LocalTerrazzoGraph.current.pinStore
+    val slotsStore = LocalTerrazzoGraph.current.wearWidgetSlotsStore
+    val scope = rememberCoroutineScope()
+
+    val slots by slotsStore.slots.collectAsState(initial = emptyList())
+    val pinnedCards by pinStore.cards.collectAsState(initial = emptyList())
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Wear widgets") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        contentWindowInsets = WindowInsets.safeDrawing,
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp),
+        ) {
+            Text(
+                text = "Each slot maps to one widget provider on your watch. " +
+                    "Empty slots are hidden from the watch's widget picker.",
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(vertical = 12.dp),
+            )
+
+            if (pinnedCards.isEmpty()) {
+                Text(
+                    text = "Pin some cards first — slots can only point at pinned cards.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(vertical = 8.dp),
+                )
+            }
+
+            LazyColumn(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(slots, key = { it.slotIndex }) { slot ->
+                    SlotRow(
+                        slot = slot,
+                        pinnedCards = pinnedCards,
+                        onAssign = { card ->
+                            scope.launch { slotsStore.setSlot(slot.slotIndex, card.key) }
+                        },
+                        onClear = {
+                            scope.launch { slotsStore.clearSlot(slot.slotIndex) }
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SlotRow(
+    slot: WearWidgetSlot,
+    pinnedCards: List<MobilePinnedCard>,
+    onAssign: (MobilePinnedCard) -> Unit,
+    onClear: () -> Unit,
+) {
+    val assignedCard = pinnedCards.firstOrNull { it.key == slot.cardKey }
+    val pickerOpen = remember { mutableStateOf(false) }
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(enabled = pinnedCards.isNotEmpty()) { pickerOpen.value = true }
+                .padding(start = 16.dp, end = 4.dp, top = 12.dp, bottom = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text("Slot ${slot.slotIndex + 1}", style = MaterialTheme.typography.titleSmall)
+                Text(
+                    text = when {
+                        assignedCard != null ->
+                            assignedCard.card.title.ifEmpty { assignedCard.card.type }
+                        slot.isAssigned ->
+                            "Assigned card no longer pinned"
+                        else -> "Unassigned"
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (assignedCard != null)
+                        MaterialTheme.colorScheme.primary
+                    else
+                        MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            if (slot.isAssigned) {
+                IconButton(onClick = onClear) {
+                    Icon(Icons.Filled.Close, contentDescription = "Clear slot")
+                }
+            }
+        }
+
+        DropdownMenu(
+            expanded = pickerOpen.value,
+            onDismissRequest = { pickerOpen.value = false },
+        ) {
+            pinnedCards.forEach { card ->
+                DropdownMenuItem(
+                    text = { Text(card.card.title.ifEmpty { card.card.type }) },
+                    onClick = {
+                        pickerOpen.value = false
+                        onAssign(card)
+                    },
+                )
+            }
+        }
+    }
+}
+

--- a/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/proto/WearSyncProto.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/proto/WearSyncProto.kt
@@ -19,6 +19,8 @@ import kotlinx.serialization.Serializable
  *   - DataClient:
  *     - `/wear/settings`            — [WearSettings]
  *     - `/wear/pinned`              — [PinnedCardSet]
+ *     - `/wear/sections`            — [PinnedSectionSet]
+ *     - `/wear/slots`               — [WearWidgetSlots]
  *     - `/wear/values`              — [LiveValues]
  *     - `/wear/dashboard/<urlPath>` — [DashboardData]
  *   - MessageClient (ephemeral):
@@ -80,7 +82,11 @@ data class EntityDelta(
     val value: EntityValue = EntityValue(),
 )
 
-/** Mirror of phone's WidgetStore — drives wear's home screen. */
+/**
+ * User-curated pinned cards. Top-level destinations on Wear and the
+ * source of truth for [WearWidgetSlots] assignments (slots reference
+ * cards by [PinnedCard.cardKey]).
+ */
 @Serializable
 data class PinnedCardSet(
     val cards: List<PinnedCard> = emptyList(),
@@ -91,6 +97,53 @@ data class PinnedCardSet(
 data class PinnedCard(
     val baseUrl: String = "",
     val card: CardSummary = CardSummary(),
+    /** Stable id chosen at pin time; referenced by [WidgetSlot.cardKey]. */
+    val cardKey: String = "",
+    /** Position in the unified Wear top-level ordering. */
+    val orderIndex: Int = 0,
+)
+
+/** User-pinned dashboard sections, each becomes a Wear nav destination. */
+@Serializable
+data class PinnedSectionSet(
+    val sections: List<PinnedSection> = emptyList(),
+    val updatedAtMs: Long = 0L,
+)
+
+@Serializable
+data class PinnedSection(
+    val baseUrl: String = "",
+    val dashboardUrlPath: String = "",
+    val viewPath: String = "",
+    /** Position-keyed; HA sections have no inherent stable id. */
+    val sectionIndex: Int = 0,
+    val title: String = "",
+    val cards: List<CardSummary> = emptyList(),
+    /** Stable id chosen at pin time. */
+    val sectionKey: String = "",
+    /** Position in the unified Wear top-level ordering. */
+    val orderIndex: Int = 0,
+)
+
+/**
+ * Mobile-assigned widget slot map. Wear declares 5 widget providers
+ * (Slot0 … Slot4); each [WidgetSlot] points its slot at a pinned card
+ * via [PinnedCard.cardKey]. An unassigned slot (`cardKey == ""`)
+ * disables the corresponding provider on the wear side so it doesn't
+ * appear in the system widget picker.
+ */
+@Serializable
+data class WearWidgetSlots(
+    val slots: List<WidgetSlot> = emptyList(),
+    val updatedAtMs: Long = 0L,
+)
+
+@Serializable
+data class WidgetSlot(
+    /** 0..4. */
+    val slotIndex: Int = 0,
+    /** Empty when the slot is unconfigured. References [PinnedCard.cardKey]. */
+    val cardKey: String = "",
 )
 
 /**
@@ -123,10 +176,15 @@ data class SyncStats(
 object WearSyncPaths {
     const val SETTINGS: String = "/wear/settings"
     const val PINNED: String = "/wear/pinned"
+    const val SECTIONS: String = "/wear/sections"
+    const val SLOTS: String = "/wear/slots"
     const val VALUES: String = "/wear/values"
     const val DASHBOARD_PREFIX: String = "/wear/dashboard/"
     const val LEASE_MESSAGE: String = "/wear/lease"
     const val STREAM_MESSAGE: String = "/wear/stream"
+
+    /** Number of wear-widget slots. Mirrors [WearWidgetSlots] capacity. */
+    const val WIDGET_SLOT_COUNT: Int = 5
 
     /** Encode a urlPath (which may be null for HA's default dashboard) into a DataItem path. */
     fun dashboardPath(urlPath: String?): String =

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstallSheet.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstallSheet.kt
@@ -8,8 +8,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PushPin
+import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
@@ -17,13 +21,16 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth as rcFillMaxWidth
 import ee.schimke.ha.model.CardConfig
@@ -38,7 +45,10 @@ import ee.schimke.ha.rc.components.HaTheme
 import ee.schimke.ha.rc.components.ProvideHaTheme
 import ee.schimke.ha.rc.widgetsProfile
 import ee.schimke.terrazzo.LocalTerrazzoGraph
+import ee.schimke.terrazzo.core.pin.MobilePinnedCard
+import ee.schimke.terrazzo.core.pin.PinStore
 import ee.schimke.terrazzo.core.widget.WidgetStore
+import ee.schimke.terrazzo.dashboard.toPinnedData
 
 /**
  * Bottom sheet shown when the user long-presses a card. Live preview
@@ -62,6 +72,7 @@ import ee.schimke.terrazzo.core.widget.WidgetStore
 @Composable
 fun WidgetInstallSheet(
     baseUrl: String,
+    dashboardUrlPath: String,
     card: CardConfig,
     snapshot: HaSnapshot,
     onDismiss: () -> Unit,
@@ -70,6 +81,8 @@ fun WidgetInstallSheet(
     val context = LocalContext.current
     val installer = remember { WidgetInstaller(context.applicationContext) }
     val store = LocalTerrazzoGraph.current.widgetStore
+    val pinStore = LocalTerrazzoGraph.current.pinStore
+    val pinScope = rememberCoroutineScope()
     val registry = remember { defaultRegistry().withEnhancedShutter() }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
@@ -79,6 +92,12 @@ fun WidgetInstallSheet(
     val heightDp = remember(card, snapshot) { registry.cardHeightDp(card, snapshot) }
     val capHit = installedCount >= WidgetStore.MAX_WIDGETS
     val pinSupported = remember { installer.isSupported() }
+
+    val cardData = remember(card) { card.toPinnedData() }
+    val pinKey = remember(baseUrl, dashboardUrlPath, cardData.rawJson) {
+        PinStore.cardKey(baseUrl, dashboardUrlPath, cardData.rawJson)
+    }
+    val isCardPinned by pinStore.isCardPinned(pinKey).collectAsState(initial = false)
 
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         Column(
@@ -125,6 +144,35 @@ fun WidgetInstallSheet(
                 enabled = pinSupported && !capHit,
                 modifier = Modifier.fillMaxWidth(),
             ) { Text(if (capHit) "All 5 slots in use" else "Add to Home Screen") }
+
+            OutlinedButton(
+                onClick = {
+                    pinScope.launch {
+                        if (isCardPinned) {
+                            pinStore.unpinCard(pinKey)
+                        } else {
+                            pinStore.pinCard(
+                                MobilePinnedCard(
+                                    key = pinKey,
+                                    baseUrl = baseUrl,
+                                    dashboardUrlPath = dashboardUrlPath,
+                                    card = cardData,
+                                )
+                            )
+                        }
+                    }
+                    onDismiss()
+                },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(
+                    imageVector = if (isCardPinned) Icons.Filled.PushPin else Icons.Outlined.PushPin,
+                    contentDescription = null,
+                )
+                Text(
+                    text = if (isCardPinned) "  Unpin from Wear" else "  Pin to Wear",
+                )
+            }
 
             onMonitor?.let { start ->
                 OutlinedButton(

--- a/app/src/main/proto/wear_sync.proto
+++ b/app/src/main/proto/wear_sync.proto
@@ -4,7 +4,9 @@
 //
 // Path conventions (mirrored in WearSyncPaths.kt):
 //   /wear/settings              — WearSettings (phone → wear; demo flag, baseUrl)
-//   /wear/pinned                — PinnedCardSet (phone → wear; mobile widget list)
+//   /wear/pinned                — PinnedCardSet (phone → wear; user-pinned cards)
+//   /wear/sections              — PinnedSectionSet (phone → wear; user-pinned sections)
+//   /wear/slots                 — WearWidgetSlots (phone → wear; 5 widget slot assignments)
 //   /wear/values                — LiveValues (phone → wear; current entity values)
 //   /wear/dashboard/<urlPath>   — DashboardData (phone → wear; one entry per dashboard)
 //   /wear/lease   (MessageClient) — WearLease (wear → phone; foreground heartbeat)
@@ -76,9 +78,9 @@ message EntityDelta {
     EntityValue value = 2;
 }
 
-// Pinned-cards mirror of phone's WidgetStore. Wear shows these as the
-// default home screen so the watch surfaces what the user has already
-// curated.
+// Pinned cards curated by the user on mobile. Surfaced as top-level
+// destinations on Wear's nav (alongside pinned sections), and the source
+// of truth for [WearWidgetSlots] assignments.
 message PinnedCardSet {
     repeated PinnedCard cards = 1;
     int64 updated_at_ms = 2;
@@ -87,6 +89,59 @@ message PinnedCardSet {
 message PinnedCard {
     string base_url = 1;
     CardSummary card = 2;
+    // Stable identifier chosen at pin time. Survives re-pin / reorder
+    // and is the value referenced by [WidgetSlot.card_key]. Mobile is
+    // responsible for issuing keys (e.g. UUID or
+    // baseUrl|dashboard|view|index).
+    string card_key = 3;
+    // Position within the unified Wear top-level ordering (sections +
+    // cards interleaved). Lower values render first. Ties broken by
+    // card_key.
+    int32 order_index = 4;
+}
+
+// User-pinned sections from the mobile dashboard view. Each becomes
+// a separate Wear nav destination that lists the section's cards.
+message PinnedSectionSet {
+    repeated PinnedSection sections = 1;
+    int64 updated_at_ms = 2;
+}
+
+message PinnedSection {
+    string base_url = 1;
+    string dashboard_url_path = 2;
+    // HA view path within the dashboard (a dashboard may contain
+    // multiple views; sections live inside one of them).
+    string view_path = 3;
+    // Index of the section within the view's `sections` list. Sections
+    // have no inherent stable id in HA's config so position is the key;
+    // mobile must republish if the user reorders sections in HA.
+    int32 section_index = 4;
+    string title = 5;
+    repeated CardSummary cards = 6;
+    // Stable identifier chosen at pin time (analogous to
+    // [PinnedCard.card_key]). Survives reorder.
+    string section_key = 7;
+    // Position within the unified Wear top-level ordering.
+    int32 order_index = 8;
+}
+
+// 5 wear-widget slots assigned by the user on mobile. Each slot points
+// at a [PinnedCard] by its [PinnedCard.card_key]; an empty card_key
+// means the slot is unconfigured and the corresponding wear-widget
+// provider should be disabled (so the system widget picker hides it).
+message WearWidgetSlots {
+    repeated WidgetSlot slots = 1;
+    int64 updated_at_ms = 2;
+}
+
+message WidgetSlot {
+    // 0..4. Stable per slot — slot index is what the wear-side widget
+    // provider keys off (Slot0WidgetProvider … Slot4WidgetProvider).
+    int32 slot_index = 1;
+    // Empty when the slot is unconfigured. References
+    // [PinnedCard.card_key].
+    string card_key = 2;
 }
 
 // Wear → phone heartbeat (MessageClient at `/wear/lease`). Phone uses

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,10 @@ compose-compiler = "1.5.15"
 remote-compose = "1.0.0-alpha010"
 remote-material3 = "1.0.0-alpha03"
 
+# AndroidX Glance Wear (alpha — runtime feature gated on Wear OS 7+ / API 37
+# inside the library; we use it for the per-slot wear widgets).
+glance-wear = "1.0.0-alpha09"
+
 # Android
 android-minSdk = "29"
 android-compileSdk = "37"
@@ -73,6 +77,10 @@ activity-compose = { module = "androidx.activity:activity-compose", version = "1
 # Wear Compose (stub module — full app lands later)
 wear-compose-material3 = { module = "androidx.wear.compose:compose-material3", version = "1.6.1" }
 wear-compose-foundation = { module = "androidx.wear.compose:compose-foundation", version = "1.6.1" }
+
+# AndroidX Glance Wear — Wear OS widget framework (alpha).
+glance-wear = { module = "androidx.glance.wear:wear", version.ref = "glance-wear" }
+glance-wear-core = { module = "androidx.glance.wear:wear-core", version.ref = "glance-wear" }
 
 # TV Compose (stub module)
 tv-material = { module = "androidx.tv:tv-material", version = "1.1.0" }

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/di/TerrazzoGraph.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/di/TerrazzoGraph.kt
@@ -9,6 +9,7 @@ import ee.schimke.terrazzo.core.auth.HaAuthService
 import ee.schimke.terrazzo.core.auth.TokenVault
 import ee.schimke.terrazzo.core.cache.OfflineCache
 import ee.schimke.terrazzo.core.pin.PinStore
+import ee.schimke.terrazzo.core.pin.WearWidgetSlotsStore
 import ee.schimke.terrazzo.core.prefs.PreferencesStore
 import ee.schimke.terrazzo.core.session.CachedHaSession
 import ee.schimke.terrazzo.core.session.DemoHaSession
@@ -31,6 +32,7 @@ interface TerrazzoGraph {
     val authService: HaAuthService
     val widgetStore: WidgetStore
     val pinStore: PinStore
+    val wearWidgetSlotsStore: WearWidgetSlotsStore
     val preferencesStore: PreferencesStore
     val offlineCache: OfflineCache
     val sessionFactory: HaSessionFactory

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/di/TerrazzoGraph.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/di/TerrazzoGraph.kt
@@ -8,6 +8,7 @@ import dev.zacsweers.metro.Inject
 import ee.schimke.terrazzo.core.auth.HaAuthService
 import ee.schimke.terrazzo.core.auth.TokenVault
 import ee.schimke.terrazzo.core.cache.OfflineCache
+import ee.schimke.terrazzo.core.pin.PinStore
 import ee.schimke.terrazzo.core.prefs.PreferencesStore
 import ee.schimke.terrazzo.core.session.CachedHaSession
 import ee.schimke.terrazzo.core.session.DemoHaSession
@@ -29,6 +30,7 @@ interface TerrazzoGraph {
     val tokenVault: TokenVault
     val authService: HaAuthService
     val widgetStore: WidgetStore
+    val pinStore: PinStore
     val preferencesStore: PreferencesStore
     val offlineCache: OfflineCache
     val sessionFactory: HaSessionFactory

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/pin/PinStore.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/pin/PinStore.kt
@@ -1,0 +1,253 @@
+package ee.schimke.terrazzo.core.pin
+
+import android.content.Context
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import ee.schimke.terrazzo.core.di.AppScope
+import java.security.MessageDigest
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Mobile-side pin store. Source of truth for the user's pinned
+ * dashboard items — both individual cards and whole sections — that the
+ * watch surfaces as nav destinations and that drive the wear-widget
+ * slot picker.
+ *
+ * Independent of [ee.schimke.terrazzo.core.widget.WidgetStore], which
+ * keeps tracking phone home-screen widget installs separately. A user
+ * who installs a card as a phone widget does not implicitly pin it for
+ * the watch, and vice versa.
+ *
+ * Storage: a single Preferences DataStore with two JSON-encoded list
+ * entries (`pinned_cards` / `pinned_sections`). JSON-in-prefs is enough
+ * for the small cardinalities involved (handful of pins) and avoids
+ * adding a second DataStore proto.
+ *
+ * Each pin owns:
+ *   - a stable `key` (used by [WearWidgetSlots] slot references and as
+ *     the de-dup token for is-pinned checks),
+ *   - an `orderIndex` shared across cards and sections so the user
+ *     controls the unified Wear top-level ordering as a single list,
+ *   - `baseUrl` and dashboard/section provenance so the manage-pinned
+ *     UI can show "where did this come from" and the wear sync layer
+ *     can scope updates to the active session.
+ *
+ * Section content (the actual card configs the watch renders) is
+ * captured into [PinnedCardData] at pin-time and stored alongside the
+ * section. This keeps the Wear publisher self-contained and avoids
+ * round-tripping the dashboard on every push. If the user edits the
+ * section in HA the captured copy goes stale until they re-pin — an
+ * acceptable v1 trade.
+ */
+@SingleIn(AppScope::class)
+@Inject
+class PinStore(private val context: Context) {
+
+    val cards: Flow<List<MobilePinnedCard>>
+        get() = context.store.data.map { it.readCards() }
+
+    val sections: Flow<List<MobilePinnedSection>>
+        get() = context.store.data.map { it.readSections() }
+
+    suspend fun cardsNow(): List<MobilePinnedCard> = cards.first()
+
+    suspend fun sectionsNow(): List<MobilePinnedSection> = sections.first()
+
+    /** Whether a card with [cardKey] is currently pinned. */
+    fun isCardPinned(cardKey: String): Flow<Boolean> =
+        context.store.data.map { prefs -> prefs.readCards().any { it.key == cardKey } }
+
+    /** Whether a section with [sectionKey] is currently pinned. */
+    fun isSectionPinned(sectionKey: String): Flow<Boolean> =
+        context.store.data.map { prefs -> prefs.readSections().any { it.key == sectionKey } }
+
+    /**
+     * Pin a card. Idempotent — re-pinning the same key updates the
+     * captured payload (e.g. title changed) without changing its order
+     * position. New pins land at the end of the unified ordering.
+     */
+    suspend fun pinCard(card: MobilePinnedCard) {
+        context.store.edit { prefs ->
+            val cards = prefs.readCards().toMutableList()
+            val existing = cards.indexOfFirst { it.key == card.key }
+            if (existing >= 0) {
+                cards[existing] = card.copy(orderIndex = cards[existing].orderIndex)
+            } else {
+                cards += card.copy(orderIndex = nextOrderIndex(prefs))
+            }
+            prefs.writeCards(cards)
+        }
+    }
+
+    suspend fun unpinCard(cardKey: String) {
+        context.store.edit { prefs ->
+            val cards = prefs.readCards().filterNot { it.key == cardKey }
+            prefs.writeCards(cards)
+        }
+    }
+
+    /** Pin a section. Same idempotent semantics as [pinCard]. */
+    suspend fun pinSection(section: MobilePinnedSection) {
+        context.store.edit { prefs ->
+            val sections = prefs.readSections().toMutableList()
+            val existing = sections.indexOfFirst { it.key == section.key }
+            if (existing >= 0) {
+                sections[existing] = section.copy(orderIndex = sections[existing].orderIndex)
+            } else {
+                sections += section.copy(orderIndex = nextOrderIndex(prefs))
+            }
+            prefs.writeSections(sections)
+        }
+    }
+
+    suspend fun unpinSection(sectionKey: String) {
+        context.store.edit { prefs ->
+            val sections = prefs.readSections().filterNot { it.key == sectionKey }
+            prefs.writeSections(sections)
+        }
+    }
+
+    /**
+     * Reorder the unified top-level list. [keysInOrder] is the desired
+     * sequence of keys (cards and sections interleaved); items are
+     * reassigned consecutive `orderIndex` values starting at 0.
+     * Unknown keys are ignored. Items not present in [keysInOrder]
+     * keep their relative order at the tail.
+     */
+    suspend fun reorder(keysInOrder: List<String>) {
+        context.store.edit { prefs ->
+            val cards = prefs.readCards()
+            val sections = prefs.readSections()
+            val cardByKey = cards.associateBy { it.key }
+            val sectionByKey = sections.associateBy { it.key }
+            val seen = mutableSetOf<String>()
+
+            val orderedCards = mutableListOf<MobilePinnedCard>()
+            val orderedSections = mutableListOf<MobilePinnedSection>()
+            var next = 0
+            for (key in keysInOrder) {
+                if (!seen.add(key)) continue
+                cardByKey[key]?.let { orderedCards += it.copy(orderIndex = next++) }
+                sectionByKey[key]?.let { orderedSections += it.copy(orderIndex = next++) }
+            }
+            for (card in cards) {
+                if (card.key in seen) continue
+                orderedCards += card.copy(orderIndex = next++)
+            }
+            for (section in sections) {
+                if (section.key in seen) continue
+                orderedSections += section.copy(orderIndex = next++)
+            }
+            prefs.writeCards(orderedCards)
+            prefs.writeSections(orderedSections)
+        }
+    }
+
+    private fun nextOrderIndex(prefs: Preferences): Int {
+        val maxCard = prefs.readCards().maxOfOrNull { it.orderIndex } ?: -1
+        val maxSection = prefs.readSections().maxOfOrNull { it.orderIndex } ?: -1
+        return maxOf(maxCard, maxSection) + 1
+    }
+
+    private fun Preferences.readCards(): List<MobilePinnedCard> =
+        this[CARDS_KEY]?.let { runCatching { json.decodeFromString<List<MobilePinnedCard>>(it) }.getOrNull() }
+            ?: emptyList()
+
+    private fun Preferences.readSections(): List<MobilePinnedSection> =
+        this[SECTIONS_KEY]?.let { runCatching { json.decodeFromString<List<MobilePinnedSection>>(it) }.getOrNull() }
+            ?: emptyList()
+
+    private fun androidx.datastore.preferences.core.MutablePreferences.writeCards(value: List<MobilePinnedCard>) {
+        this[CARDS_KEY] = json.encodeToString(value)
+    }
+
+    private fun androidx.datastore.preferences.core.MutablePreferences.writeSections(value: List<MobilePinnedSection>) {
+        this[SECTIONS_KEY] = json.encodeToString(value)
+    }
+
+    companion object {
+        private val Context.store by preferencesDataStore(name = "terrazzo_pins")
+        private val CARDS_KEY = stringPreferencesKey("pinned_cards")
+        private val SECTIONS_KEY = stringPreferencesKey("pinned_sections")
+        private val json = Json { ignoreUnknownKeys = true }
+
+        /**
+         * Stable key for a pinned card. Derived from the source-of-truth
+         * fields (HA instance + dashboard + raw card config) so that
+         * re-pinning the same card from the same dashboard yields the
+         * same key — slot assignments survive an unpin / re-pin cycle.
+         */
+        fun cardKey(baseUrl: String, dashboardUrlPath: String, cardJson: String): String =
+            sha16("c|$baseUrl|$dashboardUrlPath|$cardJson")
+
+        /**
+         * Stable key for a pinned section. Sections have no inherent id
+         * in HA's config so position is the key; if the user reorders
+         * sections in HA the key changes and the user has to re-pin.
+         */
+        fun sectionKey(
+            baseUrl: String,
+            dashboardUrlPath: String,
+            viewPath: String,
+            sectionIndex: Int,
+        ): String = sha16("s|$baseUrl|$dashboardUrlPath|$viewPath|$sectionIndex")
+
+        private fun sha16(input: String): String {
+            val digest = MessageDigest.getInstance("SHA-256").digest(input.toByteArray())
+            val sb = StringBuilder(16)
+            for (i in 0 until 8) {
+                sb.append(((digest[i].toInt() and 0xFF) or 0x100).toString(16).substring(1))
+            }
+            return sb.toString()
+        }
+    }
+}
+
+/**
+ * One pinned card. Captured at pin-time so the wear sync layer doesn't
+ * need to re-resolve the dashboard on publish.
+ */
+@Serializable
+data class MobilePinnedCard(
+    val key: String,
+    val baseUrl: String,
+    val dashboardUrlPath: String,
+    val card: PinnedCardData,
+    val orderIndex: Int = 0,
+)
+
+/**
+ * One pinned section. [cards] is the section's contents at pin-time.
+ */
+@Serializable
+data class MobilePinnedSection(
+    val key: String,
+    val baseUrl: String,
+    val dashboardUrlPath: String,
+    val viewPath: String,
+    val sectionIndex: Int,
+    val title: String,
+    val cards: List<PinnedCardData> = emptyList(),
+    val orderIndex: Int = 0,
+)
+
+/**
+ * Card snapshot stored inside the pin store. Mirrors the wire shape of
+ * `CardSummary` in the wear-sync proto without depending on it (this
+ * module sits below the proto's host).
+ */
+@Serializable
+data class PinnedCardData(
+    val type: String = "",
+    val title: String = "",
+    val primaryEntity: String = "",
+    val rawJson: String = "",
+)

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/pin/WearWidgetSlotsStore.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/pin/WearWidgetSlotsStore.kt
@@ -1,0 +1,70 @@
+package ee.schimke.terrazzo.core.pin
+
+import android.content.Context
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import ee.schimke.terrazzo.core.di.AppScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+/**
+ * Mobile-side wear-widget slot assignments. Five slots (indices 0..4),
+ * each pointing to a pinned card by [PinStore]'s `cardKey`. An empty
+ * key means the slot is unconfigured — the watch will keep its
+ * matching widget provider component disabled so it doesn't appear in
+ * the system widget picker.
+ *
+ * Storage: a single Preferences entry per slot (`slot.0.cardKey` …
+ * `slot.4.cardKey`). Keeping the schema flat (one row per slot)
+ * matches [ee.schimke.terrazzo.core.widget.WidgetStore] and avoids the
+ * JSON-list ceremony that [PinStore] needs for its variable-cardinality
+ * data.
+ *
+ * The store doesn't own the rendering pipeline — it just stores
+ * [WearWidgetSlot] rows. [ee.schimke.terrazzo.wearsync.MobileWearSyncManager]
+ * subscribes to [slots] and publishes via DataLayer to /wear/slots.
+ */
+@SingleIn(AppScope::class)
+@Inject
+class WearWidgetSlotsStore(private val context: Context) {
+
+    val slots: Flow<List<WearWidgetSlot>>
+        get() = context.store.data.map { it.readSlots() }
+
+    suspend fun slotsNow(): List<WearWidgetSlot> = slots.first()
+
+    suspend fun setSlot(slotIndex: Int, cardKey: String) {
+        require(slotIndex in 0 until SLOT_COUNT) { "slotIndex out of range: $slotIndex" }
+        context.store.edit { it[cardKeyPref(slotIndex)] = cardKey }
+    }
+
+    suspend fun clearSlot(slotIndex: Int) {
+        require(slotIndex in 0 until SLOT_COUNT) { "slotIndex out of range: $slotIndex" }
+        context.store.edit { it.remove(cardKeyPref(slotIndex)) }
+    }
+
+    private fun Preferences.readSlots(): List<WearWidgetSlot> =
+        (0 until SLOT_COUNT).map { i ->
+            WearWidgetSlot(slotIndex = i, cardKey = this[cardKeyPref(i)].orEmpty())
+        }
+
+    companion object {
+        const val SLOT_COUNT: Int = 5
+
+        private val Context.store by preferencesDataStore(name = "terrazzo_wear_slots")
+        private fun cardKeyPref(i: Int) = stringPreferencesKey("slot.$i.cardKey")
+    }
+}
+
+/** One slot assignment. Empty `cardKey` means unconfigured. */
+data class WearWidgetSlot(
+    val slotIndex: Int,
+    val cardKey: String,
+) {
+    val isAssigned: Boolean get() = cardKey.isNotEmpty()
+}

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -48,6 +48,11 @@ dependencies {
   implementation(libs.wear.compose.material3)
   implementation(libs.wear.compose.foundation)
 
+  // AndroidX Glance Wear — runtime widget rendering. Pulls
+  // remote-creation-compose, lifecycle-service, etc. transitively.
+  implementation(libs.glance.wear)
+  implementation(libs.glance.wear.core)
+
   // Proto DataStore + Horologist data layer for sync with phone.
   // Schema is documented in `src/main/proto/wear_sync.proto`; we
   // encode @Serializable Kotlin data classes to the same proto wire

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -27,5 +27,87 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!--
+          Five wear-widget slot services, one per assignable slot. All
+          start `android:enabled="false"`; WearSlotsController flips
+          each one on once the user assigns a pinned card to that slot
+          on the phone (and the runtime version actually supports
+          Glance Wear). The system widget picker only surfaces enabled
+          services, so unconfigured slots stay invisible.
+
+          Each service binds via the Glance Wear native action plus the
+          tile-provider compat action so the same service shows up on
+          watch faces that haven't migrated to the new picker yet.
+        -->
+        <service
+            android:name=".widget.Slot0WidgetService"
+            android:exported="true"
+            android:enabled="false"
+            android:label="Terrazzo slot 1">
+            <intent-filter>
+                <action android:name="androidx.glance.wear.action.BIND_WIDGET_PROVIDER" />
+                <action android:name="androidx.wear.tiles.action.BIND_TILE_PROVIDER" />
+            </intent-filter>
+            <meta-data
+                android:name="androidx.glance.wear.widget.provider"
+                android:resource="@xml/wear_slot_widget_provider" />
+        </service>
+
+        <service
+            android:name=".widget.Slot1WidgetService"
+            android:exported="true"
+            android:enabled="false"
+            android:label="Terrazzo slot 2">
+            <intent-filter>
+                <action android:name="androidx.glance.wear.action.BIND_WIDGET_PROVIDER" />
+                <action android:name="androidx.wear.tiles.action.BIND_TILE_PROVIDER" />
+            </intent-filter>
+            <meta-data
+                android:name="androidx.glance.wear.widget.provider"
+                android:resource="@xml/wear_slot_widget_provider" />
+        </service>
+
+        <service
+            android:name=".widget.Slot2WidgetService"
+            android:exported="true"
+            android:enabled="false"
+            android:label="Terrazzo slot 3">
+            <intent-filter>
+                <action android:name="androidx.glance.wear.action.BIND_WIDGET_PROVIDER" />
+                <action android:name="androidx.wear.tiles.action.BIND_TILE_PROVIDER" />
+            </intent-filter>
+            <meta-data
+                android:name="androidx.glance.wear.widget.provider"
+                android:resource="@xml/wear_slot_widget_provider" />
+        </service>
+
+        <service
+            android:name=".widget.Slot3WidgetService"
+            android:exported="true"
+            android:enabled="false"
+            android:label="Terrazzo slot 4">
+            <intent-filter>
+                <action android:name="androidx.glance.wear.action.BIND_WIDGET_PROVIDER" />
+                <action android:name="androidx.wear.tiles.action.BIND_TILE_PROVIDER" />
+            </intent-filter>
+            <meta-data
+                android:name="androidx.glance.wear.widget.provider"
+                android:resource="@xml/wear_slot_widget_provider" />
+        </service>
+
+        <service
+            android:name=".widget.Slot4WidgetService"
+            android:exported="true"
+            android:enabled="false"
+            android:label="Terrazzo slot 5">
+            <intent-filter>
+                <action android:name="androidx.glance.wear.action.BIND_WIDGET_PROVIDER" />
+                <action android:name="androidx.wear.tiles.action.BIND_TILE_PROVIDER" />
+            </intent-filter>
+            <meta-data
+                android:name="androidx.glance.wear.widget.provider"
+                android:resource="@xml/wear_slot_widget_provider" />
+        </service>
     </application>
 </manifest>

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/WearMainActivity.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/WearMainActivity.kt
@@ -22,6 +22,7 @@ import androidx.wear.compose.material3.TimeText
 import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.terrazzo.wear.data.WearPrefs
 import ee.schimke.terrazzo.wear.sync.WearLeaseController
+import ee.schimke.terrazzo.wear.sync.WearSlotsController
 import ee.schimke.terrazzo.wear.sync.WearSyncRepository
 import ee.schimke.terrazzo.wear.ui.WearDashboardScreen
 import ee.schimke.terrazzo.wear.ui.WearDashboardsScreen
@@ -47,6 +48,7 @@ import kotlinx.coroutines.launch
 class WearMainActivity : ComponentActivity() {
 
     private lateinit var repo: WearSyncRepository
+    private lateinit var slotsController: WearSlotsController
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -55,6 +57,12 @@ class WearMainActivity : ComponentActivity() {
         // Lease tracker — heartbeats while activity is foreground, so
         // phone streams live deltas instead of batching to DataStore.
         lifecycle.addObserver(WearLeaseController(lifecycleScope, repo))
+        // Slot widget plumbing — advertises the wear-widgets capability
+        // when the runtime supports it, then keeps each Slot{N}WidgetService
+        // component enabled-state in lockstep with the phone-side
+        // WearWidgetSlotsStore.
+        slotsController = WearSlotsController(applicationContext, lifecycleScope, repo)
+        slotsController.start()
 
         setContent { WearApp(repo) }
     }
@@ -62,6 +70,7 @@ class WearMainActivity : ComponentActivity() {
     override fun onDestroy() {
         super.onDestroy()
         repo.stop()
+        slotsController.stop()
     }
 }
 

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/WearMainActivity.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/WearMainActivity.kt
@@ -25,21 +25,24 @@ import ee.schimke.terrazzo.wear.sync.WearLeaseController
 import ee.schimke.terrazzo.wear.sync.WearSyncRepository
 import ee.schimke.terrazzo.wear.ui.WearDashboardScreen
 import ee.schimke.terrazzo.wear.ui.WearDashboardsScreen
-import ee.schimke.terrazzo.wear.ui.WearHomeScreen
+import ee.schimke.terrazzo.wear.ui.WearSectionScreen
 import ee.schimke.terrazzo.wear.ui.WearSettingsScreen
+import ee.schimke.terrazzo.wear.ui.WearTopLevelScreen
 import ee.schimke.terrazzo.wear.ui.terrazzoWearColorScheme
 import ee.schimke.terrazzo.wear.ui.wearTypographyFor
 import ee.schimke.terrazzo.wearsync.proto.DashboardData
 import ee.schimke.terrazzo.wearsync.proto.PinnedCardSet
+import ee.schimke.terrazzo.wearsync.proto.PinnedSectionSet
 import ee.schimke.terrazzo.wearsync.proto.WearSettings
 import kotlinx.coroutines.launch
 
 /**
- * Wear companion. Default screen surfaces phone's pinned cards; user can
- * browse to dashboards or visit settings (theme picker). Demo state is
- * driven entirely by the phone — when phone toggles demo mode the data
- * layer publishes demo dashboards and we render the same banner +
- * fixtures here.
+ * Wear companion. Top-level screen surfaces the user's pinned set
+ * (sections + cards interleaved by phone-side ordering); user can
+ * drill into a pinned section, browse the full dashboard library, or
+ * visit settings. Demo state is driven entirely by the phone — when
+ * phone toggles demo mode the data layer publishes demo dashboards
+ * and we render the same banner + fixtures here.
  */
 class WearMainActivity : ComponentActivity() {
 
@@ -62,7 +65,7 @@ class WearMainActivity : ComponentActivity() {
     }
 }
 
-private enum class WearScreen { Home, Dashboards, Dashboard, Settings }
+private enum class WearScreen { TopLevel, Section, Dashboards, Dashboard, Settings }
 
 @Composable
 private fun WearApp(repo: WearSyncRepository) {
@@ -72,11 +75,13 @@ private fun WearApp(repo: WearSyncRepository) {
     val style by prefs.themeStyle.collectAsState(initial = ThemeStyle.TerrazzoHome)
     val settings: WearSettings by repo.settings.collectAsState()
     val pinned: PinnedCardSet by repo.pinned.collectAsState()
+    val sections: PinnedSectionSet by repo.sections.collectAsState()
     val dashboards: List<DashboardData> by repo.dashboards.collectAsState()
     val values by repo.values.collectAsState()
 
-    var screen by rememberSaveable { mutableStateOf(WearScreen.Home) }
+    var screen by rememberSaveable { mutableStateOf(WearScreen.TopLevel) }
     var openedDashboard by rememberSaveable { mutableStateOf<String?>(null) }
+    var openedSectionKey by rememberSaveable { mutableStateOf<String?>(null) }
 
     MaterialTheme(
         colorScheme = terrazzoWearColorScheme(style),
@@ -85,21 +90,43 @@ private fun WearApp(repo: WearSyncRepository) {
         AppScaffold(timeText = { TimeText() }) {
             ScreenScaffold {
                 when (screen) {
-                    WearScreen.Home -> WearHomeScreen(
+                    WearScreen.TopLevel -> WearTopLevelScreen(
                         settings = settings,
                         pinned = pinned,
+                        sections = sections,
                         values = values,
+                        onOpenSection = { section ->
+                            openedSectionKey = section.sectionKey
+                            screen = WearScreen.Section
+                        },
                         onBrowseDashboards = { screen = WearScreen.Dashboards },
                         onOpenSettings = { screen = WearScreen.Settings },
                         modifier = Modifier.fillMaxSize(),
                     )
+                    WearScreen.Section -> {
+                        val key = openedSectionKey
+                        val resolved = sections.sections.firstOrNull { it.sectionKey == key }
+                        if (resolved == null && key != null) {
+                            // Section was unpinned mid-flight; bounce back so the
+                            // user lands somewhere meaningful instead of an empty
+                            // detail screen.
+                            screen = WearScreen.TopLevel
+                        } else {
+                            WearSectionScreen(
+                                section = resolved,
+                                values = values,
+                                onBack = { screen = WearScreen.TopLevel },
+                                modifier = Modifier.fillMaxSize(),
+                            )
+                        }
+                    }
                     WearScreen.Dashboards -> WearDashboardsScreen(
                         dashboards = dashboards,
                         onDashboardPicked = {
                             openedDashboard = it.urlPath
                             screen = WearScreen.Dashboard
                         },
-                        onBack = { screen = WearScreen.Home },
+                        onBack = { screen = WearScreen.TopLevel },
                         modifier = Modifier.fillMaxSize(),
                     )
                     WearScreen.Dashboard -> {
@@ -121,7 +148,7 @@ private fun WearApp(repo: WearSyncRepository) {
                         selected = style,
                         settings = settings,
                         onSelectTheme = { picked -> scope.launch { prefs.setThemeStyle(picked) } },
-                        onBack = { screen = WearScreen.Home },
+                        onBack = { screen = WearScreen.TopLevel },
                         modifier = Modifier.fillMaxSize(),
                     )
                 }

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/sync/WearOfflineStore.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/sync/WearOfflineStore.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import ee.schimke.terrazzo.wearsync.proto.DashboardData
 import ee.schimke.terrazzo.wearsync.proto.LiveValues
 import ee.schimke.terrazzo.wearsync.proto.PinnedCardSet
+import ee.schimke.terrazzo.wearsync.proto.PinnedSectionSet
 import ee.schimke.terrazzo.wearsync.proto.WearSettings
+import ee.schimke.terrazzo.wearsync.proto.WearWidgetSlots
 import ee.schimke.terrazzo.wearsync.proto.decodeProto
 import ee.schimke.terrazzo.wearsync.proto.encodeProto
 import java.io.File
@@ -22,6 +24,8 @@ import java.io.File
  * ```
  *   settings.pb        — WearSettings
  *   pinned.pb          — PinnedCardSet
+ *   sections.pb        — PinnedSectionSet
+ *   slots.pb           — WearWidgetSlots
  *   values.pb          — LiveValues  (last full snapshot or merged stream)
  *   dashboards/<file>  — DashboardData per `urlPath`
  * ```
@@ -47,6 +51,20 @@ class WearOfflineStore(context: Context) {
 
   fun writePinned(value: PinnedCardSet) {
     File(root, "pinned.pb").atomicWriteBytes(encodeProto(value))
+  }
+
+  fun readSections(): PinnedSectionSet? =
+    File(root, "sections.pb").readBytesOrNull()?.let { decodeProto<PinnedSectionSet>(it) }
+
+  fun writeSections(value: PinnedSectionSet) {
+    File(root, "sections.pb").atomicWriteBytes(encodeProto(value))
+  }
+
+  fun readSlots(): WearWidgetSlots? =
+    File(root, "slots.pb").readBytesOrNull()?.let { decodeProto<WearWidgetSlots>(it) }
+
+  fun writeSlots(value: WearWidgetSlots) {
+    File(root, "slots.pb").atomicWriteBytes(encodeProto(value))
   }
 
   fun readValues(): LiveValues? =

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/sync/WearSlotsController.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/sync/WearSlotsController.kt
@@ -1,0 +1,153 @@
+package ee.schimke.terrazzo.wear.sync
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import com.google.android.gms.wearable.CapabilityClient
+import com.google.android.gms.wearable.Wearable
+import ee.schimke.terrazzo.wear.widget.Slot0WidgetService
+import ee.schimke.terrazzo.wear.widget.Slot1WidgetService
+import ee.schimke.terrazzo.wear.widget.Slot2WidgetService
+import ee.schimke.terrazzo.wear.widget.Slot3WidgetService
+import ee.schimke.terrazzo.wear.widget.Slot4WidgetService
+import ee.schimke.terrazzo.wearsync.proto.WearWidgetSlots
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+/**
+ * Watches [WearSyncRepository.slots] and keeps the 5 slot widget
+ * services in sync with the user's mobile-side assignments:
+ *
+ *   - **Empty slot** (`cardKey == ""`) — disable the matching service
+ *     component so the system widget picker hides it.
+ *   - **Assigned slot** — enable the component, but only when the
+ *     runtime is at least [WEAR_WIDGETS_MIN_SDK]. Below that floor
+ *     every slot stays disabled regardless of phone-side assignment;
+ *     the alpha library short-circuits its own bind path on older
+ *     Wear OS versions, and an enabled-but-broken component would
+ *     only confuse the picker.
+ *
+ * Capability advertisement: when the runtime supports widgets, this
+ * controller adds the `terrazzo_wear_widgets` local capability so the
+ * phone's [WearCapabilityProbe] can discover us. Removed when the
+ * controller stops, so the phone gracefully hides the slot UI again.
+ */
+class WearSlotsController(
+    private val context: Context,
+    private val scope: CoroutineScope,
+    private val repo: WearSyncRepository,
+) {
+    private val capabilityClient: CapabilityClient by lazy {
+        Wearable.getCapabilityClient(context.applicationContext)
+    }
+
+    fun start() {
+        if (supportsWearWidgets()) {
+            advertiseCapability()
+        } else {
+            // Older Wear OS — keep all components disabled and don't
+            // advertise the capability so the phone hides the slot UI.
+            disableAll()
+            return
+        }
+        scope.launch {
+            repo.slots.collectLatest { applySlots(it) }
+        }
+    }
+
+    fun stop() {
+        // Fire-and-forget; the Task completes asynchronously and we
+        // only care about clearing the local advertisement on
+        // best-effort basis.
+        runCatching {
+            capabilityClient.removeLocalCapability(CAPABILITY)
+                .addOnFailureListener { Log.w(TAG, "removeLocalCapability failed", it) }
+        }
+    }
+
+    private fun applySlots(slots: WearWidgetSlots) {
+        val pm = context.packageManager
+        for (i in 0 until SLOT_COUNT) {
+            val component = SLOT_COMPONENTS[i]
+            val assigned = slots.slots.firstOrNull { it.slotIndex == i }?.cardKey?.isNotEmpty() == true
+            val target = if (assigned) {
+                PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+            } else {
+                PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+            }
+            val name = ComponentName(context, component)
+            val current = runCatching { pm.getComponentEnabledSetting(name) }.getOrNull()
+            if (current == target) continue
+            runCatching {
+                pm.setComponentEnabledSetting(name, target, PackageManager.DONT_KILL_APP)
+            }.onFailure { Log.w(TAG, "setComponentEnabledSetting failed for $component", it) }
+        }
+    }
+
+    private fun disableAll() {
+        val pm = context.packageManager
+        for (component in SLOT_COMPONENTS) {
+            val name = ComponentName(context, component)
+            runCatching {
+                pm.setComponentEnabledSetting(
+                    name,
+                    PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                    PackageManager.DONT_KILL_APP,
+                )
+            }.onFailure { Log.w(TAG, "disable $component failed", it) }
+        }
+    }
+
+    private fun advertiseCapability() {
+        runCatching {
+            capabilityClient.addLocalCapability(CAPABILITY)
+                .addOnFailureListener { Log.w(TAG, "addLocalCapability failed", it) }
+        }
+    }
+
+    /**
+     * Whether this device's runtime supports Glance Wear widgets.
+     * Mirrors the alpha library's internal `forceIsAtLeast37ForTesting`
+     * test knob — the public companion check is `internal` in alpha09
+     * so we can't call it directly. Bump this constant if the lib
+     * settles on a different floor before stable.
+     */
+    private fun supportsWearWidgets(): Boolean =
+        Build.VERSION.SDK_INT >= WEAR_WIDGETS_MIN_SDK
+
+    companion object {
+        private const val TAG = "WearSlots"
+
+        /**
+         * Capability advertised when the runtime supports Glance Wear
+         * widgets. Mirrored on the phone in
+         * `WearCapabilityProbe.CAPABILITY`.
+         */
+        const val CAPABILITY: String = "terrazzo_wear_widgets"
+
+        /**
+         * Minimum SDK_INT where Glance Wear widgets actually render.
+         * Inferred from the alpha09 lib's `forceIsAtLeast37ForTesting`
+         * static field: production code branches on `>= 37`. Bump if
+         * the lib's gate moves.
+         */
+        const val WEAR_WIDGETS_MIN_SDK: Int = 37
+
+        const val SLOT_COUNT: Int = 5
+
+        /**
+         * Service classes in slot-index order. The list ordering is
+         * load-bearing: [applySlots] indexes by position.
+         */
+        private val SLOT_COMPONENTS: List<Class<*>> = listOf(
+            Slot0WidgetService::class.java,
+            Slot1WidgetService::class.java,
+            Slot2WidgetService::class.java,
+            Slot3WidgetService::class.java,
+            Slot4WidgetService::class.java,
+        )
+    }
+}

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/sync/WearSyncRepository.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/sync/WearSyncRepository.kt
@@ -15,10 +15,12 @@ import ee.schimke.terrazzo.wearsync.proto.DashboardData
 import ee.schimke.terrazzo.wearsync.proto.EntityValue
 import ee.schimke.terrazzo.wearsync.proto.LiveValues
 import ee.schimke.terrazzo.wearsync.proto.PinnedCardSet
+import ee.schimke.terrazzo.wearsync.proto.PinnedSectionSet
 import ee.schimke.terrazzo.wearsync.proto.StreamUpdate
 import ee.schimke.terrazzo.wearsync.proto.WearLease
 import ee.schimke.terrazzo.wearsync.proto.WearSettings
 import ee.schimke.terrazzo.wearsync.proto.WearSyncPaths
+import ee.schimke.terrazzo.wearsync.proto.WearWidgetSlots
 import ee.schimke.terrazzo.wearsync.proto.decodeProto
 import ee.schimke.terrazzo.wearsync.proto.encodeProto
 import kotlinx.coroutines.CoroutineScope
@@ -33,6 +35,10 @@ import kotlinx.coroutines.launch
  *  - [settings]: cross-device flags (demo mode, base url) — sourced from
  *    the `/wear/settings` Proto DataStore entry
  *  - [pinned]: phone's pinned card set
+ *  - [sections]: phone's pinned section set (each becomes a Wear nav
+ *    destination)
+ *  - [slots]: phone's widget-slot assignments (drives which wear-widget
+ *    providers are enabled)
  *  - [dashboards]: one entry per `/wear/dashboard/<urlPath>`
  *  - [values]: latest entity values, merged from the
  *    `/wear/values` DataStore entry (cold reads) and
@@ -72,6 +78,14 @@ class WearSyncRepository(
     private val _pinned: MutableStateFlow<PinnedCardSet> =
         MutableStateFlow(offline.readPinned() ?: PinnedCardSet())
     val pinned: StateFlow<PinnedCardSet> = _pinned.asStateFlow()
+
+    private val _sections: MutableStateFlow<PinnedSectionSet> =
+        MutableStateFlow(offline.readSections() ?: PinnedSectionSet())
+    val sections: StateFlow<PinnedSectionSet> = _sections.asStateFlow()
+
+    private val _slots: MutableStateFlow<WearWidgetSlots> =
+        MutableStateFlow(offline.readSlots() ?: WearWidgetSlots())
+    val slots: StateFlow<WearWidgetSlots> = _slots.asStateFlow()
 
     private val _dashboards: MutableStateFlow<List<DashboardData>> =
         MutableStateFlow(offline.readAllDashboards().sortedBy { it.title })
@@ -158,6 +172,16 @@ class WearSyncRepository(
                 decodeProto<PinnedCardSet>(bytes)?.let {
                     _pinned.value = it
                     offline.writePinned(it)
+                }
+            path == WearSyncPaths.SECTIONS ->
+                decodeProto<PinnedSectionSet>(bytes)?.let {
+                    _sections.value = it
+                    offline.writeSections(it)
+                }
+            path == WearSyncPaths.SLOTS ->
+                decodeProto<WearWidgetSlots>(bytes)?.let {
+                    _slots.value = it
+                    offline.writeSlots(it)
                 }
             path == WearSyncPaths.VALUES ->
                 decodeProto<LiveValues>(bytes)?.let { live ->

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearPreviews.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearPreviews.kt
@@ -14,6 +14,8 @@ import ee.schimke.terrazzo.wearsync.proto.DashboardData
 import ee.schimke.terrazzo.wearsync.proto.EntityValue
 import ee.schimke.terrazzo.wearsync.proto.PinnedCard
 import ee.schimke.terrazzo.wearsync.proto.PinnedCardSet
+import ee.schimke.terrazzo.wearsync.proto.PinnedSection
+import ee.schimke.terrazzo.wearsync.proto.PinnedSectionSet
 import ee.schimke.terrazzo.wearsync.proto.WearSettings
 
 /**
@@ -31,6 +33,8 @@ private val PINNED_FIXTURE = PinnedCardSet(
                 title = "Living Room",
                 primaryEntityId = "sensor.living_room",
             ),
+            cardKey = "k0",
+            orderIndex = 0,
         ),
         PinnedCard(
             baseUrl = "demo://terrazzo",
@@ -39,6 +43,8 @@ private val PINNED_FIXTURE = PinnedCardSet(
                 title = "Kitchen",
                 primaryEntityId = "light.kitchen",
             ),
+            cardKey = "k1",
+            orderIndex = 2,
         ),
         PinnedCard(
             baseUrl = "demo://terrazzo",
@@ -47,6 +53,26 @@ private val PINNED_FIXTURE = PinnedCardSet(
                 title = "Front door",
                 primaryEntityId = "lock.front_door",
             ),
+            cardKey = "k2",
+            orderIndex = 3,
+        ),
+    ),
+)
+
+private val SECTIONS_FIXTURE = PinnedSectionSet(
+    sections = listOf(
+        PinnedSection(
+            baseUrl = "demo://terrazzo",
+            dashboardUrlPath = "",
+            viewPath = "view-0",
+            sectionIndex = 0,
+            title = "Climate",
+            cards = listOf(
+                CardSummary(type = "tile", title = "Living Room", primaryEntityId = "sensor.living_room"),
+                CardSummary(type = "tile", title = "Bedroom", primaryEntityId = "sensor.bedroom"),
+            ),
+            sectionKey = "s0",
+            orderIndex = 1,
         ),
     ),
 )
@@ -80,44 +106,64 @@ private val DASHBOARDS_FIXTURE = listOf(
     ),
 )
 
-@Preview(name = "Wear: home (live)", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
+@Preview(name = "Wear: top-level (live)", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
 @Composable
-fun WearHomePreview_Live() {
+fun WearTopLevelPreview_Live() {
     WearPreviewFrame {
-        WearHomeScreen(
+        WearTopLevelScreen(
             settings = WearSettings(demoMode = false, baseUrl = "https://home.assistant.io"),
             pinned = PINNED_FIXTURE,
+            sections = SECTIONS_FIXTURE,
             values = VALUES_FIXTURE,
+            onOpenSection = {},
             onBrowseDashboards = {},
             onOpenSettings = {},
         )
     }
 }
 
-@Preview(name = "Wear: home (demo)", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
+@Preview(name = "Wear: top-level (demo)", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
 @Composable
-fun WearHomePreview_Demo() {
+fun WearTopLevelPreview_Demo() {
     WearPreviewFrame {
-        WearHomeScreen(
+        WearTopLevelScreen(
             settings = WearSettings(demoMode = true, baseUrl = "demo://terrazzo"),
             pinned = PINNED_FIXTURE,
+            sections = SECTIONS_FIXTURE,
             values = VALUES_FIXTURE,
+            onOpenSection = {},
             onBrowseDashboards = {},
             onOpenSettings = {},
         )
     }
 }
 
-@Preview(name = "Wear: home (empty)", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
+@Preview(name = "Wear: top-level (empty)", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
 @Composable
-fun WearHomePreview_Empty() {
+fun WearTopLevelPreview_Empty() {
     WearPreviewFrame {
-        WearHomeScreen(
+        WearTopLevelScreen(
             settings = WearSettings(demoMode = false),
             pinned = PinnedCardSet(),
+            sections = PinnedSectionSet(),
             values = emptyMap(),
+            onOpenSection = {},
             onBrowseDashboards = {},
             onOpenSettings = {},
+        )
+    }
+}
+
+@Preview(name = "Wear: section", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
+@Composable
+fun WearSectionPreview() {
+    WearPreviewFrame {
+        WearSectionScreen(
+            section = SECTIONS_FIXTURE.sections.first(),
+            values = VALUES_FIXTURE + mapOf(
+                "sensor.bedroom" to EntityValue(state = "19.2", unit = "°C"),
+            ),
+            onBack = {},
         )
     }
 }

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearSectionScreen.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearSectionScreen.kt
@@ -1,0 +1,101 @@
+package ee.schimke.terrazzo.wear.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
+import androidx.wear.compose.foundation.lazy.items
+import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
+import androidx.wear.compose.material3.Button
+import androidx.wear.compose.material3.ButtonDefaults
+import androidx.wear.compose.material3.ListHeader
+import androidx.wear.compose.material3.MaterialTheme
+import androidx.wear.compose.material3.Text
+import ee.schimke.terrazzo.wearsync.proto.EntityValue
+import ee.schimke.terrazzo.wearsync.proto.PinnedSection
+
+/**
+ * Drill-in destination for a pinned section. Shows the section's cards
+ * as captured-at-pin-time on the phone, overlaid with live values from
+ * the wear sync repository's [EntityValue] map.
+ *
+ * If the section was unpinned mid-flight (e.g. the user toggled it off
+ * on the phone), [section] is null and we fall back to the empty state
+ * — the caller is expected to navigate back; rendering still tolerates
+ * the missing data so we don't NPE during the brief gap.
+ */
+@Composable
+fun WearSectionScreen(
+    section: PinnedSection?,
+    values: Map<String, EntityValue>,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val listState = rememberScalingLazyListState()
+    ScalingLazyColumn(
+        state = listState,
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        contentPadding = PaddingValues(horizontal = 14.dp, vertical = 8.dp),
+    ) {
+        item {
+            ListHeader { Text(section?.title?.ifEmpty { "Section" } ?: "Section") }
+        }
+
+        val cards = section?.cards.orEmpty()
+        if (cards.isEmpty()) {
+            item {
+                Text(
+                    text = "No cards in this section.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
+                )
+            }
+        } else {
+            items(cards) { card ->
+                val value = values[card.primaryEntityId]
+                val displayState = value?.let { v ->
+                    buildString {
+                        append(v.state)
+                        if (v.unit.isNotEmpty()) append(" ${v.unit}")
+                    }
+                }.orEmpty()
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 4.dp, vertical = 6.dp),
+                ) {
+                    Text(
+                        text = card.title.ifEmpty { card.primaryEntityId.ifEmpty { card.type } },
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    if (displayState.isNotEmpty()) {
+                        Text(
+                            text = displayState,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.primary,
+                        )
+                    }
+                }
+            }
+        }
+
+        item {
+            Button(
+                onClick = onBack,
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.filledTonalButtonColors(),
+            ) {
+                Text("Back")
+            }
+        }
+    }
+}

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearTopLevelScreen.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearTopLevelScreen.kt
@@ -2,12 +2,14 @@ package ee.schimke.terrazzo.wear.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -23,28 +25,47 @@ import androidx.wear.compose.material3.Text
 import ee.schimke.terrazzo.wearsync.proto.EntityValue
 import ee.schimke.terrazzo.wearsync.proto.PinnedCard
 import ee.schimke.terrazzo.wearsync.proto.PinnedCardSet
+import ee.schimke.terrazzo.wearsync.proto.PinnedSection
+import ee.schimke.terrazzo.wearsync.proto.PinnedSectionSet
 import ee.schimke.terrazzo.wearsync.proto.WearSettings
 
 /**
- * Default Wear screen — the watch surfaces the cards the user has
- * already curated as widgets on the phone. Users tap "Dashboards" to
- * browse the full HA library, or "Settings" for the (now small) theme
- * picker.
+ * Wear's top-level screen. Replaces the legacy "home" surface — there
+ * is no longer a separate landing page; the pinned set IS the landing
+ * page.
  *
- * Demo mode is purely a phone-side concept; we just render what the
- * phone publishes and stick a small "Demo" banner up top when
- * `WearSettings.demoMode` is set.
+ * Renders the user's pinned items (cards + sections) as a single list
+ * ordered by [PinnedCard.orderIndex] / [PinnedSection.orderIndex],
+ * which the mobile pin store keeps in lockstep:
+ *
+ *   - **Pinned sections** show as a tonal button with the section
+ *     title + "N cards"; tap drills into [WearSectionScreen].
+ *   - **Pinned cards** show their title + live entity value inline
+ *     (no drill-in — the user pinned them precisely because they want
+ *     top-level access).
+ *
+ * Cards inside a section can also be pinned independently as
+ * top-level entries; in that case they show twice (once at the top
+ * level, once inside the section). That's the v1 behaviour
+ * deliberately — the user pinned both, we render both.
+ *
+ * "Browse dashboards" and "Settings" stay at the bottom as utility
+ * destinations.
  */
 @Composable
-fun WearHomeScreen(
+fun WearTopLevelScreen(
     settings: WearSettings,
     pinned: PinnedCardSet,
+    sections: PinnedSectionSet,
     values: Map<String, EntityValue>,
+    onOpenSection: (PinnedSection) -> Unit,
     onBrowseDashboards: () -> Unit,
     onOpenSettings: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val listState = rememberScalingLazyListState()
+    val items = remember(pinned, sections) { mergeOrdered(pinned.cards, sections.sections) }
+
     ScalingLazyColumn(
         state = listState,
         modifier = modifier.fillMaxWidth(),
@@ -58,11 +79,19 @@ fun WearHomeScreen(
             item { DemoBanner() }
         }
 
-        if (pinned.cards.isEmpty()) {
+        if (items.isEmpty()) {
             item { EmptyPinned() }
         } else {
-            items(pinned.cards) { card ->
-                PinnedRow(card = card, value = values[card.card.primaryEntityId])
+            items(items, key = { it.key }) { entry ->
+                when (entry) {
+                    is TopLevelEntry.Card ->
+                        PinnedCardRow(card = entry.card, value = values[entry.card.card.primaryEntityId])
+                    is TopLevelEntry.Section ->
+                        PinnedSectionRow(
+                            section = entry.section,
+                            onClick = { onOpenSection(entry.section) },
+                        )
+                }
             }
         }
 
@@ -85,6 +114,40 @@ fun WearHomeScreen(
                 Text("Settings")
             }
         }
+    }
+}
+
+/**
+ * Interleave pinned cards and pinned sections by their shared
+ * `orderIndex`. Tie-break by stable key so renders don't flicker when
+ * two pins share an index.
+ */
+internal fun mergeOrdered(
+    cards: List<PinnedCard>,
+    sections: List<PinnedSection>,
+): List<TopLevelEntry> {
+    val combined = ArrayList<TopLevelEntry>(cards.size + sections.size)
+    cards.forEach { combined += TopLevelEntry.Card(it) }
+    sections.forEach { combined += TopLevelEntry.Section(it) }
+    return combined.sortedWith(
+        compareBy<TopLevelEntry> { it.orderIndex }.thenBy { it.key },
+    )
+}
+
+internal sealed interface TopLevelEntry {
+    val key: String
+    val orderIndex: Int
+
+    data class Card(val card: PinnedCard) : TopLevelEntry {
+        override val key: String
+            get() = "card:${card.cardKey.ifEmpty { card.card.primaryEntityId }}"
+        override val orderIndex: Int get() = card.orderIndex
+    }
+
+    data class Section(val section: PinnedSection) : TopLevelEntry {
+        override val key: String
+            get() = "section:${section.sectionKey.ifEmpty { section.title }}"
+        override val orderIndex: Int get() = section.orderIndex
     }
 }
 
@@ -113,7 +176,7 @@ private fun EmptyPinned() {
         contentAlignment = Alignment.Center,
     ) {
         Text(
-            text = "No pinned cards.\nLong-press a card on the phone to add one.",
+            text = "Nothing pinned yet.\nPin sections or cards from the phone.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -121,7 +184,7 @@ private fun EmptyPinned() {
 }
 
 @Composable
-private fun PinnedRow(card: PinnedCard, value: EntityValue?) {
+private fun PinnedCardRow(card: PinnedCard, value: EntityValue?) {
     val title = card.card.title.ifEmpty { card.card.primaryEntityId.ifEmpty { card.card.type } }
     val displayState = value?.let { v ->
         buildString {
@@ -138,7 +201,7 @@ private fun PinnedRow(card: PinnedCard, value: EntityValue?) {
             modifier = Modifier.fillMaxWidth(),
             contentAlignment = Alignment.CenterStart,
         ) {
-            androidx.compose.foundation.layout.Column {
+            Column {
                 Text(
                     text = title,
                     style = MaterialTheme.typography.titleSmall,
@@ -159,6 +222,30 @@ private fun PinnedRow(card: PinnedCard, value: EntityValue?) {
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun PinnedSectionRow(section: PinnedSection, onClick: () -> Unit) {
+    val title = section.title.ifEmpty { "Section" }
+    val cardCount = section.cards.size
+    Button(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth(),
+        colors = ButtonDefaults.filledTonalButtonColors(),
+    ) {
+        Column {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = "$cardCount card${if (cardCount == 1) "" else "s"}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/widget/SlotWidget.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/widget/SlotWidget.kt
@@ -1,0 +1,123 @@
+@file:Suppress("RestrictedApi", "RestrictedApiAndroidX")
+
+package ee.schimke.terrazzo.wear.widget
+
+import android.content.Context
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.layout.RemoteText
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.glance.wear.GlanceWearWidget
+import androidx.glance.wear.GlanceWearWidgetService
+import androidx.glance.wear.WearWidgetBrush
+import androidx.glance.wear.WearWidgetData
+import androidx.glance.wear.WearWidgetDocument
+import androidx.glance.wear.core.WearWidgetParams
+import ee.schimke.terrazzo.wear.sync.WearOfflineStore
+
+/**
+ * Per-slot wear widget. Five concrete subclasses ([Slot0Widget] …
+ * [Slot4Widget]); each one binds a fixed `slotIndex` and reads the
+ * matching slot from disk at render time.
+ *
+ * Render path:
+ *   1. [WearOfflineStore.readSlots] — find this slot's `cardKey`.
+ *   2. [WearOfflineStore.readPinned] — resolve the pinned card.
+ *   3. [WearOfflineStore.readValues] — pull the primary entity's
+ *      latest value.
+ *   4. Hand the resulting (title, state) pair to the RemoteCompose
+ *      composition wrapped in a [WearWidgetDocument].
+ *
+ * Content is intentionally minimal for v1 — title on top, state
+ * underneath, both as `RemoteText`. Full RemoteCompose card capture
+ * (matching the phone widget pipeline) is a follow-up; the watch
+ * doesn't have `rc-converter` on its classpath today.
+ *
+ * Empty slots / un-paired widgets short-circuit to a placeholder
+ * label; the matching service component is normally disabled via
+ * [ee.schimke.terrazzo.wear.sync.WearSlotsController] before the
+ * picker can surface them, but the fallback keeps a transient race
+ * from showing an empty card.
+ */
+abstract class SlotWidget(private val slotIndex: Int) : GlanceWearWidget() {
+
+    override suspend fun provideWidgetData(
+        context: Context,
+        params: WearWidgetParams,
+    ): WearWidgetData {
+        val store = WearOfflineStore(context.applicationContext)
+        val slot = store.readSlots()?.slots?.firstOrNull { it.slotIndex == slotIndex }
+        val card = slot?.cardKey
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { key -> store.readPinned()?.cards?.firstOrNull { it.cardKey == key } }
+        val value = card?.card?.primaryEntityId
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { entityId -> store.readValues()?.values?.get(entityId) }
+
+        val title = card?.card?.title
+            ?.ifEmpty { card.card.primaryEntityId }
+            .orEmpty()
+            .ifEmpty { "Slot ${slotIndex + 1}" }
+        val stateText = value?.let { v ->
+            buildString {
+                append(v.state)
+                if (v.unit.isNotEmpty()) append(" ${v.unit}")
+            }
+        }.orEmpty()
+
+        return WearWidgetDocument(
+            background = WearWidgetBrush.Companion,
+            content = { SlotContent(title, stateText) },
+        )
+    }
+}
+
+@Composable
+private fun SlotContent(title: String, state: String) {
+    RemoteColumn(modifier = RemoteModifier.fillMaxWidth()) {
+        RemoteText(text = title)
+        if (state.isNotEmpty()) {
+            RemoteText(text = state)
+        }
+    }
+}
+
+class Slot0Widget : SlotWidget(slotIndex = 0)
+
+class Slot1Widget : SlotWidget(slotIndex = 1)
+
+class Slot2Widget : SlotWidget(slotIndex = 2)
+
+class Slot3Widget : SlotWidget(slotIndex = 3)
+
+class Slot4Widget : SlotWidget(slotIndex = 4)
+
+/**
+ * One [GlanceWearWidgetService] per slot. The system binds these via
+ * `androidx.glance.wear.action.BIND_WIDGET_PROVIDER` (or the legacy
+ * `androidx.wear.tiles.action.BIND_TILE_PROVIDER` for tile-compat
+ * surfaces). The `widget` property exposed by
+ * [GlanceWearWidgetService] (synthesised from its Java
+ * `getWidget()` accessor) returns a stable instance per service;
+ * the framework pings it whenever the system needs a fresh frame.
+ */
+class Slot0WidgetService : GlanceWearWidgetService() {
+    override val widget: GlanceWearWidget = Slot0Widget()
+}
+
+class Slot1WidgetService : GlanceWearWidgetService() {
+    override val widget: GlanceWearWidget = Slot1Widget()
+}
+
+class Slot2WidgetService : GlanceWearWidgetService() {
+    override val widget: GlanceWearWidget = Slot2Widget()
+}
+
+class Slot3WidgetService : GlanceWearWidgetService() {
+    override val widget: GlanceWearWidget = Slot3Widget()
+}
+
+class Slot4WidgetService : GlanceWearWidgetService() {
+    override val widget: GlanceWearWidget = Slot4Widget()
+}

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wearsync/proto/WearSyncProto.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wearsync/proto/WearSyncProto.kt
@@ -19,6 +19,8 @@ import kotlinx.serialization.Serializable
  *   - DataClient:
  *     - `/wear/settings`            — [WearSettings]
  *     - `/wear/pinned`              — [PinnedCardSet]
+ *     - `/wear/sections`            — [PinnedSectionSet]
+ *     - `/wear/slots`               — [WearWidgetSlots]
  *     - `/wear/values`              — [LiveValues]
  *     - `/wear/dashboard/<urlPath>` — [DashboardData]
  *   - MessageClient (ephemeral):
@@ -80,7 +82,11 @@ data class EntityDelta(
     val value: EntityValue = EntityValue(),
 )
 
-/** Mirror of phone's WidgetStore — drives wear's home screen. */
+/**
+ * User-curated pinned cards. Top-level destinations on Wear and the
+ * source of truth for [WearWidgetSlots] assignments (slots reference
+ * cards by [PinnedCard.cardKey]).
+ */
 @Serializable
 data class PinnedCardSet(
     val cards: List<PinnedCard> = emptyList(),
@@ -91,6 +97,53 @@ data class PinnedCardSet(
 data class PinnedCard(
     val baseUrl: String = "",
     val card: CardSummary = CardSummary(),
+    /** Stable id chosen at pin time; referenced by [WidgetSlot.cardKey]. */
+    val cardKey: String = "",
+    /** Position in the unified Wear top-level ordering. */
+    val orderIndex: Int = 0,
+)
+
+/** User-pinned dashboard sections, each becomes a Wear nav destination. */
+@Serializable
+data class PinnedSectionSet(
+    val sections: List<PinnedSection> = emptyList(),
+    val updatedAtMs: Long = 0L,
+)
+
+@Serializable
+data class PinnedSection(
+    val baseUrl: String = "",
+    val dashboardUrlPath: String = "",
+    val viewPath: String = "",
+    /** Position-keyed; HA sections have no inherent stable id. */
+    val sectionIndex: Int = 0,
+    val title: String = "",
+    val cards: List<CardSummary> = emptyList(),
+    /** Stable id chosen at pin time. */
+    val sectionKey: String = "",
+    /** Position in the unified Wear top-level ordering. */
+    val orderIndex: Int = 0,
+)
+
+/**
+ * Mobile-assigned widget slot map. Wear declares 5 widget providers
+ * (Slot0 … Slot4); each [WidgetSlot] points its slot at a pinned card
+ * via [PinnedCard.cardKey]. An unassigned slot (`cardKey == ""`)
+ * disables the corresponding provider on the wear side so it doesn't
+ * appear in the system widget picker.
+ */
+@Serializable
+data class WearWidgetSlots(
+    val slots: List<WidgetSlot> = emptyList(),
+    val updatedAtMs: Long = 0L,
+)
+
+@Serializable
+data class WidgetSlot(
+    /** 0..4. */
+    val slotIndex: Int = 0,
+    /** Empty when the slot is unconfigured. References [PinnedCard.cardKey]. */
+    val cardKey: String = "",
 )
 
 /**
@@ -123,10 +176,15 @@ data class SyncStats(
 object WearSyncPaths {
     const val SETTINGS: String = "/wear/settings"
     const val PINNED: String = "/wear/pinned"
+    const val SECTIONS: String = "/wear/sections"
+    const val SLOTS: String = "/wear/slots"
     const val VALUES: String = "/wear/values"
     const val DASHBOARD_PREFIX: String = "/wear/dashboard/"
     const val LEASE_MESSAGE: String = "/wear/lease"
     const val STREAM_MESSAGE: String = "/wear/stream"
+
+    /** Number of wear-widget slots. Mirrors [WearWidgetSlots] capacity. */
+    const val WIDGET_SLOT_COUNT: Int = 5
 
     /** Encode a urlPath (which may be null for HA's default dashboard) into a DataItem path. */
     fun dashboardPath(urlPath: String?): String =

--- a/wear/src/main/proto/wear_sync.proto
+++ b/wear/src/main/proto/wear_sync.proto
@@ -4,7 +4,9 @@
 //
 // Path conventions (mirrored in WearSyncPaths.kt):
 //   /wear/settings              — WearSettings (phone → wear; demo flag, baseUrl)
-//   /wear/pinned                — PinnedCardSet (phone → wear; mobile widget list)
+//   /wear/pinned                — PinnedCardSet (phone → wear; user-pinned cards)
+//   /wear/sections              — PinnedSectionSet (phone → wear; user-pinned sections)
+//   /wear/slots                 — WearWidgetSlots (phone → wear; 5 widget slot assignments)
 //   /wear/values                — LiveValues (phone → wear; current entity values)
 //   /wear/dashboard/<urlPath>   — DashboardData (phone → wear; one entry per dashboard)
 //   /wear/lease   (MessageClient) — WearLease (wear → phone; foreground heartbeat)
@@ -76,9 +78,9 @@ message EntityDelta {
     EntityValue value = 2;
 }
 
-// Pinned-cards mirror of phone's WidgetStore. Wear shows these as the
-// default home screen so the watch surfaces what the user has already
-// curated.
+// Pinned cards curated by the user on mobile. Surfaced as top-level
+// destinations on Wear's nav (alongside pinned sections), and the source
+// of truth for [WearWidgetSlots] assignments.
 message PinnedCardSet {
     repeated PinnedCard cards = 1;
     int64 updated_at_ms = 2;
@@ -87,6 +89,59 @@ message PinnedCardSet {
 message PinnedCard {
     string base_url = 1;
     CardSummary card = 2;
+    // Stable identifier chosen at pin time. Survives re-pin / reorder
+    // and is the value referenced by [WidgetSlot.card_key]. Mobile is
+    // responsible for issuing keys (e.g. UUID or
+    // baseUrl|dashboard|view|index).
+    string card_key = 3;
+    // Position within the unified Wear top-level ordering (sections +
+    // cards interleaved). Lower values render first. Ties broken by
+    // card_key.
+    int32 order_index = 4;
+}
+
+// User-pinned sections from the mobile dashboard view. Each becomes
+// a separate Wear nav destination that lists the section's cards.
+message PinnedSectionSet {
+    repeated PinnedSection sections = 1;
+    int64 updated_at_ms = 2;
+}
+
+message PinnedSection {
+    string base_url = 1;
+    string dashboard_url_path = 2;
+    // HA view path within the dashboard (a dashboard may contain
+    // multiple views; sections live inside one of them).
+    string view_path = 3;
+    // Index of the section within the view's `sections` list. Sections
+    // have no inherent stable id in HA's config so position is the key;
+    // mobile must republish if the user reorders sections in HA.
+    int32 section_index = 4;
+    string title = 5;
+    repeated CardSummary cards = 6;
+    // Stable identifier chosen at pin time (analogous to
+    // [PinnedCard.card_key]). Survives reorder.
+    string section_key = 7;
+    // Position within the unified Wear top-level ordering.
+    int32 order_index = 8;
+}
+
+// 5 wear-widget slots assigned by the user on mobile. Each slot points
+// at a [PinnedCard] by its [PinnedCard.card_key]; an empty card_key
+// means the slot is unconfigured and the corresponding wear-widget
+// provider should be disabled (so the system widget picker hides it).
+message WearWidgetSlots {
+    repeated WidgetSlot slots = 1;
+    int64 updated_at_ms = 2;
+}
+
+message WidgetSlot {
+    // 0..4. Stable per slot — slot index is what the wear-side widget
+    // provider keys off (Slot0WidgetProvider … Slot4WidgetProvider).
+    int32 slot_index = 1;
+    // Empty when the slot is unconfigured. References
+    // [PinnedCard.card_key].
+    string card_key = 2;
 }
 
 // Wear → phone heartbeat (MessageClient at `/wear/lease`). Phone uses

--- a/wear/src/main/res/xml/wear_slot_widget_provider.xml
+++ b/wear/src/main/res/xml/wear_slot_widget_provider.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Glance Wear widget provider descriptor — shared by all 5 slot
+  services. Per-slot identity (which slot index, which pinned card) is
+  resolved at render time from the WearOfflineStore keyed off the
+  service's own component name; the manifest doesn't need 5 distinct
+  XML files.
+
+  Schema is parsed by androidx.glance.wear.core.WearWidgetProviderInfoXmlParser
+  in alpha09; attribute / tag names match its TAG_PROVIDER and ATTR_*
+  constants.
+-->
+<wearwidget-provider
+    label="Terrazzo slot"
+    description="Renders the card assigned to this Wear slot from the phone."
+    preferredType="@integer/glance_wear_container_type_small">
+    <container type="@integer/glance_wear_container_type_small" />
+    <container type="@integer/glance_wear_container_type_large" />
+</wearwidget-provider>


### PR DESCRIPTION
Extends the wear ↔ phone sync schema to support the upcoming Wear app
rework: pinned sections become Wear nav destinations, pinned cards get
a stable key + global ordering, and 5 widget slots map cards to
wear-widget providers.

* Adds PinnedSectionSet at /wear/sections (one entry per pinned section
  with its dashboard/view position, title, and resolved cards).
* Adds WearWidgetSlots at /wear/slots — 5 slots referencing pinned
  cards by stable cardKey; empty key signals an unconfigured slot so
  the watch can disable the matching widget provider.
* Extends PinnedCard with cardKey + orderIndex so cards and sections
  share a single user-controlled top-level ordering on Wear.
* Mirrors the schema across both proto sources (app/wear) and the
  Kotlin serializer copies, which the build keeps duplicated.
* Plumbs receive/persist on the wear side (state flows + offline
  store) and publish helpers on the phone side. Mobile pin store and
  UI land in the next slice.