### PR TITLE
fix: preserve integer gauge values in state formatting

### DIFF
--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/HaStateFormat.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/HaStateFormat.kt
@@ -27,8 +27,6 @@ fun formatState(entity: EntityState?): String {
             .setScale(2, RoundingMode.HALF_UP)
             .stripTrailingZeros()
             .toPlainString()
-            .trimEnd('0')
-            .trimEnd('.')
             .ifEmpty { "0" }
         return if (unit != null) "$normalized $unit" else normalized
     }

--- a/rc-converter/src/test/kotlin/ee/schimke/ha/rc/HaStateFormatTest.kt
+++ b/rc-converter/src/test/kotlin/ee/schimke/ha/rc/HaStateFormatTest.kt
@@ -47,4 +47,11 @@ class HaStateFormatTest {
 
         assertEquals("551 Mbit/s", formatState(state))
     }
+
+    @Test
+    fun keepsWholeNumberHundredsIntact() {
+        val state = EntityState("sensor.battery", "100")
+
+        assertEquals("100", formatState(state))
+    }
 }


### PR DESCRIPTION
### Motivation
- The battery/gauge label showed `1%` for `100%` because numeric state normalization was over-trimming whole-number values, so integer values like `100` must be preserved.

### Description
- Remove the extra `.trimEnd('0')`/`.trimEnd('.')` after `stripTrailingZeros()` in `formatState` so `BigDecimal(...).stripTrailingZeros().toPlainString()` returns correct whole-number strings, and add the `keepsWholeNumberHundredsIntact()` test to `HaStateFormatTest.kt`.

### Testing
- Added unit test `keepsWholeNumberHundredsIntact` and attempted to run `./gradlew :rc-converter:test --tests ee.schimke.ha.rc.HaStateFormatTest`, but the test run failed in this environment due to Gradle being unable to resolve the `com.android.application:9.2.1` plugin; the test should pass in CI where dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff7ad3b97883249fcbfdfc134a1cd8)