### PR TITLE
Add tiny gauge layout and render it for very small gauge cards

### DIFF
--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaGauge.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaGauge.kt
@@ -344,6 +344,39 @@ fun RemoteHaGaugeWide(
     }
 }
 
+
+@Composable
+@RemoteComposable
+fun RemoteHaGaugeTiny(
+    data: HaGaugeData,
+    modifier: RemoteModifier = RemoteModifier,
+) {
+    val theme = haTheme()
+    val clickable =
+        data.tapAction.toRemoteAction()?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
+
+    RemoteBox(
+        modifier =
+            modifier
+                .then(clickable)
+                .clip(RemoteRoundedCornerShape(12.rdp))
+                .background(theme.cardBackground.rc)
+                .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+                .padding(horizontal = 6.rdp, vertical = 4.rdp),
+        contentAlignment = RemoteAlignment.TopStart,
+    ) {
+        RemoteText(
+            text = data.valueText,
+            color = theme.primaryText.rc,
+            fontSize = 13.rsp,
+            fontWeight = FontWeight.SemiBold,
+            style = RemoteTextStyle.Default,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
 @Composable
 private fun animatedGaugeSweep(data: HaGaugeData): RemoteFloat {
     val span = (data.max - data.min).coerceAtLeast(0.0001)

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/GaugeCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/GaugeCardConverter.kt
@@ -28,6 +28,7 @@ import ee.schimke.ha.rc.components.LiveValues
 import ee.schimke.ha.rc.components.RemoteHaGauge
 import ee.schimke.ha.rc.components.RemoteHaGaugeCompact
 import ee.schimke.ha.rc.components.RemoteHaGaugeWide
+import ee.schimke.ha.rc.components.RemoteHaGaugeTiny
 import ee.schimke.ha.rc.defaultTapActionFor
 import ee.schimke.ha.rc.formatState
 import ee.schimke.ha.rc.parseHaAction
@@ -88,7 +89,7 @@ class GaugeCardConverter : CardConverter {
             RemoteFloat.createNamedRemoteFloatExpression(heightName, RemoteState.Domain.User) {
                 componentHeight()
             }
-        val isAboveChip = widthExpr.ge(80.rdp.toPx())
+        val isTiny = widthExpr.lt(90.rdp.toPx()).or(heightExpr.lt(90.rdp.toPx()))
         val isWideThin = widthExpr.gt(heightExpr * 1.5f.rf)
 
         RemoteBox(modifier = modifier.fillMaxSize()) {
@@ -105,9 +106,12 @@ class GaugeCardConverter : CardConverter {
                 color = Color.Transparent.rc,
             )
 
-            RemoteStateLayout(isAboveChip) { hasRoom ->
-                if (!hasRoom) {
-                    CompactStateChip(card, snapshot)
+            RemoteStateLayout(isTiny) { tiny ->
+                if (tiny) {
+                    RemoteHaGaugeTiny(
+                        gaugeData(card, snapshot),
+                        modifier = RemoteModifier.fillMaxSize(),
+                    )
                 } else {
                     RemoteStateLayout(isWideThin) { wide ->
                         if (wide) {


### PR DESCRIPTION
### Motivation

- Provide a compact single-line gauge representation for very small card sizes so the UI remains legible when there is not enough room for the dial or the existing chip layout.

### Description

- Add `RemoteHaGaugeTiny` composable implementing a compact, value-only card with rounded corners, border, padding, theme-aware colors, and optional click handling.
- Update `GaugeCardConverter` to compute an `isTiny` state from named `RemoteFloat` expressions and to render `RemoteHaGaugeTiny` when the width or height is less than `90.rdp`.
- Preserve existing rendering paths for `RemoteHaGaugeWide`, `RemoteHaGaugeCompact`, and the full `RemoteHaGauge` for other size modes.
- Add import for `RemoteHaGaugeTiny` and remove the previous `isAboveChip` branch in favor of the new tiny-detection logic.

### Testing

- Ran the project build and unit test suite (`./gradlew build`), which completed successfully.
- Executed lint and Kotlin compilation checks which passed.
- No new automated tests were added for the tiny layout in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a025eb4106083248d9efb0827ced61a)