### PR TITLE
feat: add automatic reconnection with backoff when Home Assistant connection fails

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -137,6 +137,7 @@ dependencies {
   implementation(libs.horologist.datalayer)
   implementation(libs.horologist.datalayer.phone)
   implementation(libs.androidx.lifecycle.runtime.ktx)
+  implementation(libs.androidx.lifecycle.runtime.compose)
   implementation(libs.androidx.lifecycle.process)
   implementation(libs.androidx.work.runtime)
   implementation(libs.androidx.navigation3.runtime)

--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -66,6 +66,11 @@ import ee.schimke.terrazzo.widget.WidgetRefreshScheduler
 import ee.schimke.terrazzo.widget.WidgetsScreen
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 /**
@@ -309,6 +314,35 @@ private fun DashboardsRoot(
     val readyDashboards = (dashboards as? DashboardListState.Ready)?.dashboards.orEmpty()
     val sessionConnection by session.connectionStatus.collectAsState()
     val connectionStatus = sessionConnection.toUiConnectionStatus()
+    val snackbars = remember { SnackbarHostState() }
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    // Keep the HA connection alive while the user has the app open.
+    // While the activity is RESUMED, watch for a Failed status and
+    // retry with a short backoff. Each retry either lands at Connected
+    // (loop idles) or at Failed (StateFlow re-emits and we retry
+    // again). When the activity is paused the [repeatOnLifecycle] scope
+    // cancels, so we stop poking the network in the background.
+    LaunchedEffect(session, lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            while (true) {
+                session.connectionStatus.first { it == SessionConnectionStatus.Failed }
+                delay(RECONNECT_BACKOFF_MS)
+                if (session.connectionStatus.value == SessionConnectionStatus.Failed) {
+                    runCatching { session.connect() }
+                }
+            }
+        }
+    }
+
+    val onRetryConnection: () -> Unit = {
+        scope.launch {
+            runCatching { session.connect() }
+            if (session.connectionStatus.value != SessionConnectionStatus.Connected) {
+                snackbars.showSnackbar("Couldn't connect to ${session.baseUrl}")
+            }
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -331,6 +365,7 @@ private fun DashboardsRoot(
                 },
                 actions = {
                     Surface(
+                        onClick = onRetryConnection,
                         color = connectionStatus.color.copy(alpha = 0.16f),
                         shape = MaterialTheme.shapes.small,
                         modifier = Modifier.padding(end = 8.dp),
@@ -352,6 +387,7 @@ private fun DashboardsRoot(
                 },
             )
         },
+        snackbarHost = { SnackbarHost(hostState = snackbars) },
         // Scaffold consumes the top inset for the bar; we hand the
         // bottom + sides to the content as the inner contentPadding.
         contentWindowInsets = WindowInsets.safeDrawing,
@@ -407,6 +443,13 @@ private fun DashboardsRoot(
 
 /** Sentinel for "no dashboard opened yet". null is a valid urlPath (the default dashboard). */
 private const val DASHBOARD_UNSET = "__none__"
+
+/**
+ * Backoff between automatic reconnect attempts while the activity is
+ * resumed. Short enough that a brief network blip recovers quickly,
+ * long enough that we don't hammer a genuinely-down HA instance.
+ */
+private const val RECONNECT_BACKOFF_MS = 5_000L
 
 enum class ConnectionStatus(val label: String, val color: Color) {
     Failed("Failed", Color(0xFFD32F2F)),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -161,6 +161,7 @@ horologist-datalayer-phone = { module = "com.google.android.horologist:horologis
 # documentation in `wear/src/main/proto/wear_sync.proto`.
 kotlinx-serialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "kotlinx-serialization" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version = "2.10.0" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version = "2.10.0" }
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version = "2.10.0" }
 
 # Test


### PR DESCRIPTION
## Summary
Implements automatic reconnection logic for the Home Assistant session when the connection fails, with a configurable backoff delay. The reconnection only occurs while the app is in the foreground (RESUMED state) to avoid unnecessary network activity in the background.

## Key Changes
- Added lifecycle-aware reconnection loop that monitors connection status and automatically retries failed connections with a 5-second backoff
- Implemented manual retry button in the connection status UI that attempts to reconnect and shows a snackbar on failure
- Added `SnackbarHost` to the Scaffold to display connection error messages to the user
- Lifecycle-aware implementation using `repeatOnLifecycle(Lifecycle.State.RESUMED)` ensures reconnection attempts only happen when the activity is visible
- Added `androidx.lifecycle:lifecycle-runtime-compose` dependency to support `LocalLifecycleOwner` and `repeatOnLifecycle` in Compose

## Implementation Details
- The reconnection logic uses a `while(true)` loop that waits for a Failed status, applies a 5-second delay, then attempts to reconnect if still in Failed state
- The manual retry callback (`onRetryConnection`) is triggered by clicking the connection status indicator in the top bar
- The backoff delay (5 seconds) is configurable via the `RECONNECT_BACKOFF_MS` constant and balances quick recovery from brief network blips against avoiding hammering a genuinely-down Home Assistant instance
- Uses `StateFlow.first()` to wait for the Failed state and `runCatching` to safely handle connection errors

https://claude.ai/code/session_01Y6DkKkTybqvW4h32RujPnT