### PR TITLE
Enable experimental widget ops in RC profile capture

### DIFF
--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WidgetProfile.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WidgetProfile.kt
@@ -2,8 +2,10 @@
 
 package ee.schimke.ha.rc
 
+import androidx.compose.remote.core.RcProfiles
+import androidx.compose.remote.creation.RemoteComposeWriterAndroid
+import androidx.compose.remote.creation.platform.AndroidxRcPlatformServices
 import androidx.compose.remote.creation.profile.Profile
-import androidx.compose.remote.creation.profile.RcPlatformProfiles
 
 /**
  * Profile used when capturing the `.rc` document that ships to the
@@ -15,14 +17,15 @@ import androidx.compose.remote.creation.profile.RcPlatformProfiles
  * widgets profile up-front keeps the bytes within the launcher's
  * vocabulary.
  *
- * Today: alpha010 ships [RcPlatformProfiles.WIDGETS_V7] (document API
- * level 7, `RcProfiles.PROFILE_WIDGETS` bit) — the newer of the two
- * available widget profiles. Cards that lean on AndroidX-only ops
- * (`FlowLayout`, etc.) will fail to capture under this profile —
- * expected. The compatible card subset is what's installable as a
- * widget; the dashboard / preview path keeps using `androidXExperimental`.
- *
- * `WIDGETS_V7` is `@RestrictTo(LIBRARY_GROUP)`; aliasing it here keeps
- * the suppression scoped to a single file.
+ * Shape mirrors `RcPlatformProfiles.WIDGETS_V7` (document API level 7,
+ * `RcProfiles.PROFILE_WIDGETS`) but ORs in `PROFILE_EXPERIMENTAL` so
+ * experimental widget ops are admitted at capture time.
  */
-val widgetsProfile: Profile = RcPlatformProfiles.WIDGETS_V7
+val widgetsProfile: Profile =
+    Profile(
+        7,
+        RcProfiles.PROFILE_WIDGETS or RcProfiles.PROFILE_EXPERIMENTAL,
+        AndroidxRcPlatformServices(),
+    ) { creationDisplayInfo, _, profile ->
+        RemoteComposeWriterAndroid(creationDisplayInfo, null, profile)
+    }


### PR DESCRIPTION
## Summary
Updated the `widgetsProfile` to include experimental widget operations during Remote Compose document capture, while maintaining the base WIDGETS_V7 profile configuration.

## Key Changes
- Replaced direct reference to `RcPlatformProfiles.WIDGETS_V7` with an explicit `Profile` construction
- Added `RcProfiles.PROFILE_EXPERIMENTAL` flag via bitwise OR to the profile configuration, allowing experimental widget operations to be captured
- Maintained API level 7 and `PROFILE_WIDGETS` base configuration
- Instantiated `AndroidxRcPlatformServices` and `RemoteComposeWriterAndroid` to complete the profile setup

## Implementation Details
The new profile construction mirrors the structure of `WIDGETS_V7` but extends it by combining both `PROFILE_WIDGETS` and `PROFILE_EXPERIMENTAL` flags. This allows experimental widget operations (such as `FlowLayout`) to be admitted during capture time, while the base WIDGETS_V7 configuration ensures compatibility with the standard widget vocabulary. The profile is now fully defined inline rather than aliasing a restricted library API.

https://claude.ai/code/session_01HKLCz7zQMV3Cb7vqR45YR3