### PR TITLE
ci: track play publish status in release workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -74,6 +74,7 @@ jobs:
         run: ./gradlew :app:bundleRelease --stacktrace
 
       - name: Publish to Play (internal track)
+        id: play_publish
         if: env.HAS_PLAY_CREDENTIALS == 'true' && env.HAS_SIGNING_KEYSTORE == 'true'
         env:
           ANDROID_PUBLISHER_CREDENTIALS: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
@@ -81,6 +82,24 @@ jobs:
           HARC_KEY_ALIAS: ${{ secrets.HARC_KEY_ALIAS }}
           HARC_KEY_PASSWORD: ${{ secrets.HARC_KEY_PASSWORD }}
         run: ./gradlew :app:publishBundle --stacktrace
+
+      - name: Release publish summary
+        if: always()
+        run: |
+          set -euo pipefail
+          {
+            echo "## Release publish status"
+            echo
+            echo "- Tag: ${TAG_NAME}"
+            echo "- Signing keystore configured: ${HAS_SIGNING_KEYSTORE}"
+            echo "- Play credentials configured: ${HAS_PLAY_CREDENTIALS}"
+            if [[ "${HAS_SIGNING_KEYSTORE}" == "true" && "${HAS_PLAY_CREDENTIALS}" == "true" ]]; then
+              echo "- Play publish step: attempted (internal track)"
+            else
+              echo "- Play publish step: skipped"
+              echo "- Reason: release secrets were not fully configured"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Stage release assets
         id: stage


### PR DESCRIPTION
### Motivation
- Improve visibility into release runs by recording whether Play Store publishing was attempted or skipped and why, to aid troubleshooting of release uploads.

### Description
- Add `id: play_publish` to the Play publish step so the step is explicitly addressable.
- Add a `Release publish summary` step that runs `if: always()` and appends tag and secret-availability status (`HAS_SIGNING_KEYSTORE`, `HAS_PLAY_CREDENTIALS`) to `$GITHUB_STEP_SUMMARY` and records whether publish was attempted or skipped.
- The change only adds summary reporting to `.github/workflows/release-build.yml` and does not alter publish gating logic.

### Testing
- Ran repository checks and diff validation with `git status --short` and `git diff -- .github/workflows/release-build.yml`, which succeeded.
- Changes were committed successfully and a PR was created via the automation tooling.
- The workflow was not executed locally; Play publish behavior and the summary will be validated in the GitHub Actions runtime when the release workflow runs with the appropriate secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff1b49bf8c83249a232c589dd8bace)