### PR TITLE
fix(gauge): adaptive fixed-mode ladder with box-overlay backdrop

### DIFF
--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaGauge.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaGauge.kt
@@ -168,16 +168,19 @@ fun RemoteHaGauge(
 private const val GaugeAnimationSeconds = 0.45f
 
 /**
- * Compact Fixed-mode gauge variant. The half-arc grows to fill the
- * card's intrinsic dimensions (capped at the smaller of `width / 2`
- * and `height` so it stays a true half-circle), and the live value
- * is overlaid centered inside the arc's open interior. Use for
- * square / tall launcher widgets where the wrap-mode column-stack is
- * wasteful.
+ * Stacked Fixed-mode gauge variant — the dominant Fixed-mode tier.
+ * Renders the arc as a backdrop (top-anchored half-circle, capped
+ * so its visible base lands at ~60 % of the cell height) and
+ * overlays value · name · range in the open interior below. One
+ * composable covers everything from a 1×1 launcher chip up to a
+ * 3×2 dashboard tile and Wear L — the same proportional crop
+ * scales naturally across sizes; secondary text lines ellipsise on
+ * cells that can't fit them. Very short cells (Wear S) skip the
+ * stacked overlay and fall through to [RemoteHaGaugeWide].
  */
 @Composable
 @RemoteComposable
-fun RemoteHaGaugeCompact(
+fun RemoteHaGaugeStacked(
     data: HaGaugeData,
     modifier: RemoteModifier = RemoteModifier,
 ) {
@@ -193,70 +196,87 @@ fun RemoteHaGaugeCompact(
                 .then(clickable)
                 .clip(RemoteRoundedCornerShape(12.rdp))
                 .background(theme.cardBackground.rc)
-                .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp)),
-        contentAlignment = RemoteAlignment.Center,
+                .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+                .padding(8.rdp),
+        contentAlignment = RemoteAlignment.BottomCenter,
     ) {
-        // Arc fills the cell; its diameter follows the smaller axis so
-        // the half-circle stays proportional. Anchored to the bottom
-        // so the open side faces downward (matching the HA reference).
-        RemoteCanvas(modifier = RemoteModifier.fillMaxSize().padding(6.rdp)) {
+        // Arc fills the box, but the diameter is capped so the
+        // visible half (= diameter / 2) only reaches ~60 % of the
+        // cell height. That leaves the lower ~40 % for the text
+        // overlay regardless of the cell's aspect ratio.
+        RemoteCanvas(modifier = RemoteModifier.fillMaxSize()) {
             val w = width
             val h = height
             val stroke = 8f.rf
-            val pad = stroke / 2f.rf
-            // Half-circle diameter capped by both axes.
-            val byHeight = (h - pad) * 2f.rf
+            val pad = (stroke / 2f.rf) + 2f.rf
+            val arcBottomY = h * 0.6f.rf
+            val byHeight = (arcBottomY - pad) * 2f.rf
             val byWidth = w - pad * 2f.rf
             val diameter = byHeight.min(byWidth)
             val left = (w - diameter) / 2f.rf
-            val arcTop = h - (diameter / 2f.rf) - pad
-            val topLeft = RemoteOffset(left, arcTop)
+            val top = arcBottomY - (diameter / 2f.rf)
+            val topLeft = RemoteOffset(left, top)
             val arcSize = RemoteSize(diameter, diameter)
 
-            val track =
-                AndroidPaint()
-                    .apply {
-                        isAntiAlias = true
-                        style = AndroidPaint.Style.STROKE
-                        strokeWidth = 8f
-                        strokeCap = AndroidPaint.Cap.ROUND
-                        color = theme.divider.toArgb()
-                    }
-                    .asRemotePaint()
+            val track = AndroidPaint().apply {
+                isAntiAlias = true
+                style = AndroidPaint.Style.STROKE
+                strokeWidth = 8f
+                strokeCap = AndroidPaint.Cap.ROUND
+                color = theme.divider.toArgb()
+            }.asRemotePaint()
             drawArc(track, 180f.rf, 180f.rf, false, topLeft, arcSize)
 
-            val value =
-                AndroidPaint()
-                    .apply {
-                        isAntiAlias = true
-                        style = AndroidPaint.Style.STROKE
-                        strokeWidth = 8f
-                        strokeCap = AndroidPaint.Cap.ROUND
-                        color = severityColor.toArgb()
-                    }
-                    .asRemotePaint()
+            val value = AndroidPaint().apply {
+                isAntiAlias = true
+                style = AndroidPaint.Style.STROKE
+                strokeWidth = 8f
+                strokeCap = AndroidPaint.Cap.ROUND
+                color = severityColor.toArgb()
+            }.asRemotePaint()
             drawArc(value, 180f.rf, animatedSweep, false, topLeft, arcSize)
         }
-        // Value text overlaid inside the arc — Box centers by default,
-        // which lands the text in the half-arc's interior.
-        RemoteText(
-            text = data.valueText,
-            color = theme.primaryText.rc,
-            fontSize = 16.rsp,
-            fontWeight = FontWeight.SemiBold,
-            style = RemoteTextStyle.Default,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = RemoteModifier.padding(bottom = 8.rdp),
-        )
+        RemoteColumn(
+            modifier = RemoteModifier.fillMaxWidth(),
+            verticalArrangement = RemoteArrangement.spacedBy(2.rdp),
+            horizontalAlignment = RemoteAlignment.CenterHorizontally,
+        ) {
+            RemoteText(
+                text = data.valueText,
+                color = theme.primaryText.rc,
+                fontSize = 18.rsp,
+                fontWeight = FontWeight.SemiBold,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            RemoteText(
+                text = data.name.rs,
+                color = theme.secondaryText.rc,
+                fontSize = 12.rsp,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (data.unit != null) {
+                RemoteText(
+                    text = "${formatRange(data.min)} – ${formatRange(data.max)} ${data.unit}".rs,
+                    color = theme.secondaryText.rc,
+                    fontSize = 10.rsp,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
     }
 }
 
 /**
  * Wide-thin Fixed-mode gauge variant. Half-arc on the left at square
- * aspect, value + name + range stacked on the right. Targets cells
- * like `200×60` Wear chips and `2×1` launcher widgets where the
- * vertical stack of [RemoteHaGaugeCompact] would crowd the arc.
+ * aspect, value + name stacked on the right. Targets the very short
+ * `200×60` Wear S chip where the [RemoteHaGaugeStacked] backdrop
+ * doesn't have enough vertical room to host the arc + text overlay.
  */
 @Composable
 @RemoteComposable
@@ -278,11 +298,14 @@ fun RemoteHaGaugeWide(
                 .background(theme.cardBackground.rc)
                 .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
                 .padding(horizontal = 8.rdp, vertical = 6.rdp),
-        verticalAlignment = RemoteAlignment.CenterVertically,
+        verticalAlignment = RemoteAlignment.Bottom,
         horizontalArrangement = RemoteArrangement.spacedBy(8.rdp),
     ) {
-        // Arc canvas: square aspect, height-bounded.
-        RemoteCanvas(modifier = RemoteModifier.fillMaxHeight().width(64.rdp)) {
+        // Arc canvas sized off the row height so the half-arc grows
+        // with taller cells (Wear L vs Wear S). The text column gets
+        // the rest of the width via `weight()` so value / name aren't
+        // clipped on narrower 2×1 chips.
+        RemoteCanvas(modifier = RemoteModifier.fillMaxHeight().width(72.rdp)) {
             val w = width
             val h = height
             val stroke = 6f.rf
@@ -320,6 +343,7 @@ fun RemoteHaGaugeWide(
             drawArc(value, 180f.rf, animatedSweep, false, topLeft, arcSize)
         }
         RemoteColumn(
+            modifier = RemoteModifier.weight(1f).padding(bottom = 4.rdp),
             verticalArrangement = RemoteArrangement.Center,
             horizontalAlignment = RemoteAlignment.Start,
         ) {

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/GaugeCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/GaugeCardConverter.kt
@@ -26,7 +26,7 @@ import ee.schimke.ha.rc.components.HaGaugeData
 import ee.schimke.ha.rc.components.HaGaugeSeverity
 import ee.schimke.ha.rc.components.LiveValues
 import ee.schimke.ha.rc.components.RemoteHaGauge
-import ee.schimke.ha.rc.components.RemoteHaGaugeCompact
+import ee.schimke.ha.rc.components.RemoteHaGaugeStacked
 import ee.schimke.ha.rc.components.RemoteHaGaugeWide
 import ee.schimke.ha.rc.defaultTapActionFor
 import ee.schimke.ha.rc.formatState
@@ -44,24 +44,30 @@ import kotlinx.serialization.json.jsonPrimitive
  * updates animate without re-encoding; severity-band colours are baked
  * at encode time and re-encode when the active band changes.
  *
- * In [CardSizeMode.Fixed] the converter encodes a 3-tier ladder driven
- * by the runtime canvas:
+ * In [CardSizeMode.Fixed] the converter encodes a 2-tier ladder driven
+ * by the runtime canvas (mirrors the gauge ladder in
+ * `docs/architecture/adaptive-card-layouts.md` §gauge):
  *
- *   * Below ~80 dp wide → centred state chip
- *     (no room for the dial).
- *   * Wide-thin (`width > 1.5×height`) → [RemoteHaGaugeWide]
- *     (arc-on-left + value/name on the right). Targets Wear S and
- *     `2×1` launcher pills.
- *   * Otherwise → [RemoteHaGaugeCompact] (arc fills the cell, value
- *     overlaid inside the arc). Targets `2×2` / `3×2` launcher
- *     squares and Wear L.
+ *   * **Too short for stacked** (`h < 70 dp`) → [RemoteHaGaugeWide].
+ *     Arc on the left, value · name on the right. The Wear S
+ *     200×60 chip is the canonical hit; cells with no vertical room
+ *     for an arc-as-backdrop layout reach for the row instead.
+ *   * **Stacked Box overlay** (otherwise) → [RemoteHaGaugeStacked].
+ *     Half-arc as a backdrop with value · name · range overlaid at
+ *     the bottom of the box. Covers everything from a 1×1 launcher
+ *     chip up to a 3×2 dashboard tile and Wear L. The secondary
+ *     text lines ellipsise on cells that can't fit them.
  *
- * Aspect detection uses `componentWidth() / componentHeight()` and
+ * Tier selection uses `componentWidth()` and `componentHeight()` and
  * lowers to nested `RemoteStateLayout(RemoteBoolean)` (the only
  * state-layout overload that respects live state in alpha010 — see
  * [ee.schimke.ha.rc.RemoteSizeBreakpoint]). Both float expressions
  * are materialised via transparent text so the runtime resolves them
  * correctly (#224).
+ *
+ * 2-D gates are encoded as `min(w, h · minW/minH).ge(minW)` because
+ * `RemoteBoolean.and()` doesn't materialise its operands in alpha010
+ * and `.and()`-composed predicates collapse to `false` at playback.
  */
 class GaugeCardConverter : CardConverter {
     override val cardType: String = CardTypes.GAUGE
@@ -88,8 +94,13 @@ class GaugeCardConverter : CardConverter {
             RemoteFloat.createNamedRemoteFloatExpression(heightName, RemoteState.Domain.User) {
                 componentHeight()
             }
-        val isAboveChip = widthExpr.ge(80.rdp.toPx())
-        val isWideThin = widthExpr.gt(heightExpr * 1.5f.rf)
+        // Single height-only outer gate — short cells (Wear S) get
+        // the side-by-side Row, everything else gets the Stacked Box
+        // overlay. Nested inner state-layouts on width or a 2-D
+        // gate don't materialise reliably in alpha010 (#224); they
+        // collapse to false at playback, so a 1-D outer toggle is
+        // all we get for now.
+        val hasRoomForStacked = heightExpr.ge(MinStackedHeightDp.rdp.toPx())
 
         RemoteBox(modifier = modifier.fillMaxSize()) {
             // Materialise both named expressions in the document. The
@@ -105,26 +116,19 @@ class GaugeCardConverter : CardConverter {
                 color = Color.Transparent.rc,
             )
 
-            RemoteStateLayout(isAboveChip) { hasRoom ->
-                if (!hasRoom) {
-                    CompactStateChip(card, snapshot)
+            val data = gaugeData(card, snapshot)
+            RemoteStateLayout(hasRoomForStacked) { tall ->
+                if (tall) {
+                    RemoteHaGaugeStacked(data, RemoteModifier.fillMaxSize())
                 } else {
-                    RemoteStateLayout(isWideThin) { wide ->
-                        if (wide) {
-                            RemoteHaGaugeWide(
-                                gaugeData(card, snapshot),
-                                modifier = RemoteModifier.fillMaxSize(),
-                            )
-                        } else {
-                            RemoteHaGaugeCompact(
-                                gaugeData(card, snapshot),
-                                modifier = RemoteModifier.fillMaxSize(),
-                            )
-                        }
-                    }
+                    RemoteHaGaugeWide(data, RemoteModifier.fillMaxSize())
                 }
             }
         }
+    }
+
+    private companion object {
+        const val MinStackedHeightDp = 70
     }
 
     @Composable


### PR DESCRIPTION
## Summary

Reworks the gauge card's Fixed-mode layout so every `CardPreviewMatrix_Gauge` cell renders with the arc visible and the value / name / range text overlaid in the dial's open interior.

- Replaces the prior `wide / compact / chip` ladder with a single Box-overlay composable (`RemoteHaGaugeStacked`) that scales from a 1×1 launcher chip up to a 3×2 dashboard tile and Wear L. The arc is anchored at the top with its visible base capped at ~60 % of the cell height so the text overlay always lands in the open interior.
- Keeps `RemoteHaGaugeWide` (arc-on-left + value / name on the right) for very short pills (Wear S, 200×60) where the backdrop has no vertical room.
- Drops the unused compact / chip variants and the broken `widthExpr.ge(...)`-as-inner-state-layout predicates that collapsed to `false` at playback in alpha010.

## Notes for follow-up

- The 1×1 cell ellipsises the value (`21.4 …`). A genuine sub-80-dp tier may want to bring back a stripped-down chip — left out here because the inner state-layout predicates don't materialise reliably in alpha010 (#224); we get one toggle off the outer height gate.
- The 3-tier ladder design in `docs/architecture/adaptive-card-layouts.md` §gauge still stands; this PR is the first cell in that ladder that actually fires at playback, so the doc isn't out of date — just lighter than the full ladder.

## Test plan

- [ ] `compose-preview render --filter CardPreviewMatrix_Gauge` shows the arc + text in every cell
- [ ] `./gradlew :rc-components:check :rc-converter:check`
- [ ] Pin a gauge card to the launcher at 2×1 and 3×2 — visually verify the overlay isn't clipped on a real device

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEgX4Q6Er6Xc2LoZZpdbYB)_