### PR TITLE
Add responsive size variants for arc dial and weather cards

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviewMatrix.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviewMatrix.kt
@@ -409,6 +409,63 @@ fun CardPreviewMatrix_Button() {
 }
 
 @Preview(
+    name = "matrix — thermostat",
+    showBackground = false,
+    widthDp = MATRIX_CANVAS_WIDTH_DP,
+    heightDp = 360,
+)
+@Composable
+fun CardPreviewMatrix_Thermostat() {
+    val card = card("""{"type":"thermostat","entity":"climate.living_room"}""")
+    CardPreviewMatrix(
+        card = card,
+        snapshot = Fixtures.thermostat,
+        baseGridSize = WidgetGridSize(cellsW = 3, cellsH = 3),
+        appWidthDp = 240,
+        label = "thermostat · climate.living_room",
+    )
+}
+
+@Preview(
+    name = "matrix — humidifier",
+    showBackground = false,
+    widthDp = MATRIX_CANVAS_WIDTH_DP,
+    heightDp = 360,
+)
+@Composable
+fun CardPreviewMatrix_Humidifier() {
+    val card = card("""{"type":"humidifier","entity":"humidifier.bedroom"}""")
+    CardPreviewMatrix(
+        card = card,
+        snapshot = Fixtures.humidifier,
+        baseGridSize = WidgetGridSize(cellsW = 3, cellsH = 3),
+        appWidthDp = 240,
+        label = "humidifier · humidifier.bedroom",
+    )
+}
+
+@Preview(
+    name = "matrix — weather-forecast",
+    showBackground = false,
+    widthDp = MATRIX_CANVAS_WIDTH_DP,
+    heightDp = 280,
+)
+@Composable
+fun CardPreviewMatrix_WeatherForecast() {
+    val card = card(
+        """{"type":"weather-forecast","entity":"weather.forecast_home",
+            "show_current":true,"show_forecast":true}"""
+    )
+    CardPreviewMatrix(
+        card = card,
+        snapshot = Fixtures.weather,
+        baseGridSize = WidgetGridSize(cellsW = 5, cellsH = 2),
+        appWidthDp = 320,
+        label = "weather-forecast · weather.forecast_home",
+    )
+}
+
+@Preview(
     name = "matrix — entities",
     showBackground = false,
     widthDp = MATRIX_CANVAS_WIDTH_DP,

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaArcDial.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaArcDial.kt
@@ -22,11 +22,14 @@ import androidx.compose.remote.creation.compose.modifier.background
 import androidx.compose.remote.creation.compose.modifier.border
 import androidx.compose.remote.creation.compose.modifier.clickable
 import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxHeight
+import androidx.compose.remote.creation.compose.modifier.fillMaxSize
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
 import androidx.compose.remote.creation.compose.modifier.padding
 import androidx.compose.remote.creation.compose.modifier.size
 import androidx.compose.remote.creation.compose.shapes.RemoteCircleShape
 import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.RemoteFloat
 import androidx.compose.remote.creation.compose.state.RemoteString
 import androidx.compose.remote.creation.compose.state.asRemotePaint
 import androidx.compose.remote.creation.compose.state.rc
@@ -58,6 +61,12 @@ import androidx.wear.compose.remote.material3.RemoteIcon
  * [HaArcDialData.targetFraction] is set, a small marker dot is drawn
  * on the arc at that fraction (rendered as a near-zero-sweep arc with
  * a round stroke cap, which avoids capture-time trig on RemoteFloat).
+ *
+ * This is the full vertical card — used at the app preferred width and
+ * for larger launcher widget sizes. Smaller surfaces fall through to
+ * [RemoteHaArcDialWide] (arc-left, text-right) or [RemoteHaArcDialMini]
+ * (just arc + value); the thermostat / humidifier converters pick the
+ * variant via [ee.schimke.ha.rc.RemoteSizeBreakpoint] at playback.
  */
 @Composable
 @RemoteComposable
@@ -100,13 +109,148 @@ fun RemoteHaArcDial(
     }
 }
 
