### PR TITLE
Configure Gradle Play Publisher and add Play Store listings for Wear module

### DIFF
--- a/docs/wear-play-publishing.md
+++ b/docs/wear-play-publishing.md
@@ -1,0 +1,27 @@
+# Wear Play publishing checklist
+
+This repo is configured to publish the `:wear` app module using Gradle Play Publisher (GPP).
+
+## Local/CI publish commands
+
+- Dry-run style build: `./gradlew :wear:bundleRelease`
+- Upload internal track draft: `./gradlew :wear:publishBundle`
+
+Publishing is gated by `ANDROID_PUBLISHER_CREDENTIALS` (path to service-account JSON).
+
+## Play Console steps (one-time)
+
+1. Publish Wear under the **same package name** as mobile: `ee.schimke.harc` (same signing key lineage).
+2. In **Setup > App access / Content** complete required declarations.
+3. In the same Play app, add/enable the Wear form factor and create an Internal testing release if prompted.
+4. Create a Google Cloud service account and grant Play Console permissions (at least Release manager for this app).
+5. Download the JSON key and set `ANDROID_PUBLISHER_CREDENTIALS=/path/key.json` in CI secrets/runtime.
+6. Add store listing text and graphics under `wear/src/main/play/listings/en-US/...`.
+7. Upload first draft with `:wear:publishBundle`, then review and roll out in Console.
+
+## Ongoing release flow
+
+1. Bump `wear` `versionCode`/`versionName`.
+2. Build/sign release AAB.
+3. Run `:wear:publishBundle`.
+4. Promote from Internal -> Closed/Open/Production in Play Console when ready.

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -3,13 +3,14 @@ plugins {
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.compose.preview)
   alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.play.publisher)
 }
 
 android {
   namespace = "ee.schimke.terrazzo.wear"
   compileSdk = libs.versions.android.compileSdk.get().toInt()
   defaultConfig {
-    applicationId = "ee.schimke.terrazzo.wear"
+    applicationId = "ee.schimke.harc"
     minSdk = 30
     targetSdk = libs.versions.android.targetSdk.get().toInt()
     versionCode = 1
@@ -34,6 +35,15 @@ composePreview {
   variant.set("debug")
   sdkVersion.set(34)
   enabled.set(true)
+}
+
+play {
+  // First Wear rollout uses Play internal testing for watch-only QA.
+  track.set("internal")
+  defaultToAppBundles.set(true)
+  releaseStatus.set(com.github.triplet.gradle.androidpublisher.ReleaseStatus.DRAFT)
+  // Only publish when CI/local env provides a Play service-account json file path.
+  enabled.set(System.getenv("ANDROID_PUBLISHER_CREDENTIALS") != null)
 }
 
 dependencies {

--- a/wear/src/main/play/listings/en-US/full-description.txt
+++ b/wear/src/main/play/listings/en-US/full-description.txt
@@ -1,0 +1,7 @@
+Terrazzo for Wear OS puts your Home Assistant dashboard on your wrist with glanceable cards and configurable wear-widget slots.
+
+- Watch-first dashboard browsing
+- Five configurable widget slots (small/large variants)
+- Syncs pinned cards and live values from the paired phone app
+
+Designed for quick control and status checks on Wear OS devices.

--- a/wear/src/main/play/listings/en-US/graphics/README.md
+++ b/wear/src/main/play/listings/en-US/graphics/README.md
@@ -1,0 +1,11 @@
+# Wear Play Store graphics
+
+Put Wear listing assets in this folder tree; Gradle Play Publisher uploads them on `:wear:publishBundle`.
+
+| Directory | Required? | Notes |
+|---|---|---|
+| `icon/` | yes | Wear hi-res icon, PNG, 512x512. |
+| `feature-graphic/` | yes | PNG/JPEG, 1024x500. |
+| `wear-screenshots/` | yes (>=2) | PNG/JPEG screenshots from Wear emulator/device. |
+
+Recommended naming: `01-home.png`, `02-widget-picker.png`, etc.

--- a/wear/src/main/play/listings/en-US/release-notes.txt
+++ b/wear/src/main/play/listings/en-US/release-notes.txt
@@ -1,0 +1,1 @@
+Initial internal testing track for Wear OS publishing setup.

--- a/wear/src/main/play/listings/en-US/short-description.txt
+++ b/wear/src/main/play/listings/en-US/short-description.txt
@@ -1,0 +1,1 @@
+Home Assistant dashboards and widgets for Wear OS.

--- a/wear/src/main/play/listings/en-US/title.txt
+++ b/wear/src/main/play/listings/en-US/title.txt
@@ -1,0 +1,1 @@
+Terrazzo for Wear OS


### PR DESCRIPTION
### Motivation

- Support publishing the Wear app module to Google Play using Gradle Play Publisher (GPP) and document the flow.
- Ensure the Wear app is published under the same package/signing lineage as the mobile app (`ee.schimke.harc`).
- Provide Play Store listing content and graphics guidance so the module can be uploaded from CI or locally.

### Description

- Added `play` plugin to `wear/build.gradle.kts` and a `play {}` configuration that defaults to the `internal` track, uses AABs, sets draft releases, and gates publishing on the `ANDROID_PUBLISHER_CREDENTIALS` environment variable.
- Changed `applicationId` in `wear` module to `ee.schimke.harc` to match mobile package/signing lineage.
- Added Play Store listing assets under `wear/src/main/play/listings/en-US/` including `title.txt`, `short-description.txt`, `full-description.txt`, `release-notes.txt`, and a `graphics/README.md` describing required assets.
- Added documentation `docs/wear-play-publishing.md` with local/CI commands and one-time Play Console setup and ongoing release flow steps.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff7025990c8324be3420ad7ed170c4)