### PR TITLE
fix: prevent settings demo toggle text clipping

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -443,13 +443,14 @@ private fun SettingsScreen(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
             ) {
-                Column {
+                Column(modifier = Modifier.weight(1f)) {
                     Text("Demo mode", style = MaterialTheme.typography.titleMedium)
                     Text(
                         "Populate the app with an interesting set of fake widgets that animate.",
                         style = MaterialTheme.typography.bodySmall,
                     )
                 }
+                Spacer(Modifier.width(12.dp))
                 Switch(
                     checked = isDemo,
                     onCheckedChange = onToggleDemo,


### PR DESCRIPTION
### Motivation
- Fix a layout bug where the Demo mode description in Settings could be clipped or overlap the toggle on narrow screens.

### Description
- Constrain the text block in the Demo mode row with `Modifier.weight(1f)` and add `Spacer(Modifier.width(12.dp))` between the text and the `Switch` so the copy wraps and stays clear of the toggle.

### Testing
- Attempted a Kotlin compile with `./gradlew :app:compileDebugKotlin`, which failed in this environment due to a JDK toolchain download error (Foojay returned HTTP 403), so the change could not be verified by a local build here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff3203560c83249a67a7e3175e4816)