### PR TITLE
Bind Home Assistant template expressions in Markdown to live RemoteString values

### DIFF
--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Markdown.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Markdown.kt
@@ -16,6 +16,7 @@ import org.intellij.markdown.parser.MarkdownParser
 data class MarkdownBlock(
     val kind: Kind,
     val text: String,
+    val boundText: androidx.compose.remote.creation.compose.state.RemoteString? = null,
     val level: Int = 0,
 ) {
     enum class Kind { Heading, Paragraph, Bullet, Divider }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaMarkdown.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaMarkdown.kt
@@ -52,6 +52,7 @@ fun RemoteHaMarkdown(data: HaMarkdownData, modifier: RemoteModifier = RemoteModi
                 RemoteBox(modifier = RemoteModifier.padding(top = 4.rdp))
             }
             data.blocks.forEach { block ->
+                val text = block.boundText ?: block.text.rs
                 when (block.kind) {
                     MarkdownBlock.Kind.Heading -> {
                         val size = when (block.level) {
@@ -61,7 +62,7 @@ fun RemoteHaMarkdown(data: HaMarkdownData, modifier: RemoteModifier = RemoteModi
                             else -> 13
                         }
                         RemoteText(
-                            text = block.text.rs,
+                            text = text,
                             color = theme.primaryText.rc,
                             fontSize = size.rsp,
                             fontWeight = FontWeight.SemiBold,
@@ -70,7 +71,7 @@ fun RemoteHaMarkdown(data: HaMarkdownData, modifier: RemoteModifier = RemoteModi
                     }
                     MarkdownBlock.Kind.Bullet -> {
                         RemoteText(
-                            text = "• ${block.text}".rs,
+                            text = "• ".rs + text,
                             color = theme.primaryText.rc,
                             fontSize = 13.rsp,
                             style = RemoteTextStyle.Default,
@@ -87,7 +88,7 @@ fun RemoteHaMarkdown(data: HaMarkdownData, modifier: RemoteModifier = RemoteModi
                     }
                     MarkdownBlock.Kind.Paragraph -> {
                         RemoteText(
-                            text = block.text.rs,
+                            text = text,
                             color = theme.primaryText.rc,
                             fontSize = 13.rsp,
                             style = RemoteTextStyle.Default,

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/MarkdownCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/MarkdownCardConverter.kt
@@ -7,8 +7,12 @@ import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.CardConverter
 import ee.schimke.ha.rc.components.HaMarkdownData
+import ee.schimke.ha.rc.components.LiveValues
 import ee.schimke.ha.rc.components.Markdown
+import ee.schimke.ha.rc.components.MarkdownBlock
 import ee.schimke.ha.rc.components.RemoteHaMarkdown
+import androidx.compose.remote.creation.compose.state.RemoteString
+import androidx.compose.remote.creation.compose.state.rs
 import kotlinx.serialization.json.jsonPrimitive
 
 class MarkdownCardConverter : CardConverter {
@@ -27,7 +31,57 @@ class MarkdownCardConverter : CardConverter {
     override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
         val title = card.raw["title"]?.jsonPrimitive?.content
         val content = card.raw["content"]?.jsonPrimitive?.content ?: ""
-        val blocks = Markdown.parse(content)
+        val template = MarkdownTemplateBindings.from(content, snapshot)
+        val blocks = Markdown.parse(template.rendered).bind(template)
         RemoteHaMarkdown(HaMarkdownData(title = title, blocks = blocks), modifier = modifier)
+    }
+
+    private fun List<MarkdownBlock>.bind(template: MarkdownTemplateBindings): List<MarkdownBlock> =
+        map { block ->
+            block.copy(boundText = template.bind(block.text))
+        }
+
+    private data class MarkdownTemplateBindings(
+        val rendered: String,
+        private val bindings: List<Binding>,
+    ) {
+        data class Binding(val token: String, val entityId: String, val initial: String)
+
+        fun bind(text: String): RemoteString? {
+            val tokenRegex = Regex("__HA_EXPR_\\d+__")
+            if (!tokenRegex.containsMatchIn(text)) return null
+            var expr: RemoteString = "".rs
+            var cursor = 0
+            tokenRegex.findAll(text).forEach { match ->
+                if (match.range.first > cursor) expr += text.substring(cursor, match.range.first)
+                val binding = bindings.firstOrNull { it.token == match.value }
+                expr += if (binding != null) LiveValues.state(binding.entityId, binding.initial) else match.value
+                cursor = match.range.last + 1
+            }
+            if (cursor < text.length) expr += text.substring(cursor)
+            return expr
+        }
+
+        companion object {
+            fun from(content: String, snapshot: HaSnapshot): MarkdownTemplateBindings {
+                if (!content.contains("{{")) return MarkdownTemplateBindings(content, emptyList())
+                val expr = Regex("\\{\\{\\s*([\\s\\S]*?)\\s*}}")
+                val bindings = mutableListOf<Binding>()
+                var index = 0
+                val rendered = expr.replace(content) { match ->
+                    val body = match.groupValues[1]
+                    val entityId = Regex("states\\('([^']+)'\\)").find(body)?.groupValues?.get(1)
+                    if (entityId != null) {
+                        val token = "__HA_EXPR_${index++}__"
+                        val initial = snapshot.states[entityId]?.state ?: "—"
+                        bindings += Binding(token = token, entityId = entityId, initial = initial)
+                        token
+                    } else {
+                        match.value
+                    }
+                }
+                return MarkdownTemplateBindings(rendered, bindings)
+            }
+        }
     }
 }


### PR DESCRIPTION
### Motivation

- Enable Markdown cards to include Home Assistant template expressions that update live by binding parsed entity states into remote-friendly `RemoteString` values.

### Description

- Add an optional `boundText: RemoteString?` to `MarkdownBlock` so blocks can carry either static text or a dynamic `RemoteString` value.  
- Use `boundText` when rendering in `RemoteHaMarkdown` so headings, paragraphs and bullets display the live-bound text when available.  
- Update `MarkdownCardConverter.Render` to preprocess card content with `MarkdownTemplateBindings.from`, parse the rendered markdown, and `bind` parsed blocks to produce `boundText` values.  
- Implement `MarkdownTemplateBindings` to extract `{{ ... }}` expressions, replace them with tokens, capture initial entity state from `HaSnapshot`, and build `RemoteString` instances by composing literal parts with `LiveValues.state` lookups for dynamic entities.

### Testing

- Ran a full project build and test suite with `./gradlew build`, and the build and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff31e738688324924e18a0f991805f)