### PR TITLE
Add still-frame video plan, RecordingBitmapLoader probe, preview URL-frame probes, and camera frame support

### DIFF
--- a/docs/followups/images-video-implementation-plan.md
+++ b/docs/followups/images-video-implementation-plan.md
@@ -1,0 +1,181 @@
+# Images + video support plan (RemoteCompose)
+
+## Goals
+
+- Make image-backed cards (`picture`, `picture-entity`, `picture-glance`, `picture-elements`) robust across app runtime, widgets, and previews.
+- Support "video" cards initially as **still-frame streams** (periodic image refresh), then decide if/when to add full video playback overlay UX.
+- Validate all behavior in deterministic previews/tests using fake loaders (no live network dependency).
+
+## Current behavior snapshot (code anchors)
+
+- `RemoteHaImageUrl` serializes URL-only image references and relies on player-side `BitmapLoader.loadBitmap(url)` at playback.
+- `HaEmbeddedPlayer` is the host wrapper that can inject a custom `BitmapLoader`; `RemotePreview` cannot.
+- `CoilBitmapLoader` does synchronous memory-cache lookup and, on miss, enqueues async warm-up then returns empty bytes for that render pass.
+- Preview infrastructure already includes `previewCoilBitmapLoader(...)` backed by `FakeImageLoaderEngine` and explicit memory-cache priming.
+
+## Key open question: when does RemoteCompose re-fetch image URLs?
+
+### Existing code touchpoints
+
+- `rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaImage.kt`
+  - `RemoteHaImageInline`, `RemoteHaImageNamed`, `RemoteHaImageUrl`
+- `rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaEmbeddedPlayer.kt`
+  - player host that accepts a `BitmapLoader`
+- `rc-image-coil/src/main/kotlin/ee/schimke/ha/rc/image/CoilBitmapLoader.kt`
+  - sync memory lookup + async warm-up on miss
+- `previews/src/main/kotlin/ee/schimke/ha/previews/PreviewCoil.kt`
+  - fake-coil helper for deterministic preview loading
+- `previews/src/main/kotlin/ee/schimke/ha/previews/ImagePreviews.kt`
+  - sample preview entrypoints for inline/named/url images
+
+
+### What we know
+
+- We control the loader implementation (`CoilBitmapLoader`), but the player controls `loadBitmap` call timing.
+- On first miss, the loader warms cache asynchronously and returns empty stream; image appears only if the player retries decode later.
+
+### Verification task (must-do first)
+
+1. Add a small instrumentation probe loader (`RecordingBitmapLoader`) that records every `loadBitmap(name)` call and timestamp.
+2. Wire the probe into `HaEmbeddedPlayer` in a preview-only experiment screen.
+3. Exercise scenarios:
+   - Initial render with cold cache.
+   - Cache warm-up completion.
+   - Parent recomposition without document change.
+   - Document regeneration with same URL.
+   - Document regeneration with URL cache-buster (`?t=...`).
+4. Capture observed retry policy:
+   - "No automatic retry" vs "retries on next frame" vs "retries on invalidation only".
+5. Document result in `docs/followups/...` and convert into implementation rules.
+
+## Implementation track A — still-frame "video" (recommended first)
+
+Treat video cards/camera feeds as image URLs refreshed on a fixed cadence.
+
+### A1. Data model + converter
+
+- Extend card model(s) with optional frame-refresh settings:
+  - `frameUrl` (or derived from existing entity/camera endpoint)
+  - `frameIntervalMs` (e.g. 1000–5000 ms)
+  - optional `cacheBustStrategy` (`none`, `queryTimestamp`, `etagVersion`)
+- Add converter support for HA card types that expose camera/video stills.
+
+### A2. Refresh orchestration
+
+- In app host layer (outside RemoteCompose document generation), create a refresh scheduler per visible card:
+  - ticks every `frameIntervalMs`
+  - computes next URL (with cache-bust if needed)
+  - triggers document regeneration or targeted card regeneration
+- Prefer batching refreshes by dashboard/page to avoid N timers.
+
+### A3. Re-fetch strategy based on verification result
+
+- If player retries automatically after cache warm-up: keep stable URL, rely on cache updates.
+- If player does **not** retry automatically:
+  - force invalidation by changing URL token per frame (`?frame=<tick>`), or
+  - force document/card refresh to trigger new decode pass.
+
+### A4. Performance guardrails
+
+- Backoff refresh when app is backgrounded or dashboard tab not visible.
+- Cap minimum interval (e.g. >= 500 ms) and default conservatively (e.g. 2 s).
+- Track decoded bitmap size and memory/cache hit rate.
+
+## Implementation track B — click-to-open video overlay
+
+Add richer playback UX without requiring inline RC video rendering.
+
+### B1. Interaction contract
+
+- In RemoteCompose card: show still frame + play affordance.
+- Tap action emits existing navigation/event action with payload: media URL/entity id.
+
+### B2. Host overlay player
+
+- In app Compose UI (outside RC), show modal/bottom-sheet/fullscreen video player overlay.
+- Reuse dashboard context underneath; dismiss returns user to same scroll position.
+
+### B3. Decision criteria
+
+Use overlay when:
+- stream is high frame-rate or interactive (seek/audio controls), or
+- still-frame polling cost is too high.
+
+Keep still-frame-only mode for:
+- glanceable cameras where low fps is acceptable.
+
+## Preview/testing plan
+
+## 1) Fake loader preview tests (requested)
+
+- Build preview scenarios using `previewCoilBitmapLoader`:
+  - URL resolves from preseeded cache (instant success).
+  - URL initially missing, then added to fake cache after delay (simulate late frame availability).
+  - Rotating URLs for per-frame updates.
+- Add snapshot previews demonstrating frame 0/1/2 progression.
+
+## 2) Unit tests
+
+- `CoilBitmapLoader` behavior:
+  - cache hit returns non-empty stream
+  - miss enqueues warm-up and returns empty
+  - keying respects cache-buster URL differences
+- Scheduler tests:
+  - emits ticks at configured cadence
+  - suspends when hidden/backgrounded
+  - resumes without burst storm
+
+## 3) Integration checks
+
+- Dashboard screen with fake clock + fake loader to confirm visible frame updates.
+- Verify no crashes when offline and URLs unreachable.
+
+## Rollout plan
+
+1. **Phase 1:** probe + verify RemoteCompose re-fetch timing semantics.
+2. **Phase 2:** implement still-frame refresh for one card type (camera/picture proof-of-concept).
+3. **Phase 3:** expand to remaining image/video-like cards.
+4. **Phase 4:** optional click-to-open overlay video player behind feature flag.
+
+## Risks / mitigations
+
+- **Risk:** player never re-decodes same URL after initial miss.
+  - **Mitigation:** URL cache-busting + explicit doc/card invalidation.
+- **Risk:** excessive network + battery from polling.
+  - **Mitigation:** visibility-aware scheduler + interval caps.
+- **Risk:** cache churn/memory pressure.
+  - **Mitigation:** bounded frame sizes, disk-cache leverage, and per-dashboard refresh budgets.
+
+## Definition of done
+
+- Image cards render via wired loader in runtime + previews with deterministic fake-loader tests.
+- Still-frame video mode updates at fixed interval with documented retry/invalidation behavior.
+- User can tap a video-capable card and either:
+  - continue with still-frame mode, or
+  - open overlay player (if Phase 4 enabled).
+- Performance and offline behavior are documented and regression-tested.
+
+
+## Delivery checklist (ordered)
+
+1. Build `RecordingBitmapLoader` experiment and publish findings in this doc.
+2. Implement still-frame refresh POC for one card type behind a feature flag.
+3. Add fake-loader preview coverage for cache-hit, cache-miss, and URL-rotation cases.
+4. Add scheduler unit tests (timing + visibility lifecycle).
+5. Validate dashboard integration (foreground/background/offline).
+6. Decide whether overlay video player is required for v1 based on usability + perf data.
+
+## Decision log template
+
+When the probe results are in, record them in this format:
+
+- Date:
+- Build/branch:
+- Scenario tested:
+- Observed `loadBitmap` call pattern:
+- Outcome category:
+  - [ ] auto-retry
+  - [ ] retry-on-invalidation
+  - [ ] no-retry
+- Chosen strategy:
+- Follow-up implementation tasks:

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/ImagePreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/ImagePreviews.kt
@@ -55,6 +55,9 @@ private const val SAMPLE_BITMAP_PX = 96
 private const val SAMPLE_NAME = "samples/weather-now"
 private const val SAMPLE_URL = "https://example.test/samples/weather-now.png"
 
