### PR TITLE
Add the domain `homeassistant` to the list of domains with clear text allowed.

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -11,5 +11,6 @@
         <domain includeSubdomains="false">10.0.2.2</domain>
         <domain includeSubdomains="false">127.0.0.1</domain>
         <domain includeSubdomains="false">localhost</domain>
+        <domain includeSubdomains="true">homeassistant</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
* Add the domain `homeassistant` to the list of included domains for clear text traffic.

Fixes:

```
05-13 13:41:37.540  7024  7024 E LoginController: token exchange failed: code=3 type=0 desc=Network error cause=java.io.IOException: Cleartext HTTP traffic to 192.168.0.186 not permitted
05-13 13:41:37.540  7024  7024 E LoginController: AuthorizationException: {"type":0,"code":3,"errorDescription":"Network error"}
05-13 13:41:37.540  7024  7024 E LoginController:       at hk.doInBackground(r8-map-id-bd64ee4ee73a2a22d25e34d98b5d46ffff558b4a6d17cd0fd9908af28058affd:194)
05-13 13:41:37.540  7024  7024 E LoginController:       at android.os.AsyncTask$3.call(AsyncTask.java:396)
05-13 13:41:37.540  7024  7024 E LoginController:       at java.util.concurrent.FutureTask.run(FutureTask.java:317)
05-13 13:41:37.540  7024  7024 E LoginController:       at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:307)
05-13 13:41:37.540  7024  7024 E LoginController:       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1154)
05-13 13:41:37.540  7024  7024 E LoginController:       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:652)
05-13 13:41:37.540  7024  7024 E LoginController:       at java.lang.Thread.run(Thread.java:1564)
05-13 13:41:37.540  7024  7024 E LoginController: Caused by: java.io.IOException: Cleartext HTTP traffic to 192.168.0.186 not permitted
05-13 13:41:37.540  7024  7024 E LoginController:       at com.android.okhttp.HttpHandler$CleartextURLFilter.checkURLPermitted(HttpHandler.java:127)
05-13 13:41:37.540  7024  7024 E LoginController:       at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:462)
05-13 13:41:37.540  7024  7024 E LoginController:       at com.android.okhttp.internal.huc.HttpURLConnectionImpl.connect(HttpURLConnectionImpl.java:131)
05-13 13:41:37.540  7024  7024 E LoginController:       at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getOutputStream(HttpURLConnectionImpl.java:262)
05-13 13:41:37.540  7024  7024 E LoginController:       at hk.doInBackground(r8-map-id-bd64ee4ee73a2a22d25e34d98b5d46ffff558b4a6d17cd0fd9908af28058affd:93)
05-13 13:41:37.540  7024  7024 E LoginController:       ... 6 more
```