### PR TITLE
test: broaden markdown template parsing coverage

### DIFF
--- a/rc-converter/src/test/kotlin/ee/schimke/ha/rc/MarkdownCardConverterTest.kt
+++ b/rc-converter/src/test/kotlin/ee/schimke/ha/rc/MarkdownCardConverterTest.kt
@@ -8,17 +8,38 @@ import kotlin.test.assertEquals
 
 class MarkdownCardConverterTest {
 
+    private val snapshot =
+        HaSnapshot(
+            states =
+                mapOf(
+                    "sensor.living_room_temperature" to
+                        EntityState("sensor.living_room_temperature", "21.5"),
+                    "sensor.office_humidity" to EntityState("sensor.office_humidity", "44"),
+                )
+        )
+
     @Test
-    fun markdownTemplateBindingSupportsMultilineExpressions() {
-        val snapshot =
-            HaSnapshot(
-                states =
-                    mapOf(
-                        "sensor.living_room_temperature" to
-                            EntityState("sensor.living_room_temperature", "21.5")
-                    )
+    fun markdownWithoutTemplatesIsUnchanged() {
+        val content = "## Notes\nNo templates here."
+
+        val template = MarkdownCardConverter.MarkdownTemplateBindings.from(content, snapshot)
+
+        assertEquals(content, template.rendered)
+    }
+
+    @Test
+    fun markdownTemplateBindingSupportsSingleLineExpressions() {
+        val template =
+            MarkdownCardConverter.MarkdownTemplateBindings.from(
+                "Temperature: {{ states('sensor.living_room_temperature') }}",
+                snapshot,
             )
 
+        assertEquals("Temperature: __HA_EXPR_0__", template.rendered)
+    }
+
+    @Test
+    fun markdownTemplateBindingSupportsMultilineExpressions() {
         val template =
             MarkdownCardConverter.MarkdownTemplateBindings.from(
                 """
@@ -31,5 +52,45 @@ class MarkdownCardConverterTest {
             )
 
         assertEquals("Temperature:\n__HA_EXPR_0__", template.rendered)
+    }
+
+    @Test
+    fun markdownTemplateBindingSupportsMultipleExpressions() {
+        val template =
+            MarkdownCardConverter.MarkdownTemplateBindings.from(
+                "Temp {{ states('sensor.living_room_temperature') }} / Humidity {{ states('sensor.office_humidity') }}",
+                snapshot,
+            )
+
+        assertEquals("Temp __HA_EXPR_0__ / Humidity __HA_EXPR_1__", template.rendered)
+    }
+
+    @Test
+    fun unsupportedTemplateExpressionsRemainLiteral() {
+        val content = "Value: {{ state_attr('sensor.office_humidity', 'friendly_name') }}"
+
+        val template = MarkdownCardConverter.MarkdownTemplateBindings.from(content, snapshot)
+
+        assertEquals(content, template.rendered)
+    }
+
+    @Test
+    fun malformedTemplateExpressionsRemainLiteral() {
+        val content = "Temperature {{ states('sensor.living_room_temperature') "
+
+        val template = MarkdownCardConverter.MarkdownTemplateBindings.from(content, snapshot)
+
+        assertEquals(content, template.rendered)
+    }
+
+    @Test
+    fun templatesCanBeEmbeddedInMarkdownFormatting() {
+        val template =
+            MarkdownCardConverter.MarkdownTemplateBindings.from(
+                "- **Temp**: {{ states('sensor.living_room_temperature') }} °C",
+                snapshot,
+            )
+
+        assertEquals("- **Temp**: __HA_EXPR_0__ °C", template.rendered)
     }
 }


### PR DESCRIPTION
### Motivation
- Increase unit-test coverage for `MarkdownCardConverter` template parsing to reduce regression risk and exercise real-world markdown/template combinations that can crash during card conversion. 
- Cover single-line, multiline, multiple-expression, unsupported, malformed, and embedded-template scenarios to validate tokenization and binding behavior.

### Description
- Add a shared `HaSnapshot` fixture and expand `rc-converter/src/test/kotlin/ee/schimke/ha/rc/MarkdownCardConverterTest.kt` with additional focused tests. 
- Add tests for no-template content, single-line `{{ states(...) }}` bindings, multiline template expressions, and multiple expressions in one card. 
- Add tests that verify unsupported template expressions remain literal, malformed/partially-closed braces do not crash or replace, and templates embedded in markdown formatting are replaced safely with `__HA_EXPR_n__` tokens.

### Testing
- Executed `./gradlew :rc-converter:test --tests ee.schimke.ha.rc.MarkdownCardConverterTest`, which failed in this environment due to Gradle being unable to resolve the Android Gradle plugin (`com.android.application:9.2.0`).
- Unit tests were added under `rc-converter/src/test/kotlin/ee/schimke/ha/rc/MarkdownCardConverterTest.kt` and are expected to pass in CI once the project dependencies/plugins are resolvable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff966d5ae08324aa38dc4335851cb9)