### PR TITLE
Allow two section columns for Medium window size in landscape

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/ui/WindowSize.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/ui/WindowSize.kt
@@ -69,7 +69,9 @@ private val ExpandedMaxWidth = 840.dp
 @Composable
 @ReadOnlyComposable
 fun rememberLayoutConfig(): LayoutConfig {
-    val widthDp = LocalConfiguration.current.screenWidthDp
+    val configuration = LocalConfiguration.current
+    val widthDp = configuration.screenWidthDp
+    val isLandscape = configuration.screenWidthDp > configuration.screenHeightDp
     return when (WindowSize.fromWidthDp(widthDp)) {
         WindowSize.Compact -> LayoutConfig(
             windowSize = WindowSize.Compact,
@@ -83,11 +85,10 @@ fun rememberLayoutConfig(): LayoutConfig {
             compactCardsPerRow = 3,
             maxContentWidth = Dp.Unspecified,
             horizontalGutter = 16.dp,
-            // Medium is 600..839 dp — splitting 3 sections across that
-            // would give ~260 dp / col which is below the ~320 dp
-            // floor most HA cards read well at. Keep single-column;
-            // section titles still preserve structure.
-            maxSectionColumns = 1,
+            // In phone landscape we intentionally allow two section
+            // columns so responsive dashboards can make use of the
+            // extra width instead of remaining stacked.
+            maxSectionColumns = if (isLandscape) 2 else 1,
         )
         WindowSize.Expanded -> LayoutConfig(
             windowSize = WindowSize.Expanded,


### PR DESCRIPTION
### Motivation
- Phone landscape provides extra horizontal space but Medium width was forcing single-column sections, making responsive dashboards underutilize available width.
- The configuration was read multiple times; centralizing it makes it easier to inspect height/width for orientation-aware decisions.

### Description
- Read `LocalConfiguration.current` into a local `configuration` variable and compute `isLandscape` from `configuration.screenWidthDp > configuration.screenHeightDp`.
- For `WindowSize.Medium` set `maxSectionColumns` to `if (isLandscape) 2 else 1` so phone landscape can display two section columns.
- Preserved existing layout values for `Compact` and `Expanded` modes and kept `ExpandedMaxWidth` behavior unchanged.

### Testing
- Built the app with `./gradlew assembleDebug` and the build completed successfully.
- Ran unit tests with `./gradlew test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff325a891c8324a5cbfd0aca0b587b)