### PR TITLE
fix: use named argument for markdown heading level

### DIFF
--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Markdown.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Markdown.kt
@@ -81,7 +81,7 @@ object Markdown {
     private fun heading(node: ASTNode, src: String, level: Int, out: MutableList<MarkdownBlock>) {
         val text = visibleText(node, src)
         if (text.isNotEmpty()) {
-            out += MarkdownBlock(MarkdownBlock.Kind.Heading, text, level)
+            out += MarkdownBlock(MarkdownBlock.Kind.Heading, text, level = level)
         }
     }
 


### PR DESCRIPTION
### Motivation
- Fix a Kotlin constructor argument binding bug in `Markdown.heading` where positional arguments caused an `Int` to be passed into `boundText: RemoteString?`, producing a compile error.

### Description
- Use a named argument when creating `MarkdownBlock` in `heading` (`out += MarkdownBlock(..., level = level)`) so `level` binds to the `level` parameter.

### Testing
- Ran `./gradlew :rc-components:compileDebugKotlin --console=plain`, but the build could not complete in this environment due to an unresolved Android Gradle plugin `com.android.application:9.2.1`, and the change is a single-line fix that addresses the reported compilation error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff6891a6fc8324ae52ce36fdb72062)