### PR TITLE
ci: pass Play credentials JSON via env var, not file path

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -71,16 +71,6 @@ jobs:
           echo "HARC_KEYSTORE_PATH=$keystore" >> "$GITHUB_ENV"
 
 
-      - name: Write Play credentials file
-        if: env.HAS_PLAY_CREDENTIALS == 'true'
-        env:
-          PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
-        run: |
-          set -euo pipefail
-          creds_file="${RUNNER_TEMP}/play-service-account.json"
-          printf '%s' "$PLAY_SERVICE_ACCOUNT_JSON" > "$creds_file"
-          echo "ANDROID_PUBLISHER_CREDENTIALS=$creds_file" >> "$GITHUB_ENV"
-
       - name: Assemble release APK
         env:
           HARC_KEYSTORE_PASSWORD: ${{ secrets.HARC_KEYSTORE_PASSWORD }}
@@ -103,6 +93,7 @@ jobs:
           HARC_KEYSTORE_PASSWORD: ${{ secrets.HARC_KEYSTORE_PASSWORD }}
           HARC_KEY_ALIAS: ${{ secrets.HARC_KEY_ALIAS }}
           HARC_KEY_PASSWORD: ${{ secrets.HARC_KEY_PASSWORD }}
+          ANDROID_PUBLISHER_CREDENTIALS: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
         run: ./gradlew :app:publishBundle --stacktrace
 
 
@@ -112,6 +103,7 @@ jobs:
           HARC_KEYSTORE_PASSWORD: ${{ secrets.HARC_KEYSTORE_PASSWORD }}
           HARC_KEY_ALIAS: ${{ secrets.HARC_KEY_ALIAS }}
           HARC_KEY_PASSWORD: ${{ secrets.HARC_KEY_PASSWORD }}
+          ANDROID_PUBLISHER_CREDENTIALS: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
         run: ./gradlew :wear:publishBundle --stacktrace
 
       - name: Release publish summary


### PR DESCRIPTION
## Summary
- The release job was failing at `:app:publishReleaseBundle` with: *Credential parsing may have failed. Ensure credential files supplied in the DSL contain valid JSON and/or the ANDROID_PUBLISHER_CREDENTIALS envvar contains valid JSON (not a file path).*
- The triplet Play Publisher plugin has always required `ANDROID_PUBLISHER_CREDENTIALS` to contain the JSON content itself; our workflow was writing the secret to a tempfile and exporting the file path.
- Drop the file-write step and pass `secrets.PLAY_SERVICE_ACCOUNT_JSON` as a step-level env var on the `:app:publishBundle` and `:wear:publishBundle` steps. The `enabled.set(System.getenv(\"ANDROID_PUBLISHER_CREDENTIALS\") != null)` gate in the gradle config still works — assemble steps don't see the var, publish steps do.

## Test plan
- [ ] Re-run the release workflow on a tag and confirm `:app:publishReleaseBundle` succeeds.
- [ ] Verify assemble-only paths (no publish) still build cleanly with the env var unset.