### PR TITLE
chore(image): tighter disk-cache bounds + Coil event-listener diagnostics

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/image/HaImageStack.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/image/HaImageStack.kt
@@ -6,11 +6,18 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.util.Log
 import coil3.BitmapImage
+import coil3.EventListener
 import coil3.ImageLoader
+import coil3.decode.DataSource
 import coil3.disk.DiskCache
+import coil3.fetch.FetchResult
+import coil3.fetch.Fetcher
+import coil3.fetch.ImageFetchResult
+import coil3.fetch.SourceFetchResult
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.ErrorResult
 import coil3.request.ImageRequest
+import coil3.request.Options
 import coil3.request.SuccessResult
 import coil3.request.allowHardware
 import dev.zacsweers.metro.Inject
@@ -76,9 +83,18 @@ class HaImageStack(
   }
 
   private val diskCache: DiskCache by lazy {
+    // Pin sane bounds explicitly so the cache behaves predictably on
+    // every device: at least 10 MB even when free space is tight, no
+    // more than 100 MB so a long-running camera dashboard with
+    // token-rotating URLs can't blow up the cache directory. Coil's
+    // default `maxSizePercent` (0.02) still gates between these
+    // bounds.
     DiskCache.Builder()
       .directory(context.applicationContext.cacheDir.resolve(IMAGE_CACHE_DIR).toOkioPath())
+      .minimumMaxSizeBytes(MIN_DISK_CACHE_BYTES)
+      .maximumMaxSizeBytes(MAX_DISK_CACHE_BYTES)
       .build()
+      .also { Log.d(TAG, "diskCache built at $IMAGE_CACHE_DIR maxSize=${it.maxSize}") }
   }
 
   /**
@@ -92,10 +108,13 @@ class HaImageStack(
         .addInterceptor(LanConnectionPolicyInterceptor(lanPolicy))
         .addInterceptor(HaBearerAuthInterceptor({ haHost }, { accessToken }))
         .build()
+    Log.d(TAG, "imageLoader building (host=$haHost hasToken=${accessToken != null})")
     ImageLoader.Builder(context.applicationContext)
       .components { add(OkHttpNetworkFetcherFactory(callFactory = { client })) }
       .diskCache(diskCache)
+      .eventListener(LoggingEventListener)
       .build()
+      .also { Log.d(TAG, "imageLoader built") }
   }
 
   override suspend fun resolve(url: String): Bitmap? {
@@ -139,8 +158,80 @@ class HaImageStack(
     return prefix + url
   }
 
+  /**
+   * Coil [EventListener] that logs each stage of an image request to
+   * logcat under [TAG]. Filterable with
+   *
+   * ```
+   * adb logcat -s HaImageStack
+   * ```
+   *
+   * The default Coil pipeline runs many stages (size resolve → map →
+   * key → fetch → decode → transform → transition); we only emit a
+   * line for the ones useful for diagnosing why a tile stays gray:
+   * the chosen fetcher (network vs. memory cache hit), the fetch
+   * outcome with its [DataSource] (so a stale fetch from `MEMORY` /
+   * `DISK` is visible), and the final success / error.
+   */
+  private object LoggingEventListener : EventListener() {
+    override fun fetchStart(request: ImageRequest, fetcher: Fetcher, options: Options) {
+      Log.d(
+        TAG,
+        "fetchStart data=${request.data} fetcher=${fetcher::class.java.simpleName}",
+      )
+    }
+
+    override fun fetchEnd(
+      request: ImageRequest,
+      fetcher: Fetcher,
+      options: Options,
+      result: FetchResult?,
+    ) {
+      val source: DataSource? =
+        when (result) {
+          is SourceFetchResult -> result.dataSource
+          is ImageFetchResult -> result.dataSource
+          else -> null
+        }
+      Log.d(
+        TAG,
+        "fetchEnd data=${request.data} fetcher=${fetcher::class.java.simpleName} " +
+          "result=${result?.let { it::class.java.simpleName } ?: "null"} dataSource=$source",
+      )
+    }
+
+    override fun onSuccess(request: ImageRequest, result: SuccessResult) {
+      val img = result.image
+      val dims =
+        if (img is BitmapImage) "${img.bitmap.width}x${img.bitmap.height}"
+        else img::class.java.simpleName
+      Log.d(
+        TAG,
+        "onSuccess data=${request.data} dataSource=${result.dataSource} image=$dims",
+      )
+    }
+
+    override fun onError(request: ImageRequest, result: ErrorResult) {
+      Log.w(
+        TAG,
+        "onError data=${request.data} " +
+          "throwable=${result.throwable::class.java.simpleName}: ${result.throwable.message}",
+      )
+    }
+  }
+
   private companion object {
     private const val IMAGE_CACHE_DIR = "ha_image_cache"
     private const val TAG = "HaImageStack"
+
+    // 10 MB floor — even tight-storage devices keep enough room to
+    // cache a screenful of dashboard thumbnails.
+    private const val MIN_DISK_CACHE_BYTES = 10L * 1024 * 1024
+
+    // 100 MB ceiling — a token-rotating camera URL is a new cache
+    // key every refresh; we don't want that to balloon the cache
+    // dir while the user's away. LRU eviction reclaims under the
+    // ceiling.
+    private const val MAX_DISK_CACHE_BYTES = 100L * 1024 * 1024
   }
 }


### PR DESCRIPTION
## Summary

Continue the gray-tile investigation by tightening the disk cache config and adding one more diagnostic layer at the Coil engine.

### Disk cache bounds

`HaImageStack.diskCache` now pins explicit min / max:
- **10 MB floor** (`minimumMaxSizeBytes`) — even tight-storage devices keep enough room for a screenful of thumbnails after `cacheDir` reclamation.
- **100 MB ceiling** (`maximumMaxSizeBytes`) — a `camera_proxy` URL with rotating `?token=` is a brand-new Coil cache key on every refresh; the ceiling stops that from ballooning the cache dir while the user's away. LRU eviction reclaims under the ceiling.
- Coil's default `maxSizePercent` (2 % of free space) still applies between the bounds.

### Coil `EventListener`

Wire a `LoggingEventListener` to the `ImageLoader` so the engine surfaces per-request stages under the `HaImageStack` tag:

```
fetchStart    — request data + chosen Fetcher class
fetchEnd      — FetchResult type + DataSource (NETWORK / DISK / MEMORY / MEMORY_CACHE)
onSuccess     — final image dimensions + dataSource
onError       — throwable type + message
```

`fetchEnd`'s `dataSource` is the line that tells you whether a picture-entity URL is coming from cache (and which layer) vs. going to the network.

```
adb logcat -s HaImageStack,CoilBitmapLoader,HaCoilImageResolver,CachedCardPreview
```

shows the full pipeline alongside the existing tags from #268.

## Test plan

- [ ] Open a dashboard with picture-entity tiles; filter logcat by `HaImageStack`
- [ ] Confirm first-paint `fetchEnd dataSource=NETWORK`, then on subsequent fetches `DISK` or `MEMORY`
- [ ] Cold restart: confirm `fetchEnd dataSource=DISK` instead of `NETWORK` for already-cached URLs
- [ ] If gray persists, the new lines should make it obvious whether (a) the fetch fails, (b) it succeeds from the wrong source, or (c) the fetch isn't being attempted at all

Refs #264

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJK2zDradnW4MV2o1kjZkv)_