### PR TITLE
Show login errors as snackbars, scaffold Discovery screen, and add themed previews

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -61,6 +61,8 @@ import ee.schimke.terrazzo.wearsync.WearWidgetsScreen
 import ee.schimke.terrazzo.widget.WidgetInstallSheet
 import ee.schimke.terrazzo.widget.WidgetRefreshScheduler
 import ee.schimke.terrazzo.widget.WidgetsScreen
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import kotlinx.coroutines.launch
 
 /**
@@ -186,16 +188,19 @@ private fun UnauthenticatedScreen(
     onDemoSelected: () -> Unit,
     error: Throwable?,
 ) {
+    val snackbars = remember { SnackbarHostState() }
+    LaunchedEffect(error) {
+        val message = error?.message ?: error?.javaClass?.simpleName
+        if (!message.isNullOrBlank()) {
+            snackbars.showSnackbar("Login failed: $message")
+        }
+    }
+
     DiscoveryScreen(
         onInstancePicked = onInstancePicked,
         onDemoSelected = onDemoSelected,
+        snackbarHost = { SnackbarHost(hostState = snackbars) },
     )
-    error?.let { err ->
-        Column(Modifier.fillMaxSize().padding(24.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text("Login failed", style = MaterialTheme.typography.titleMedium)
-            Text(err.message ?: err::class.simpleName.orEmpty())
-        }
-    }
 }
 
 private enum class AppScreen { Dashboards, Settings, Widgets, Pinned, WearWidgets, SyncDiagnostics }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/discovery/DiscoveryScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/discovery/DiscoveryScreen.kt
@@ -4,11 +4,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -36,32 +37,40 @@ import androidx.compose.ui.unit.dp
 fun DiscoveryScreen(
     onInstancePicked: (baseUrl: String) -> Unit,
     onDemoSelected: () -> Unit = {},
+    snackbarHost: @Composable () -> Unit = {},
 ) {
     var host by rememberSaveable { mutableStateOf(DEMO_HOST) }
 
-    Column(
-        modifier = Modifier.fillMaxSize().safeDrawingPadding().padding(24.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-    ) {
-        Text("Connect to Home Assistant", style = MaterialTheme.typography.headlineMedium)
-        Text(
-            "Defaulted to the integration Docker HA on the emulator-loopback " +
-                "address. Edit to point at your own instance if needed.",
-            style = MaterialTheme.typography.bodyMedium,
-        )
-        OutlinedTextField(
-            value = host,
-            onValueChange = { host = it },
-            label = { Text("Base URL") },
-            modifier = Modifier.fillMaxWidth(),
-            singleLine = true,
-        )
-        Button(
-            onClick = { onInstancePicked(host.trim().removeSuffix("/")) },
-            enabled = host.isNotBlank(),
-        ) { Text("Connect") }
-        TextButton(onClick = onDemoSelected) {
-            Text("Try demo mode (no login)")
+    Scaffold(snackbarHost = snackbarHost) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .imePadding()
+                .padding(innerPadding)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text("Connect to Home Assistant", style = MaterialTheme.typography.headlineMedium)
+            Text(
+                "Defaulted to the integration Docker HA on the emulator-loopback " +
+                    "address. Edit to point at your own instance if needed.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            OutlinedTextField(
+                value = host,
+                onValueChange = { host = it },
+                label = { Text("Base URL") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+            )
+            Button(
+                onClick = { onInstancePicked(host.trim().removeSuffix("/")) },
+                enabled = host.isNotBlank(),
+            ) { Text("Connect") }
+            TextButton(onClick = onDemoSelected) {
+                Text("Try demo mode (no login)")
+            }
         }
     }
 }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
@@ -132,15 +132,48 @@ fun Screen_Discovery() = PhoneHost {
     DiscoveryScreen(onInstancePicked = {}, onDemoSelected = {})
 }
 
+@Preview(name = "discovery · theme", showBackground = false, widthDp = PHONE_WIDTH_DP, heightDp = PHONE_HEIGHT_DP)
+@Composable
+fun Screen_Discovery_ThemeStyle(
+    @PreviewParameter(ThemeStyleProvider::class) style: ThemeStyle,
+) = PhoneHost(style = style) {
+    DiscoveryScreen(onInstancePicked = {}, onDemoSelected = {})
+}
+
 @Preview(name = "widgets", showBackground = false, widthDp = PHONE_WIDTH_DP, heightDp = PHONE_HEIGHT_DP)
 @Composable
 fun Screen_Widgets() = PhoneHost {
     WidgetsScreen(onBack = {})
 }
 
+@Preview(name = "widgets · theme", showBackground = false, widthDp = PHONE_WIDTH_DP, heightDp = PHONE_HEIGHT_DP)
+@Composable
+fun Screen_Widgets_ThemeStyle(
+    @PreviewParameter(ThemeStyleProvider::class) style: ThemeStyle,
+) = PhoneHost(style = style) {
+    WidgetsScreen(onBack = {})
+}
+
 @Preview(name = "dashboard picker", showBackground = false, widthDp = PHONE_WIDTH_DP, heightDp = PHONE_HEIGHT_DP)
 @Composable
 fun Screen_DashboardPicker() = PhoneHost {
+    DashboardPickerScreen(
+        state = DashboardListState.Ready(
+            dashboards = listOf(
+                DashboardSummary(urlPath = null, title = "Home"),
+                DashboardSummary(urlPath = "lovelace-mobile", title = "Living room"),
+                DashboardSummary(urlPath = "lovelace-garage", title = "Garage"),
+            ),
+        ),
+        onDashboardPicked = {},
+    )
+}
+
+@Preview(name = "dashboard picker · theme", showBackground = false, widthDp = PHONE_WIDTH_DP, heightDp = PHONE_HEIGHT_DP)
+@Composable
+fun Screen_DashboardPicker_ThemeStyle(
+    @PreviewParameter(ThemeStyleProvider::class) style: ThemeStyle,
+) = PhoneHost(style = style) {
     DashboardPickerScreen(
         state = DashboardListState.Ready(
             dashboards = listOf(


### PR DESCRIPTION
### Motivation
- Surface login/discovery errors as transient snackbars instead of a persistent inline error block to improve UX.
- Make the Discovery screen keyboard-safe and able to host snackbars by wrapping it in a `Scaffold`.
- Add theme-parameterised previews so UI palettes can be validated per theme in PR screenshots.

### Description
- Added a `SnackbarHostState` and `SnackbarHost` to `UnauthenticatedScreen` and show login failures from `error` via `LaunchedEffect` using `snackbars.showSnackbar`.
- Extended `DiscoveryScreen` with a `snackbarHost: @Composable () -> Unit` parameter and wrapped its UI in `Scaffold(snackbarHost = ...)`, added `imePadding()` and used the `innerPadding` to handle insets, and updated the explanatory text color to `MaterialTheme.colorScheme.onSurfaceVariant`.
- Removed the previous inline error column from `UnauthenticatedScreen` and wired the snackbar into the discovery flow.
- Added preview variants parameterised by `ThemeStyle` for discovery, widgets, and dashboard picker (`Screen_Discovery_ThemeStyle`, `Screen_Widgets_ThemeStyle`, `Screen_DashboardPicker_ThemeStyle`).

### Testing
- Built the app with `./gradlew assembleDebug`, which completed successfully.
- Ran unit tests with `./gradlew testDebugUnitTest`, which passed.
- Ran static checks with `./gradlew lint`, which completed without new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff9ffd543c832498e8378c21d259c3)