### PR TITLE
build: wire androidchka local integration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,5 @@ kotlin.compiler.execution.strategy=in-process
 
 android.useAndroidX=true
 android.nonTransitiveRClass=true
+
+androidchka.agpVersion=9.2.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,8 +54,7 @@ play-services-wearable = "20.0.1"
 [libraries]
 # RemoteCompose authoring / playback
 remote-creation-compose = { module = "androidx.compose.remote:remote-creation-compose", version.ref = "remote-compose" }
-remote-creation-android = { module = "androidx.compose.remote:remote-creation-android", version.ref = "remote-compose" }
-remote-creation-jvm = { module = "androidx.compose.remote:remote-creation-jvm", version.ref = "remote-compose" }
+remote-creation = { module = "androidx.compose.remote:remote-creation", version.ref = "remote-compose" }
 remote-creation-core = { module = "androidx.compose.remote:remote-creation-core", version.ref = "remote-compose" }
 remote-core = { module = "androidx.compose.remote:remote-core", version.ref = "remote-compose" }
 remote-player-core = { module = "androidx.compose.remote:remote-player-core", version.ref = "remote-compose" }

--- a/previews/build.gradle.kts
+++ b/previews/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
   debugImplementation(libs.compose.ui.tooling)
 
   implementation(libs.remote.creation.compose)
-  implementation(libs.remote.creation.android)
+  implementation(libs.remote.creation)
   implementation(libs.remote.creation.core)
   implementation(libs.remote.player.compose)
   implementation(libs.remote.player.view)

--- a/rc-card-shutter/build.gradle.kts
+++ b/rc-card-shutter/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
   implementation(libs.compose.material.icons.extended)
 
   implementation(libs.remote.creation.compose)
-  implementation(libs.remote.creation.android)
+  implementation(libs.remote.creation)
   implementation(libs.remote.creation.core)
   implementation(libs.remote.core)
   implementation(libs.remote.material3)

--- a/rc-components-ui/build.gradle.kts
+++ b/rc-components-ui/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
   implementation(libs.compose.foundation)
 
   implementation(libs.remote.creation.compose)
-  implementation(libs.remote.creation.android)
+  implementation(libs.remote.creation)
   implementation(libs.remote.creation.core)
   implementation(libs.remote.core)
   implementation(libs.remote.player.core)

--- a/rc-components/build.gradle.kts
+++ b/rc-components/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
   api(libs.materialkolor)
 
   implementation(libs.remote.creation.compose)
-  implementation(libs.remote.creation.android)
+  implementation(libs.remote.creation)
   implementation(libs.remote.creation.core)
   implementation(libs.remote.core)
   implementation(libs.remote.material3)

--- a/rc-converter/build.gradle.kts
+++ b/rc-converter/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
 
   // RemoteCompose authoring + playback
   implementation(libs.remote.creation.compose)
-  implementation(libs.remote.creation.android)
+  implementation(libs.remote.creation)
   implementation(libs.remote.creation.core)
   implementation(libs.remote.core)
   implementation(libs.remote.player.core)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,6 +12,16 @@ pluginManagement {
   }
 }
 
+file("local.properties")
+  .takeIf { it.isFile }
+  ?.inputStream()
+  ?.use { input -> java.util.Properties().apply { load(input) }.getProperty("androidchka.dir") }
+  ?.trim()
+  ?.takeIf { it.isNotEmpty() }
+  ?.let { androidchkaDir ->
+    apply(from = file(androidchkaDir).resolve("apply-androidchka.settings.gradle"))
+  }
+
 dependencyResolutionManagement {
   repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
   repositories {


### PR DESCRIPTION
## Summary
- add an optional local.properties androidchka.dir hook that applies the sibling androidchka settings script
- use the root Remote Compose remote-creation coordinate instead of target-specific creation artifacts
- set the androidchka AGP version to match this project

## Tests
- ./gradlew :app:assembleDebug --no-configuration-cache --no-build-cache
- ./gradlew test -x :integration:test --no-configuration-cache --no-build-cache