### PR TITLE
fix(dashboard): use first heading card as section header

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -446,7 +446,7 @@ private data class SectionHeadingModel(
     val visibleCards: List<CardConfig>,
 )
 
-private val SECTION_HEADER_CARD_TYPES: Set<String> = setOf("button", "tile", "entity")
+private val SECTION_HEADER_CARD_TYPES: Set<String> = setOf("heading", "button", "tile", "entity")
 
 private fun resolveSectionHeading(section: SectionLayout, sectionIndex: Int): SectionHeadingModel {
     section.title?.let { return SectionHeadingModel(title = it, visibleCards = section.cards) }


### PR DESCRIPTION
## Original request

> The Section header isn't meant to be "Section 1", 2, 3 etc.
>
> It's meant to be the first item, which is typically a text header.

(Reported against the Security demo dashboard — the first section has no `title`, and its first card is `{ "type": "heading", "heading": "🚪 Garage door" }`. The section header rendered as "Section 1" with the heading card duplicated immediately below.)

## Analysis

`DashboardViewScreen.resolveSectionHeading` already promotes a section's first card to the section heading when:

1. the section has no explicit `title`, and
2. the first card "looks heading-like" — its `type` is in an allow-list and it has no entity binding.

The allow-list — `SECTION_HEADER_CARD_TYPES` — covered `button`, `tile`, and `entity`, but **not** Home Assistant's dedicated `heading` card type. So sections whose first card was an actual `heading` card fell through to the `"Section ${index + 1}"` fallback, and the heading card then rendered a second time as a regular card below.

`headingLikeTitle()` already reads the `heading` field, so once `heading` is in the allow-list everything else falls into place: the card's text becomes the section title, and it's dropped from `visibleCards`.

## Fix

One-line change in `app/.../dashboard/DashboardViewScreen.kt`:

```kotlin
-private val SECTION_HEADER_CARD_TYPES: Set<String> = setOf("button", "tile", "entity")
+private val SECTION_HEADER_CARD_TYPES: Set<String> = setOf("heading", "button", "tile", "entity")
```

The `canActAsSectionHeader()` entity/entities guards are already satisfied by heading cards (no `entity` / `entities` fields), so no further changes are required.

## Before / after previews

The `preview-comment` workflow renders the `app:` previews on `main` and on this PR head and posts a before/after image grid as a PR comment. The relevant previews are in `app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt` and already exercise this code path on the affected dashboard:

| Preview | What it shows | Expected diff |
| --- | --- | --- |
| `Screen_DashboardView` | Phone, Security demo dashboard (the user's screenshot) | First section header changes from **"Section 1"** to **"🚪 Garage door"**; the duplicated `heading` card disappears from the body. Subsequent sections similarly switch to **"📷 Outdoor cameras"**, **"🚶 Motion"**, **"🔔 Alarm"**. |
| `Screen_DashboardView · phone landscape medium` | Same dashboard, landscape | Same change as above. |
| `Play_Phone_01_HomeLight` / `Play_Phone_02_HomeDark` | Play Store listing screenshots (Pixel 2, light & dark) | Same change as above. |
| `Screen_DashboardView · theme` | One render per `ThemeStyle` | Same change as above, repeated across themes. |

The user-supplied screenshot at the top of this thread is the "before" state for `Screen_DashboardView`. The CI-posted comment will carry the post-fix render.

## Test plan

- [ ] `:app` builds and ktfmt passes (verified locally by the pre-commit hook).
- [ ] `preview-comment` workflow posts before/after images; visually confirm the four section headers on the Security board switch from `Section N` to the heading text.
- [ ] Spot-check a section whose first card is **not** a heading-like card (e.g. an `entities` card or a `tile` with an entity) still renders with the `Section N` fallback / explicit title and no card is dropped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KjwmkDHLWYyXYrSb32FHvZ)_