### PR TITLE
fix: suppress RestrictedApi lint in WearWidgetParamsProvider

### DIFF
--- a/wear/src/main/kotlin/androidx/glance/wear/tooling/preview/WearWidgetParamsProvider.kt
+++ b/wear/src/main/kotlin/androidx/glance/wear/tooling/preview/WearWidgetParamsProvider.kt
@@ -24,6 +24,7 @@
 
 package androidx.glance.wear.tooling.preview
 
+import android.annotation.SuppressLint
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.glance.wear.core.ContainerInfo
 import androidx.glance.wear.core.WearWidgetParams
@@ -37,6 +38,7 @@ import androidx.glance.wear.core.WidgetInstanceId
  * parameter with `@PreviewParameter(WearWidgetParamsProvider::class)`.
  */
 public class WearWidgetParamsProvider : PreviewParameterProvider<WearWidgetParams> {
+    @SuppressLint("RestrictedApi")
     override val values: Sequence<WearWidgetParams> =
         sequenceOf(
             // Large Widget Preview


### PR DESCRIPTION
### Motivation
- Silence a `RestrictedApi` lint error triggered by the vendored preview helper calling `WearWidgetParams` across library groups so IDE/preview lint does not fail on this known cross-library usage.

### Description
- Add `import android.annotation.SuppressLint` and annotate the `values` property with `@SuppressLint("RestrictedApi")` in `wear/src/main/kotlin/androidx/glance/wear/tooling/preview/WearWidgetParamsProvider.kt` to exempt the intentional usage from the lint rule.

### Testing
- Ran `./gradlew :wear:lintDebug --quiet`, which failed in this environment before lint execution due to inability to resolve the Android Gradle Plugin `com.android.application:9.2.1`, so lint could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff3b84fb588324b5d9e174eeaa6dfc)