### PR TITLE
Promote first suitable card to section heading and hide it from card list; adjust AGP version

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -384,8 +384,10 @@ private fun LazyListScope.renderView(
             val expanded = !collapsible || expandedSectionIndex == sectionIndex
             item(key = sectionKey) {
                 SectionGroupSurface(haTheme) {
-                    val headingTitle = section.title ?: "Section ${sectionIndex + 1}"
-                    if (collapsible || section.title != null) {
+                    val headingModel = resolveSectionHeading(section, sectionIndex)
+                    val headingTitle = headingModel.title
+                    val showHeading = collapsible || section.title != null
+                    if (showHeading) {
                         PinnableSectionHeading(
                             title = headingTitle,
                             collapsible = collapsible,
@@ -397,7 +399,8 @@ private fun LazyListScope.renderView(
                         )
                     }
                     if (expanded) {
-                        val rows = packAndChunk(section.cards, cfg.compactCardsPerRow) { c ->
+                        val renderedCards = if (showHeading) headingModel.visibleCards else section.cards
+                        val rows = packAndChunk(renderedCards, cfg.compactCardsPerRow) { c ->
                             registry.cardWidthClass(c, snapshot)
                         }
                         rows.forEach { row ->
@@ -436,6 +439,40 @@ private fun LazyListScope.renderView(
         }
     }
 }
+
+private data class SectionHeadingModel(
+    val title: String,
+    val visibleCards: List<CardConfig>,
+)
+
+private val SECTION_HEADER_CARD_TYPES: Set<String> = setOf("button", "tile", "entity")
+
+private fun resolveSectionHeading(section: SectionLayout, sectionIndex: Int): SectionHeadingModel {
+    section.title?.let { return SectionHeadingModel(title = it, visibleCards = section.cards) }
+    val firstCard = section.cards.firstOrNull()
+    if (firstCard != null && firstCard.canActAsSectionHeader()) {
+        return SectionHeadingModel(
+            title = firstCard.headingLikeTitle(),
+            visibleCards = section.cards.drop(1),
+        )
+    }
+    return SectionHeadingModel(
+        title = "Section ${sectionIndex + 1}",
+        visibleCards = section.cards,
+    )
+}
+
+private fun CardConfig.canActAsSectionHeader(): Boolean {
+    if (type !in SECTION_HEADER_CARD_TYPES) return false
+    val entity = raw["entity"]?.jsonPrimitive?.contentOrNull
+    val entities = raw["entities"]?.jsonArray?.isNotEmpty() == true
+    return entity.isNullOrBlank() && !entities && headingLikeTitle().isNotBlank()
+}
+
+private fun CardConfig.headingLikeTitle(): String = raw["title"]?.jsonPrimitive?.contentOrNull
+    ?: raw["heading"]?.jsonPrimitive?.contentOrNull
+    ?: raw["name"]?.jsonPrimitive?.contentOrNull
+    ?: type
 
 /**
  * Heading for a section title. Shared between single-column and wide

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Toolchain
 kotlin = "2.3.21"
-agp = "9.2.1"
+agp = "9.2.0"
 java = "21"
 play-publisher = "4.0.0"
 


### PR DESCRIPTION
### Motivation
- Improve UX by using an untitled section's first suitable card as the visible heading so sections authored without titles remain discoverable and compact.
- Avoid duplicating a card as both the heading and an item inside the section when it can serve as the header.
- Keep build metadata consistent by adjusting the Android Gradle Plugin version in the versions catalog.

### Description
- Add `SectionHeadingModel` and `resolveSectionHeading` to determine a section title and which cards should be visible when the section has no explicit title.
- Introduce helpers on `CardConfig`: `canActAsSectionHeader()` and `headingLikeTitle()` and a set `SECTION_HEADER_CARD_TYPES` to decide which card types can be promoted to headers and how to extract their title.
- Update single-column rendering to use the resolved heading, render the heading when appropriate, and hide the first card from the visible list when it is used as the heading.
- Update `gradle/libs.versions.toml` to set `agp` to `9.2.0`.

### Testing
- Built the app with `./gradlew assembleDebug` and verified the debug APK was produced successfully.
- Ran unit tests with `./gradlew test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff7a5d7fe48324979710467458a541)