### PR TITLE
fix: wire Coil bitmap loader in app card players

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -97,6 +97,7 @@ dependencies {
   implementation(project(":rc-converter"))
   implementation(project(":rc-components"))
   implementation(project(":rc-card-shutter"))
+  implementation(project(":rc-image-coil"))
   implementation(project(":terrazzo-core"))
 
   implementation(platform(libs.compose.bom))
@@ -134,6 +135,7 @@ dependencies {
   implementation(libs.androidx.navigation3.ui)
   implementation(libs.androidx.material3.adaptive.navigation.suite)
   implementation(libs.appauth)
+  implementation(libs.coil.network.okhttp)
 
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.kotlinx.serialization.json)

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -73,6 +73,7 @@ import ee.schimke.ha.rc.components.HaTheme
 import ee.schimke.ha.rc.components.ProvideHaTheme
 import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.ha.rc.components.haThemeFor
+import ee.schimke.ha.rc.image.CoilBitmapLoader
 import ee.schimke.terrazzo.LocalTerrazzoGraph
 import ee.schimke.terrazzo.ui.LayoutConfig
 import ee.schimke.terrazzo.ui.LocalIsDarkTheme
@@ -827,6 +828,8 @@ private fun CardSlot(
     val cacheKey = remember(card, style, dark, captureEpoch) {
         CardSlotCacheKey(card, style, dark, captureEpoch)
     }
+    val context = androidx.compose.ui.platform.LocalContext.current
+    val bitmapLoader = remember(context) { CoilBitmapLoader(context.applicationContext) }
     Box(
         modifier = modifier
             // Stable semantics tag so uiautomator / Compose tests can
@@ -850,6 +853,7 @@ private fun CardSlot(
             profile = androidXExperimentalWrap,
             card = card,
             snapshot = snapshot,
+            bitmapLoader = bitmapLoader,
         ) {
             ProvideCardRegistry(registry) {
                 ProvideHaTheme(haTheme) {

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstallSheet.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstallSheet.kt
@@ -45,6 +45,7 @@ import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.cards.shutter.withEnhancedShutter
 import ee.schimke.ha.rc.components.HaTheme
 import ee.schimke.ha.rc.components.ProvideHaTheme
+import ee.schimke.ha.rc.image.CoilBitmapLoader
 import ee.schimke.ha.rc.widgetsProfile
 import ee.schimke.terrazzo.LocalTerrazzoGraph
 import ee.schimke.terrazzo.core.pin.MobilePinnedCard
@@ -86,6 +87,7 @@ fun WidgetInstallSheet(
     val pinStore = LocalTerrazzoGraph.current.pinStore
     val pinScope = rememberCoroutineScope()
     val registry = remember { defaultRegistry().withEnhancedShutter() }
+    val bitmapLoader = remember(context) { CoilBitmapLoader(context.applicationContext) }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     var installedCount by remember { mutableIntStateOf(0) }
@@ -124,6 +126,7 @@ fun WidgetInstallSheet(
                     profile = widgetsProfile,
                     card = card,
                     snapshot = snapshot,
+                    bitmapLoader = bitmapLoader,
                     modifier = Modifier
                         .width(previewSize.widthDp.dp)
                         .height(previewSize.heightDp.dp),


### PR DESCRIPTION
### Motivation
- Runtime card hosts were using the default `BitmapLoader.UNSUPPORTED`, so URL-backed / named bitmaps were not being resolved at playback and images fell back to placeholders.
- The app needs a concrete `BitmapLoader` (Coil) wired into in-app players so `RemoteHaImageUrl` and named-bitmaps resolve in production hosts.

### Description
- Add the `:rc-image-coil` project and `coil-network-okhttp` dependency to the `app` module (`app/build.gradle.kts`) to enable Coil-backed bitmap resolution at runtime.
- Import and construct a `CoilBitmapLoader` in dashboard card slots and pass it into `CachedCardPreview` (`CardSlot` in `DashboardViewScreen.kt`).
- Construct a `CoilBitmapLoader` in the widget install sheet preview and pass it into `CachedCardPreview` (`WidgetInstallSheet.kt`).
- Keep the loader creation local to the composables via `remember(...)` and use `context.applicationContext` when instantiating `CoilBitmapLoader`.

### Testing
- Ran `./gradlew :app:compileDebugKotlin -q`, which failed in this environment because Gradle could not resolve the `com.android.application` plugin `9.2.0` from configured repositories, so a full compile in CI/locally is required to verify build success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff9f7aa1048324a316047ead94f2ec)