+/**
+ * Horizontal arc-left / text-right variant — used for shorter widget
+ * cells (Wear L, compact launcher tiles) where the full vertical card
+ * doesn't fit. Arc canvas is sized off the row height (square); the
+ * text column shows the mode chip and target. Steppers are omitted on
+ * this layout — the cells that hit this tier (Wear S/L) don't have
+ * vertical room for them.
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaArcDialWide(
+    data: HaArcDialData,
+    modifier: RemoteModifier = RemoteModifier,
+) {
+    val theme = haTheme()
+    val click = data.tapAction.toRemoteAction()
+        ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
+    RemoteRow(
+        modifier = modifier
+            .then(click)
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(horizontal = 10.rdp, vertical = 8.rdp),
+        verticalAlignment = RemoteAlignment.CenterVertically,
+        horizontalArrangement = RemoteArrangement.spacedBy(10.rdp),
+    ) {
+        RemoteBox(
+            modifier = RemoteModifier.fillMaxHeight().size(56.rdp),
+            contentAlignment = RemoteAlignment.Center,
+        ) {
+            ArcCanvas(
+                data = data,
+                theme = theme,
+                trackStrokePx = 6f,
+                fillStrokePx = 6f,
+                markerStrokePx = 8f,
+                paddingPx = 3f,
+            )
+            RemoteText(
+                text =
+                    LiveValues.attribute(
+                        data.entityId,
+                        data.centerLabelAttribute,
+                        data.centerLabel,
+                    ),
+                color = theme.primaryText.rc,
+                fontSize = 13.rsp,
+                fontWeight = FontWeight.SemiBold,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        RemoteColumn(
+            modifier = RemoteModifier.weight(1f),
+            verticalArrangement = RemoteArrangement.Center,
+            horizontalAlignment = RemoteAlignment.Start,
+        ) {
+            ModeChip(data.modeChip, data.accent)
+            if (data.supportingLabel != null && data.supportingLabelAttribute != null) {
+                RemoteText(
+                    text =
+                        LiveValues.attribute(
+                            data.entityId,
+                            data.supportingLabelAttribute,
+                            data.supportingLabel,
+                        ),
+                    color = data.accent.rc,
+                    fontSize = 11.rsp,
+                    style = RemoteTextStyle.Default,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Smallest arc-dial variant — fills its container with just the arc +
+ * centre value. No name, no mode chip, no target, no steppers. Used by
+ * 1×1 launcher chips where there's no room for the side-by-side
+ * layout.
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaArcDialMini(
+    data: HaArcDialData,
+    modifier: RemoteModifier = RemoteModifier,
+) {
+    val theme = haTheme()
+    val click = data.tapAction.toRemoteAction()
+        ?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
+    RemoteBox(
+        modifier = modifier
+            .then(click)
+            .clip(RemoteRoundedCornerShape(12.rdp))
+            .background(theme.cardBackground.rc)
+            .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+            .padding(4.rdp),
+        contentAlignment = RemoteAlignment.Center,
+    ) {
+        ArcCanvas(
+            data = data,
+            theme = theme,
+            trackStrokePx = 6f,
+            fillStrokePx = 6f,
+            markerStrokePx = 8f,
+            paddingPx = 3f,
+        )
+        RemoteText(
+            text =
+                LiveValues.attribute(
+                    data.entityId,
+                    data.centerLabelAttribute,
+                    data.centerLabel,
+                ),
+            color = theme.primaryText.rc,
+            fontSize = 14.rsp,
+            fontWeight = FontWeight.SemiBold,
+            style = RemoteTextStyle.Default,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
 @Composable
 private fun DialBody(data: HaArcDialData, theme: HaTheme) {
     RemoteBox(
         modifier = RemoteModifier.size(180.rdp),
         contentAlignment = RemoteAlignment.Center,
     ) {
-        ArcCanvas(data, theme)
+        ArcCanvas(
+            data = data,
+            theme = theme,
+            trackStrokePx = 12f,
+            fillStrokePx = 12f,
+            markerStrokePx = 14f,
+            paddingPx = 4f,
+        )
         RemoteColumn(
             horizontalAlignment = RemoteAlignment.CenterHorizontally,
             verticalArrangement = RemoteArrangement.spacedBy(2.rdp),
@@ -181,16 +325,27 @@ private fun ChipText(text: RemoteString, accent: Color) {
     )
 }
 
+/**
+ * Common arc rendering. Sizes itself off the box it sits inside via
+ * `fillMaxSize`, so callers control the arc footprint by sizing the
+ * surrounding container (e.g. 180 dp box in the vertical card vs.
+ * 56 dp box in the wide variant). Stroke widths are passed as
+ * pixel-space floats — small variants want thinner strokes so the
+ * dial doesn't read as a clumsy donut at chip sizes.
+ */
 @Composable
