### PR TITLE
fix(ws): clear dead HA socket and bridge state into reconnect

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -2,6 +2,7 @@
 
 package ee.schimke.terrazzo.dashboard
 
+import android.util.Log
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -83,6 +84,7 @@ import ee.schimke.terrazzo.ui.LocalThemeStyle
 import ee.schimke.terrazzo.ui.rememberLayoutConfig
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
@@ -142,15 +144,26 @@ fun DashboardViewScreen(
         // Poll when the session opts in (demo mode does, at ~1s) so
         // values visibly change; a one-shot fetch otherwise.
         while (true) {
-            runCatching { session.loadDashboard(urlPath) }
-                .onSuccess { (dashboard, snapshot) ->
-                    state = DashboardState.Ready(dashboard, snapshot)
+            try {
+                val (dashboard, snapshot) = session.loadDashboard(urlPath)
+                state = DashboardState.Ready(dashboard, snapshot)
+            } catch (ce: CancellationException) {
+                // Dashboard switch or composition leaving — let the new
+                // LaunchedEffect take over. `runCatching` used to absorb
+                // this and overwrite state with the cancellation message.
+                throw ce
+            } catch (t: Throwable) {
+                // Log so logcat actually carries the cause. Previously
+                // the message was stuffed straight into the UI state
+                // with no stack trace, so reports like "Software caused
+                // connection abort" arrived with nothing to debug from.
+                Log.w(TAG, "loadDashboard($urlPath) failed", t)
+                if (state is DashboardState.Loading) {
+                    state = DashboardState.Error(
+                        t.message ?: t::class.simpleName ?: "error"
+                    )
                 }
-                .onFailure {
-                    if (state is DashboardState.Loading) {
-                        state = DashboardState.Error(it.message ?: it::class.simpleName ?: "error")
-                    }
-                }
+            }
             val interval = session.refreshIntervalMillis ?: break
             delay(interval)
         }
@@ -201,6 +214,8 @@ fun DashboardViewScreen(
         }
     }
 }
