### PR TITLE
fix: pass callback to RemoteComposeWriterAndroid in widgetsProfile

### DIFF
--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WidgetProfile.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WidgetProfile.kt
@@ -26,6 +26,6 @@ val widgetsProfile: Profile =
         7,
         RcProfiles.PROFILE_WIDGETS or RcProfiles.PROFILE_EXPERIMENTAL,
         AndroidxRcPlatformServices(),
-    ) { creationDisplayInfo, _, profile ->
-        RemoteComposeWriterAndroid(creationDisplayInfo, null, profile)
+    ) { creationDisplayInfo, profile, callback ->
+        RemoteComposeWriterAndroid(creationDisplayInfo, null, profile, callback)
     }


### PR DESCRIPTION
The Profile writer lambda is (creationDisplayInfo, profile, callback);
the previous code ignored the second slot and passed the callback as
the third constructor arg, which no RemoteComposeWriterAndroid ctor
matches. Mirror the lambda shape used by androidXExperimental.