### PR TITLE
feat: split climate dashboard section at live view

### DIFF
--- a/terrazzo-core/src/androidMain/resources/dashboards/climate/lovelace_config.json
+++ b/terrazzo-core/src/androidMain/resources/dashboards/climate/lovelace_config.json
@@ -86,7 +86,13 @@
               "grid_options": {
                 "columns": "full"
               }
-            },
+            }
+          ]
+        },
+        {
+          "type": "grid",
+          "column_span": 4,
+          "cards": [
             {
               "type": "heading",
               "heading": "📷  Live view",


### PR DESCRIPTION
### Motivation
- Create a clearer visual/content boundary in the climate dashboard so the Live view cameras start a new section. 
- Align the dashboard structure with the requested UX by grouping the weather summary separately from live camera and indoor climate content.

### Description
- Split the single `sections[0].cards` list into two `sections` entries in `terrazzo-core/src/androidMain/resources/dashboards/climate/lovelace_config.json` so the first section contains the "🌤️  Outside right now" summary and the second starts at the "📷  Live view" heading. 
- Both new sections are `type: "grid"` with `column_span: 4`, and the original card ordering and properties are preserved. 

### Testing
- Re-parsed and inspected the JSON with a short `python` script to locate the Live view heading and confirm the split index was correct. 
- Re-parsed the modified file with `python` to ensure the JSON remains valid and the `views`/`sections` structure is intact. 
- Printed and reviewed the updated file with `nl -ba` to verify the new `sections` boundary and that all cards after the Live view heading are kept together.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff88db48b08324bf4779ace1193dcf)