### PR TITLE
fix: stabilize sizing constraint matrix preview

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/SizingExperimentPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/SizingExperimentPreviews.kt
@@ -454,6 +454,11 @@ private fun ConstraintMatrix(
                                 variant = variant,
                                 card = cardConfig,
                                 profile = profile,
+                                kind = when (label) {
+                                    "tile" -> CardKind.Tile
+                                    "entities" -> CardKind.Entities
+                                    else -> CardKind.Glance
+                                },
                                 registry = registry,
                             )
                         }
@@ -468,21 +473,28 @@ private data class Variant(
     val label: String,
     /** dp, or `-1` for `fillMaxWidth()`. */
     val widthDp: Int,
-    /** dp; `null` + `!wrapHeight` falls back to the converter's `naturalHeightDp`. */
+    /** dp; `null` + `!wrapHeight` falls back to [CardKind.baselineHeightDp]. */
     val heightDp: Int?,
     /** When `true`, no height modifier — the slot tries to wrap to content. */
     val wrapHeight: Boolean,
 )
 
+private enum class CardKind(val baselineHeightDp: Int) {
+    Tile(96),
+    Entities(132),
+    Glance(118),
+}
+
 @Composable
 private fun ConstraintRow(
     variant: Variant,
     card: CardConfig,
+    kind: CardKind,
     profile: Profile,
     registry: ee.schimke.ha.rc.CardRegistry,
 ) {
     val snapshot = Fixtures.mixed
-    val natural = registry.cardHeightDp(card, snapshot)
+    val baseline = kind.baselineHeightDp
     val widthMod = if (variant.widthDp == -1) {
         Modifier.fillMaxWidth()
     } else {
@@ -492,7 +504,7 @@ private fun ConstraintRow(
         variant.wrapHeight -> widthMod to "wrap"
         variant.heightDp != null ->
             widthMod.height(variant.heightDp.dp) to "${variant.heightDp}dp"
-        else -> widthMod.height(natural.dp) to "${natural}dp"
+        else -> widthMod.height(baseline.dp) to "${baseline}dp"
     }
     Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
         Text(
@@ -504,7 +516,7 @@ private fun ConstraintRow(
         // `Modifier.fillMaxWidth()` (host fills available width).
         Row(modifier = Modifier.fillMaxWidth().border(1.dp, Color(0xFF2E7D32))) {
             CachedCardPreview(
-                cacheKey = ConstraintCacheKey(card, profile, variant),
+                cacheKey = ConstraintCacheKey(card, profile, variant, kind),
                 profile = profile,
                 modifier = slotMod.border(1.dp, Color(0xFFD32F2F)),
             ) {
@@ -522,6 +534,7 @@ private data class ConstraintCacheKey(
     val card: CardConfig,
     val profile: Profile,
     val variant: Variant,
+    val kind: CardKind,
 )
 
 private fun experimentCards(): List<Pair<String, CardConfig>> = listOf(


### PR DESCRIPTION
### Motivation
- The `Sizing_ConstraintMatrix_Wrap` preview was producing non-deterministic diffs because row heights were derived at render time, causing the preview to change between runs. 
- The matrix should be a stable sizing reference, so host constraints and cache identities must be deterministic.

### Description
- Introduce a `CardKind` enum with explicit `baselineHeightDp` values for `Tile`, `Entities`, and `Glance` and use it as the canonical baseline for "natural" slot variants. 
- Change `ConstraintRow` to accept a `kind: CardKind` and `registry` and replace runtime `natural` height lookups with the `kind` baseline. 
- Include `kind` in `ConstraintCacheKey` and wire call sites so each matrix row has an explicit, stable cache identity used by `CachedCardPreview`.

### Testing
- Attempted to compile the previews module with `./gradlew :previews:compileDebugKotlin -q` to validate the changes, but the build failed in this environment because the Android Gradle Plugin `com.android.application:9.2.0` could not be resolved from configured repositories. 
- No other automated test failures were observed from local file edits and compilation attempts (compile could not complete due to AGP resolution in CI-like environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffc410d45483248a8ab484820d33df)