### PR TITLE
fix: sanitize wear preview name

### DIFF
--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/widget/SlotWidgetPreviews.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/widget/SlotWidgetPreviews.kt
@@ -44,7 +44,7 @@ private class PreviewSlotWidget(
 }
 
 /** Assigned slot showing a sensor reading — typical case. */
-@Preview(name = "Slot widget — assigned w/ value")
+@Preview(name = "Slot widget — assigned with value")
 @Composable
 fun SlotWidgetPreview_AssignedWithValue(
     @PreviewParameter(WearWidgetParamsProvider::class) params: WearWidgetParams,


### PR DESCRIPTION
## Summary
- replace the Wear slot widget preview name's slash with plain text
- avoids compose-preview treating the display name as part of a nested output path

## Test
- ./gradlew :wear:renderAllPreviews