### PR TITLE
fix: improve adaptive gauge layout across small surfaces

### DIFF
--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaGauge.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaGauge.kt
@@ -242,7 +242,7 @@ fun RemoteHaGaugeCompact(
         RemoteText(
             text = data.valueText,
             color = theme.primaryText.rc,
-            fontSize = 16.rsp,
+            fontSize = 15.rsp,
             fontWeight = FontWeight.SemiBold,
             style = RemoteTextStyle.Default,
             maxLines = 1,
@@ -277,12 +277,12 @@ fun RemoteHaGaugeWide(
                 .clip(RemoteRoundedCornerShape(12.rdp))
                 .background(theme.cardBackground.rc)
                 .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
-                .padding(horizontal = 8.rdp, vertical = 6.rdp),
+                .padding(horizontal = 8.rdp, vertical = 4.rdp),
         verticalAlignment = RemoteAlignment.CenterVertically,
         horizontalArrangement = RemoteArrangement.spacedBy(8.rdp),
     ) {
         // Arc canvas: square aspect, height-bounded.
-        RemoteCanvas(modifier = RemoteModifier.fillMaxHeight().width(64.rdp)) {
+        RemoteCanvas(modifier = RemoteModifier.fillMaxHeight().width(72.rdp)) {
             val w = width
             val h = height
             val stroke = 6f.rf
@@ -326,7 +326,7 @@ fun RemoteHaGaugeWide(
             RemoteText(
                 text = data.valueText,
                 color = theme.primaryText.rc,
-                fontSize = 16.rsp,
+                fontSize = 15.rsp,
                 fontWeight = FontWeight.SemiBold,
                 style = RemoteTextStyle.Default,
                 maxLines = 1,
@@ -340,6 +340,16 @@ fun RemoteHaGaugeWide(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
+            if (data.unit != null) {
+                RemoteText(
+                    text = "${formatRange(data.min)} – ${formatRange(data.max)} ${data.unit}".rs,
+                    color = theme.secondaryText.rc,
+                    fontSize = 10.rsp,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         }
     }
 }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/GaugeCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/GaugeCardConverter.kt
@@ -88,8 +88,8 @@ class GaugeCardConverter : CardConverter {
             RemoteFloat.createNamedRemoteFloatExpression(heightName, RemoteState.Domain.User) {
                 componentHeight()
             }
-        val isAboveChip = widthExpr.ge(80.rdp.toPx())
-        val isWideThin = widthExpr.gt(heightExpr * 1.5f.rf)
+        val isAboveChip = widthExpr.ge(56.rdp.toPx())
+        val isWideThin = widthExpr.gt(heightExpr * 1.25f.rf)
 
         RemoteBox(modifier = modifier.fillMaxSize()) {
             // Materialise both named expressions in the document. The


### PR DESCRIPTION
### Motivation
- Small launcher/wear surfaces were falling back to the compact state chip or truncating text instead of rendering a text-capable gauge layout. 
- The gauge arc did not always use the available vertical space on short/wide targets, reducing readability.

### Description
- Lowered the adaptive minimum width so small tiles use the gauge layout (`isAboveChip` 80dp → 56dp) and broadened the wide-detection threshold (`isWideThin` 1.5 → 1.25) in `rc-converter/src/main/kotlin/.../GaugeCardConverter.kt` to pick the wide/text-capable variant more often.
- Tuned compact/wide typography and spacing in `rc-components/src/main/kotlin/.../RemoteHaGauge.kt` by reducing value text sizes (16sp → 15sp) and reducing wide-row vertical padding (6rdp → 4rdp).
- Increased the wide gauge arc canvas width (64rdp → 72rdp) so the arc occupies more vertical space on short/wide surfaces.
- Expanded the wide gauge text stack to include the min/max range line when units are present, improving information density for 2×1 / Wear targets.

### Testing
- Ran `compose-preview render --preview 'CardPreviewMatrix_Gauge'`, which completed successfully and rendered 194 previews (194 changed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02dbb097bc83248e36425da129e186)