### PR TITLE
fix: clamp adaptive player size

### DIFF
--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WrapAdaptiveRemoteDocumentPlayer.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WrapAdaptiveRemoteDocumentPlayer.kt
@@ -88,8 +88,8 @@ fun WrapAdaptiveRemoteDocumentPlayer(
                     addIdActionListener { id, value -> onNamedAction(id.toString(), value) }
                 }
             }
-        val widthDp = with(density) { view.measuredWidth.toDp() }
-        val heightDp = with(density) { view.measuredHeight.toDp() }
+        val widthDp = with(density) { clampWarmupDimension(view.measuredWidth, maxWPx).toDp() }
+        val heightDp = with(density) { clampWarmupDimension(view.measuredHeight, maxHPx).toDp() }
         Box(modifier = Modifier.size(widthDp, heightDp)) {
             AndroidView(factory = { view }, modifier = Modifier.fillMaxSize())
         }


### PR DESCRIPTION
## Summary
- clamp measured RemoteCompose player dimensions before converting them back to Compose Dp
- prevents unbounded-height parents from producing Android's infinity sentinel as a Compose constraint

## Test
- ./gradlew :previews:renderAllPreviews
- ktfmtCheck via commit hook

This targets the crash from LongPressInstallTest where WrapAdaptiveRemoteDocumentPlayer reported height 16777215.