### PR TITLE
feat(auth): upgrade cache-only session via refresh token on cold start

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -113,11 +113,31 @@ fun TerrazzoApp(
     // Also re-arms the widget refresh chain in case the worker queue
     // was flushed (e.g. "Clear data" via system Settings). When a
     // cache-only [initialSession] was passed in (cold-start auto-resume
-    // from a prior login), the demo path overrides it.
+    // from a prior login), the demo path overrides it; otherwise we
+    // mint a fresh access token from the vault's refresh token and
+    // swap the stub for a real live session in the background.
     LaunchedEffect(Unit) {
         if (graph.preferencesStore.demoModeNow()) {
             session = graph.sessionFactory.createDemo()
             widgetScheduler.scheduleDemo()
+        } else if (initialSession != null) {
+            val baseUrl = initialSession.baseUrl
+            val refreshToken = graph.tokenVault.get(baseUrl)
+            if (refreshToken != null) {
+                runCatching { graph.authService.refreshAccessToken(baseUrl, refreshToken) }
+                    .onSuccess { tokens ->
+                        val access = tokens.accessToken
+                        // The user may have signed out or toggled demo
+                        // in the time the refresh was in flight; only
+                        // swap if we're still on the cache-only stub.
+                        if (access != null && session === initialSession) {
+                            val previous = session
+                            session = graph.sessionFactory.create(baseUrl, access)
+                            previous?.close()
+                        }
+                        tokens.refreshToken?.let { graph.tokenVault.put(baseUrl, it) }
+                    }
+            }
         }
     }
 

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/auth/HaAuthService.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/auth/HaAuthService.kt
@@ -18,7 +18,9 @@ import net.openid.appauth.AuthorizationRequest
 import net.openid.appauth.AuthorizationResponse
 import net.openid.appauth.AuthorizationService
 import net.openid.appauth.AuthorizationServiceConfiguration
+import net.openid.appauth.GrantTypeValues
 import net.openid.appauth.ResponseTypeValues
+import net.openid.appauth.TokenRequest
 import net.openid.appauth.TokenResponse
 import net.openid.appauth.connectivity.ConnectionBuilder
 
@@ -90,6 +92,32 @@ class HaAuthService(context: Context) {
         suspendCancellableCoroutine { cont ->
             val tokenRequest = response.createTokenExchangeRequest()
             appAuth.performTokenRequest(tokenRequest) { tokens, ex ->
+                when {
+                    tokens != null -> cont.resume(tokens)
+                    ex != null -> cont.resumeWithException(ex)
+                    else -> cont.resumeWithException(AuthorizationException.GeneralErrors.NETWORK_ERROR)
+                }
+            }
+        }
+
+    /**
+     * Mint a fresh access token from a stored refresh token. Used on
+     * cold-start auto-resume so the app upgrades from the cache-only
+     * stub session to a live one without sending the user back through
+     * the Custom Tab. HA usually doesn't rotate the refresh token on
+     * this exchange, but if it does the response carries the new one.
+     */
+    suspend fun refreshAccessToken(baseUrl: String, refreshToken: String): TokenResponse =
+        suspendCancellableCoroutine { cont ->
+            val config = AuthorizationServiceConfiguration(
+                Uri.parse("$baseUrl/auth/authorize"),
+                Uri.parse("$baseUrl/auth/token"),
+            )
+            val request = TokenRequest.Builder(config, CLIENT_ID)
+                .setGrantType(GrantTypeValues.REFRESH_TOKEN)
+                .setRefreshToken(refreshToken)
+                .build()
+            appAuth.performTokenRequest(request) { tokens, ex ->
                 when {
                     tokens != null -> cont.resume(tokens)
                     ex != null -> cont.resumeWithException(ex)


### PR DESCRIPTION
## Summary

`MainActivity` builds a `CachedHaSession(OfflineOnlySession)` from the last-known instance pointer so the first frame paints from the offline cache — but `OfflineOnlySession.connectionStatus` is hardcoded `Failed` and its `connect()` is a no-op, leaving the status pill stuck at "Failed" forever. The comment in `MainActivity` already promised a `LaunchedEffect` that minted a fresh access token in the background; that effect didn't exist. This is the underlying cause flagged as a follow-up in #269.

- Add `HaAuthService.refreshAccessToken(baseUrl, refreshToken)` — AppAuth `TokenRequest` with `grant_type=refresh_token` against the same `{baseUrl}/auth/token` endpoint `exchangeCode` uses.
- Extend the existing demo-mode `LaunchedEffect` in `TerrazzoApp`: if demo is off and an `initialSession` is present, look up the refresh token in `TokenVault`, mint a fresh access token, and swap the stub for a real `LiveHaSession`-backed session via `sessionFactory.create(baseUrl, access)`. Guarded by `session === initialSession` so a concurrent demo toggle or sign-out wins. If HA returns a rotated refresh token, the new one is written back to the vault.
- On any failure (no refresh token in vault, HA unreachable, refresh revoked) the cache-only session stays in place: the UI is still usable from disk, and the keep-alive + tap-to-retry from #269 still give the user a manual path forward.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin :terrazzo-core:compileAndroidMain`
- [x] `./gradlew :app:testDebugUnitTest`
- [x] `./gradlew :app:ktfmtCheck :terrazzo-core:ktfmtCheck`
- [ ] Manual: launch the app with a prior signed-in instance + valid refresh token → status pill goes Connecting → Connected without user interaction.
- [ ] Manual: same flow with the refresh token cleared from the vault → cache-only session remains, tap-to-retry surfaces snackbar (no crash).
- [ ] Manual: with demo mode persisted ON → demo session wins, no refresh attempt fires.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6DkKkTybqvW4h32RujPnT)_