+private const val SAMPLE_URL_FRAME_0 = "https://example.test/samples/weather-now.png?frame=0"
+private const val SAMPLE_URL_FRAME_1 = "https://example.test/samples/weather-now.png?frame=1"
+
 private fun sampleBitmap(): ImageBitmap {
     val size = SAMPLE_BITMAP_PX.toFloat()
     val bmp = ImageBitmap(SAMPLE_BITMAP_PX, SAMPLE_BITMAP_PX)
@@ -189,6 +192,54 @@ private fun FakeCoilUrlHost(theme: HaTheme) {
                 RemoteHaImageUrl(
                     url = SAMPLE_URL,
                     contentDescription = "url sample".rs,
+                    modifier = RemoteModifier.fillMaxWidth().height(IMAGE_BOX_HEIGHT_DP.rdp),
+                )
+            }
+        }
+    }
+}
+
+
+// ─── URL refresh probe (fixed-frame preview variants) ───────────────
+
+@Preview(
+    name = "image-url probe frame=0",
+    showBackground = false,
+    widthDp = 200,
+    heightDp = IMAGE_BOX_HEIGHT_DP,
+)
+@Composable
+fun ImageUrl_Probe_Frame0() = ProbeUrlHost(theme = HaTheme.Light, url = SAMPLE_URL_FRAME_0)
+
+@Preview(
+    name = "image-url probe frame=1",
+    showBackground = false,
+    widthDp = 200,
+    heightDp = IMAGE_BOX_HEIGHT_DP,
+)
+@Composable
+fun ImageUrl_Probe_Frame1() = ProbeUrlHost(theme = HaTheme.Light, url = SAMPLE_URL_FRAME_1)
+
+@Composable
+private fun ProbeUrlHost(theme: HaTheme, url: String) {
+    val context = LocalContext.current
+    val frame0 = remember { sampleBitmap() }
+    val frame1 = remember { resolvedSampleBitmap() }
+    val bitmapLoader =
+        remember(context, frame0, frame1) {
+            RecordingBitmapLoader(
+                previewCoilBitmapLoader(
+                    context,
+                    mappings = mapOf(SAMPLE_URL_FRAME_0 to frame0, SAMPLE_URL_FRAME_1 to frame1),
+                ),
+            )
+        }
+    Box(modifier = Modifier.uiFillMaxWidth().uiHeight(IMAGE_BOX_HEIGHT_DP.dp)) {
+        HaEmbeddedPlayer(profile = androidXExperimental, bitmapLoader = bitmapLoader) {
+            ProvideHaTheme(theme) {
+                RemoteHaImageUrl(
+                    url = url,
+                    contentDescription = "url probe sample".rs,
                     modifier = RemoteModifier.fillMaxWidth().height(IMAGE_BOX_HEIGHT_DP.rdp),
                 )
             }

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/RecordingBitmapLoader.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/RecordingBitmapLoader.kt
@@ -1,0 +1,33 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.previews
+
+import androidx.compose.remote.player.core.platform.BitmapLoader
+import java.io.InputStream
+
+/**
+ * Small probe loader for image-refresh experiments.
+ *
+ * Wraps a [delegate] [BitmapLoader] and records every `loadBitmap(name)`
+ * call in [events], preserving call order.
+ */
+class RecordingBitmapLoader(
+    private val delegate: BitmapLoader,
+) : BitmapLoader {
+
+    data class Event(
+        val sequence: Int,
+        val name: String,
+        val timestampMs: Long,
+    )
+
+    private val _events = mutableListOf<Event>()
+    val events: List<Event> get() = _events
+
+    override fun loadBitmap(name: String): InputStream {
+        synchronized(_events) {
+            _events += Event(sequence = _events.size + 1, name = name, timestampMs = System.currentTimeMillis())
+        }
+        return delegate.loadBitmap(name)
+    }
+}

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Models.kt
@@ -117,6 +117,8 @@ data class HaPictureEntityData(
     val accent: HaToggleAccent,
     val showName: Boolean = true,
     val showState: Boolean = true,
+    val imageUrl: String? = null,
+    val frameStamp: String? = null,
     val tapAction: HaAction = HaAction.None,
 )
 

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaPictureEntity.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaPictureEntity.kt
@@ -82,12 +82,36 @@ fun RemoteHaPictureEntity(
                     .background(accent.copy(alpha = accent.alpha * 0.10f.rf)),
                 contentAlignment = RemoteAlignment.Center,
             ) {
-                RemoteIcon(
-                    imageVector = data.icon,
-                    contentDescription = data.name.rs,
-                    modifier = RemoteModifier.size(40.rdp),
-                    tint = accent.copy(alpha = accent.alpha * 0.55f.rf),
-                )
+                if (data.imageUrl != null) {
+                    RemoteHaImageUrl(
+                        url = data.imageUrl,
+                        contentDescription = data.name.rs,
+                        modifier = RemoteModifier.fillMaxSize(),
+                    )
+                } else {
+                    RemoteIcon(
+                        imageVector = data.icon,
+                        contentDescription = data.name.rs,
+                        modifier = RemoteModifier.size(40.rdp),
+                        tint = accent.copy(alpha = accent.alpha * 0.55f.rf),
+                    )
+                }
+                if (data.frameStamp != null) {
+                    RemoteBox(
+                        modifier = RemoteModifier
+                            .padding(8.rdp)
+                            .background(theme.cardBackground.rc.copy(alpha = theme.cardBackground.rc.alpha * 0.8f.rf))
+                            .padding(horizontal = 6.rdp, vertical = 2.rdp),
+                    ) {
+                        RemoteText(
+                            text = data.frameStamp.rs,
+                            color = theme.secondaryText.rc,
+                            fontSize = 10.rsp,
+                            style = RemoteTextStyle.Default,
+                            maxLines = 1,
+                        )
+                    }
+                }
             }
             if (showStrip) {
                 val barBg = theme.cardBackground.rc

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/PictureEntityCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/PictureEntityCardConverter.kt
@@ -46,6 +46,8 @@ class PictureEntityCardConverter : CardConverter {
         else defaultTapActionFor(entityId)
 
         val isActive = entity?.toTyped()?.isActive
+        val imageUrl = entity?.attributes?.get("entity_picture")?.jsonPrimitive?.content
+        val frameStamp = entity?.attributes?.get("demo_frame_stamp")?.jsonPrimitive?.content
         RemoteHaPictureEntity(
             HaPictureEntityData(
                 entityId = entityId,
@@ -61,6 +63,8 @@ class PictureEntityCardConverter : CardConverter {
                     ),
                 showName = showName,
                 showState = showState,
+                imageUrl = imageUrl,
+                frameStamp = frameStamp,
                 tapAction = tapAction,
             ),
             modifier = modifier,

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/DemoHaSession.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/DemoHaSession.kt
@@ -236,9 +236,16 @@ object DemoData {
             }
             else -> null
         }
-        return if (newState != null && newState != base.state) {
+        val withState = if (newState != null && newState != base.state) {
             base.copy(state = newState)
         } else base
+        if (!entityId.startsWith("camera.")) return withState
+
+        val frameTick = (nowMs / 10_000L)
+        val attrs = withState.attributes.toMutableMap()
+        attrs["entity_picture"] = JsonPrimitive("https://demo.local/camera/${entityId.substringAfter('.')}.jpg?frame=$frameTick")
+        attrs["demo_frame_stamp"] = JsonPrimitive("frame ${frameTick % 1000}")
+        return withState.copy(attributes = JsonObject(attrs))
     }
 
     private fun formatLikeOriginal(original: String, value: Double): String {


### PR DESCRIPTION
### Motivation

- Define a concrete implementation plan for image-backed cards and still-frame "video" support and capture re-fetch semantics for RemoteCompose. 
- Provide a deterministic preview probe to observe `BitmapLoader.loadBitmap` call timing and enable experiments without live network access. 
- Surface per-entity camera frame URLs and stamps in demo data so previews can exercise frame rotation. 

### Description

- Add a design/implementation doc `docs/followups/images-video-implementation-plan.md` outlining goals, verification tasks, two implementation tracks (still-frame polling and overlay player), scheduler and cache-busting strategies, and a rollout checklist. 
- Add `RecordingBitmapLoader` in `previews` to wrap a `BitmapLoader` and record every `loadBitmap(name)` call with sequence and timestamp for probe experiments. 
- Add fixed-frame preview probes in `previews/ImagePreviews.kt` (`ImageUrl_Probe_Frame0` and `ImageUrl_Probe_Frame1`) which use `RecordingBitmapLoader` + `previewCoilBitmapLoader` to demonstrate URL-frame resolution and record loader calls. 
- Wire optional camera frame support into the component model and UI: add `imageUrl` and `frameStamp` fields to `HaPictureEntityData`, render `RemoteHaImageUrl` and a small `frameStamp` overlay in `RemoteHaPictureEntity`, and populate those attributes from entity data in `PictureEntityCardConverter`. 
- Update demo session (`DemoHaSession`) to emit rotating `entity_picture` URLs and `demo_frame_stamp` for `camera.*` entities to enable live-demo frame rotation in previews. 

### Testing

- Built and exercised UI previews that include the new frame probes to validate loader resolution behavior with the fake coil loader; previews compiled and rendered locally. 
- Ran the project's automated checks with `./gradlew check` to ensure no compile or unit-test regressions; the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff1af000348324b0df6cb36736338a)