### PR TITLE
feat: live picture-entity bitmap refresh for running players

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -73,8 +73,11 @@ import ee.schimke.ha.rc.components.HaTheme
 import ee.schimke.ha.rc.components.ProvideHaTheme
 import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.ha.rc.components.haThemeFor
+import ee.schimke.ha.rc.LocalRemoteImageResolver
+import ee.schimke.ha.rc.RemoteImageResolver
 import ee.schimke.ha.rc.image.CoilBitmapLoader
 import ee.schimke.terrazzo.LocalTerrazzoGraph
+import ee.schimke.terrazzo.image.HaCoilImageResolver
 import ee.schimke.terrazzo.image.haSessionImageLoader
 import ee.schimke.terrazzo.ui.LayoutConfig
 import ee.schimke.terrazzo.ui.LocalIsDarkTheme
@@ -241,6 +244,20 @@ private fun DashboardList(
             lanPolicy = lanPolicy,
         )
     }
+    // The picture-entity refresh path: when the snapshot's
+    // entity_picture URL rotates, `CachedCardPreview` calls this
+    // resolver to fetch fresh bytes and overrides the player's
+    // named-bitmap slot via `setUserLocalBitmap`. Same Coil
+    // [imageLoader] as the player's `BitmapLoader` warm-up, so
+    // auth / LAN policy / disk cache are shared.
+    val imageResolver: RemoteImageResolver =
+        remember(context, baseUrl, imageLoader) {
+            HaCoilImageResolver(
+                context = context.applicationContext,
+                imageLoader = imageLoader,
+                baseUrl = baseUrl,
+            )
+        }
 
     val sectionColumns = (cfg.maxSectionColumns).coerceAtMost(layout.sectionCount).coerceAtLeast(1)
     val sideBySide = sectionColumns >= 2
@@ -275,6 +292,7 @@ private fun DashboardList(
     // are derived from a single source.
     val haTheme = remember(style, dark) { haThemeFor(style, dark) }
 
+    CompositionLocalProvider(LocalRemoteImageResolver provides imageResolver) {
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.TopCenter,
@@ -317,6 +335,7 @@ private fun DashboardList(
                 )
             }
         }
+    }
     }
 }
 

--- a/app/src/main/kotlin/ee/schimke/terrazzo/image/HaCoilImageResolver.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/image/HaCoilImageResolver.kt
@@ -1,0 +1,56 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.terrazzo.image
+
+import android.content.Context
+import android.graphics.Bitmap
+import coil3.BitmapImage
+import coil3.ImageLoader
+import coil3.request.ImageRequest
+import coil3.request.allowHardware
+import ee.schimke.ha.rc.RemoteImageResolver
+
+/**
+ * [RemoteImageResolver] backed by a per-session Coil [ImageLoader].
+ *
+ * Refreshes picture-entity tiles in a running player: when an entity's
+ * `entity_picture` rotates, `CachedCardPreview` calls [resolve] with
+ * the new URL, awaits the bitmap, and pushes it through
+ * `StateUpdater.setUserLocalBitmap`. The override sticks across paint
+ * — the original URL stays baked in the document, so first-paint and
+ * subsequent rotations both render fresh bytes without re-encoding the
+ * `.rc`.
+ *
+ * Reuses the session's [imageLoader] so cache, auth (bearer), and LAN
+ * policy are shared with the player's `BitmapLoader` warm-up path.
+ * Server-relative URLs (`/api/camera_proxy/...?token=...`) are
+ * resolved against [baseUrl] before the fetch, mirroring
+ * `CoilBitmapLoader`'s resolution rule.
+ *
+ * `allowHardware(false)` so the returned `Bitmap` has CPU-side pixels
+ * — `setUserLocalBitmap` reads them on the player's render thread,
+ * and hardware bitmaps would throw on draw paths that need them
+ * upload-able.
+ */
+class HaCoilImageResolver(
+  private val context: Context,
+  private val imageLoader: ImageLoader,
+  private val baseUrl: String?,
+) : RemoteImageResolver {
+
+  private val baseUrlPrefix: String? = baseUrl?.trimEnd('/')
+
+  override suspend fun resolve(url: String): Bitmap? {
+    val resolved = resolveAgainstBase(url)
+    val request =
+      ImageRequest.Builder(context).data(resolved).allowHardware(false).build()
+    val result = imageLoader.execute(request)
+    return (result.image as? BitmapImage)?.bitmap
+  }
+
+  private fun resolveAgainstBase(url: String): String {
+    val prefix = baseUrlPrefix ?: return url
+    if (!url.startsWith('/')) return url
+    return prefix + url
+  }
+}

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstallSheet.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstallSheet.kt
@@ -45,6 +45,8 @@ import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.cards.shutter.withEnhancedShutter
 import ee.schimke.ha.rc.components.HaTheme
 import ee.schimke.ha.rc.components.ProvideHaTheme
