### PR TITLE
fix: detect landscape via configuration orientation for section columns

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
@@ -55,6 +55,8 @@ import ee.schimke.terrazzo.widget.WidgetsScreen
  */
 private const val PHONE_WIDTH_DP = 412
 private const val PHONE_HEIGHT_DP = 892
+private const val PHONE_LANDSCAPE_MEDIUM_WIDTH_DP = 732
+private const val PHONE_LANDSCAPE_MEDIUM_HEIGHT_DP = 412
 
 // Play-Store device specs. dpi is tuned per-device so the rendered PNG
 // stays under 1800 px in either dimension while preserving the real
@@ -189,6 +191,21 @@ fun Screen_DashboardPicker_ThemeStyle(
 @Preview(name = "dashboard view", showBackground = false, widthDp = PHONE_WIDTH_DP, heightDp = PHONE_HEIGHT_DP)
 @Composable
 fun Screen_DashboardView() = PhoneHost {
+    DashboardViewScreen(
+        session = demoSession(),
+        urlPath = null,
+        onCardLongPress = {},
+    )
+}
+
+@Preview(
+    name = "dashboard view · phone landscape medium",
+    showBackground = false,
+    widthDp = PHONE_LANDSCAPE_MEDIUM_WIDTH_DP,
+    heightDp = PHONE_LANDSCAPE_MEDIUM_HEIGHT_DP,
+)
+@Composable
+fun Screen_DashboardView_PhoneLandscapeMedium() = PhoneHost {
     DashboardViewScreen(
         session = demoSession(),
         urlPath = null,

--- a/app/src/main/kotlin/ee/schimke/terrazzo/ui/WindowSize.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/ui/WindowSize.kt
@@ -1,5 +1,6 @@
 package ee.schimke.terrazzo.ui
 
+import android.content.res.Configuration
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.platform.LocalConfiguration
@@ -71,7 +72,7 @@ private val ExpandedMaxWidth = 840.dp
 fun rememberLayoutConfig(): LayoutConfig {
     val configuration = LocalConfiguration.current
     val widthDp = configuration.screenWidthDp
-    val isLandscape = configuration.screenWidthDp > configuration.screenHeightDp
+    val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
     return when (WindowSize.fromWidthDp(widthDp)) {
         WindowSize.Compact -> LayoutConfig(
             windowSize = WindowSize.Compact,


### PR DESCRIPTION
### Motivation
- Medium-size phones in landscape were not reliably enabling two section columns because landscape detection compared `screenWidthDp` and `screenHeightDp` instead of using the system orientation flag.

### Description
- Update `rememberLayoutConfig()` in `app/src/main/kotlin/ee/schimke/terrazzo/ui/WindowSize.kt` to `import android.content.res.Configuration` and compute `isLandscape` with `configuration.orientation == Configuration.ORIENTATION_LANDSCAPE`, so `maxSectionColumns = if (isLandscape) 2 else 1` on `WindowSize.Medium`.

### Testing
- Attempted `./gradlew :app:compileDebugKotlin`, but the build could not complete in this environment because the Android Gradle Plugin `com.android.application:9.2.0` could not be resolved from configured repositories, so compilation could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffc3bdee7c8324ac4d4f481961d1e6)