+
+private const val TAG = "DashboardView"
 
 private sealed interface DashboardState {
     data object Loading : DashboardState

--- a/app/src/test/kotlin/ee/schimke/terrazzo/integration/LiveHaSessionReconnectTest.kt
+++ b/app/src/test/kotlin/ee/schimke/terrazzo/integration/LiveHaSessionReconnectTest.kt
@@ -1,0 +1,190 @@
+package ee.schimke.terrazzo.integration
+
+import ee.schimke.terrazzo.core.session.LiveHaSession
+import ee.schimke.terrazzo.core.session.SessionConnectionStatus
+import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.routing.routing
+import io.ktor.server.websocket.WebSockets
+import io.ktor.server.websocket.webSocket
+import io.ktor.websocket.Frame
+import io.ktor.websocket.readText
+import io.ktor.websocket.send
+import java.net.ServerSocket
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+/**
+ * Regression for "Failed: Software caused connection abort" on dashboard switch.
+ *
+ * Before the fix: when the underlying WebSocket died (server hang-up, idle TCP
+ * timeout, network change), `HaClient.receiveLoop` set `state = Error` but left
+ * `session` pointing at the dead socket. The next `awaitCommand` (e.g. a
+ * dashboard switch triggering `lovelace/config`) called `send` on that socket
+ * and Android surfaced `SocketException: Software caused connection abort` —
+ * with no path back to a healthy session, because `LiveHaSession.connectionStatus`
+ * was never wired to the underlying HaClient state. So the app's
+ * `repeatOnLifecycle(RESUMED)` reconnect loop (which watches `connectionStatus`)
+ * never fired either.
+ *
+ * After the fix:
+ *   - `receiveLoop` clears `session` and flips state to `Disconnected` on the way
+ *     out, so the next send fails fast with a clear "Not connected" error instead
+ *     of a raw SocketException.
+ *   - `LiveHaSession` observes `HaClient.state` and propagates Disconnected/Error
+ *     to `connectionStatus = Failed`, so the existing reconnect loop wakes up.
+ */
+class LiveHaSessionReconnectTest {
+
+  private lateinit var server: EmbeddedServer<*, *>
+  private var port: Int = 0
+  private val handler = HaProtocolHandler()
+
+  private val baseUrl: String
+    get() = "http://127.0.0.1:$port"
+
+  @BeforeTest
+  fun start() {
+    port = freePort()
+    server = newServer(port)
+  }
+
+  @AfterTest
+  fun stop() {
+    runCatching { server.stop(gracePeriodMillis = 50, timeoutMillis = 500) }
+  }
+
+  @Test
+  fun mid_flight_disconnect_flips_status_to_failed_and_clears_dead_session() {
+    runBlocking {
+      val session = LiveHaSession(baseUrl = baseUrl, accessToken = "test-token")
+      try {
+        session.connect()
+        assertEquals(SessionConnectionStatus.Connected, session.connectionStatus.value)
+
+        // First fetch lands on the live socket.
+        val (home, _) = session.loadDashboard(null)
+        assertEquals("Home", home.title)
+
+        // Kill the server out from under us — simulates HA restart, idle
+        // TCP timeout, or an Android network change. The read loop will
+        // catch the resulting close and tear down its session reference.
+        server.stop(gracePeriodMillis = 50, timeoutMillis = 500)
+
+        // The bridge into connectionStatus must surface this — without
+        // it, the app's reconnect loop never fires and the user is stuck
+        // on a dead session.
+        withTimeout(3_000) {
+          session.connectionStatus.filter { it == SessionConnectionStatus.Failed }.first()
+        }
+
+        // A subsequent fetch must not be a `SocketException: Software
+        // caused connection abort` from a stale socket. The session
+        // reference was cleared on read-loop exit, so we get a clean
+        // "Not connected" error the UI can either retry or fall back
+        // from. The exact message isn't load-bearing — we just verify
+        // we don't fall through into a dead socket.
+        assertFailsWith<Throwable> { session.loadDashboard(null) }
+      } finally {
+        session.close()
+      }
+    }
+  }
+
+  @Test
+  fun reconnect_after_server_returns_restores_connected_status() {
+    runBlocking {
+      val session = LiveHaSession(baseUrl = baseUrl, accessToken = "test-token")
+      try {
+        session.connect()
+        assertEquals("Home", session.loadDashboard(null).first.title)
+
+        // Bounce the server: stop, then bring a fresh one up on the same
+        // port so the existing baseUrl still resolves. Mirrors an HA
+        // restart from the user's perspective.
+        server.stop(gracePeriodMillis = 50, timeoutMillis = 500)
+        withTimeout(3_000) {
+          session.connectionStatus.filter { it == SessionConnectionStatus.Failed }.first()
+        }
+
+        server = newServer(port)
+        // Drive the recovery path the app itself drives (the
+        // `repeatOnLifecycle(RESUMED)` loop in TerrazzoApp).
+        session.connect()
+        withTimeout(3_000) {
+          session.connectionStatus.filter { it == SessionConnectionStatus.Connected }.first()
+        }
+        assertEquals("Home", session.loadDashboard(null).first.title)
+      } finally {
+        session.close()
+      }
+    }
+  }
+
+  private fun newServer(port: Int): EmbeddedServer<*, *> =
+    embeddedServer(CIO, port = port, host = "127.0.0.1") {
+        install(WebSockets)
+        routing {
+          webSocket("/api/websocket") {
+            send(Frame.Text("""{"type":"auth_required","ha_version":"test"}"""))
+            for (frame in incoming) {
+              if (frame !is Frame.Text) continue
+              val msg = JSON.parseToJsonElement(frame.readText()).jsonObject
+              handler.handle(msg)?.let { reply ->
+                send(Frame.Text(JSON.encodeToString(JsonObject.serializer(), reply)))
+              }
+            }
+          }
+        }
+      }
+      .start(wait = false)
+
+  private class HaProtocolHandler {
+    fun handle(msg: JsonObject): JsonObject? {
+      val type = msg["type"]?.jsonPrimitive?.content ?: return null
+      if (type == "auth") return buildJsonObject { put("type", "auth_ok") }
+      val id = msg["id"]?.jsonPrimitive?.intOrNull ?: return null
+      return when (type) {
+        "lovelace/config" -> result(id, dashboardConfig())
+        "get_states" -> result(id, buildJsonArray {})
+        else -> null
+      }
+    }
+
+    private fun dashboardConfig() = buildJsonObject {
+      put("title", "Home")
+      put("views", buildJsonArray { add(buildJsonObject {}) })
+    }
+
+    private fun result(id: Int, value: kotlinx.serialization.json.JsonElement) = buildJsonObject {
+      put("id", id)
+      put("type", "result")
+      put("success", true)
+      put("result", value)
+    }
+  }
+
+  companion object {
+    private val JSON = Json { ignoreUnknownKeys = true }
+
+    private fun freePort(): Int = ServerSocket(0).use { it.localPort }
+  }
+}

--- a/ha-client/src/commonMain/kotlin/ee/schimke/ha/client/HaClient.kt
+++ b/ha-client/src/commonMain/kotlin/ee/schimke/ha/client/HaClient.kt
@@ -75,6 +75,9 @@ class HaClient(private val config: HaConfig, engine: HttpClientEngine? = null) {
   private var nextId = 1
   private val pending = mutableMapOf<Int, CompletableDeferred<JsonObject>>()
   private val pendingMutex = Mutex()
+  // Guards mutation of [session] / [receiveJob] and serialises [send] so two
+  // concurrent commands can't interleave frames on the same socket.
+  private val sessionMutex = Mutex()
   private var session: DefaultWebSocketSession? = null
   private var receiveJob: Job? = null
 
@@ -90,37 +93,40 @@ class HaClient(private val config: HaConfig, engine: HttpClientEngine? = null) {
   }
 
   suspend fun connect() {
-    if (session != null) return
-    _state.value = ConnectionState.Connecting
-    val wsUrl = config.baseUrl.toWsUrl() + "/api/websocket"
-    val s = httpClient.webSocketSession { url(wsUrl) }
-    session = s
+    sessionMutex.withLock {
+      if (session != null) return
+      _state.value = ConnectionState.Connecting
+      val wsUrl = config.baseUrl.toWsUrl() + "/api/websocket"
+      val s = httpClient.webSocketSession { url(wsUrl) }
 
-    // Handshake on this coroutine — then spin up the receive loop.
-    val authRequired = readMessage(s)
-    require(authRequired["type"]?.jsonPrimitive?.content == "auth_required") {
-      "expected auth_required, got $authRequired"
-    }
-    _state.value = ConnectionState.Authenticating
-    s.send(
-      json.encodeToString(
-        JsonObject.serializer(),
-        buildJsonObject {
-          put("type", "auth")
-          put("access_token", config.accessToken)
-        },
-      )
-    )
-    val authResult = readMessage(s)
-    when (authResult["type"]?.jsonPrimitive?.content) {
-      "auth_ok" -> _state.value = ConnectionState.Ready
-      else -> {
-        _state.value = ConnectionState.Error
-        throw IllegalStateException("auth rejected: $authResult")
+      // Handshake on this coroutine — then spin up the receive loop.
+      val authRequired = readMessage(s)
+      require(authRequired["type"]?.jsonPrimitive?.content == "auth_required") {
+        "expected auth_required, got $authRequired"
       }
-    }
+      _state.value = ConnectionState.Authenticating
+      s.send(
+        json.encodeToString(
+          JsonObject.serializer(),
+          buildJsonObject {
+            put("type", "auth")
+            put("access_token", config.accessToken)
+          },
+        )
+      )
+      val authResult = readMessage(s)
+      when (authResult["type"]?.jsonPrimitive?.content) {
+        "auth_ok" -> _state.value = ConnectionState.Ready
+        else -> {
+          _state.value = ConnectionState.Error
+          runCatching { s.close(CloseReason(CloseReason.Codes.PROTOCOL_ERROR, "auth")) }
+          throw IllegalStateException("auth rejected: $authResult")
+        }
+      }
 
-    receiveJob = scope.launch { receiveLoop(s) }
+      session = s
+      receiveJob = scope.launch { receiveLoop(s) }
+    }
   }
 
   suspend fun fetchDashboard(urlPath: String? = null): Dashboard {
@@ -182,9 +188,14 @@ class HaClient(private val config: HaConfig, engine: HttpClientEngine? = null) {
   }
 
   suspend fun close() {
-    receiveJob?.cancel()
-    runCatching { session?.close(CloseReason(CloseReason.Codes.NORMAL, "bye")) }
-    session = null
+    val s = sessionMutex.withLock {
+      val current = session
+      session = null
+      receiveJob?.cancel()
+      receiveJob = null
+      current
+    }
+    runCatching { s?.close(CloseReason(CloseReason.Codes.NORMAL, "bye")) }
     scope.cancel()
     httpClient.close()
     _state.value = ConnectionState.Disconnected
@@ -219,19 +230,37 @@ class HaClient(private val config: HaConfig, engine: HttpClientEngine? = null) {
       put("type", type)
       extra()
     }
-    s.send(json.encodeToString(JsonObject.serializer(), msg))
-    return withTimeout(30_000) {
-      val resp = deferred.await()
-      val success = resp["success"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: true
-      if (!success) {
-        val err = resp["error"]?.jsonObject?.get("message")?.jsonPrimitive?.content ?: "unknown"
-        error("HA command $type failed: $err")
+    try {
+      // Serialise WebSocket writes: Ktor's send is a suspend over a single
+      // outgoing channel, but cancelling one sender mid-encode while
+      // another tries to send produces interleaved/corrupted frames the
+      // server will close on. Holding [sessionMutex] also pins the
+      // current socket across the write so a reconnect can't swap it
+      // out under us.
+      sessionMutex.withLock {
+        val live = session ?: error("Not connected — socket closed before send (cmd=$type)")
+        if (live !== s) error("Connection replaced before send (cmd=$type)")
+        live.send(json.encodeToString(JsonObject.serializer(), msg))
       }
-      resp
+      return withTimeout(30_000) {
+        val resp = deferred.await()
+        val success = resp["success"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: true
+        if (!success) {
+          val err = resp["error"]?.jsonObject?.get("message")?.jsonPrimitive?.content ?: "unknown"
+          error("HA command $type failed: $err")
+        }
+        resp
+      }
+    } finally {
+      // Always remove our pending entry — covers normal completion,
+      // timeout, host-side cancellation (dashboard switch), and send
+      // failures. Leaking deferreds slowly grew the map on every reload.
+      pendingMutex.withLock { pending.remove(id) }
     }
   }
 
   private suspend fun receiveLoop(s: DefaultWebSocketSession) {
+    var failure: Throwable? = null
     try {
       for (frame in s.incoming) {
         val text = (frame as? Frame.Text)?.readText() ?: continue
@@ -240,12 +269,22 @@ class HaClient(private val config: HaConfig, engine: HttpClientEngine? = null) {
         pendingMutex.withLock { pending.remove(id) }?.complete(obj)
       }
     } catch (t: Throwable) {
-      pendingMutex.withLock {
-        pending.values.forEach { it.completeExceptionally(t) }
-        pending.clear()
-      }
-      _state.value = ConnectionState.Error
+      failure = t
     }
+    // The socket is gone — either the server closed `incoming` cleanly
+    // or we caught a throwable. Either way, the connection isn't usable
+    // anymore: drop our reference so the next [connect] reopens it
+    // instead of routing fresh `awaitCommand`s into a dead socket
+    // (which surfaces as `SocketException: Software caused connection
+    // abort` on the next send). Also fail any in-flight deferreds so
+    // their callers see a clear cause instead of timing out at 30s.
+    val cause = failure ?: IllegalStateException("WebSocket closed by peer")
+    pendingMutex.withLock {
+      pending.values.forEach { it.completeExceptionally(cause) }
+      pending.clear()
+    }
+    sessionMutex.withLock { if (session === s) session = null }
+    _state.value = ConnectionState.Disconnected
   }
 
   private suspend fun readMessage(s: DefaultWebSocketSession): JsonObject {

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/HaSession.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/HaSession.kt
@@ -6,8 +6,14 @@ import ee.schimke.ha.client.HaConfig
 import ee.schimke.ha.model.Dashboard
 import ee.schimke.ha.model.HaSnapshot
 import io.ktor.client.engine.HttpClientEngine
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.serialization.json.JsonObject
 
 /**
@@ -74,6 +80,31 @@ class LiveHaSession(
         HaClient(HaConfig(baseUrl = baseUrl, accessToken = accessToken), engine = engine)
     private val _connectionStatus = MutableStateFlow(SessionConnectionStatus.Connecting)
     override val connectionStatus: StateFlow<SessionConnectionStatus> = _connectionStatus
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    init {
+        // Bridge the underlying socket's state into our session status so
+        // a mid-flight disconnect (read loop catches a throwable, peer
+        // hangs up) flips us to Failed. Without this, the app's
+        // RESUMED-state reconnect loop never fires after the WebSocket
+        // dies under a long-lived session — the next dashboard switch
+        // sees the dead session and surfaces "Software caused connection
+        // abort" with no recovery path.
+        client.state
+            .onEach { state ->
+                when (state) {
+                    HaClient.ConnectionState.Ready ->
+                        _connectionStatus.value = SessionConnectionStatus.Connected
+                    HaClient.ConnectionState.Connecting,
+                    HaClient.ConnectionState.Authenticating ->
+                        _connectionStatus.value = SessionConnectionStatus.Connecting
+                    HaClient.ConnectionState.Disconnected,
+                    HaClient.ConnectionState.Error ->
+                        _connectionStatus.value = SessionConnectionStatus.Failed
+                }
+            }
+            .launchIn(scope)
+    }
 
     override suspend fun connect() {
         _connectionStatus.value = SessionConnectionStatus.Connecting
@@ -95,6 +126,7 @@ class LiveHaSession(
     ) = client.callService(domain, service, entityId, serviceData)
     override suspend fun close() {
         client.close()
+        scope.cancel()
         _connectionStatus.value = SessionConnectionStatus.Failed
     }
 }


### PR DESCRIPTION
Switching dashboards after the HA WebSocket had silently died — peer
hang-up, idle TCP timeout, network change — surfaced as
"Failed: Software caused connection abort" with no logcat output and
no recovery path. Three things conspired:

  - `HaClient.receiveLoop` set state to `Error` on socket failure but
    left `session` pointing at the dead WebSocket. The next dashboard
    fetch called `send()` on it and got the raw SocketException.
  - `LiveHaSession.connectionStatus` was independent of `HaClient.state`,
    so the lifecycle-aware reconnect loop in `TerrazzoApp` never fired
    when the underlying socket died — it only watched the session flow.
  - `DashboardViewScreen` wrapped the fetch in `runCatching` and stuffed
    `it.message` straight into UI state with no `Log.w`, so logcat
    captured nothing on the failing dashboard switch.

Fix the chain end to end:

  - `receiveLoop` now clears `session` and flips state to `Disconnected`
    on the way out (clean close or thrown). Pending deferreds are failed
    with the cause so callers see a real exception instead of timing out
    at 30s.
  - `awaitCommand` is now cancellation-safe: pending entries are removed
    in `finally`, and the actual `send` runs under `sessionMutex` so two
    concurrent commands can't interleave frames or race with a
    reconnect. `connect`/`close` use the same mutex.
  - `LiveHaSession` observes `HaClient.state` and propagates
    Disconnected/Error to `connectionStatus = Failed`, waking the
    existing app-level reconnect loop.
  - `DashboardViewScreen` lets `CancellationException` propagate (so
    dashboard switches don't overwrite the new state with the old
    coroutine's cancel message) and logs other failures with stack
    traces.

Regression test (`LiveHaSessionReconnectTest`) spins up an embedded
Ktor HA-protocol fake, kills the server mid-session, asserts
`connectionStatus` flips to `Failed`, and then verifies the session
reconnects cleanly when the server returns.