### PR TITLE
fix: align discovery/login surfaces with app theme

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -61,6 +61,8 @@ import ee.schimke.terrazzo.wearsync.WearWidgetsScreen
 import ee.schimke.terrazzo.widget.WidgetInstallSheet
 import ee.schimke.terrazzo.widget.WidgetRefreshScheduler
 import ee.schimke.terrazzo.widget.WidgetsScreen
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import kotlinx.coroutines.launch
 
 /**
@@ -186,16 +188,19 @@ private fun UnauthenticatedScreen(
     onDemoSelected: () -> Unit,
     error: Throwable?,
 ) {
+    val snackbars = remember { SnackbarHostState() }
+    LaunchedEffect(error) {
+        val message = error?.message ?: error?.javaClass?.simpleName
+        if (!message.isNullOrBlank()) {
+            snackbars.showSnackbar("Login failed: $message")
+        }
+    }
+
     DiscoveryScreen(
         onInstancePicked = onInstancePicked,
         onDemoSelected = onDemoSelected,
+        snackbarHost = { SnackbarHost(hostState = snackbars) },
     )
-    error?.let { err ->
-        Column(Modifier.fillMaxSize().padding(24.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text("Login failed", style = MaterialTheme.typography.titleMedium)
-            Text(err.message ?: err::class.simpleName.orEmpty())
-        }
-    }
 }
 
 private enum class AppScreen { Dashboards, Settings, Widgets, Pinned, WearWidgets, SyncDiagnostics }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/discovery/DiscoveryScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/discovery/DiscoveryScreen.kt
@@ -4,11 +4,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -36,32 +38,41 @@ import androidx.compose.ui.unit.dp
 fun DiscoveryScreen(
     onInstancePicked: (baseUrl: String) -> Unit,
     onDemoSelected: () -> Unit = {},
+    snackbarHost: @Composable () -> Unit = {},
 ) {
     var host by rememberSaveable { mutableStateOf(DEMO_HOST) }
 
-    Column(
-        modifier = Modifier.fillMaxSize().safeDrawingPadding().padding(24.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        Text("Connect to Home Assistant", style = MaterialTheme.typography.headlineMedium)
-        Text(
-            "Defaulted to the integration Docker HA on the emulator-loopback " +
-                "address. Edit to point at your own instance if needed.",
-            style = MaterialTheme.typography.bodyMedium,
-        )
-        OutlinedTextField(
-            value = host,
-            onValueChange = { host = it },
-            label = { Text("Base URL") },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = true,
-        )
-        Button(
-            onClick = { onInstancePicked(host.trim().removeSuffix("/")) },
-            enabled = host.isNotBlank(),
-        ) { Text("Connect") }
-        TextButton(onClick = onDemoSelected) {
-            Text("Try demo mode (no login)")
+    Scaffold(snackbarHost = snackbarHost) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .safeDrawingPadding()
+                .imePadding()
+                .padding(innerPadding)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text("Connect to Home Assistant", style = MaterialTheme.typography.headlineMedium)
+            Text(
+                "Defaulted to the integration Docker HA on the emulator-loopback " +
+                    "address. Edit to point at your own instance if needed.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            OutlinedTextField(
+                value = host,
+                onValueChange = { host = it },
+                label = { Text("Base URL") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+            )
+            Button(
+                onClick = { onInstancePicked(host.trim().removeSuffix("/")) },
+                enabled = host.isNotBlank(),
+            ) { Text("Connect") }
+            TextButton(onClick = onDemoSelected) {
+                Text("Try demo mode (no login)")
+            }
         }
     }
 }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/discovery/DiscoveryScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/discovery/DiscoveryScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -46,7 +45,6 @@ fun DiscoveryScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .safeDrawingPadding()
                 .imePadding()
                 .padding(innerPadding)
                 .padding(24.dp),


### PR DESCRIPTION
### Motivation
- The discovery/login screen was hard to read in some themes and did not consistently use Material container styling, and the keyboard could obscure inputs.
- Login errors were rendered as an unthemed full-screen overlay that clashed with the app theme and UX expectations.

### Description
- Wrap `DiscoveryScreen` content in a `Scaffold` and add an injectable `snackbarHost` slot so the screen uses Material container semantics across themes (`app/src/main/kotlin/ee/schimke/terrazzo/discovery/DiscoveryScreen.kt`).
- Add `imePadding()` to the discovery UI so inputs remain visible when the soft keyboard is open (`DiscoveryScreen.kt`).
- Use `MaterialTheme.colorScheme.onSurfaceVariant` for the explanatory body copy to improve readability across light/dark themes (`DiscoveryScreen.kt`).
- Replace the unstyled error overlay in the unauthenticated flow with a themed snackbar driven by a `SnackbarHostState` and `LaunchedEffect` in `UnauthenticatedScreen`, routing the `snackbarHost` into `DiscoveryScreen` (`app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt`).

### Testing
- Attempted to compile with `./gradlew :app:compileDebugKotlin`, which failed in this environment because Gradle could not resolve the `com.android.application` plugin version `9.2.0` from configured repositories (repository resolution issue), so no successful build artifacts were produced.
- No additional automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff9ffd543c832498e8378c21d259c3)