### PR TITLE
chore: sweep build warnings

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,6 +77,7 @@ activity-compose = { module = "androidx.activity:activity-compose", version = "1
 # Wear Compose (stub module — full app lands later)
 wear-compose-material3 = { module = "androidx.wear.compose:compose-material3", version = "1.6.1" }
 wear-compose-foundation = { module = "androidx.wear.compose:compose-foundation", version = "1.6.1" }
+wear-tooling-preview = { module = "androidx.wear:wear-tooling-preview", version = "1.0.0" }
 
 # AndroidX Glance Wear — Wear OS widget framework (alpha).
 glance-wear = { module = "androidx.glance.wear:wear", version.ref = "glance-wear" }

--- a/ha-client/build.gradle.kts
+++ b/ha-client/build.gradle.kts
@@ -7,10 +7,11 @@ plugins {
 kotlin {
   jvmToolchain(libs.versions.java.get().toInt())
 
-  androidLibrary {
+  android {
     namespace = "ee.schimke.ha.client"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
     minSdk = libs.versions.android.minSdk.get().toInt()
+    withHostTest {}
   }
   jvm()
 

--- a/ha-model/build.gradle.kts
+++ b/ha-model/build.gradle.kts
@@ -7,10 +7,11 @@ plugins {
 kotlin {
   jvmToolchain(libs.versions.java.get().toInt())
 
-  androidLibrary {
+  android {
     namespace = "ee.schimke.ha.model"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
     minSdk = libs.versions.android.minSdk.get().toInt()
+    withHostTest {}
   }
   jvm()
 

--- a/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/HaState.kt
+++ b/ha-model/src/commonMain/kotlin/ee/schimke/ha/model/HaState.kt
@@ -1,6 +1,6 @@
 package ee.schimke.ha.model
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RestrictedApi")
+@file:Suppress("COMPOSE_APPLIER_CALL_MISMATCH", "RestrictedApi")
 
 package ee.schimke.ha.previews
 

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/Fixtures.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
+import kotlin.time.Instant
 
 private val json = Json { ignoreUnknownKeys = true; isLenient = true }
 
@@ -412,7 +413,7 @@ object Fixtures {
             22.4f, 22.7f, 22.9f, 23.0f, 23.1f, 23.0f, 22.9f, 22.8f,
             22.6f, 22.5f, 22.4f, 22.3f, 22.3f, 22.2f, 22.2f, 22.2f,
         )
-        val baseTime = kotlinx.datetime.Instant.parse("2026-05-05T00:00:00Z")
+        val baseTime = Instant.parse("2026-05-05T00:00:00Z")
         fun series(name: String, samples: List<Float>) =
             samples.mapIndexed { i, v ->
                 ee.schimke.ha.model.HistoryPoint(
@@ -452,7 +453,7 @@ object Fixtures {
                 )),
             ),
         )
-        val baseTime = kotlinx.datetime.Instant.parse("2026-05-05T00:00:00Z")
+        val baseTime = Instant.parse("2026-05-05T00:00:00Z")
         // Mean power consumption per hour — house draws are baseline
         // ~600W, peaks during cooking + evening; solar follows midday.
         val houseMeans = listOf(

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/ImagePreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/ImagePreviews.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RestrictedApi")
+@file:Suppress("COMPOSE_APPLIER_CALL_MISMATCH", "RestrictedApi")
 
 package ee.schimke.ha.previews
 

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/ThemePreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/ThemePreviews.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RestrictedApi")
+@file:Suppress("COMPOSE_APPLIER_CALL_MISMATCH", "RestrictedApi")
 
 package ee.schimke.ha.previews
 

--- a/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaUiHost.kt
+++ b/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaUiHost.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RestrictedApi")
+@file:Suppress("COMPOSE_APPLIER_CALL_MISMATCH", "RestrictedApi")
 
 package ee.schimke.ha.rc.ui
 

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/AreaCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/AreaCardConverter.kt
@@ -10,7 +10,6 @@ import androidx.compose.material.icons.filled.Window
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
@@ -89,7 +88,7 @@ class AreaCardConverter : CardConverter {
                     }
                 HaAreaAction(
                     entityId = id,
-                    icon = icon as ImageVector,
+                    icon = icon,
                     accent = accent,
                     initiallyActive = entity.state == "on" || entity.state == "open",
                     tapAction = HaAction.Toggle(id),

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ClockCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ClockCardConverter.kt
@@ -70,7 +70,7 @@ class ClockCardConverter : CardConverter {
         } else 0
 
         val display = card.raw["display"]?.jsonPrimitive?.content ?: "primary"
-        val secondaryLabel = if (display == "primary" || display == null) {
+        val secondaryLabel = if (display == "primary") {
             clockNow(tz, previewNow).format(DateTimeFormatter.ofPattern("EEE d MMM"))
         } else null
         val size = card.raw["clock_size"]?.jsonPrimitive?.content

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/LogbookCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/LogbookCardConverter.kt
@@ -17,6 +17,7 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
+import kotlin.time.Instant
 
 /**
  * `logbook` card. The dashboard JSON only carries the entity ids — real
@@ -64,7 +65,7 @@ private fun entityIds(card: CardConfig): List<String> {
     }
 }
 
-private fun formatRelative(instant: kotlinx.datetime.Instant?): String {
+private fun formatRelative(instant: Instant?): String {
     if (instant == null) return ""
     return instant.toString().substringBefore('T')
 }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/icons/HaIconMap.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/icons/HaIconMap.kt
@@ -1,6 +1,7 @@
 package ee.schimke.ha.rc.icons
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Help
 import androidx.compose.material.icons.filled.AcUnit
 import androidx.compose.material.icons.filled.Air
 import androidx.compose.material.icons.filled.Alarm
@@ -11,7 +12,6 @@ import androidx.compose.material.icons.filled.Devices
 import androidx.compose.material.icons.filled.DoorFront
 import androidx.compose.material.icons.filled.ElectricBolt
 import androidx.compose.material.icons.filled.EnergySavingsLeaf
-import androidx.compose.material.icons.filled.Help
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Lightbulb
 import androidx.compose.material.icons.filled.Lock
@@ -46,7 +46,7 @@ import kotlinx.serialization.json.jsonPrimitive
  *   1. Explicit `icon:` on the card config
  *   2. Entity's `icon` attribute
  *   3. Domain- or device-class default via [HaEntity] dispatch
- *   4. Fallback [Icons.Filled.Help]
+ *   4. Fallback [Icons.AutoMirrored.Filled.Help]
  */
 object HaIconMap {
 
@@ -54,7 +54,7 @@ object HaIconMap {
         iconOverride?.let { mdi(it)?.let { v -> return v } }
         entity?.attributes?.get("icon")?.jsonPrimitive?.content
             ?.let { mdi(it)?.let { v -> return v } }
-        val typed = entity?.toTyped() ?: return Icons.Filled.Help
+        val typed = entity?.toTyped() ?: return Icons.AutoMirrored.Filled.Help
         if (typed is HaEntity.Other) byDomain(entity.entityId)?.let { return it }
         return typed.defaultIcon()
     }
@@ -99,7 +99,7 @@ object HaIconMap {
         }
         is HaEntity.Person, is HaEntity.DeviceTracker -> Icons.Filled.Mood
         is HaEntity.Weather -> Icons.Filled.Umbrella
-        is HaEntity.Other -> Icons.Filled.Help
+        is HaEntity.Other -> Icons.AutoMirrored.Filled.Help
     }
 
     /** `mdi:thermometer` → `Icons.Filled.Thermostat`, or null when unmapped. */

--- a/terrazzo-core/build.gradle.kts
+++ b/terrazzo-core/build.gradle.kts
@@ -9,12 +9,13 @@ plugins {
 kotlin {
   jvmToolchain(libs.versions.java.get().toInt())
 
-  androidLibrary {
+  android {
     namespace = "ee.schimke.terrazzo.core"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
     // RemoteCompose widget needs API 35+; align with :app so Android
     // sources can reference the same platform APIs.
     minSdk = 35
+    withHostTest {}
   }
 
   sourceSets {

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
 
   implementation(libs.wear.compose.material3)
   implementation(libs.wear.compose.foundation)
+  implementation(libs.wear.tooling.preview)
 
   // AndroidX Glance Wear — runtime widget rendering. Pulls
   // remote-creation-compose, lifecycle-service, etc. transitively.

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearPreviews.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/ui/WearPreviews.kt
@@ -1,13 +1,13 @@
 package ee.schimke.terrazzo.wear.ui
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.wear.compose.material3.AppScaffold
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.TimeSource
 import androidx.wear.compose.material3.TimeText
+import androidx.wear.tooling.preview.devices.WearDevices
 import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.terrazzo.wearsync.proto.CardSummary
 import ee.schimke.terrazzo.wearsync.proto.DashboardData
@@ -106,7 +106,7 @@ private val DASHBOARDS_FIXTURE = listOf(
     ),
 )
 
-@Preview(name = "Wear: top-level (live)", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
+@Preview(name = "Wear: top-level (live)", device = WearDevices.SMALL_ROUND, showSystemUi = true)
 @Composable
 fun WearTopLevelPreview_Live() {
     WearPreviewFrame {
@@ -122,7 +122,7 @@ fun WearTopLevelPreview_Live() {
     }
 }
 
-@Preview(name = "Wear: top-level (demo)", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
+@Preview(name = "Wear: top-level (demo)", device = WearDevices.SMALL_ROUND, showSystemUi = true)
 @Composable
 fun WearTopLevelPreview_Demo() {
     WearPreviewFrame {
@@ -138,7 +138,7 @@ fun WearTopLevelPreview_Demo() {
     }
 }
 
-@Preview(name = "Wear: top-level (empty)", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
+@Preview(name = "Wear: top-level (empty)", device = WearDevices.SMALL_ROUND, showSystemUi = true)
 @Composable
 fun WearTopLevelPreview_Empty() {
     WearPreviewFrame {
@@ -154,7 +154,7 @@ fun WearTopLevelPreview_Empty() {
     }
 }
 
-@Preview(name = "Wear: section", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
+@Preview(name = "Wear: section", device = WearDevices.SMALL_ROUND, showSystemUi = true)
 @Composable
 fun WearSectionPreview() {
     WearPreviewFrame {
@@ -168,7 +168,7 @@ fun WearSectionPreview() {
     }
 }
 
-@Preview(name = "Wear: dashboards", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
+@Preview(name = "Wear: dashboards", device = WearDevices.SMALL_ROUND, showSystemUi = true)
 @Composable
 fun WearDashboardsPreview() {
     WearPreviewFrame {
@@ -180,7 +180,7 @@ fun WearDashboardsPreview() {
     }
 }
 
-@Preview(name = "Wear: dashboard", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
+@Preview(name = "Wear: dashboard", device = WearDevices.SMALL_ROUND, showSystemUi = true)
 @Composable
 fun WearDashboardPreview() {
     WearPreviewFrame {
@@ -202,7 +202,7 @@ fun WearDashboardPreview() {
     }
 }
 
-@Preview(name = "Wear: settings", device = Devices.WEAR_OS_SMALL_ROUND, showSystemUi = true)
+@Preview(name = "Wear: settings", device = WearDevices.SMALL_ROUND, showSystemUi = true)
 @Composable
 fun WearSettingsPreview() {
     WearPreviewFrame {


### PR DESCRIPTION
## Summary
- migrate KMP Android targets off deprecated androidLibrary blocks and enable host tests
- replace deprecated Instant and Wear preview APIs
- remove smaller Kotlin/Compose warnings from converter and preview code

## Test
- ./gradlew lintDebug --rerun-tasks
- ./gradlew lintDebug
- ktfmtCheck via commit hook