-private fun ArcCanvas(data: HaArcDialData, theme: HaTheme) {
-    // Live host binding for the value & (optional) target fraction —
-    // wrapped in `animateRemoteFloat` so any state push from the host
-    // tweens the sweep/marker over [DialAnimationSeconds] instead of
-    // snapping. Constant when entityId is null (preview).
+private fun ArcCanvas(
+    data: HaArcDialData,
+    theme: HaTheme,
+    trackStrokePx: Float,
+    fillStrokePx: Float,
+    markerStrokePx: Float,
+    paddingPx: Float,
+) {
     val v = data.valueFraction.coerceIn(0f, 1f)
     val rawValueFraction = LiveValues.namedFloat(data.entityId, "value_fraction", v)
     val animatedValueFraction = animateRemoteFloat(rawValueFraction, DialAnimationSeconds)
-    val animatedSweep = animatedValueFraction * 270f.rf
+    val animatedSweep: RemoteFloat = animatedValueFraction * 270f.rf
 
     val target = data.targetFraction
     val rawTargetFraction = if (target != null) {
@@ -200,18 +355,23 @@ private fun ArcCanvas(data: HaArcDialData, theme: HaTheme) {
         ?.let { animateRemoteFloat(it, DialAnimationSeconds) }
     val animatedMarkerAngle = animatedTargetFraction?.let { 135f.rf + it * 270f.rf }
 
-    RemoteCanvas(modifier = RemoteModifier.size(180.rdp)) {
+    RemoteCanvas(modifier = RemoteModifier.fillMaxSize()) {
         val w = width
         val h = height
-        val stroke = 12f.rf
-        val pad = stroke / 2f.rf + 4f.rf
-        val topLeft = RemoteOffset(pad, pad)
-        val arcSize = RemoteSize(w - pad * 2f.rf, h - pad * 2f.rf)
+        val pad = (trackStrokePx.coerceAtLeast(fillStrokePx) / 2f) + paddingPx
+        val padTwice = (pad * 2f).rf
+        val byHeight = h - padTwice
+        val byWidth = w - padTwice
+        val side = byHeight.min(byWidth)
+        val left = (w - side) / 2f.rf
+        val top = (h - side) / 2f.rf
+        val topLeft = RemoteOffset(left, top)
+        val arcSize = RemoteSize(side, side)
 
         val track = AndroidPaint().apply {
             isAntiAlias = true
             style = AndroidPaint.Style.STROKE
-            strokeWidth = 12f
+            strokeWidth = trackStrokePx
             strokeCap = AndroidPaint.Cap.ROUND
             color = theme.divider.toArgb()
         }.asRemotePaint()
@@ -220,7 +380,7 @@ private fun ArcCanvas(data: HaArcDialData, theme: HaTheme) {
         val fill = AndroidPaint().apply {
             isAntiAlias = true
             style = AndroidPaint.Style.STROKE
-            strokeWidth = 12f
+            strokeWidth = fillStrokePx
             strokeCap = AndroidPaint.Cap.ROUND
             color = data.accent.toArgb()
         }.asRemotePaint()
@@ -230,7 +390,7 @@ private fun ArcCanvas(data: HaArcDialData, theme: HaTheme) {
             val marker = AndroidPaint().apply {
                 isAntiAlias = true
                 style = AndroidPaint.Style.STROKE
-                strokeWidth = 14f
+                strokeWidth = markerStrokePx
                 strokeCap = AndroidPaint.Cap.ROUND
                 color = theme.primaryText.toArgb()
             }.asRemotePaint()

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaWeatherForecast.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaWeatherForecast.kt
@@ -13,6 +13,7 @@ import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.background
 import androidx.compose.remote.creation.compose.modifier.border
 import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxSize
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
 import androidx.compose.remote.creation.compose.modifier.padding
 import androidx.compose.remote.creation.compose.modifier.size
@@ -121,6 +122,113 @@ private fun CurrentRow(data: HaWeatherForecastData, theme: HaTheme) {
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
+    }
+}
+
+/**
+ * Wide-thin Fixed-mode weather variant — icon + condition stacked on
+ * the left, big temperature right. Targets short widget cells (Wear
+ * S/L) where the full card's forecast strip won't fit. The condition
+ * text ellipsises rather than wrapping so the row stays one line.
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaWeatherForecastWide(
+    data: HaWeatherForecastData,
+    modifier: RemoteModifier = RemoteModifier,
+) {
+    val theme = haTheme()
+    RemoteRow(
+        modifier =
+            modifier
+                .clip(RemoteRoundedCornerShape(12.rdp))
+                .background(theme.cardBackground.rc)
+                .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+                .padding(horizontal = 10.rdp, vertical = 8.rdp),
+        verticalAlignment = RemoteAlignment.CenterVertically,
+        horizontalArrangement = RemoteArrangement.spacedBy(8.rdp),
+    ) {
+        RemoteIcon(
+            imageVector = data.icon,
+            contentDescription = data.condition,
+            modifier = RemoteModifier.size(28.rdp),
+            tint = theme.primaryText.rc,
+        )
+        RemoteColumn(
+            modifier = RemoteModifier.weight(1f),
+            verticalArrangement = RemoteArrangement.Center,
+        ) {
+            RemoteText(
+                text = data.condition,
+                color = theme.primaryText.rc,
+                fontSize = 13.rsp,
+                fontWeight = FontWeight.Medium,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            RemoteText(
+                text = (data.supportingLine ?: data.name).rs,
+                color = theme.secondaryText.rc,
+                fontSize = 11.rsp,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        RemoteText(
+            text = LiveValues.attribute(data.entityId, "temperature_label", data.temperature),
+            color = theme.primaryText.rc,
+            fontSize = 20.rsp,
+            fontWeight = FontWeight.Light,
+            style = RemoteTextStyle.Default,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
+/**
+ * Smallest weather variant — just the icon + temperature stacked. No
+ * condition text, no forecast. Used by 1×1 launcher chips.
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaWeatherForecastMini(
+    data: HaWeatherForecastData,
+    modifier: RemoteModifier = RemoteModifier,
+) {
+    val theme = haTheme()
+    RemoteBox(
+        modifier =
+            modifier
+                .clip(RemoteRoundedCornerShape(12.rdp))
+                .background(theme.cardBackground.rc)
+                .border(1.rdp, theme.divider.rc, RemoteRoundedCornerShape(12.rdp))
+                .padding(4.rdp),
+        contentAlignment = RemoteAlignment.Center,
+    ) {
+        RemoteColumn(
+            modifier = RemoteModifier.fillMaxSize(),
+            verticalArrangement = RemoteArrangement.Center,
+            horizontalAlignment = RemoteAlignment.CenterHorizontally,
+        ) {
+            RemoteIcon(
+                imageVector = data.icon,
+                contentDescription = data.condition,
+                modifier = RemoteModifier.size(22.rdp),
+                tint = theme.primaryText.rc,
+            )
+            RemoteText(
+                text = LiveValues.attribute(data.entityId, "temperature_label", data.temperature),
+                color = theme.primaryText.rc,
+                fontSize = 13.rsp,
+                fontWeight = FontWeight.Medium,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
     }
 }
 

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/HumidifierCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/HumidifierCardConverter.kt
@@ -10,7 +10,6 @@ import ee.schimke.ha.rc.CardConverter
 import ee.schimke.ha.rc.components.HaAction
 import ee.schimke.ha.rc.components.HaArcDialData
 import ee.schimke.ha.rc.components.HaModeChip
-import ee.schimke.ha.rc.components.RemoteHaArcDial
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -58,30 +57,28 @@ class HumidifierCardConverter : CardConverter {
 
         val (incAction, decAction) = stepperActions(entity?.entityId, target, 5f)
 
-        RemoteHaArcDial(
-            HaArcDialData(
-                entityId = entity?.entityId,
-                name = name,
-                valueFraction = valueFraction.coerceIn(0f, 1f),
-                targetFraction = targetFraction?.coerceIn(0f, 1f),
-                centerLabel = centerLabel,
-                centerLabelAttribute = "current_humidity_label",
-                supportingLabel = supportingLabel,
-                supportingLabelAttribute = supportingLabel?.let { "humidity_label" },
-                modeChip =
-                    HaModeChip.Static(
-                        entityId = entity?.entityId,
-                        attribute = "action_label",
-                        initial = modeChip,
-                    ),
-                accent = Color(0xFF00ACC1),
-                showSteppers = target != null,
-                centerIcon = null,
-                incrementAction = incAction,
-                decrementAction = decAction,
-            ),
-            modifier = modifier,
+        val data = HaArcDialData(
+            entityId = entity?.entityId,
+            name = name,
+            valueFraction = valueFraction.coerceIn(0f, 1f),
+            targetFraction = targetFraction?.coerceIn(0f, 1f),
+            centerLabel = centerLabel,
+            centerLabelAttribute = "current_humidity_label",
+            supportingLabel = supportingLabel,
+            supportingLabelAttribute = supportingLabel?.let { "humidity_label" },
+            modeChip =
+                HaModeChip.Static(
+                    entityId = entity?.entityId,
+                    attribute = "action_label",
+                    initial = modeChip,
+                ),
+            accent = Color(0xFF00ACC1),
+            showSteppers = target != null,
+            centerIcon = null,
+            incrementAction = incAction,
+            decrementAction = decAction,
         )
+        RenderArcDial(data, modifier)
     }
 }
 

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ThermostatCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/ThermostatCardConverter.kt
@@ -1,6 +1,9 @@
+@file:Suppress("RestrictedApi")
+
 package ee.schimke.ha.rc.cards
 
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import ee.schimke.ha.model.CardConfig
@@ -8,10 +11,15 @@ import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.EntityState
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.CardSizeMode
+import ee.schimke.ha.rc.LocalCardSizeMode
+import ee.schimke.ha.rc.RemoteSizeBreakpoint
 import ee.schimke.ha.rc.components.HaAction
 import ee.schimke.ha.rc.components.HaArcDialData
 import ee.schimke.ha.rc.components.HaModeChip
 import ee.schimke.ha.rc.components.RemoteHaArcDial
+import ee.schimke.ha.rc.components.RemoteHaArcDialMini
+import ee.schimke.ha.rc.components.RemoteHaArcDialWide
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -67,32 +75,57 @@ class ThermostatCardConverter : CardConverter {
 
         val (incAction, decAction) = stepperActions(entity, target, step) ?: (HaAction.None to HaAction.None)
 
-        RemoteHaArcDial(
-            HaArcDialData(
-                entityId = entityId,
-                name = name,
-                valueFraction = valueFraction.coerceIn(0f, 1f),
-                targetFraction = targetFraction?.coerceIn(0f, 1f),
-                centerLabel = centerLabel,
-                centerLabelAttribute = "current_temperature_label",
-                supportingLabel = supportingLabel,
-                supportingLabelAttribute = supportingLabel?.let { "temperature_label" },
-                modeChip =
-                    HaModeChip.Static(
-                        entityId = entityId,
-                        attribute = "hvac_action_label",
-                        initial = modeChip,
-                    ),
-                accent = accent,
-                showSteppers = target != null,
-                centerIcon = null,
-                incrementAction = incAction,
-                decrementAction = decAction,
-            ),
-            modifier = modifier,
+        val data = HaArcDialData(
+            entityId = entityId,
+            name = name,
+            valueFraction = valueFraction.coerceIn(0f, 1f),
+            targetFraction = targetFraction?.coerceIn(0f, 1f),
+            centerLabel = centerLabel,
+            centerLabelAttribute = "current_temperature_label",
+            supportingLabel = supportingLabel,
+            supportingLabelAttribute = supportingLabel?.let { "temperature_label" },
+            modeChip =
+                HaModeChip.Static(
+                    entityId = entityId,
+                    attribute = "hvac_action_label",
+                    initial = modeChip,
+                ),
+            accent = accent,
+            showSteppers = target != null,
+            centerIcon = null,
+            incrementAction = incAction,
+            decrementAction = decAction,
         )
+
+        RenderArcDial(data, modifier)
     }
 }
+
+/**
+ * Width ladder shared by thermostat / humidifier. Mirrors the gauge
+ * tier list in [GaugeCardConverter]: narrow chip → arc-only Mini,
+ * medium row → arc-left Wide, full cell → vertical card with steppers.
+ */
+@Composable
+internal fun RenderArcDial(data: HaArcDialData, modifier: RemoteModifier) {
+    when (LocalCardSizeMode.current) {
+        CardSizeMode.Wrap -> RemoteHaArcDial(data, modifier)
+        CardSizeMode.Fixed ->
+            RemoteSizeBreakpoint(
+                thresholdsDp = intArrayOf(ArcDialMiniMaxDp, ArcDialWideMaxDp),
+                modifier = modifier.fillMaxSize(),
+            ) { tier ->
+                when (tier) {
+                    0 -> RemoteHaArcDialMini(data, RemoteModifier.fillMaxSize())
+                    1 -> RemoteHaArcDialWide(data, RemoteModifier.fillMaxSize())
+                    else -> RemoteHaArcDial(data, RemoteModifier.fillMaxSize())
+                }
+            }
+    }
+}
+
+private const val ArcDialMiniMaxDp = 130
+private const val ArcDialWideMaxDp = 260
 
 private fun stepperActions(
     entity: EntityState?,

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/WeatherForecastCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/WeatherForecastCardConverter.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RestrictedApi")
+
 package ee.schimke.ha.rc.cards
 
 import androidx.compose.material.icons.Icons
@@ -10,17 +12,23 @@ import androidx.compose.material.icons.filled.WbCloudy
 import androidx.compose.material.icons.filled.WbSunny
 import androidx.compose.material.icons.outlined.Cloud
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.CardSizeMode
+import ee.schimke.ha.rc.LocalCardSizeMode
+import ee.schimke.ha.rc.RemoteSizeBreakpoint
 import ee.schimke.ha.rc.formatValueWithUnit
 import ee.schimke.ha.rc.components.HaWeatherDay
 import ee.schimke.ha.rc.components.HaWeatherForecastData
 import ee.schimke.ha.rc.components.LiveValues
 import ee.schimke.ha.rc.components.RemoteHaWeatherForecast
+import ee.schimke.ha.rc.components.RemoteHaWeatherForecastMini
+import ee.schimke.ha.rc.components.RemoteHaWeatherForecastWide
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
@@ -74,20 +82,35 @@ class WeatherForecastCardConverter : CardConverter {
                 }
             else emptyList()
 
-        RemoteHaWeatherForecast(
-            HaWeatherForecastData(
-                entityId = entityId,
-                name = name,
-                condition = LiveValues.state(entityId, formatCondition(condition)),
-                temperature = temperature,
-                supportingLine = null,
-                icon = weatherIcon(condition),
-                days = days,
-            ),
-            modifier = modifier,
+        val data = HaWeatherForecastData(
+            entityId = entityId,
+            name = name,
+            condition = LiveValues.state(entityId, formatCondition(condition)),
+            temperature = temperature,
+            supportingLine = null,
+            icon = weatherIcon(condition),
+            days = days,
         )
+
+        when (LocalCardSizeMode.current) {
+            CardSizeMode.Wrap -> RemoteHaWeatherForecast(data, modifier)
+            CardSizeMode.Fixed ->
+                RemoteSizeBreakpoint(
+                    thresholdsDp = intArrayOf(WeatherMiniMaxDp, WeatherWideMaxDp),
+                    modifier = modifier.fillMaxSize(),
+                ) { tier ->
+                    when (tier) {
+                        0 -> RemoteHaWeatherForecastMini(data, RemoteModifier.fillMaxSize())
+                        1 -> RemoteHaWeatherForecastWide(data, RemoteModifier.fillMaxSize())
+                        else -> RemoteHaWeatherForecast(data, RemoteModifier.fillMaxSize())
+                    }
+                }
+        }
     }
 }
+
+private const val WeatherMiniMaxDp = 130
+private const val WeatherWideMaxDp = 260
 
 private fun weatherIcon(condition: String?): ImageVector = when (condition) {
     "sunny", "clear-night" -> Icons.Filled.WbSunny


### PR DESCRIPTION
## Summary
Introduces responsive layout variants for arc dial (thermostat/humidifier) and weather forecast cards to support different widget sizes and form factors. Cards now adapt their layout based on available space using a size breakpoint system.

## Key Changes

### Arc Dial Components
- **New `RemoteHaArcDialWide`**: Horizontal arc-left/text-right layout for medium-sized cells (Wear S/L, compact launcher tiles). Omits steppers due to space constraints.
- **New `RemoteHaArcDialMini`**: Minimal variant with just arc + center value for 1×1 launcher chips.
- **Refactored `ArcCanvas`**: Extracted common arc rendering logic with parameterized stroke widths and padding. Now uses `fillMaxSize()` to adapt to container dimensions rather than fixed 180dp sizing.
- **Updated `DialBody`**: Passes explicit stroke parameters to `ArcCanvas` for the full vertical card variant.

### Weather Forecast Components
- **New `RemoteHaWeatherForecastWide`**: Icon + condition stacked left, temperature right. Targets short widget cells with single-line ellipsized condition text.
- **New `RemoteHaWeatherForecastMini`**: Icon + temperature stacked vertically for 1×1 launcher chips.

### Card Converters
- **ThermostatCardConverter**: Extracted rendering logic into `RenderArcDial()` helper that uses `RemoteSizeBreakpoint` to select appropriate variant based on available width (Mini ≤130dp, Wide ≤260dp, full card otherwise).
- **HumidifierCardConverter**: Updated to use shared `RenderArcDial()` helper.
- **WeatherForecastCardConverter**: Implements similar size-based variant selection with `RemoteSizeBreakpoint`.

### Preview Updates
Added three new preview matrices for thermostat, humidifier, and weather-forecast cards to visualize responsive behavior across different grid sizes.

## Implementation Details
- Size breakpoints use `RemoteSizeBreakpoint` composable to measure available width at runtime and select the appropriate variant tier.
- Stroke widths are parameterized in `ArcCanvas` to allow smaller variants to use thinner strokes (6-8px vs 12-14px) for better visual balance at chip sizes.
- All variants maintain consistent styling (rounded corners, borders, padding) while adapting content density.
- Humidifier and thermostat converters share the same responsive logic via `RenderArcDial()`.

https://claude.ai/code/session_01P88NAvQmqMwtMVdPF7h6R7