### PR TITLE
fix: centralize Play Publisher plugin classpath

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
   alias(libs.plugins.kotlin.jvm) apply false
   alias(libs.plugins.kotlin.serialization) apply false
   alias(libs.plugins.compose.compiler) apply false
+  alias(libs.plugins.play.publisher) apply false
   alias(libs.plugins.tapmoc) apply false
   alias(libs.plugins.ktfmt) apply false
 }


### PR DESCRIPTION
## Summary
- declare the Gradle Play Publisher plugin once at the root with apply false
- keep app and wear publishing modules resolving the plugin from the same classpath to avoid the Params_Decorated cast failure

## Verification
- reproduced the failure with ANDROID_PUBLISHER_CREDENTIALS set and ./gradlew :app:publishBundle --stacktrace --no-configuration-cache
- after the fix, the build progressed past project configuration into release tasks; stopped the long fake-credential publish run to create this PR