### PR TITLE
feat(wear): wrap slot widget previews in simulated watch face

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviewMatrix.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviewMatrix.kt
@@ -2,6 +2,8 @@
 
 package ee.schimke.ha.previews
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -9,14 +11,21 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.sp
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth as rcFillMaxWidth
 import androidx.compose.runtime.Composable
@@ -39,6 +48,7 @@ import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.components.HaTheme
 import ee.schimke.ha.rc.components.ProvideHaTheme
 import ee.schimke.ha.rc.enableRemoteComposeWrapContent
+import ee.schimke.ha.rc.components.R as ComponentsR
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 
@@ -145,10 +155,14 @@ fun CardPreviewMatrix(
                         )
                     }
                     // Row 1 — App preferred + the two Wear container shapes.
-                    // App and Wear render at watch / mobile densities (Wear
-                    // cells override LocalDensity to 2×); grouping them on
-                    // the same line keeps the "dashboard tile + wear tile"
-                    // story together.
+                    // App renders at the mobile preview density; the wear
+                    // cells render inside a circular watch-face frame at
+                    // wear-typical 2× density (see WatchFaceCell). The
+                    // frame matches the WearWidgetPreviewSnapshot helper
+                    // used by the slot widget previews — same chrome
+                    // (black 227dp circle, app icon, label band) so the
+                    // matrix shows the card in its actual surface, not
+                    // as a floating rectangle.
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -159,19 +173,17 @@ fun CardPreviewMatrix(
                             cellWidthDp = appWidthDp,
                             label = "App ${appWidthDp}dp",
                         )
-                        FixedModeCell(
+                        WatchFaceCell(
                             card = card,
                             snapshot = snapshot,
                             sizeDp = WearSmall,
                             label = "Wear S",
-                            densityScale = WearDensityScale,
                         )
-                        FixedModeCell(
+                        WatchFaceCell(
                             card = card,
                             snapshot = snapshot,
                             sizeDp = WearLarge,
                             label = "Wear L",
-                            densityScale = WearDensityScale,
                         )
                     }
                     // Row 2 — three launcher widget sizes around the base
@@ -295,6 +307,98 @@ private fun FixedModeCell(
     }
 }
 
