### PR TITLE
fix: escape markdown template regex

### DIFF
--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/MarkdownCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/MarkdownCardConverter.kt
@@ -43,7 +43,7 @@ class MarkdownCardConverter : CardConverter {
             block.copy(boundText = template.bind(block.text))
         }
 
-    private data class MarkdownTemplateBindings(
+    internal data class MarkdownTemplateBindings(
         val rendered: String,
         private val bindings: List<Binding>,
     ) {
@@ -71,7 +71,7 @@ class MarkdownCardConverter : CardConverter {
         companion object {
             fun from(content: String, snapshot: HaSnapshot): MarkdownTemplateBindings {
                 if (!content.contains("{{")) return MarkdownTemplateBindings(content, emptyList())
-                val expr = Regex("\\{\\{\\s*([\\s\\S]*?)\\s*}}")
+                val expr = Regex("\\{\\{\\s*(.*?)\\s*\\}\\}", RegexOption.DOT_MATCHES_ALL)
                 val bindings = mutableListOf<Binding>()
                 var index = 0
                 val rendered = expr.replace(content) { match ->

--- a/rc-converter/src/test/kotlin/ee/schimke/ha/rc/MarkdownCardConverterTest.kt
+++ b/rc-converter/src/test/kotlin/ee/schimke/ha/rc/MarkdownCardConverterTest.kt
@@ -1,0 +1,35 @@
+package ee.schimke.ha.rc
+
+import ee.schimke.ha.model.EntityState
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.cards.MarkdownCardConverter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MarkdownCardConverterTest {
+
+    @Test
+    fun markdownTemplateBindingSupportsMultilineExpressions() {
+        val snapshot =
+            HaSnapshot(
+                states =
+                    mapOf(
+                        "sensor.living_room_temperature" to
+                            EntityState("sensor.living_room_temperature", "21.5")
+                    )
+            )
+
+        val template =
+            MarkdownCardConverter.MarkdownTemplateBindings.from(
+                """
+                Temperature:
+                {{
+                  states('sensor.living_room_temperature')
+                }}
+                """.trimIndent(),
+                snapshot,
+            )
+
+        assertEquals("Temperature:\n__HA_EXPR_0__", template.rendered)
+    }
+}


### PR DESCRIPTION
## Summary
- fix Android 16 launch crash from markdown template regex compilation
- escape closing template braces and use DOT_MATCHES_ALL for multiline Home Assistant expressions
- add a regression test for multiline states(...) markdown bindings

## Phone log
Pixel_10a logs showed ee.schimke.harc 0.1.11 crashing on launch with:

```text
java.util.regex.PatternSyntaxException: Syntax error in regexp pattern near index 21
\{\{\s*([\s\S]*?)\s*}}
                     ^
```

## Test
- ./gradlew :rc-converter:testDebugUnitTest
- ./gradlew :app:assembleDebug