### PR TITLE
Remove obsolete `PreviewAppRoot` preview from ScreenPreviews

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
@@ -317,10 +317,3 @@ fun Play_Tablet10_01_Home() = PhoneHost(darkMode = DarkModePref.Light) {
     DashboardViewScreen(session = demoSession(), urlPath = null, onCardLongPress = {})
 }
 
-@Preview(name = "App Root (empty)", group = "Screens", showBackground = true)
-@Composable
-fun PreviewAppRoot() {
-    PhoneHost {
-        TerrazzoApp()
-    }
-}


### PR DESCRIPTION
### Motivation
- Remove an unused/duplicate preview entry that added an `App Root` preview in `ScreenPreviews.kt` to reduce clutter and avoid showing an empty root preview in tooling.

### Description
- Deleted the `PreviewAppRoot` composable preview (the `@Preview`-annotated `PreviewAppRoot` function) from `app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a025e0e773c83249bd51682b571f365)