### PR TITLE
fix(image): resolve relative entity_picture paths against baseUrl

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -390,6 +390,7 @@ private fun DashboardsRoot(
     installPending?.let { (card, snapshot) ->
         WidgetInstallSheet(
             baseUrl = session.baseUrl,
+            accessToken = session.accessToken,
             dashboardUrlPath = openedValue.takeIf { it != DASHBOARD_UNSET } ?: "",
             card = card,
             snapshot = snapshot,

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -285,6 +285,7 @@ private fun DashboardList(
                         expandedSectionByView[viewIndex] =
                             if (expandedSectionByView[viewIndex] == sectionIndex) null else sectionIndex
                     },
+                    baseUrl = baseUrl,
                     onLongPress = onCardLongPress,
                     pinContext = SectionPinContext(
                         baseUrl = baseUrl,
@@ -352,6 +353,7 @@ private fun LazyListScope.renderView(
     collapsedMode: Boolean,
     expandedSectionIndex: Int?,
     onToggleSection: (Int) -> Unit,
+    baseUrl: String?,
     onLongPress: (CardConfig) -> Unit,
     pinContext: SectionPinContext,
 ) {
@@ -364,6 +366,7 @@ private fun LazyListScope.renderView(
             snapshot = snapshot,
             registry = registry,
             compactPerRow = cfg.compactCardsPerRow,
+            baseUrl = baseUrl,
             onLongPress = onLongPress,
         )
     }
@@ -405,7 +408,7 @@ private fun LazyListScope.renderView(
                             registry.cardWidthClass(c, snapshot)
                         }
                         rows.forEach { row ->
-                            CardRow(row, snapshot, registry, onLongPress)
+                            CardRow(row, snapshot, registry, baseUrl, onLongPress)
                         }
                     }
                 }
@@ -419,6 +422,7 @@ private fun LazyListScope.renderView(
                 snapshot = snapshot,
                 registry = registry,
                 haTheme = haTheme,
+                baseUrl = baseUrl,
                 onLongPress = onLongPress,
                 pinContext = pinContext,
             )
@@ -433,6 +437,7 @@ private fun LazyListScope.renderView(
                     snapshot = snapshot,
                     registry = registry,
                     haTheme = haTheme,
+                    baseUrl = baseUrl,
                     onLongPress = onLongPress,
                     pinContext = pinContext,
                 )
@@ -634,6 +639,7 @@ private fun SectionRow(
     snapshot: HaSnapshot,
     registry: ee.schimke.ha.rc.CardRegistry,
     haTheme: HaTheme,
+    baseUrl: String?,
     onLongPress: (CardConfig) -> Unit,
     pinContext: SectionPinContext,
 ) {
@@ -649,6 +655,7 @@ private fun SectionRow(
                 snapshot = snapshot,
                 registry = registry,
                 haTheme = haTheme,
+                baseUrl = baseUrl,
                 onLongPress = onLongPress,
                 pinContext = pinContext,
                 modifier = Modifier.weight(1f),
@@ -684,6 +691,7 @@ private fun SectionGrid(
     snapshot: HaSnapshot,
     registry: ee.schimke.ha.rc.CardRegistry,
     haTheme: HaTheme,
+    baseUrl: String?,
     onLongPress: (CardConfig) -> Unit,
     pinContext: SectionPinContext,
 ) {
@@ -701,6 +709,7 @@ private fun SectionGrid(
                 snapshot = snapshot,
                 registry = registry,
                 haTheme = haTheme,
+                baseUrl = baseUrl,
                 onLongPress = onLongPress,
                 pinContext = pinContext,
                 modifier = Modifier.gridItem(),
@@ -716,6 +725,7 @@ private fun SectionColumn(
     snapshot: HaSnapshot,
     registry: ee.schimke.ha.rc.CardRegistry,
     haTheme: HaTheme,
+    baseUrl: String?,
     onLongPress: (CardConfig) -> Unit,
     pinContext: SectionPinContext,
     modifier: Modifier = Modifier,
@@ -740,6 +750,7 @@ private fun SectionColumn(
                 card = card,
                 snapshot = snapshot,
                 registry = registry,
+                baseUrl = baseUrl,
                 onLongPress = onLongPress,
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -758,6 +769,7 @@ private fun LazyListScope.cardRows(
     snapshot: HaSnapshot,
     registry: ee.schimke.ha.rc.CardRegistry,
     compactPerRow: Int,
+    baseUrl: String?,
     onLongPress: (CardConfig) -> Unit,
 ) {
     val rows = packAndChunk(cards, compactPerRow) { c ->
@@ -765,7 +777,7 @@ private fun LazyListScope.cardRows(
     }
     rows.forEachIndexed { rowIndex, row ->
         item(key = "$keyPrefix-r$rowIndex") {
-            CardRow(row, snapshot, registry, onLongPress)
+            CardRow(row, snapshot, registry, baseUrl, onLongPress)
         }
     }
 }
@@ -783,6 +795,7 @@ private fun CardRow(
     row: DashboardRow,
     snapshot: HaSnapshot,
     registry: ee.schimke.ha.rc.CardRegistry,
+    baseUrl: String?,
     onLongPress: (CardConfig) -> Unit,
 ) {
     Row(
@@ -794,6 +807,7 @@ private fun CardRow(
                 card = card,
                 snapshot = snapshot,
                 registry = registry,
+                baseUrl = baseUrl,
                 onLongPress = onLongPress,
                 modifier = Modifier.weight(1f),
             )
@@ -811,6 +825,7 @@ private fun CardSlot(
     card: CardConfig,
     snapshot: HaSnapshot,
     registry: ee.schimke.ha.rc.CardRegistry,
+    baseUrl: String?,
     onLongPress: (CardConfig) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -829,7 +844,9 @@ private fun CardSlot(
         CardSlotCacheKey(card, style, dark, captureEpoch)
     }
     val context = androidx.compose.ui.platform.LocalContext.current
-    val bitmapLoader = remember(context) { CoilBitmapLoader(context.applicationContext) }
+    val bitmapLoader = remember(context, baseUrl) {
+        CoilBitmapLoader(context.applicationContext, baseUrl = baseUrl)
+    }
     Box(
         modifier = modifier
             // Stable semantics tag so uiautomator / Compose tests can

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -75,10 +75,12 @@ import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.ha.rc.components.haThemeFor
 import ee.schimke.ha.rc.image.CoilBitmapLoader
 import ee.schimke.terrazzo.LocalTerrazzoGraph
+import ee.schimke.terrazzo.image.haSessionImageLoader
 import ee.schimke.terrazzo.ui.LayoutConfig
 import ee.schimke.terrazzo.ui.LocalIsDarkTheme
 import ee.schimke.terrazzo.ui.LocalThemeStyle
 import ee.schimke.terrazzo.ui.rememberLayoutConfig
+import coil3.ImageLoader
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
@@ -190,6 +192,7 @@ fun DashboardViewScreen(
                     dashboard = s.dashboard,
                     snapshot = s.snapshot,
                     baseUrl = session.baseUrl,
+                    accessToken = session.accessToken,
                     dashboardUrlPath = urlPath ?: "",
                     onCardLongPress = onCardLongPress,
                     contentPadding = contentPadding,
@@ -209,6 +212,7 @@ private fun DashboardList(
     dashboard: Dashboard,
     snapshot: HaSnapshot,
     baseUrl: String,
+    accessToken: String?,
     dashboardUrlPath: String,
     onCardLongPress: (CardConfig) -> Unit,
     contentPadding: PaddingValues,
@@ -222,6 +226,21 @@ private fun DashboardList(
         .preferencesStore.experimentalGridLayout.collectAsState(initial = false)
     val collapsedMode by LocalTerrazzoGraph.current
         .preferencesStore.collapsedMode.collectAsState(initial = true)
+    // Build the image loader once per (baseUrl, accessToken) and share
+    // it across every CardSlot in the list. The loader keeps an
+    // OkHttp connection pool + Coil memory cache; one-per-card would
+    // re-establish those for each card, blowing the cache on every
+    // recomposition.
+    val context = androidx.compose.ui.platform.LocalContext.current
+    val lanPolicy = LocalTerrazzoGraph.current.lanConnectionPolicy
+    val imageLoader: ImageLoader = remember(context, baseUrl, accessToken, lanPolicy) {
+        haSessionImageLoader(
+            context = context.applicationContext,
+            baseUrl = baseUrl,
+            accessToken = accessToken,
+            lanPolicy = lanPolicy,
+        )
+    }
 
     val sectionColumns = (cfg.maxSectionColumns).coerceAtMost(layout.sectionCount).coerceAtLeast(1)
     val sideBySide = sectionColumns >= 2
@@ -286,6 +305,7 @@ private fun DashboardList(
                             if (expandedSectionByView[viewIndex] == sectionIndex) null else sectionIndex
                     },
                     baseUrl = baseUrl,
+                    imageLoader = imageLoader,
                     onLongPress = onCardLongPress,
                     pinContext = SectionPinContext(
                         baseUrl = baseUrl,
@@ -354,6 +374,7 @@ private fun LazyListScope.renderView(
     expandedSectionIndex: Int?,
     onToggleSection: (Int) -> Unit,
     baseUrl: String?,
+    imageLoader: ImageLoader,
     onLongPress: (CardConfig) -> Unit,
     pinContext: SectionPinContext,
 ) {
@@ -367,6 +388,7 @@ private fun LazyListScope.renderView(
             registry = registry,
             compactPerRow = cfg.compactCardsPerRow,
             baseUrl = baseUrl,
+            imageLoader = imageLoader,
             onLongPress = onLongPress,
         )
     }
@@ -408,7 +430,7 @@ private fun LazyListScope.renderView(
                             registry.cardWidthClass(c, snapshot)
                         }
                         rows.forEach { row ->
-                            CardRow(row, snapshot, registry, baseUrl, onLongPress)
+                            CardRow(row, snapshot, registry, baseUrl, imageLoader, onLongPress)
                         }
                     }
                 }
@@ -423,6 +445,7 @@ private fun LazyListScope.renderView(
                 registry = registry,
                 haTheme = haTheme,
                 baseUrl = baseUrl,
+                imageLoader = imageLoader,
                 onLongPress = onLongPress,
                 pinContext = pinContext,
             )
@@ -438,6 +461,7 @@ private fun LazyListScope.renderView(
                     registry = registry,
                     haTheme = haTheme,
                     baseUrl = baseUrl,
+                    imageLoader = imageLoader,
                     onLongPress = onLongPress,
                     pinContext = pinContext,
                 )
@@ -640,6 +664,7 @@ private fun SectionRow(
     registry: ee.schimke.ha.rc.CardRegistry,
     haTheme: HaTheme,
     baseUrl: String?,
+    imageLoader: ImageLoader,
     onLongPress: (CardConfig) -> Unit,
     pinContext: SectionPinContext,
 ) {
@@ -656,6 +681,7 @@ private fun SectionRow(
                 registry = registry,
                 haTheme = haTheme,
                 baseUrl = baseUrl,
+                imageLoader = imageLoader,
                 onLongPress = onLongPress,
                 pinContext = pinContext,
                 modifier = Modifier.weight(1f),
@@ -692,6 +718,7 @@ private fun SectionGrid(
     registry: ee.schimke.ha.rc.CardRegistry,
     haTheme: HaTheme,
     baseUrl: String?,
+    imageLoader: ImageLoader,
     onLongPress: (CardConfig) -> Unit,
     pinContext: SectionPinContext,
 ) {
@@ -710,6 +737,7 @@ private fun SectionGrid(
                 registry = registry,
                 haTheme = haTheme,
                 baseUrl = baseUrl,
+                imageLoader = imageLoader,
                 onLongPress = onLongPress,
                 pinContext = pinContext,
                 modifier = Modifier.gridItem(),
@@ -726,6 +754,7 @@ private fun SectionColumn(
     registry: ee.schimke.ha.rc.CardRegistry,
     haTheme: HaTheme,
     baseUrl: String?,
+    imageLoader: ImageLoader,
     onLongPress: (CardConfig) -> Unit,
     pinContext: SectionPinContext,
     modifier: Modifier = Modifier,
@@ -751,6 +780,7 @@ private fun SectionColumn(
                 snapshot = snapshot,
                 registry = registry,
                 baseUrl = baseUrl,
+                imageLoader = imageLoader,
                 onLongPress = onLongPress,
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -770,6 +800,7 @@ private fun LazyListScope.cardRows(
     registry: ee.schimke.ha.rc.CardRegistry,
     compactPerRow: Int,
     baseUrl: String?,
+    imageLoader: ImageLoader,
     onLongPress: (CardConfig) -> Unit,
 ) {
     val rows = packAndChunk(cards, compactPerRow) { c ->
@@ -777,7 +808,7 @@ private fun LazyListScope.cardRows(
     }
     rows.forEachIndexed { rowIndex, row ->
         item(key = "$keyPrefix-r$rowIndex") {
-            CardRow(row, snapshot, registry, baseUrl, onLongPress)
+            CardRow(row, snapshot, registry, baseUrl, imageLoader, onLongPress)
         }
     }
 }
@@ -796,6 +827,7 @@ private fun CardRow(
     snapshot: HaSnapshot,
     registry: ee.schimke.ha.rc.CardRegistry,
     baseUrl: String?,
+    imageLoader: ImageLoader,
     onLongPress: (CardConfig) -> Unit,
 ) {
     Row(
@@ -808,6 +840,7 @@ private fun CardRow(
                 snapshot = snapshot,
                 registry = registry,
                 baseUrl = baseUrl,
+                imageLoader = imageLoader,
                 onLongPress = onLongPress,
                 modifier = Modifier.weight(1f),
             )
@@ -826,6 +859,7 @@ private fun CardSlot(
     snapshot: HaSnapshot,
     registry: ee.schimke.ha.rc.CardRegistry,
     baseUrl: String?,
+    imageLoader: ImageLoader,
     onLongPress: (CardConfig) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -844,8 +878,12 @@ private fun CardSlot(
         CardSlotCacheKey(card, style, dark, captureEpoch)
     }
     val context = androidx.compose.ui.platform.LocalContext.current
-    val bitmapLoader = remember(context, baseUrl) {
-        CoilBitmapLoader(context.applicationContext, baseUrl = baseUrl)
+    val bitmapLoader = remember(context, baseUrl, imageLoader) {
+        CoilBitmapLoader(
+            context.applicationContext,
+            imageLoader = imageLoader,
+            baseUrl = baseUrl,
+        )
     }
     Box(
         modifier = modifier

--- a/app/src/main/kotlin/ee/schimke/terrazzo/image/HaSessionImageLoader.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/image/HaSessionImageLoader.kt
@@ -1,0 +1,76 @@
+package ee.schimke.terrazzo.image
+
+import android.content.Context
+import coil3.ImageLoader
+import coil3.network.okhttp.OkHttpNetworkFetcherFactory
+import ee.schimke.terrazzo.core.network.LanConnectionPolicy
+import ee.schimke.terrazzo.core.network.LanConnectionPolicyInterceptor
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Response
+
+/**
+ * Build a Coil [ImageLoader] scoped to a single HA session.
+ *
+ * Two concerns the singleton `ImageLoader` doesn't cover:
+ *
+ *  - HA's `image_proxy` URLs, addon icons, and custom-integration
+ *    paths need `Authorization: Bearer <accessToken>`. We attach it
+ *    only when the request's host matches [baseUrl]'s host, so the
+ *    token doesn't leak when an HA dashboard references an external
+ *    CDN. `camera_proxy` paths carry HA's `?token=` signed-path
+ *    token and don't need the header, but adding it on a same-host
+ *    request is harmless either way.
+ *  - LAN trust: image fetches off the HA server must observe the
+ *    same [LanConnectionPolicy] as the WebSocket / REST stack —
+ *    otherwise a session that signed in on Wi-Fi could keep talking
+ *    cleartext to a private IP after the device switches to
+ *    cellular.
+ *
+ * [accessToken] may be `null` for demo / offline sessions. In that
+ * case we still install the LAN-policy interceptor, but skip the
+ * bearer.
+ */
+fun haSessionImageLoader(
+  context: Context,
+  baseUrl: String,
+  accessToken: String?,
+  lanPolicy: LanConnectionPolicy,
+): ImageLoader {
+  val haHost = baseUrl.toHttpUrlOrNull()?.host
+  val client =
+    OkHttpClient.Builder()
+      .addInterceptor(LanConnectionPolicyInterceptor(lanPolicy))
+      .apply {
+        if (accessToken != null && !haHost.isNullOrEmpty()) {
+          addInterceptor(HaBearerAuthInterceptor(haHost, accessToken))
+        }
+      }
+      .build()
+  return ImageLoader.Builder(context)
+    .components { add(OkHttpNetworkFetcherFactory(callFactory = { client })) }
+    .build()
+}
+
+/**
+ * OkHttp interceptor that attaches `Authorization: Bearer …` to requests
+ * whose host matches the HA server's host. Other hosts (CDN icons,
+ * external thumbnails) pass through unmodified so the bearer doesn't
+ * leak off-server.
+ */
+internal class HaBearerAuthInterceptor(
+  private val haHost: String,
+  private val accessToken: String,
+) : Interceptor {
+  override fun intercept(chain: Interceptor.Chain): Response {
+    val request = chain.request()
+    val outgoing =
+      if (request.url.host.equals(haHost, ignoreCase = true)) {
+        request.newBuilder().header("Authorization", "Bearer $accessToken").build()
+      } else {
+        request
+      }
+    return chain.proceed(outgoing)
+  }
+}

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstallSheet.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstallSheet.kt
@@ -52,6 +52,7 @@ import ee.schimke.terrazzo.core.pin.MobilePinnedCard
 import ee.schimke.terrazzo.core.pin.PinStore
 import ee.schimke.terrazzo.core.widget.WidgetStore
 import ee.schimke.terrazzo.dashboard.toPinnedData
+import ee.schimke.terrazzo.image.haSessionImageLoader
 
 /**
  * Bottom sheet shown when the user long-presses a card. Live preview
@@ -75,6 +76,7 @@ import ee.schimke.terrazzo.dashboard.toPinnedData
 @Composable
 fun WidgetInstallSheet(
     baseUrl: String,
+    accessToken: String?,
     dashboardUrlPath: String,
     card: CardConfig,
     snapshot: HaSnapshot,
@@ -87,8 +89,21 @@ fun WidgetInstallSheet(
     val pinStore = LocalTerrazzoGraph.current.pinStore
     val pinScope = rememberCoroutineScope()
     val registry = remember { defaultRegistry().withEnhancedShutter() }
-    val bitmapLoader = remember(context, baseUrl) {
-        CoilBitmapLoader(context.applicationContext, baseUrl = baseUrl)
+    val lanPolicy = LocalTerrazzoGraph.current.lanConnectionPolicy
+    val imageLoader = remember(context, baseUrl, accessToken, lanPolicy) {
+        haSessionImageLoader(
+            context = context.applicationContext,
+            baseUrl = baseUrl,
+            accessToken = accessToken,
+            lanPolicy = lanPolicy,
+        )
+    }
+    val bitmapLoader = remember(context, baseUrl, imageLoader) {
+        CoilBitmapLoader(
+            context.applicationContext,
+            imageLoader = imageLoader,
+            baseUrl = baseUrl,
+        )
     }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstallSheet.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstallSheet.kt
@@ -87,7 +87,9 @@ fun WidgetInstallSheet(
     val pinStore = LocalTerrazzoGraph.current.pinStore
     val pinScope = rememberCoroutineScope()
     val registry = remember { defaultRegistry().withEnhancedShutter() }
-    val bitmapLoader = remember(context) { CoilBitmapLoader(context.applicationContext) }
+    val bitmapLoader = remember(context, baseUrl) {
+        CoilBitmapLoader(context.applicationContext, baseUrl = baseUrl)
+    }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     var installedCount by remember { mutableIntStateOf(0) }

--- a/app/src/test/kotlin/ee/schimke/terrazzo/image/HaBearerAuthInterceptorTest.kt
+++ b/app/src/test/kotlin/ee/schimke/terrazzo/image/HaBearerAuthInterceptorTest.kt
@@ -1,0 +1,94 @@
+package ee.schimke.terrazzo.image
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+
+class HaBearerAuthInterceptorTest {
+
+  @Test
+  fun attaches_bearer_for_matching_host() {
+    val interceptor = HaBearerAuthInterceptor(haHost = "ha.example.test", accessToken = "tok-123")
+    val chain = FakeChain(Request.Builder().url("https://ha.example.test/api/image_proxy/x").build())
+
+    interceptor.intercept(chain)
+
+    assertEquals("Bearer tok-123", chain.lastProceededRequest!!.header("Authorization"))
+  }
+
+  @Test
+  fun matches_host_case_insensitively() {
+    // OkHttp lowercases hosts internally, but explicit case-insensitive
+    // matching keeps the contract resilient to upstream changes.
+    val interceptor = HaBearerAuthInterceptor(haHost = "HA.Example.Test", accessToken = "tok-x")
+    val chain = FakeChain(Request.Builder().url("https://ha.example.test/api/state").build())
+
+    interceptor.intercept(chain)
+
+    assertEquals("Bearer tok-x", chain.lastProceededRequest!!.header("Authorization"))
+  }
+
+  @Test
+  fun does_not_attach_bearer_to_different_host() {
+    // The HA dashboard may reference an external CDN icon. Sending
+    // the HA bearer to that CDN would leak the user's credentials —
+    // this test pins the host-only behaviour.
+    val interceptor = HaBearerAuthInterceptor(haHost = "ha.example.test", accessToken = "tok-x")
+    val chain = FakeChain(Request.Builder().url("https://cdn.example.test/icon.png").build())
+
+    interceptor.intercept(chain)
+
+    assertNull(chain.lastProceededRequest!!.header("Authorization"))
+  }
+
+  @Test
+  fun does_not_attach_bearer_to_subdomain_of_ha_host() {
+    val interceptor = HaBearerAuthInterceptor(haHost = "ha.example.test", accessToken = "tok-x")
+    val chain =
+      FakeChain(Request.Builder().url("https://api.ha.example.test/icon.png").build())
+
+    interceptor.intercept(chain)
+
+    assertNull(chain.lastProceededRequest!!.header("Authorization"))
+  }
+
+  private class FakeChain(private val request: Request) : Interceptor.Chain {
+    var lastProceededRequest: Request? = null
+      private set
+
+    override fun request(): Request = request
+
+    override fun proceed(request: Request): Response {
+      lastProceededRequest = request
+      return Response.Builder()
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .code(200)
+        .message("OK")
+        .body("".toResponseBody("text/plain".toMediaType()))
+        .build()
+    }
+
+    override fun call(): okhttp3.Call = error("not used")
+
+    override fun connectTimeoutMillis(): Int = 0
+
+    override fun connection(): okhttp3.Connection? = null
+
+    override fun readTimeoutMillis(): Int = 0
+
+    override fun withConnectTimeout(timeout: Int, unit: java.util.concurrent.TimeUnit) = this
+
+    override fun withReadTimeout(timeout: Int, unit: java.util.concurrent.TimeUnit) = this
+
+    override fun withWriteTimeout(timeout: Int, unit: java.util.concurrent.TimeUnit) = this
+
+    override fun writeTimeoutMillis(): Int = 0
+  }
+}

--- a/rc-image-coil/src/main/kotlin/ee/schimke/ha/rc/image/CoilBitmapLoader.kt
+++ b/rc-image-coil/src/main/kotlin/ee/schimke/ha/rc/image/CoilBitmapLoader.kt
@@ -73,28 +73,55 @@ import java.io.InputStream
  * `name` is whatever Coil's mappers accept as `ImageRequest.data`:
  * `http(s)://…`, `file://…`, `content://…`, `android.resource://…`,
  * an absolute file path, etc.
+ *
+ * Home Assistant returns `entity_picture` (and addon icon paths,
+ * image_proxy URLs, …) as **server-relative** strings like
+ * `/api/camera_proxy/camera.foo?token=…`. Coil's `HttpUriFetcher`
+ * can't resolve a path-only URI, so a relative `name` would fetch
+ * to silent error and the memory cache would stay empty. Pass
+ * [baseUrl] to resolve names starting with `/` against the HA
+ * server's origin before the cache lookup / enqueue; keep the
+ * document itself host-agnostic.
  */
 open class CoilBitmapLoader(
     private val context: Context,
     private val imageLoader: ImageLoader = SingletonImageLoader.get(context),
+    private val baseUrl: String? = null,
     private val compressFormat: Bitmap.CompressFormat = Bitmap.CompressFormat.PNG,
     private val compressQuality: Int = 100,
     private val configure: ImageRequest.Builder.() -> Unit = {},
 ) : BitmapLoader {
 
+    private val baseUrlPrefix: String? = baseUrl?.trimEnd('/')
+
     final override fun loadBitmap(name: String): InputStream {
-        val key = memoryCacheKeyFor(name)
+        val resolved = resolveName(name)
+        val key = memoryCacheKeyFor(resolved)
         val image = imageLoader.memoryCache?.get(key)?.image
         val bytes = image?.let(::encodeImage)
         if (bytes != null) return ByteArrayInputStream(bytes)
-        warmUpAsync(name, key)
+        warmUpAsync(resolved, key)
         return ByteArrayInputStream(EMPTY)
+    }
+
+    /**
+     * Resolve a server-relative `name` against [baseUrl]; pass anything
+     * else through unchanged. Names with a scheme (`http(s)://`,
+     * `content://`, `file://`, `android.resource://`, …) or that don't
+     * start with `/` are returned as-is.
+     */
+    private fun resolveName(name: String): String {
+        val prefix = baseUrlPrefix ?: return name
+        if (!name.startsWith('/')) return name
+        return prefix + name
     }
 
     /**
      * Stable key used both for the direct memory-cache lookup and for
      * the warm-up [ImageRequest.memoryCacheKey], so writes and reads
-     * agree.
+     * agree. The argument is the **resolved** URL, not the raw `name`
+     * passed to [loadBitmap], so subclasses that override this see the
+     * same string the warm-up will use as request data.
      */
     protected open fun memoryCacheKeyFor(name: String): MemoryCache.Key = MemoryCache.Key(name)
 

--- a/rc-image-coil/src/test/kotlin/ee/schimke/ha/rc/image/CoilBitmapLoaderTest.kt
+++ b/rc-image-coil/src/test/kotlin/ee/schimke/ha/rc/image/CoilBitmapLoaderTest.kt
@@ -130,6 +130,125 @@ class CoilBitmapLoaderTest {
         assertEquals(listOf(customKey), cache.getCalls)
         assertEquals(listOf(customKey), warmUpKeys)
     }
+
+    @Test
+    fun relativeNameResolvesAgainstBaseUrlForLookupAndWarmUp() {
+        // Home Assistant's `entity_picture` is path-only —
+        // `/api/camera_proxy/...?token=...`. Coil's HttpUriFetcher
+        // can't resolve a path-only URI; without resolution the
+        // memory-cache lookup misses every call and the warm-up
+        // silently errors. With baseUrl wired, both sides see the
+        // absolute URL.
+        val baseUrl = "https://ha.example.test"
+        val relative = "/api/camera_proxy/camera.front?token=abc"
+        val absolute = "$baseUrl$relative"
+        val cache = RecordingMemoryCache(initial = emptyMap())
+        val loader = StubImageLoader(memCache = cache)
+        val warmUpCalls = mutableListOf<Pair<String, MemoryCache.Key>>()
+
+        val coil =
+            object : CoilBitmapLoader(
+                context = NULL_CONTEXT,
+                imageLoader = loader,
+                baseUrl = baseUrl,
+            ) {
+                override fun warmUpAsync(name: String, key: MemoryCache.Key) {
+                    warmUpCalls += name to key
+                }
+            }
+
+        coil.loadBitmap(relative)
+
+        assertEquals(listOf(MemoryCache.Key(absolute)), cache.getCalls)
+        assertEquals(listOf(absolute to MemoryCache.Key(absolute)), warmUpCalls)
+    }
+
+    @Test
+    fun absoluteAndSchemedNamesPassThroughEvenWithBaseUrl() {
+        // Anything that isn't a relative server path is forwarded
+        // unchanged: HTTPS, content://, file://, android.resource://,
+        // and untyped non-slash names (e.g. registry-style "logo").
+        val baseUrl = "https://ha.example.test/"
+        val cache = RecordingMemoryCache(initial = emptyMap())
+        val loader = StubImageLoader(memCache = cache)
+        val warmUpNames = mutableListOf<String>()
+
+        val coil =
+            object : CoilBitmapLoader(
+                context = NULL_CONTEXT,
+                imageLoader = loader,
+                baseUrl = baseUrl,
+            ) {
+                override fun warmUpAsync(name: String, key: MemoryCache.Key) {
+                    warmUpNames += name
+                }
+            }
+
+        listOf(
+            "https://cdn.example.test/icon.png",
+            "content://media/external/images/42",
+            "file:///data/local/tmp/img.png",
+            "android.resource://ee.schimke.terrazzo/2131099648",
+            "logo",
+        ).forEach { coil.loadBitmap(it) }
+
+        assertEquals(
+            listOf(
+                "https://cdn.example.test/icon.png",
+                "content://media/external/images/42",
+                "file:///data/local/tmp/img.png",
+                "android.resource://ee.schimke.terrazzo/2131099648",
+                "logo",
+            ),
+            warmUpNames,
+        )
+    }
+
+    @Test
+    fun trailingSlashOnBaseUrlIsTrimmedSoResolutionHasOneSeparator() {
+        val cache = RecordingMemoryCache(initial = emptyMap())
+        val loader = StubImageLoader(memCache = cache)
+        val warmUpNames = mutableListOf<String>()
+
+        val coil =
+            object : CoilBitmapLoader(
+                context = NULL_CONTEXT,
+                imageLoader = loader,
+                baseUrl = "https://ha.example.test/",
+            ) {
+                override fun warmUpAsync(name: String, key: MemoryCache.Key) {
+                    warmUpNames += name
+                }
+            }
+
+        coil.loadBitmap("/api/image_proxy/foo")
+
+        assertEquals(listOf("https://ha.example.test/api/image_proxy/foo"), warmUpNames)
+    }
+
+    @Test
+    fun nullBaseUrlLeavesRelativeNameUntouched() {
+        // Back-compat path: when no baseUrl is wired (preview / tests
+        // that haven't been updated), relative names still flow
+        // through. The fetch will fail like before — this just
+        // confirms we didn't change the legacy behaviour.
+        val name = "/api/camera_proxy/camera.x"
+        val cache = RecordingMemoryCache(initial = emptyMap())
+        val loader = StubImageLoader(memCache = cache)
+        val warmUpNames = mutableListOf<String>()
+
+        val coil =
+            object : CoilBitmapLoader(context = NULL_CONTEXT, imageLoader = loader) {
+                override fun warmUpAsync(name: String, key: MemoryCache.Key) {
+                    warmUpNames += name
+                }
+            }
+
+        coil.loadBitmap(name)
+
+        assertEquals(listOf(MemoryCache.Key(name)), cache.getCalls)
+        assertEquals(listOf(name), warmUpNames)
+    }
 }
 
 private val NULL_CONTEXT = ContextWrapper(null)

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/CachedHaSession.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/CachedHaSession.kt
@@ -31,6 +31,9 @@ class CachedHaSession(private val delegate: HaSession, private val cache: Offlin
   override val baseUrl: String
     get() = delegate.baseUrl
 
+  override val accessToken: String?
+    get() = delegate.accessToken
+
   override val refreshIntervalMillis: Long?
     get() = delegate.refreshIntervalMillis
   override val connectionStatus: StateFlow<SessionConnectionStatus>

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/HaSession.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/HaSession.kt
@@ -23,6 +23,15 @@ interface HaSession {
     val connectionStatus: StateFlow<SessionConnectionStatus>
 
     /**
+     * HA long-lived bearer token, if this session has one. Live sessions
+     * mint one at login; demo / offline sessions return null. Surfaced
+     * here so the image stack can build an `ImageLoader` that adds
+     * `Authorization: Bearer ...` to `image_proxy` / addon-icon fetches
+     * (paths that don't carry HA's `?token=` signed-path token).
+     */
+    val accessToken: String? get() = null
+
+    /**
      * If non-null, dashboard screens should re-fetch snapshots at this
      * cadence so values visibly change on screen. Live sessions return
      * null until we wire real subscriptions.
@@ -58,7 +67,7 @@ enum class SessionConnectionStatus {
 /** Live session backed by an HA WebSocket. */
 class LiveHaSession(
     override val baseUrl: String,
-    accessToken: String,
+    override val accessToken: String,
     engine: HttpClientEngine? = null,
 ) : HaSession {
     private val client =


### PR DESCRIPTION
Home Assistant returns `entity_picture` as a server-relative path
(`/api/camera_proxy/...?token=...`). The path-only URI was passed
straight to Coil, whose `HttpUriFetcher` can't resolve it, so the
memory cache stayed empty and every `loadBitmap` returned a 0-byte
stream — visible as gray picture-entity tiles and `Failed to create
image decoder with message 'unimplemented'` spam in HWUI.

Add a `baseUrl` parameter to `CoilBitmapLoader` and resolve names
that start with `/` against it before the memory-cache lookup and
the warm-up `enqueue`. Wire `session.baseUrl` through both
construction sites (dashboard + widget-install). Absolute URLs and
schemed URIs (`content://`, `file://`, `android.resource://`,
non-slash names) pass through unchanged.

Camera tiles work from this fix alone via HA's `?token=` signed
path; non-token paths (`image_proxy`, addon icons) still need
bearer auth on the `ImageLoader`, tracked separately.

Refs #264