### PR TITLE
feat: add responsive card previews and adaptive title sizing

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/ResponsiveCardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/ResponsiveCardPreviews.kt
@@ -1,0 +1,58 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.previews
+
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import ee.schimke.ha.rc.RenderChild
+import ee.schimke.ha.rc.components.HaTheme
+
+/**
+ * Responsive tolerance previews using realistic widths a dashboard commonly hits:
+ * narrow phone column, standard mobile width, and tablet pane.
+ */
+
+@Preview(name = "entities responsive narrow", widthDp = 260, heightDp = 180, showBackground = false)
+@Preview(name = "entities responsive standard", widthDp = 381, heightDp = 180, showBackground = false)
+@Preview(name = "entities responsive wide", widthDp = 480, heightDp = 180, showBackground = false)
+@Composable
+fun Entities_Responsive_Light() = CardHost(HaTheme.Light) {
+    RenderChild(
+        card("""{"type":"entities","title":"Living Room and Kitchen Devices with Very Long Heading","entities":["sensor.living_room","light.kitchen","switch.coffee_maker"]}"""),
+        Fixtures.mixed,
+        RemoteModifier.fillMaxWidth(),
+    )
+}
+
+@Preview(name = "glance responsive narrow", widthDp = 260, heightDp = 170, showBackground = false)
+@Preview(name = "glance responsive standard", widthDp = 381, heightDp = 170, showBackground = false)
+@Preview(name = "glance responsive wide", widthDp = 480, heightDp = 170, showBackground = false)
+@Composable
+fun Glance_Responsive_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(
+        card("""{"type":"glance","title":"Overview and Alerting Summary for Main Floor","entities":["sensor.living_room","light.kitchen","lock.front_door"]}"""),
+        Fixtures.mixed,
+        RemoteModifier.fillMaxWidth(),
+    )
+}
+
+@Preview(name = "markdown responsive narrow", widthDp = 260, heightDp = 140, showBackground = false)
+@Preview(name = "markdown responsive standard", widthDp = 381, heightDp = 140, showBackground = false)
+@Composable
+fun Markdown_Responsive_Light() = CardHost(HaTheme.Light) {
+    RenderChild(
+        card("""{"type":"markdown","title":"Notes for This Evening and Tomorrow","content":"Welcome home.\n- Dishwasher running\n- Back door locked"}"""),
+        Fixtures.mixed,
+        RemoteModifier.fillMaxWidth(),
+    )
+}
+
+@Preview(name = "tile responsive narrow", widthDp = 150, heightDp = 48, showBackground = false)
+@Preview(name = "tile responsive standard", widthDp = 187, heightDp = 48, showBackground = false)
+@Preview(name = "tile responsive wide", widthDp = 260, heightDp = 48, showBackground = false)
+@Composable
+fun Tile_Responsive_Dark() = CardHost(HaTheme.Dark) {
+    RenderChild(card("""{"type":"tile","entity":"sensor.living_room"}"""), Fixtures.mixed, RemoteModifier.fillMaxWidth())
+}

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/AdaptiveTitle.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/AdaptiveTitle.kt
@@ -1,0 +1,10 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+internal fun adaptiveTitleSizeSp(title: String, baseSp: Int = 15): Int =
+    when {
+        title.length > 36 -> baseSp - 2
+        title.length > 24 -> baseSp - 1
+        else -> baseSp
+    }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaEntities.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaEntities.kt
@@ -21,6 +21,7 @@ import androidx.compose.remote.creation.compose.state.rsp
 import androidx.compose.remote.creation.compose.text.RemoteTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 
 /**
  * HA `entities` card — stacked list of [RemoteHaEntityRow]s with an
@@ -43,9 +44,11 @@ fun RemoteHaEntities(data: HaEntitiesData, modifier: RemoteModifier = RemoteModi
                 RemoteText(
                     text = data.title.rs,
                     color = theme.primaryText.rc,
-                    fontSize = 15.rsp,
+                    fontSize = adaptiveTitleSizeSp(data.title).rsp,
                     fontWeight = FontWeight.Medium,
                     style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
                 RemoteBox(modifier = RemoteModifier.padding(top = 4.rdp))
             }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaGlance.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaGlance.kt
@@ -26,6 +26,7 @@ import androidx.compose.remote.creation.compose.state.rsp
 import androidx.compose.remote.creation.compose.text.RemoteTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.wear.compose.remote.material3.RemoteIcon
 
 /**
@@ -49,9 +50,11 @@ fun RemoteHaGlance(data: HaGlanceData, modifier: RemoteModifier = RemoteModifier
                 RemoteText(
                     text = data.title.rs,
                     color = theme.primaryText.rc,
-                    fontSize = 15.rsp,
+                    fontSize = adaptiveTitleSizeSp(data.title).rsp,
                     fontWeight = FontWeight.Medium,
                     style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
                 RemoteBox(modifier = RemoteModifier.padding(top = 6.rdp))
             }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaMarkdown.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaMarkdown.kt
@@ -21,6 +21,7 @@ import androidx.compose.remote.creation.compose.state.rsp
 import androidx.compose.remote.creation.compose.text.RemoteTextStyle
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 
 /**
  * HA `markdown` card — renders parsed markdown blocks inside the card
@@ -45,9 +46,11 @@ fun RemoteHaMarkdown(data: HaMarkdownData, modifier: RemoteModifier = RemoteModi
                 RemoteText(
                     text = data.title.rs,
                     color = theme.primaryText.rc,
-                    fontSize = 15.rsp,
+                    fontSize = adaptiveTitleSizeSp(data.title).rsp,
                     fontWeight = FontWeight.Medium,
                     style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
                 RemoteBox(modifier = RemoteModifier.padding(top = 4.rdp))
             }


### PR DESCRIPTION
### Motivation

- Long card titles could overflow or look oversized on narrow dashboards, so titles should adapt and truncate predictably.
- Provide focused preview coverage to exercise realistic narrow/standard/wide widths and verify overflow/truncation behavior.

### Description

- Add `AdaptiveTitle.kt` with `adaptiveTitleSizeSp()` to slightly scale down long titles (defaults to 15sp, drops to 14sp/13sp by length). (`rc-components/src/main/kotlin/ee/schimke/ha/rc/components/AdaptiveTitle.kt`)
- Apply adaptive sizing and single-line truncation with `TextOverflow.Ellipsis` to entities, glance, and markdown card headers. (`rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaEntities.kt`, `RemoteHaGlance.kt`, `RemoteHaMarkdown.kt`)
- Add responsive preview scenarios for `entities`, `glance`, `markdown`, and `tile` across narrow/standard/wide widths to demonstrate title scaling and overflow tolerance. (`previews/src/main/kotlin/ee/schimke/ha/previews/ResponsiveCardPreviews.kt`)

### Testing

- Attempted to compile the `rc-components` and `previews` modules with `./gradlew :rc-components:compileDebugKotlin :previews:compileDebugKotlin`. The build failed due to a JDK toolchain download error (foojay HTTP 403) in this environment, so compilation could not complete.
- No other automated tests were run in this environment; previews were added to exercise behavior in IDE/preview tooling once toolchain/network issues are resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff32ec3e688324bae521f070650092)