### PR TITLE
fix(previews): wire wear sync through Metro so PreviewAppRoot renders

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -100,9 +100,7 @@ fun TerrazzoApp(
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
     val widgetScheduler = remember(context) { WidgetRefreshScheduler(context.applicationContext) }
-    val wearSync = remember(context) {
-        (context.applicationContext as TerrazzoApplication).wearSync
-    }
+    val wearSync = graph.wearSyncManager
 
     // Persisted demo-mode flag survives process restarts, so a user who
     // opted into demo doesn't see the login screen again on relaunch.
@@ -225,6 +223,7 @@ private fun AuthenticatedShell(
 
     val context = LocalContext.current
     val app = remember(context) { context.applicationContext as TerrazzoApplication }
+    val graph = LocalTerrazzoGraph.current
 
     when (screen) {
         AppScreen.Dashboards -> DashboardsRoot(
@@ -253,7 +252,7 @@ private fun AuthenticatedShell(
             onBack = { screen = AppScreen.Dashboards },
         )
         AppScreen.SyncDiagnostics -> {
-            val streaming by app.wearSync.streamActive.collectAsState()
+            val streaming by graph.wearSyncManager.streamActive.collectAsState()
             ee.schimke.terrazzo.wearsync.SyncDiagnosticsScreen(
                 statsStore = app.syncStats,
                 streamActive = streaming,

--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApplication.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApplication.kt
@@ -23,15 +23,12 @@ import ee.schimke.terrazzo.wearsync.MobileWearSyncManager
  */
 class TerrazzoApplication : Application() {
 
-    val graph: TerrazzoGraph by lazy {
-        val cardMonitor = createMonitor(applicationContext)
-        createGraphFactory<AppGraph.Factory>().create(applicationContext, cardMonitor)
-    }
-
     /**
-     * Phone-only wear sync. Held outside the Metro graph because the
-     * wear-data layer dependency stack (play-services-wearable +
-     * Horologist) only lives in this module. Started on first access.
+     * Phone-only wear sync deps held outside the graph because the
+     * wear-data layer stack (play-services-wearable + Horologist) only
+     * lives in this module. [syncStats] feeds [wearSync] (the graph's
+     * [WearSyncManager] binding), and is also consumed directly by the
+     * sync-diagnostics screen.
      */
     val syncStats: MobileSyncStatsStore by lazy { MobileSyncStatsStore(applicationContext) }
     val wearSync: MobileWearSyncManager by lazy {
@@ -39,6 +36,11 @@ class TerrazzoApplication : Application() {
     }
     val wearCapabilityProbe: ee.schimke.terrazzo.wearsync.WearCapabilityProbe by lazy {
         ee.schimke.terrazzo.wearsync.WearCapabilityProbe(applicationContext)
+    }
+
+    val graph: TerrazzoGraph by lazy {
+        val cardMonitor = createMonitor(applicationContext)
+        createGraphFactory<AppGraph.Factory>().create(applicationContext, cardMonitor, wearSync)
     }
 
     override fun onCreate() {
@@ -57,7 +59,7 @@ class TerrazzoApplication : Application() {
         // demo / pinned-card updates even when the phone UI is in the
         // background). PreferencesStore + WidgetStore are read from the
         // graph; the manager owns its own lazy DataClient/MessageClient.
-        wearSync.start(
+        graph.wearSyncManager.start(
             scope = ProcessLifecycleOwner.get().lifecycleScope,
             prefs = graph.preferencesStore,
             pinStore = graph.pinStore,

--- a/app/src/main/kotlin/ee/schimke/terrazzo/di/AppGraph.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/di/AppGraph.kt
@@ -6,6 +6,7 @@ import dev.zacsweers.metro.Provides
 import ee.schimke.terrazzo.core.di.AppScope
 import ee.schimke.terrazzo.core.di.TerrazzoGraph
 import ee.schimke.terrazzo.core.monitor.CardMonitor
+import ee.schimke.terrazzo.core.wearsync.WearSyncManager
 
 @DependencyGraph(scope = AppScope::class)
 interface AppGraph : TerrazzoGraph {
@@ -13,7 +14,8 @@ interface AppGraph : TerrazzoGraph {
     fun interface Factory {
         fun create(
             @Provides context: Context,
-            @Provides cardMonitor: CardMonitor
+            @Provides cardMonitor: CardMonitor,
+            @Provides wearSyncManager: WearSyncManager,
         ): AppGraph
     }
 }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
@@ -31,6 +31,8 @@ import ee.schimke.terrazzo.core.pin.WearWidgetSlotsStore
 import ee.schimke.terrazzo.core.prefs.DarkModePref
 import ee.schimke.terrazzo.core.prefs.PreferencesStore
 import ee.schimke.terrazzo.core.session.DemoHaSession
+import ee.schimke.terrazzo.core.wearsync.NoOpWearSyncManager
+import ee.schimke.terrazzo.core.wearsync.WearSyncManager
 import ee.schimke.terrazzo.core.widget.WidgetStore
 import ee.schimke.terrazzo.dashboard.DashboardListState
 import ee.schimke.terrazzo.dashboard.DashboardPickerScreen
@@ -100,10 +102,13 @@ private fun rememberPreviewGraph(): TerrazzoGraph {
             override val wearWidgetSlotsStore: WearWidgetSlotsStore = WearWidgetSlotsStore(context)
             override val widgetStore: WidgetStore
                 get() = error("widgetStore not wired in previews")
-            override val tokenVault: TokenVault
-                get() = error("tokenVault not wired in previews")
-            override val authService: HaAuthService
-                get() = error("authService not wired in previews")
+            // Previews compose TerrazzoApp's root, which builds a
+            // LoginController eagerly. Both bindings are pure
+            // context-backed wrappers (vault → encrypted DataStore,
+            // authService → AppAuth client config) so a real instance
+            // is cheap and reaches no network until the user signs in.
+            override val tokenVault: TokenVault = TokenVault(context)
+            override val authService: HaAuthService = HaAuthService(context)
             override val sessionFactory: HaSessionFactory
                 get() = error("sessionFactory not wired in previews")
             override val cardMonitor: CardMonitor
@@ -111,6 +116,7 @@ private fun rememberPreviewGraph(): TerrazzoGraph {
                     override val isEnabled: Boolean = false
                     override fun start(card: CardConfig, durationMinutes: Int) {}
                 }
+            override val wearSyncManager: WearSyncManager = NoOpWearSyncManager()
         }
     }
 }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/MobileWearSyncManager.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/MobileWearSyncManager.kt
@@ -18,6 +18,7 @@ import ee.schimke.terrazzo.core.pin.WearWidgetSlot
 import ee.schimke.terrazzo.core.pin.WearWidgetSlotsStore
 import ee.schimke.terrazzo.core.prefs.PreferencesStore
 import ee.schimke.terrazzo.core.session.HaSession
+import ee.schimke.terrazzo.core.wearsync.WearSyncManager
 import ee.schimke.terrazzo.wearsync.proto.CardSummary
 import ee.schimke.terrazzo.wearsync.proto.DashboardData
 import ee.schimke.terrazzo.wearsync.proto.EntityDelta
@@ -77,7 +78,7 @@ import kotlinx.serialization.json.jsonPrimitive
 class MobileWearSyncManager(
     private val context: Context,
     private val statsStore: MobileSyncStatsStore,
-) {
+) : WearSyncManager {
 
     private val dataClient: DataClient by lazy { Wearable.getDataClient(context) }
     private val messageClient: MessageClient by lazy { Wearable.getMessageClient(context) }
@@ -105,7 +106,7 @@ class MobileWearSyncManager(
     }
 
     /** Update the active session whenever login/demo state changes. */
-    fun setSession(session: HaSession?) {
+    override fun setSession(session: HaSession?) {
         sessionState.value = session
     }
 
@@ -114,7 +115,7 @@ class MobileWearSyncManager(
      * with pinned-cards count to decide between streaming and batched
      * DataStore writes.
      */
-    val streamActive: StateFlow<Boolean> by lazy {
+    override val streamActive: StateFlow<Boolean> by lazy {
         leaseState.map { isLeaseFresh(it) }
             .stateIn(managerScope, SharingStarted.Eagerly, false)
     }
@@ -123,7 +124,7 @@ class MobileWearSyncManager(
      * Wires the manager to its data sources. Call once from
      * Application.onCreate. Subsequent session changes use [setSession].
      */
-    fun start(
+    override fun start(
         scope: CoroutineScope,
         prefs: PreferencesStore,
         pinStore: PinStore,

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/di/TerrazzoGraph.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/di/TerrazzoGraph.kt
@@ -15,6 +15,7 @@ import ee.schimke.terrazzo.core.session.DemoHaSession
 import ee.schimke.terrazzo.core.session.HaSession
 import ee.schimke.terrazzo.core.session.LiveHaSession
 import ee.schimke.terrazzo.core.session.OfflineOnlySession
+import ee.schimke.terrazzo.core.wearsync.WearSyncManager
 import ee.schimke.terrazzo.core.widget.WidgetStore
 
 /**
@@ -35,6 +36,7 @@ interface TerrazzoGraph {
     val offlineCache: OfflineCache
     val sessionFactory: HaSessionFactory
     val cardMonitor: CardMonitor
+    val wearSyncManager: WearSyncManager
 
     fun interface Factory {
         fun create(context: Context): TerrazzoGraph

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/wearsync/WearSyncManager.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/wearsync/WearSyncManager.kt
@@ -1,0 +1,43 @@
+package ee.schimke.terrazzo.core.wearsync
+
+import ee.schimke.terrazzo.core.pin.PinStore
+import ee.schimke.terrazzo.core.pin.WearWidgetSlotsStore
+import ee.schimke.terrazzo.core.prefs.PreferencesStore
+import ee.schimke.terrazzo.core.session.HaSession
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Phone-side wear sync engine surface, lifted to terrazzo-core so the
+ * dependency graph can bind it without dragging the play-services-wearable
+ * stack across module boundaries. The real implementation lives in
+ * `:app` (`MobileWearSyncManager`); previews and Robolectric tests swap
+ * in [NoOpWearSyncManager].
+ */
+interface WearSyncManager {
+    fun setSession(session: HaSession?)
+    val streamActive: StateFlow<Boolean>
+    fun start(
+        scope: CoroutineScope,
+        prefs: PreferencesStore,
+        pinStore: PinStore,
+        slotsStore: WearWidgetSlotsStore,
+    )
+}
+
+/**
+ * Inert [WearSyncManager] for environments without a paired wear device
+ * (previews, Robolectric, unit tests). All side-effecting methods are
+ * no-ops; [streamActive] stays false.
+ */
+class NoOpWearSyncManager : WearSyncManager {
+    override fun setSession(session: HaSession?) {}
+    override val streamActive: StateFlow<Boolean> = MutableStateFlow(false)
+    override fun start(
+        scope: CoroutineScope,
+        prefs: PreferencesStore,
+        pinStore: PinStore,
+        slotsStore: WearWidgetSlotsStore,
+    ) {}
+}


### PR DESCRIPTION
## Original report

> `renderAllPreviews: render produced no output file for 1 of 17 preview(s): ee.schimke.terrazzo.previews.ScreenPreviewsKt.PreviewAppRoot_App Root (empty). This means renderPreviews was skipped or silently did nothing — on Android that usually means it reported NO-SOURCE because RobolectricRenderTest.class wasn't discoverable on its testClassesDirs.`

## Root cause

The error message's "NO-SOURCE" hint is a red herring for this case — the test classes are discoverable, the render simply threw at composition. The plugin writes the exception to `app/build/compose-previews/renders/PreviewAppRoot_App_Root_empty.png.error.json`:

```
java.lang.ClassCastException: class android.app.Application cannot be cast to
class ee.schimke.terrazzo.TerrazzoApplication
    at ee.schimke.terrazzo.TerrazzoAppKt.TerrazzoApp(TerrazzoApp.kt:104)
```

`compose-ai-tools` deliberately overrides the manifest-declared `Application` with a stub `android.app.Application` during preview rendering (the generated `robolectric.properties` explains the intent: skip DI / BridgingManager / Firebase / WorkManager / wear startup). `TerrazzoApp` then crashed pulling the phone-side wear-sync manager directly off the application object:

```kotlin
val wearSync = remember(context) {
    (context.applicationContext as TerrazzoApplication).wearSync
}
```

Only `PreviewAppRoot` (the only preview that composes `TerrazzoApp()` itself) hits this path — the other 16 previews mount individual screens that go through `LocalTerrazzoGraph`, never through the application cast.

## Fix

Per the project's existing DI pattern (cf. `CardMonitor`), lift wear-sync into Metro and feed the concrete impl in through the `AppGraph` factory:

- New interface **`terrazzo-core/.../wearsync/WearSyncManager`** with the surface `TerrazzoApp` / `TerrazzoApplication` actually consume (`setSession`, `streamActive`, `start(scope, prefs, pinStore, slotsStore)`), and a sibling **`NoOpWearSyncManager`** for previews / Robolectric / unit tests.
- **`MobileWearSyncManager`** (concrete, app-only — owns the play-services-wearable + Horologist deps) now implements `WearSyncManager`. No behaviour change.
- **`TerrazzoGraph`** exposes `wearSyncManager: WearSyncManager`. **`AppGraph.Factory.create`** takes it as a `@Provides` parameter alongside the existing `cardMonitor`; **`TerrazzoApplication`** constructs `MobileWearSyncManager` once and hands it to the factory, then calls `graph.wearSyncManager.start(…)` in `onCreate`.
- **`TerrazzoApp`** drops the `applicationContext as TerrazzoApplication` casts for wear-sync access and reads `graph.wearSyncManager` (and `graph.wearSyncManager.streamActive` on the sync-diagnostics screen) from `LocalTerrazzoGraph`. The remaining `app` casts (`syncStats`, `wearCapabilityProbe` in `DashboardsRoot`) are scoped to authenticated state and aren't on the preview path; they can move to the graph later if desired.

`PreviewAppRoot` then surfaced two follow-on crashers in `rememberLoginController` (`graph.authService` and `graph.tokenVault` were `error(…)`-stubbed in the preview graph). Both are pure context-backed wrappers — the vault is an encrypted DataStore, the auth service is an AppAuth client config, neither touches the network until the user signs in — so the preview graph now hands out real instances rather than stubs, and registers `NoOpWearSyncManager`.

## Files

```
terrazzo-core/.../core/wearsync/WearSyncManager.kt   (new — interface + no-op)
terrazzo-core/.../core/di/TerrazzoGraph.kt           (+1 line: wearSyncManager)
app/.../di/AppGraph.kt                               (+1 factory param)
app/.../wearsync/MobileWearSyncManager.kt            (: WearSyncManager + override)
app/.../TerrazzoApplication.kt                       (feed wearSync to factory; use graph.wearSyncManager.start)
app/.../TerrazzoApp.kt                               (drop cast; use graph.wearSyncManager)
app/.../previews/ScreenPreviews.kt                   (NoOpWearSyncManager + real authService/tokenVault)
```

## Before / after

| Preview | Before | After |
| --- | --- | --- |
| `PreviewAppRoot` ("App Root (empty)") | render task fails — `ClassCastException` written to `.png.error.json`, no PNG produced | renders the unauthenticated "Connect to Home Assistant" discovery screen (Base URL field + Connect button + "Try demo mode") |

The `preview-comment` workflow will post the rendered image on this PR.

## Test plan

- [x] `:app:renderAllPreviews` — all 17 previews produce PNGs, no `*.error.json` written. Verified locally.
- [x] `:app:assembleDebug` — debug build green.
- [x] `:app:testDebugUnitTest` — unit tests pass.
- [ ] CI `preview-comment` posts the new `PreviewAppRoot` render.
- [ ] On-device smoke: launch the app, confirm wear sync still starts (manifest `TerrazzoApplication` constructs `MobileWearSyncManager` once and feeds the graph, so `graph.wearSyncManager.start(…)` in `onCreate` is the same instance as before).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KjwmkDHLWYyXYrSb32FHvZ)_