+import androidx.compose.runtime.CompositionLocalProvider
+import ee.schimke.ha.rc.LocalRemoteImageResolver
 import ee.schimke.ha.rc.image.CoilBitmapLoader
 import ee.schimke.ha.rc.widgetsProfile
 import ee.schimke.terrazzo.LocalTerrazzoGraph
@@ -52,6 +54,7 @@ import ee.schimke.terrazzo.core.pin.MobilePinnedCard
 import ee.schimke.terrazzo.core.pin.PinStore
 import ee.schimke.terrazzo.core.widget.WidgetStore
 import ee.schimke.terrazzo.dashboard.toPinnedData
+import ee.schimke.terrazzo.image.HaCoilImageResolver
 import ee.schimke.terrazzo.image.haSessionImageLoader
 
 /**
@@ -105,6 +108,13 @@ fun WidgetInstallSheet(
             baseUrl = baseUrl,
         )
     }
+    val imageResolver = remember(context, baseUrl, imageLoader) {
+        HaCoilImageResolver(
+            context = context.applicationContext,
+            imageLoader = imageLoader,
+            baseUrl = baseUrl,
+        )
+    }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
     var installedCount by remember { mutableIntStateOf(0) }
@@ -123,6 +133,7 @@ fun WidgetInstallSheet(
     val isCardPinned by pinStore.isCardPinned(pinKey).collectAsState(initial = false)
 
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
+      CompositionLocalProvider(LocalRemoteImageResolver provides imageResolver) {
         Column(
             modifier = Modifier.fillMaxWidth().padding(24.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -212,6 +223,7 @@ fun WidgetInstallSheet(
                 ) { Text("Monitor for 15 min") }
             }
         }
+      }
     }
 }
 

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/PictureBindingName.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/PictureBindingName.kt
@@ -1,0 +1,21 @@
+package ee.schimke.ha.rc.components
+
+/**
+ * Stable named-bitmap-registry name for a picture-entity card's image
+ * slot.
+ *
+ * Used in two places that must agree:
+ *  1. Capture time — passed as `RemoteHaImageUrl.name` so the doc
+ *     registers the bitmap slot under this name (independent of the
+ *     URL, which may rotate as HA refreshes its `?token=`).
+ *  2. Runtime — passed to `StateUpdater.setUserLocalBitmap` so the
+ *     host can override the player's URL-fetched bytes with a
+ *     freshly fetched bitmap when the entity's `entity_picture`
+ *     attribute rotates. The override channel takes precedence over
+ *     the doc's URL-load result, so subsequent paints render the
+ *     latest pushed bitmap without re-capturing the document.
+ *
+ * Mirrors `LiveValues`' "<entityId>.<channel>" convention used by
+ * `state` / `is_on` bindings.
+ */
+fun pictureBindingName(entityId: String): String = "$entityId.entity_picture"

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaPictureEntity.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaPictureEntity.kt
@@ -83,8 +83,19 @@ fun RemoteHaPictureEntity(
                 contentAlignment = RemoteAlignment.Center,
             ) {
                 if (data.imageUrl != null) {
+                    // Pass a stable [name] derived from `entityId` so the host
+                    // can override the URL-fetched bytes via
+                    // `StateUpdater.setUserLocalBitmap(pictureBindingName(id), …)`.
+                    // The URL itself is still passed to the player's
+                    // `BitmapLoader` for first paint; the override stacks on
+                    // top of that for live refreshes / token rotation.
+                    // Anonymous-card fallback (no `entityId`) keeps the
+                    // default URL-as-name behaviour.
+                    val bindingName =
+                        data.entityId?.let(::pictureBindingName) ?: data.imageUrl
                     RemoteHaImageUrl(
                         url = data.imageUrl,
+                        name = bindingName,
                         contentDescription = data.name.rs,
                         modifier = RemoteModifier.fillMaxSize(),
                     )

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CachedCardPreview.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CachedCardPreview.kt
@@ -20,7 +20,9 @@ import androidx.compose.ui.platform.LocalContext
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.components.HA_ACTION_NAME
+import ee.schimke.ha.rc.components.pictureBindingName
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.contentOrNull
 
 /**
  * Cached counterpart to upstream
@@ -119,8 +121,11 @@ fun CachedCardPreview(
         }
 
     val dispatcher = LocalHaActionDispatcher.current
+    val imageResolver = LocalRemoteImageResolver.current
 
     val entityIds = remember(card) { card?.let { cardEntityIds(it) }.orEmpty() }
+    val pictureEntityIds =
+        remember(card) { card?.let { cardPictureEntityIds(it) }.orEmpty() }
     // The handle survives recomposition but is replaced if the player
     // is torn down and rebuilt (cache invalidation, theme flip).
     val updaterHolder = remember { mutableStateOf<StateUpdater?>(null) }
@@ -129,11 +134,41 @@ fun CachedCardPreview(
     // [cacheKey] changes — the new document carries its own initial
     // bake, and we want the next push to be unconditional.
     val pushed = remember(cacheKey) { HashMap<String, Any?>() }
+    // Picture-entity URLs we've already fetched + pushed. Distinct map
+    // because the channel (setUserLocalBitmap) is separate from the
+    // string / int channel above and the values are URLs, not the
+    // bitmaps themselves (we don't want to retain bitmap references).
+    val pushedPictureUrls = remember(cacheKey) { HashMap<String, String>() }
 
     if (card != null && snapshot != null && entityIds.isNotEmpty()) {
         LaunchedEffect(updaterHolder.value, snapshot) {
             val updater = updaterHolder.value ?: return@LaunchedEffect
             pushSnapshotBindings(updater, entityIds, snapshot, pushed)
+        }
+    }
+
+    // Live bitmap push for picture-entity cards. Distinct from the
+    // string / boolean push above because resolving a URL to bytes is
+    // suspending (Coil fetch), so we can't fold it into the
+    // synchronous binding loop. Skips quietly when no resolver is
+    // wired — call sites that don't provide one (previews, host-less
+    // tests) fall back to whatever the player's BitmapLoader returns
+    // for the URL baked into the document.
+    if (
+        card != null &&
+            snapshot != null &&
+            pictureEntityIds.isNotEmpty() &&
+            imageResolver != null
+    ) {
+        LaunchedEffect(updaterHolder.value, snapshot) {
+            val updater = updaterHolder.value ?: return@LaunchedEffect
+            pushPictureEntityBitmaps(
+                updater = updater,
+                entityIds = pictureEntityIds,
+                snapshot = snapshot,
+                pushedUrls = pushedPictureUrls,
+                resolver = imageResolver,
+            )
         }
     }
 
@@ -191,5 +226,43 @@ private fun pushSnapshotBindings(
         if (pushed[name] == value) continue
         runCatching { updater.setUserLocalInt(name, if (value) 1 else 0) }
             .onSuccess { pushed[name] = value }
+    }
+}
+
+/**
+ * For each picture-entity in [entityIds], read the current
+ * `entity_picture` URL from [snapshot] and — if it changed since the
+ * last push — ask [resolver] for a fresh [Bitmap] and write it into
+ * the running player under `pictureBindingName(id)`.
+ *
+ * `setUserLocalBitmap` writes through `RemoteContext.setNamedDataOverride`,
+ * which takes precedence over whatever the player's `BitmapLoader`
+ * resolved from the URL baked at capture time. So the document keeps
+ * its original URL and the override is what's drawn — no re-capture
+ * needed when HA rotates the `?token=`.
+ *
+ * Per-entity errors are caught so a single failing fetch (404, network
+ * blip, decode error) doesn't take down the whole push.
+ */
+private suspend fun pushPictureEntityBitmaps(
+    updater: StateUpdater,
+    entityIds: Set<String>,
+    snapshot: HaSnapshot,
+    pushedUrls: MutableMap<String, String>,
+    resolver: RemoteImageResolver,
+) {
+    for (entityId in entityIds) {
+        val url =
+            snapshot.states[entityId]
+                ?.attributes
+                ?.get("entity_picture")
+                ?.let { it as? kotlinx.serialization.json.JsonPrimitive }
+                ?.contentOrNull
+                ?: continue
+        if (pushedUrls[entityId] == url) continue
+        val bitmap = runCatching { resolver.resolve(url) }.getOrNull() ?: continue
+        val name = pictureBindingName(entityId)
+        runCatching { updater.setUserLocalBitmap(name, bitmap) }
+            .onSuccess { pushedUrls[entityId] = url }
     }
 }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardEntities.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardEntities.kt
@@ -92,3 +92,35 @@ fun cardSnapshotBindings(
     }
     return CardSnapshotBindings(strings, booleans)
 }
+
+/**
+ * Recursively walks [card] for `type: picture-entity` nodes (including
+ * picture-entity cards nested in stack / grid / conditional / horizontal
+ * / vertical layouts) and returns the `entity:` referenced by each.
+ * Used by `CachedCardPreview` to discover which slots need a live
+ * bitmap override when `entity_picture` rotates.
+ *
+ * The set is ordered by first appearance for stable iteration. Entries
+ * without a `domain.id`-shaped value are skipped (mirrors
+ * [cardEntityIds]).
+ */
+fun cardPictureEntityIds(card: CardConfig): Set<String> {
+    val out = LinkedHashSet<String>()
+    collectPictureEntities(card.raw, out)
+    return out
+}
+
+private fun collectPictureEntities(element: JsonElement, out: MutableSet<String>) {
+    when (element) {
+        is JsonObject -> {
+            val type = element["type"]?.let { it as? JsonPrimitive }?.contentOrNull
+            if (type == "picture-entity") {
+                val entity = element["entity"]?.let { it as? JsonPrimitive }?.contentOrNull
+                if (entity != null && entity.contains('.')) out.add(entity)
+            }
+            for ((_, value) in element) collectPictureEntities(value, out)
+        }
+        is JsonArray -> element.forEach { collectPictureEntities(it, out) }
+        else -> {}
+    }
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/RemoteImageResolver.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/RemoteImageResolver.kt
@@ -1,0 +1,35 @@
+package ee.schimke.ha.rc
+
+import android.graphics.Bitmap
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * Suspending host-side hook for fetching an image URL to a [Bitmap].
+ *
+ * Used by `CachedCardPreview` to refresh picture-entity tiles in a
+ * running player: when an entity's `entity_picture` URL rotates (HA's
+ * `?token=` cycles, a camera updates its thumbnail, a media player
+ * changes track), the host fetches fresh bytes and pushes them through
+ * `StateUpdater.setUserLocalBitmap` so the displayed image updates
+ * **without** re-capturing the `.rc` document.
+ *
+ * Implementations live in the host module (Coil-backed in
+ * `rc-image-coil`; a fake in `previews` for tests / @Preview). The
+ * interface stays neutral so this module doesn't acquire a Coil
+ * dependency.
+ *
+ * Returning `null` skips the push: the player keeps whatever bitmap it
+ * already has (placeholder, the URL-fetched first frame, or the
+ * previously pushed override).
+ */
+fun interface RemoteImageResolver {
+  suspend fun resolve(url: String): Bitmap?
+}
+
+/**
+ * CompositionLocal a host provides to give the captured cards a way to
+ * refresh their picture-entity bitmaps. Defaults to `null` (no
+ * refresh) so unwired call sites still render — first-paint bytes come
+ * from the player's `BitmapLoader` exactly as before.
+ */
+val LocalRemoteImageResolver = staticCompositionLocalOf<RemoteImageResolver?> { null }

--- a/rc-converter/src/test/kotlin/ee/schimke/ha/rc/CardEntitiesTest.kt
+++ b/rc-converter/src/test/kotlin/ee/schimke/ha/rc/CardEntitiesTest.kt
@@ -120,4 +120,51 @@ class CardEntitiesTest {
         assertTrue(bindings.strings.isEmpty())
         assertTrue(bindings.booleans.isEmpty())
     }
+
+    @Test
+    fun pictureEntityIdsTopLevel() {
+        val ids = cardPictureEntityIds(card(
+            """{"type":"picture-entity","entity":"camera.front"}""",
+            type = "picture-entity",
+        ))
+        assertEquals(setOf("camera.front"), ids)
+    }
+
+    @Test
+    fun pictureEntityIdsSkipsNonPictureCards() {
+        // Same `entity` key in a tile card — must not be picked up.
+        val ids = cardPictureEntityIds(card(
+            """{"type":"tile","entity":"camera.front"}""",
+            type = "tile",
+        ))
+        assertTrue(ids.isEmpty())
+    }
+
+    @Test
+    fun pictureEntityIdsInsideStack() {
+        // A vertical-stack of mixed cards; only the picture-entity
+        // children should surface their entities.
+        val ids = cardPictureEntityIds(card(
+            """{
+              "type":"vertical-stack",
+              "cards":[
+                {"type":"tile","entity":"light.kitchen"},
+                {"type":"picture-entity","entity":"camera.front"},
+                {"type":"picture-entity","entity":"camera.back"}
+              ]
+            }""",
+            type = "vertical-stack",
+        ))
+        assertEquals(setOf("camera.front", "camera.back"), ids)
+    }
+
+    @Test
+    fun pictureEntityIdsSkipsEntitiesWithoutDomain() {
+        // `entity:"front"` (no domain.id dot) — HA-illegal, skip.
+        val ids = cardPictureEntityIds(card(
+            """{"type":"picture-entity","entity":"front"}""",
+            type = "picture-entity",
+        ))
+        assertTrue(ids.isEmpty())
+    }
 }