+/**
+ * Wear cell that frames the captured widget inside a simulated
+ * circular watch face — 227dp black circle, app icon + "Terrazzo
+ * slot" caption at the top, widget offset 14dp below centre.
+ * Mirrors the visual chrome of
+ * [androidx.glance.wear.tooling.preview.WearWidgetPreviewSnapshot]
+ * (vendored from
+ * https://github.com/android/wear-os-samples/pull/1371); this module
+ * doesn't depend on `androidx.glance.wear` so the frame is inlined
+ * rather than calling the snapshot helper directly. Keep the two
+ * surfaces in sync if either side moves.
+ */
+@Composable
+private fun WatchFaceCell(
+    card: CardConfig,
+    snapshot: HaSnapshot,
+    sizeDp: WidgetSizeDp,
+    label: String,
+) {
+    val parentDensity = LocalDensity.current
+    val cellDensity = Density(WearDensityScale, parentDensity.fontScale)
+    CompositionLocalProvider(LocalDensity provides cellDensity) {
+        CellLabelled(label = label, widthDp = WatchFaceDiameterDp) {
+            Box(
+                modifier =
+                    Modifier
+                        .size(WatchFaceDiameterDp.dp)
+                        .clip(CircleShape)
+                        .background(Color.Black),
+                contentAlignment = Alignment.Center,
+            ) {
+                Box(
+                    modifier =
+                        Modifier
+                            .offset(y = 14.dp)
+                            .size(sizeDp.widthDp.dp, sizeDp.heightDp.dp),
+                ) {
+                    CachedCardPreview(
+                        cacheKey =
+                            MatrixCellKey(
+                                card,
+                                CardSizeMode.Fixed,
+                                sizeDp.widthDp,
+                                sizeDp.heightDp,
+                                WearDensityScale,
+                            ),
+                        profile = androidXExperimentalWrap,
+                        modifier = Modifier.fillMaxSize(),
+                        card = card,
+                        snapshot = snapshot,
+                    ) {
+                        ProvideCardRegistry(defaultRegistry()) {
+                            ProvideHaTheme(HaTheme.Dark) {
+                                ProvideCardSizeMode(CardSizeMode.Fixed) {
+                                    RenderChild(card, snapshot, RemoteModifier.rcFillMaxWidth())
+                                }
+                            }
+                        }
+                    }
+                }
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.fillMaxSize().padding(top = 10.dp),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier.size(40.dp).clip(CircleShape).background(Color(0xFFE0E0E0)),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Image(
+                            painter =
+                                painterResource(id = ComponentsR.drawable.ic_launcher_foreground),
+                            contentDescription = null,
+                            modifier = Modifier.size(38.dp),
+                            colorFilter = ColorFilter.tint(Color(0xFF424242)),
+                        )
+                    }
+                    Text(
+                        text = "Terrazzo slot",
+                        color = Color.White,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.padding(top = 2.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+private const val WatchFaceDiameterDp: Int = 227
+
 @Composable
 private fun CellLabelled(
     label: String,
@@ -344,8 +448,9 @@ private data class MatrixCellKey(
 // Layout is two rows: row 1 is App + Wear S + Wear L; row 2 is the
 // three launcher widget sizes (base ±1). Width pinned to 1100 dp so
 // the widest row (a 6×3 weather widget at base+1 ≈ 432 dp) fits at
-// typical preview density. Heights are tuned per card to fit both
-// rows without padding the canvas — measured cell-by-cell.
+// typical preview density. Heights leave room for the 227dp watch-face
+// frame that wraps the wear cells (see [WatchFaceCell]) plus the
+// launcher row beneath.
 
 private const val MATRIX_CANVAS_WIDTH_DP = 1100
 
@@ -353,7 +458,7 @@ private const val MATRIX_CANVAS_WIDTH_DP = 1100
     name = "matrix — tile",
     showBackground = false,
     widthDp = MATRIX_CANVAS_WIDTH_DP,
-    heightDp = 260,
+    heightDp = 400,
 )
 @Composable
 fun CardPreviewMatrix_Tile() {
@@ -370,7 +475,7 @@ fun CardPreviewMatrix_Tile() {
     name = "matrix — entity",
     showBackground = false,
     widthDp = MATRIX_CANVAS_WIDTH_DP,
-    heightDp = 260,
+    heightDp = 400,
 )
 @Composable
 fun CardPreviewMatrix_Entity() {
@@ -387,7 +492,7 @@ fun CardPreviewMatrix_Entity() {
     name = "matrix — gauge",
     showBackground = false,
     widthDp = MATRIX_CANVAS_WIDTH_DP,
-    heightDp = 380,
+    heightDp = 500,
 )
 @Composable
 fun CardPreviewMatrix_Gauge() {
@@ -410,7 +515,7 @@ fun CardPreviewMatrix_Gauge() {
     name = "matrix — button",
     showBackground = false,
     widthDp = MATRIX_CANVAS_WIDTH_DP,
-    heightDp = 340,
+    heightDp = 460,
 )
 @Composable
 fun CardPreviewMatrix_Button() {
@@ -429,7 +534,7 @@ fun CardPreviewMatrix_Button() {
     name = "matrix — thermostat",
     showBackground = false,
     widthDp = MATRIX_CANVAS_WIDTH_DP,
-    heightDp = 660,
+    heightDp = 780,
 )
 @Composable
 fun CardPreviewMatrix_Thermostat() {
@@ -447,7 +552,7 @@ fun CardPreviewMatrix_Thermostat() {
     name = "matrix — humidifier",
     showBackground = false,
     widthDp = MATRIX_CANVAS_WIDTH_DP,
-    heightDp = 660,
+    heightDp = 780,
 )
 @Composable
 fun CardPreviewMatrix_Humidifier() {
@@ -465,7 +570,7 @@ fun CardPreviewMatrix_Humidifier() {
     name = "matrix — weather-forecast",
     showBackground = false,
     widthDp = MATRIX_CANVAS_WIDTH_DP,
-    heightDp = 460,
+    heightDp = 580,
 )
 @Composable
 fun CardPreviewMatrix_WeatherForecast() {
@@ -486,7 +591,7 @@ fun CardPreviewMatrix_WeatherForecast() {
     name = "matrix — entities",
     showBackground = false,
     widthDp = MATRIX_CANVAS_WIDTH_DP,
-    heightDp = 620,
+    heightDp = 740,
 )
 @Composable
 fun CardPreviewMatrix_Entities() {

--- a/wear/src/main/kotlin/androidx/glance/wear/tooling/preview/WearWidgetPreviewSnapshot.kt
+++ b/wear/src/main/kotlin/androidx/glance/wear/tooling/preview/WearWidgetPreviewSnapshot.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Snapshot helper that renders a Glance Wear widget inside a
+// simulated circular watch face (black background, app icon + label
+// overlay, widget below). Mirrors the WearWidget sample preview helper
+// from https://github.com/android/wear-os-samples/pull/1371. The
+// upstream sample marks the helper as "temporary, drop once
+// androidx.glance.wear:wear-tooling-preview ships the equivalent
+// surface"; same deal here.
+//
+// The simpler box-only variant (no watch-face overlay) is provided
+// by the vendored androidx.glance.wear.tooling.preview.WearWidgetPreview
+// in this directory.
+
+package androidx.glance.wear.tooling.preview
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.remote.tooling.preview.RemoteDocPreview
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.wear.GlanceWearWidget
+import androidx.glance.wear.core.WearWidgetParams
+import androidx.wear.compose.material3.Text
+import ee.schimke.ha.rc.components.R
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Previews a [GlanceWearWidget] inside a simulated Wear OS watch face
+ * — a circular black surface with the app icon and title at the top
+ * and the widget rendered below.
+ *
+ * Goes a step beyond [WearWidgetPreview] (which renders just the
+ * widget rectangle) so reviewers can sanity-check how a widget reads
+ * against the surrounding watch chrome.
+ *
+ * @param widget The [GlanceWearWidget] instance to preview.
+ * @param params The [WearWidgetParams] describing container type,
+ *   dimensions and padding.
+ * @param modifier The [Modifier] applied to the inner widget surface.
+ * @param title Caption rendered above the widget; defaults to the
+ *   widget's class simple-name with spaces inserted before each
+ *   uppercase letter.
+ */
+@SuppressLint("RestrictedApi")
+@Composable
+public fun WearWidgetPreviewSnapshot(
+    widget: GlanceWearWidget,
+    params: WearWidgetParams,
+    modifier: Modifier = Modifier,
+    title: String = widget.javaClass.simpleName.replace(Regex("(?<=.)(?=\\p{Lu})"), " "),
+) {
+    val context = LocalContext.current
+    val document =
+        remember(widget, params, context) {
+            runBlocking {
+                val widgetData = widget.provideWidgetData(context, params)
+                widgetData.captureRawContent(context, params).rcDocument
+            }
+        }
+
+    Box(
+        modifier = Modifier.size(227.dp).clip(CircleShape).background(Color.Black),
+        contentAlignment = Alignment.Center,
+    ) {
+        RemoteDocPreview(
+            document,
+            modifier =
+                modifier
+                    .offset(y = 14.dp)
+                    .width((params.widthDp + 2f * params.horizontalPaddingDp).dp)
+                    .height((params.heightDp + 2f * params.verticalPaddingDp).dp),
+        )
+
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.fillMaxSize().padding(top = 10.dp),
+        ) {
+            Box(
+                modifier = Modifier.size(40.dp).clip(CircleShape).background(Color(0xFFE0E0E0)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.ic_launcher_foreground),
+                    contentDescription = null,
+                    modifier = Modifier.size(38.dp),
+                    colorFilter = ColorFilter.tint(Color(0xFF424242)),
+                )
+            }
+            Text(
+                text = title,
+                color = Color.White,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(top = 2.dp),
+            )
+        }
+    }
+}

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/widget/SlotWidgetPreviews.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/widget/SlotWidgetPreviews.kt
@@ -17,7 +17,7 @@ import androidx.glance.wear.WearWidgetDocument
 import androidx.glance.wear.core.ContainerInfo
 import androidx.glance.wear.core.WearWidgetParams
 import androidx.glance.wear.core.WidgetInstanceId
-import androidx.glance.wear.tooling.preview.WearWidgetPreview
+import androidx.glance.wear.tooling.preview.WearWidgetPreviewSnapshot
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.EntityState
 import ee.schimke.ha.model.HaSnapshot
@@ -38,13 +38,16 @@ import kotlinx.serialization.json.put
 
 /**
  * Wear-specific @Preview fixtures that exercise the Glance Wear
- * capture path end-to-end (via [WearWidgetPreview] /
- * [WearWidgetDocument]). The cross-surface "how does this card look at
- * each size" picture lives in
- * [ee.schimke.ha.previews.CardPreviewMatrix] — these previews are kept
- * thin and deliberately wear-shaped: small + large slot containers,
- * dark theme, one fixture per shape so we catch wear-profile
- * regressions in CI.
+ * capture path end-to-end (via [WearWidgetPreviewSnapshot] /
+ * [WearWidgetDocument]). [WearWidgetPreviewSnapshot] wraps the
+ * captured widget in a simulated circular watch face so reviewers can
+ * eyeball how the card reads against the watch chrome.
+ *
+ * The cross-surface "how does this card look at each size" picture
+ * lives in [ee.schimke.ha.previews.CardPreviewMatrix] — these previews
+ * are kept thin and deliberately wear-shaped: small + large slot
+ * containers, dark theme, one fixture per shape so we catch
+ * wear-profile regressions in CI.
  */
 
 private class PreviewSlotWidget(
@@ -120,11 +123,13 @@ private fun SlotWidgetPreviewFixture(
     card: CardConfig?,
     snapshot: HaSnapshot,
     container: ContainerType,
+    title: String = "Terrazzo slot",
 ) {
     val params = if (container == ContainerType.Large) largePreviewParams else smallPreviewParams
-    WearWidgetPreview(
+    WearWidgetPreviewSnapshot(
         widget = PreviewSlotWidget(card = card, snapshot = snapshot),
         params = params,
+        title = title,
     )
 }
 


### PR DESCRIPTION
Mirrors the WearWidgetPreviewSnapshot helper from
https://github.com/android/wear-os-samples/pull/1371: a 227dp
circular black surface with the app icon + label at the top and
the captured Glance Wear widget rendered below. Gives slot widget
@Preview entries the same watch-chrome context reviewers see in
the wear-os-samples WearWidget sample so the slot card reads in
its actual surface, not as a floating rectangle.

SlotWidgetPreviewFixture now calls WearWidgetPreviewSnapshot
instead of the bare WearWidgetPreview rectangle; the snapshot
helper sits next to the existing vendored WearWidgetPreview /
WearWidgetParamsProvider under androidx.glance.wear.tooling.preview.