### PR TITLE
fix: align launcher widget capture size with host bounds

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/TerrazzoWidgetProvider.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/TerrazzoWidgetProvider.kt
@@ -7,7 +7,6 @@ import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.os.Build
 import android.util.Log
-import android.util.TypedValue
 import android.widget.RemoteViews
 import androidx.annotation.RequiresApi
 import androidx.compose.remote.creation.compose.capture.RemoteCreationDisplayInfo
@@ -89,8 +88,13 @@ class TerrazzoWidgetProvider : AppWidgetProvider() {
         val haTheme = haThemeFor(style, dark)
         val registry = defaultRegistry().withEnhancedShutter()
 
-        val widthPx = dpToPx(context, WIDGET_WIDTH_DP)
-        val heightPx = dpToPx(context, registry.cardHeightDp(entry.card, snapshot))
+        val targetSizeDp = WidgetSizing.forWidgetCapture(
+            appWidgetManager = appWidgetManager,
+            widgetId = widgetId,
+            cardHeightDp = registry.cardHeightDp(entry.card, snapshot),
+        )
+        val widthPx = WidgetSizing.dpToPx(context, targetSizeDp.widthDp)
+        val heightPx = WidgetSizing.dpToPx(context, targetSizeDp.heightDp)
         val densityDpi = context.resources.configuration.densityDpi
 
         val captured = runCatching {
@@ -141,16 +145,8 @@ class TerrazzoWidgetProvider : AppWidgetProvider() {
         ThemePref.TerrazzoKiosk -> ThemeStyle.TerrazzoKiosk
     }
 
-    private fun dpToPx(context: Context, dp: Int): Int =
-        TypedValue.applyDimension(
-            TypedValue.COMPLEX_UNIT_DIP,
-            dp.toFloat(),
-            context.resources.displayMetrics,
-        ).toInt()
-
     private companion object {
         val EMPTY_SNAPSHOT = HaSnapshot()
-        const val WIDGET_WIDTH_DP = 320
         const val TAG = "TerrazzoWidgetProvider"
     }
 }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstallSheet.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstallSheet.kt
@@ -5,6 +5,7 @@ package ee.schimke.terrazzo.widget
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -28,6 +29,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
@@ -89,7 +91,9 @@ fun WidgetInstallSheet(
     var installedCount by remember { mutableIntStateOf(0) }
     LaunchedEffect(Unit) { installedCount = store.count() }
 
-    val heightDp = remember(card, snapshot) { registry.cardHeightDp(card, snapshot) }
+    val previewSize = remember(card, snapshot) {
+        WidgetSizing.forPreview(registry.cardHeightDp(card, snapshot))
+    }
     val capHit = installedCount >= WidgetStore.MAX_WIDGETS
     val pinSupported = remember { installer.isSupported() }
 
@@ -112,13 +116,17 @@ fun WidgetInstallSheet(
             )
 
             Box(
-                modifier = Modifier.fillMaxWidth().height(heightDp.dp),
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.Center,
             ) {
                 CachedCardPreview(
                     cacheKey = WidgetPreviewCacheKey(card, HaTheme.Light, widgetsProfile),
                     profile = widgetsProfile,
                     card = card,
                     snapshot = snapshot,
+                    modifier = Modifier
+                        .width(previewSize.widthDp.dp)
+                        .height(previewSize.heightDp.dp),
                 ) {
                     ProvideCardRegistry(registry) {
                         ProvideHaTheme(HaTheme.Light) {

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetSizing.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetSizing.kt
@@ -1,0 +1,41 @@
+package ee.schimke.terrazzo.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.os.Bundle
+import android.util.TypedValue
+
+internal data class WidgetSizeDp(
+    val widthDp: Int,
+    val heightDp: Int,
+)
+
+internal object WidgetSizing {
+    const val DEFAULT_WIDTH_DP = 180
+    const val DEFAULT_HEIGHT_DP = 48
+
+    fun forPreview(cardHeightDp: Int): WidgetSizeDp =
+        WidgetSizeDp(widthDp = DEFAULT_WIDTH_DP, heightDp = cardHeightDp.coerceAtLeast(DEFAULT_HEIGHT_DP))
+
+    fun forWidgetCapture(
+        appWidgetManager: AppWidgetManager,
+        widgetId: Int,
+        cardHeightDp: Int,
+    ): WidgetSizeDp {
+        val options = appWidgetManager.getAppWidgetOptions(widgetId)
+        val minWidth = options.getDp(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH, DEFAULT_WIDTH_DP)
+        val maxHeight = options.getDp(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT, cardHeightDp)
+        val targetHeight = cardHeightDp.coerceIn(DEFAULT_HEIGHT_DP, maxHeight.coerceAtLeast(DEFAULT_HEIGHT_DP))
+        return WidgetSizeDp(widthDp = minWidth, heightDp = targetHeight)
+    }
+
+    fun dpToPx(context: Context, dp: Int): Int =
+        TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            dp.toFloat(),
+            context.resources.displayMetrics,
+        ).toInt()
+
+    private fun Bundle.getDp(key: String, fallback: Int): Int =
+        getInt(key, fallback).takeIf { it > 0 } ?: fallback
+}


### PR DESCRIPTION
### Motivation
- Fix a mismatch between the install-sheet preview and the actual pinned home-screen widget where the provider used a hard-coded capture width while the preview rendered full-sheet width, producing inaccurate previews and clipped widgets. 
- Centralize launcher-slot sizing logic so both preview and capture follow the same rules and respect per-instance launcher options.

### Description
- Add `WidgetSizing.kt` which provides `WidgetSizing.forPreview`, `WidgetSizing.forWidgetCapture`, `WidgetSizeDp`, and a `dpToPx` helper to centralize default launcher dimensions and conversions.
- Update `TerrazzoWidgetProvider` to size `captureSingleRemoteDocument` from `WidgetSizing.forWidgetCapture` and `WidgetSizing.dpToPx` instead of a hard-coded `WIDGET_WIDTH_DP`, and remove the duplicated `dpToPx` helper.
- Update the install-sheet preview in `WidgetInstallSheet` to render the `CachedCardPreview` centered in a fixed launcher-like slot using `WidgetSizing.forPreview` so the preview more closely matches home-screen placement and dimensions.
- Read launcher-provided bounds via `AppWidgetManager` options (`OPTION_APPWIDGET_MIN_WIDTH` and `OPTION_APPWIDGET_MAX_HEIGHT`) when available to better match host constraints.

### Testing
- Ran a Kotlin compile attempt with `./gradlew :app:compileDebugKotlin --no-daemon`, which failed in this environment due to the Java toolchain download being blocked by foojay (HTTP 403) and so could not complete automated compilation verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff32427ef083249ca96f4a2fdc8a3c)