### PR DESCRIPTION
## Summary
Add support for refreshing picture-entity card images in running players when the entity's `entity_picture` attribute rotates (e.g., camera thumbnail updates, media player track changes, HA token refresh). The host can now push fresh bitmaps to the player without re-capturing the document.

## Key Changes

- **New `RemoteImageResolver` interface** (`rc-converter`): Suspending hook for fetching image URLs to bitmaps. Defaults to `null` so unwired call sites (previews, tests) still render using the player's built-in `BitmapLoader`.

- **`HaCoilImageResolver` implementation** (`app`): Coil-backed resolver that reuses the session's `ImageLoader` for shared cache, auth, and LAN policy. Resolves server-relative URLs against `baseUrl` and disables hardware bitmaps so pixels are CPU-accessible for the player's render thread.

- **Picture-entity discovery** (`CardEntities.kt`): New `cardPictureEntityIds()` function recursively walks card configs to find all `picture-entity` nodes (including nested in stacks/grids/layouts) and extracts their entity IDs.

- **Live bitmap push** (`CachedCardPreview`): New `pushPictureEntityBitmaps()` coroutine reads `entity_picture` URLs from the snapshot, detects changes, fetches fresh bitmaps via the resolver, and pushes them through `StateUpdater.setUserLocalBitmap()`. Per-entity errors are caught so one failure doesn't block others.

- **Stable binding names** (`PictureBindingName.kt`): New `pictureBindingName(entityId)` function generates stable registry names (`"<entityId>.entity_picture"`) used at both capture time (document registration) and runtime (override push).

- **Composition local wiring** (`DashboardViewScreen`, `WidgetInstallSheet`): Provide `LocalRemoteImageResolver` to `CachedCardPreview` so it can refresh bitmaps during dashboard and widget preview rendering.

## Implementation Details

- The override channel (`setUserLocalBitmap`) takes precedence over the player's URL-fetched bytes, so subsequent paints render the latest pushed bitmap without re-capturing.
- The original URL stays baked in the document, enabling first-paint and subsequent rotations to both render fresh bytes.
- Reuses the session's `ImageLoader` so cache, auth (bearer token), and LAN policy are shared with the player's warm-up path.
- `allowHardware(false)` ensures returned bitmaps have CPU-side pixels readable on the player's render thread.

https://claude.ai/code/session_01XJK2zDradnW4MV2o1kjZkv