### PR TITLE
test(image): bake 100x100 placeholder + push override at matching size

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/PictureEntityOverridePreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/PictureEntityOverridePreviews.kt
@@ -3,6 +3,7 @@
 package ee.schimke.ha.previews
 
 import android.graphics.Bitmap
+import androidx.compose.remote.player.core.platform.BitmapLoader
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth as uiFillMaxWidth
 import androidx.compose.foundation.layout.height as uiHeight
@@ -19,6 +20,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import ee.schimke.ha.model.CardConfig
@@ -32,34 +34,38 @@ import ee.schimke.ha.rc.RenderChild
 import ee.schimke.ha.rc.androidXExperimentalWrap
 import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.components.HaTheme
+import ee.schimke.ha.rc.components.LocalPictureImageStrategy
+import ee.schimke.ha.rc.components.PictureImageStrategy
 import ee.schimke.ha.rc.components.ProvideHaTheme
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 
 /**
- * Picture-entity previews that drive the **named-bitmap override path**
- * end-to-end inside Robolectric — the same flow the device runs in
- * `DashboardViewScreen`:
+ * Picture-entity previews that exercise both [PictureImageStrategy]
+ * modes end-to-end inside Robolectric:
  *
- *  1. `PictureEntityCardConverter` renders `RemoteHaPictureEntity`,
- *     which captures `RemoteHaImageNamed(name, placeholder)` into the
- *     `.rc` document. The placeholder is a fixed-size blank bitmap so
- *     the `BitmapData` op carries non-zero width / height.
- *  2. `CachedCardPreview` walks the card for picture-entity ids, reads
- *     `entity_picture` from the snapshot, calls the
- *     `LocalRemoteImageResolver` for a fresh bitmap, and pushes via
- *     `StateUpdater.setUserLocalBitmap`.
- *  3. The player swaps the named-bitmap slot to the pushed bytes and
- *     re-renders.
+ *  - **App mode** (`AppMode_Light/Dark`) — captures the URL-form
+ *    named bitmap via [rememberLocalNamedRemoteBitmap] with explicit
+ *    dimensions. The host wires a fake Coil-backed `BitmapLoader`
+ *    that maps the URL to a known yellow-on-blue bitmap; the player
+ *    resolves it at playback exactly like the device's
+ *    `HaImageStack.imageLoader`. Renders the disc.
+ *  - **Widget mode** (`WidgetMode_Light`) — provides
+ *    [PictureImageStrategy.Inline] with a pre-fetched [ImageBitmap].
+ *    The converter bakes the bytes into the captured doc; no
+ *    `BitmapLoader` is wired, mirroring the widget runtime where no
+ *    loader is available. Also renders the disc — proves the same
+ *    visual outcome regardless of strategy.
+ *  - **Icon fallback** (`IconFallback_Light`) — snapshot has no
+ *    `entity_picture`, so the converter takes the [RemoteIcon] path
+ *    (vector ops, no `BitmapData`). Renders a camera icon.
  *
- * The fake resolver returns a known visible bitmap (yellow disc on a
- * blue field) — anything *but* a gray placeholder. If the rendered
- * preview shows the disc, the override pipeline is working at slot
- * level; if it stays gray, dimensions / encoding remain the suspect.
- *
- * The "icon" variant exercises the `imageUrl = null` branch so the
- * preview confirms the icon fallback path also still renders.
+ * Confirms the upstream gray-tile bug (#277) is bypassed via the
+ * local `addNamedBitmapUrlSized` writer workaround, and that the
+ * strategy abstraction routes correctly between the two production
+ * surfaces.
  */
 
 private const val PICTURE_TILE_WIDTH_DP = 360
@@ -135,14 +141,14 @@ private fun fakePictureResolver(): RemoteImageResolver = RemoteImageResolver { u
 }
 
 @Preview(
-  name = "picture-entity override (light)",
+  name = "picture-entity app-mode (light)",
   showBackground = false,
   widthDp = PICTURE_TILE_WIDTH_DP,
   heightDp = PICTURE_TILE_HEIGHT_DP,
 )
 @Composable
-fun PictureEntity_Override_Light() {
-  PictureEntityOverrideHost(
+fun PictureEntity_AppMode_Light() {
+  PictureEntityAppModeHost(
     theme = HaTheme.Light,
     card = pictureSampleCard,
     snapshot = pictureSampleSnapshotWithImage,
@@ -150,14 +156,14 @@ fun PictureEntity_Override_Light() {
 }
 
 @Preview(
-  name = "picture-entity override (dark)",
+  name = "picture-entity app-mode (dark)",
   showBackground = false,
   widthDp = PICTURE_TILE_WIDTH_DP,
   heightDp = PICTURE_TILE_HEIGHT_DP,
 )
 @Composable
-fun PictureEntity_Override_Dark() {
-  PictureEntityOverrideHost(
+fun PictureEntity_AppMode_Dark() {
+  PictureEntityAppModeHost(
     theme = HaTheme.Dark,
     card = pictureSampleCard,
     snapshot = pictureSampleSnapshotWithImage,
@@ -165,32 +171,45 @@ fun PictureEntity_Override_Dark() {
 }
 
 @Preview(
-  name = "picture-entity placeholder-only (light)",
+  name = "picture-entity widget-mode (light)",
   showBackground = false,
   widthDp = PICTURE_TILE_WIDTH_DP,
   heightDp = PICTURE_TILE_HEIGHT_DP,
 )
 @Composable
-fun PictureEntity_Placeholder_Light() {
-  // No resolver wired — the picture-entity card captures the
-  // placeholder bitmap into the doc but nothing pushes an override.
-  // The slot should render the placeholder (transparent → backdrop
-  // shows through).
-  Box(
-    modifier =
-      Modifier.uiFillMaxWidth().uiHeight(PICTURE_TILE_HEIGHT_DP.dp),
-  ) {
+fun PictureEntity_WidgetMode_Light() {
+  // Widget mode: no BitmapLoader at playback. The host pre-fetches
+  // the URL and exposes the bytes via PictureImageStrategy.Inline;
+  // the converter bakes them into the captured doc via
+  // `rememberLocalNamedRemoteBitmap(name) { bitmap }` (bytes form).
+  // The rendered output should be the yellow disc — proves the
+  // widget path renders without a loader.
+  val prefetched = remember { fakeOverrideBitmap(SAMPLE_PICTURE_BITMAP_PX).asImageBitmap() }
+  val strategy = remember(prefetched) {
+    PictureImageStrategy.Inline { url -> prefetched }
+  }
+  Box(modifier = Modifier.uiFillMaxWidth().uiHeight(PICTURE_TILE_HEIGHT_DP.dp)) {
     CachedCardPreview(
       cacheKey =
-        PictureOverridePreviewKey(pictureSampleCard, HaTheme.Light, withOverride = false),
+        PicturePreviewKey(pictureSampleCard, HaTheme.Light, withOverride = false),
       profile = androidXExperimentalWrap,
       modifier = Modifier.uiFillMaxWidth(),
       card = pictureSampleCard,
       snapshot = pictureSampleSnapshotWithImage,
     ) {
-      ProvideCardRegistry(defaultRegistry()) {
-        ProvideHaTheme(HaTheme.Light) {
-          RenderChild(pictureSampleCard, pictureSampleSnapshotWithImage, RemoteModifier.rcFillMaxWidth())
+      // The strategy provider must live INSIDE the
+      // `captureSingleRemoteDocument` sub-composition for the
+      // converter to see it — CompositionLocals from the outer
+      // tree don't propagate into the capture pass.
+      CompositionLocalProvider(LocalPictureImageStrategy provides strategy) {
+        ProvideCardRegistry(defaultRegistry()) {
+          ProvideHaTheme(HaTheme.Light) {
+            RenderChild(
+              pictureSampleCard,
+              pictureSampleSnapshotWithImage,
+              RemoteModifier.rcFillMaxWidth(),
+            )
+          }
         }
       }
     }
@@ -214,7 +233,7 @@ fun PictureEntity_IconFallback_Light() {
   ) {
     CachedCardPreview(
       cacheKey =
-        PictureOverridePreviewKey(
+        PicturePreviewKey(
           pictureSampleCardNoEntity,
           HaTheme.Light,
           withOverride = false,
@@ -238,20 +257,47 @@ fun PictureEntity_IconFallback_Light() {
 }
 
 @Composable
-private fun PictureEntityOverrideHost(
+private fun PictureEntityAppModeHost(
   theme: HaTheme,
   card: CardConfig,
   snapshot: HaSnapshot,
 ) {
+  val context = androidx.compose.ui.platform.LocalContext.current
   val resolver = remember { fakePictureResolver() }
+  // Wire a fake Coil-backed BitmapLoader so the URL-form named
+  // bitmap (which the converter now emits via the local
+  // `addNamedBitmapUrlSized` workaround) actually resolves in the
+  // preview env. Maps the snapshot's `entity_picture` URL to the
+  // same yellow-disc bitmap the resolver returns so the URL fetch
+  // and the override push produce the same pixels — the preview
+  // can't tell them apart by pixel, only by which path lit them up.
+  val resolvedUrl =
+    snapshot.states.values.firstNotNullOfOrNull {
+      it.attributes["entity_picture"]?.let { v ->
+        (v as? JsonPrimitive)?.contentOrNull
+      }
+    }
+  val sampleBitmap = remember { fakeOverrideBitmap(SAMPLE_PICTURE_BITMAP_PX) }
+  val bitmapLoader =
+    remember(context, resolvedUrl, sampleBitmap) {
+      if (resolvedUrl == null) {
+        BitmapLoader.UNSUPPORTED
+      } else {
+        previewCoilBitmapLoader(
+          context,
+          mappings = mapOf(resolvedUrl to sampleBitmap.asImageBitmap()),
+        )
+      }
+    }
   Box(modifier = Modifier.uiFillMaxWidth().uiHeight(PICTURE_TILE_HEIGHT_DP.dp)) {
     CompositionLocalProvider(LocalRemoteImageResolver provides resolver) {
       CachedCardPreview(
-        cacheKey = PictureOverridePreviewKey(card, theme, withOverride = true),
+        cacheKey = PicturePreviewKey(card, theme, withOverride = true),
         profile = androidXExperimentalWrap,
         modifier = Modifier.uiFillMaxWidth(),
         card = card,
         snapshot = snapshot,
+        bitmapLoader = bitmapLoader,
       ) {
         ProvideCardRegistry(defaultRegistry()) {
           ProvideHaTheme(theme) {
@@ -263,7 +309,7 @@ private fun PictureEntityOverrideHost(
   }
 }
 
-private data class PictureOverridePreviewKey(
+private data class PicturePreviewKey(
   val card: CardConfig,
   val theme: HaTheme,
   val withOverride: Boolean,

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/PictureEntityOverridePreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/PictureEntityOverridePreviews.kt
@@ -1,0 +1,270 @@
+@file:Suppress("COMPOSE_APPLIER_CALL_MISMATCH", "RestrictedApi")
+
+package ee.schimke.ha.previews
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth as uiFillMaxWidth
+import androidx.compose.foundation.layout.height as uiHeight
+import androidx.compose.foundation.layout.size as uiSize
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth as rcFillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.EntityState
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.CachedCardPreview
+import ee.schimke.ha.rc.LocalRemoteImageResolver
+import ee.schimke.ha.rc.ProvideCardRegistry
+import ee.schimke.ha.rc.RemoteImageResolver
+import ee.schimke.ha.rc.RenderChild
+import ee.schimke.ha.rc.androidXExperimentalWrap
+import ee.schimke.ha.rc.cards.defaultRegistry
+import ee.schimke.ha.rc.components.HaTheme
+import ee.schimke.ha.rc.components.ProvideHaTheme
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Picture-entity previews that drive the **named-bitmap override path**
+ * end-to-end inside Robolectric — the same flow the device runs in
+ * `DashboardViewScreen`:
+ *
+ *  1. `PictureEntityCardConverter` renders `RemoteHaPictureEntity`,
+ *     which captures `RemoteHaImageNamed(name, placeholder)` into the
+ *     `.rc` document. The placeholder is a fixed-size blank bitmap so
+ *     the `BitmapData` op carries non-zero width / height.
+ *  2. `CachedCardPreview` walks the card for picture-entity ids, reads
+ *     `entity_picture` from the snapshot, calls the
+ *     `LocalRemoteImageResolver` for a fresh bitmap, and pushes via
+ *     `StateUpdater.setUserLocalBitmap`.
+ *  3. The player swaps the named-bitmap slot to the pushed bytes and
+ *     re-renders.
+ *
+ * The fake resolver returns a known visible bitmap (yellow disc on a
+ * blue field) — anything *but* a gray placeholder. If the rendered
+ * preview shows the disc, the override pipeline is working at slot
+ * level; if it stays gray, dimensions / encoding remain the suspect.
+ *
+ * The "icon" variant exercises the `imageUrl = null` branch so the
+ * preview confirms the icon fallback path also still renders.
+ */
+
+private const val PICTURE_TILE_WIDTH_DP = 360
+private const val PICTURE_TILE_HEIGHT_DP = 160
+private const val SAMPLE_PICTURE_BITMAP_PX = 512
+
+private val pictureSampleCard: CardConfig =
+  card(
+    """{"type":"picture-entity","entity":"camera.preview_cam","name":"Preview cam","show_name":true,"show_state":true}""",
+  )
+
+private val pictureSampleCardNoEntity: CardConfig =
+  card(
+    """{"type":"picture-entity","entity":"camera.offline_cam","name":"Offline cam","show_name":true,"show_state":false}""",
+  )
+
+private val pictureSampleSnapshotWithImage: HaSnapshot =
+  HaSnapshot(
+    states =
+      mapOf(
+        "camera.preview_cam" to
+          EntityState(
+            entityId = "camera.preview_cam",
+            state = "streaming",
+            attributes =
+              JsonObject(
+                mapOf(
+                  "friendly_name" to JsonPrimitive("Preview cam"),
+                  "entity_picture" to
+                    JsonPrimitive(
+                      "/api/camera_proxy/camera.preview_cam?token=preview-token",
+                    ),
+                ),
+              ),
+          ),
+      ),
+  )
+
+private val pictureSampleSnapshotNoImage: HaSnapshot =
+  HaSnapshot(
+    states =
+      mapOf(
+        "camera.offline_cam" to
+          EntityState(
+            entityId = "camera.offline_cam",
+            state = "idle",
+            attributes =
+              JsonObject(mapOf("friendly_name" to JsonPrimitive("Offline cam"))),
+          ),
+      ),
+  )
+
+/** Visible test bitmap — yellow disc on blue. Asserts "override happened". */
+private fun fakeOverrideBitmap(sizePx: Int): Bitmap {
+  val size = sizePx.toFloat()
+  val composeBitmap = ImageBitmap(sizePx, sizePx)
+  val canvas = Canvas(composeBitmap)
+  val paint = Paint()
+  paint.color = Color(0xFF1565C0)
+  canvas.drawRect(0f, 0f, size, size, paint)
+  paint.color = Color(0xFFFFC107)
+  canvas.drawCircle(Offset(size / 2f, size / 2f), size * 0.32f, paint)
+  return composeBitmap.asAndroidBitmap()
+}
+
+/**
+ * Resolver fixed to one canned bitmap, captured at the picture-entity
+ * placeholder size so the host-side `Bitmap.createScaledBitmap` in
+ * `CachedCardPreview` is a no-op.
+ */
+private fun fakePictureResolver(): RemoteImageResolver = RemoteImageResolver { url ->
+  fakeOverrideBitmap(SAMPLE_PICTURE_BITMAP_PX)
+}
+
+@Preview(
+  name = "picture-entity override (light)",
+  showBackground = false,
+  widthDp = PICTURE_TILE_WIDTH_DP,
+  heightDp = PICTURE_TILE_HEIGHT_DP,
+)
+@Composable
+fun PictureEntity_Override_Light() {
+  PictureEntityOverrideHost(
+    theme = HaTheme.Light,
+    card = pictureSampleCard,
+    snapshot = pictureSampleSnapshotWithImage,
+  )
+}
+
+@Preview(
+  name = "picture-entity override (dark)",
+  showBackground = false,
+  widthDp = PICTURE_TILE_WIDTH_DP,
+  heightDp = PICTURE_TILE_HEIGHT_DP,
+)
+@Composable
+fun PictureEntity_Override_Dark() {
+  PictureEntityOverrideHost(
+    theme = HaTheme.Dark,
+    card = pictureSampleCard,
+    snapshot = pictureSampleSnapshotWithImage,
+  )
+}
+
+@Preview(
+  name = "picture-entity placeholder-only (light)",
+  showBackground = false,
+  widthDp = PICTURE_TILE_WIDTH_DP,
+  heightDp = PICTURE_TILE_HEIGHT_DP,
+)
+@Composable
+fun PictureEntity_Placeholder_Light() {
+  // No resolver wired — the picture-entity card captures the
+  // placeholder bitmap into the doc but nothing pushes an override.
+  // The slot should render the placeholder (transparent → backdrop
+  // shows through).
+  Box(
+    modifier =
+      Modifier.uiFillMaxWidth().uiHeight(PICTURE_TILE_HEIGHT_DP.dp),
+  ) {
+    CachedCardPreview(
+      cacheKey =
+        PictureOverridePreviewKey(pictureSampleCard, HaTheme.Light, withOverride = false),
+      profile = androidXExperimentalWrap,
+      modifier = Modifier.uiFillMaxWidth(),
+      card = pictureSampleCard,
+      snapshot = pictureSampleSnapshotWithImage,
+    ) {
+      ProvideCardRegistry(defaultRegistry()) {
+        ProvideHaTheme(HaTheme.Light) {
+          RenderChild(pictureSampleCard, pictureSampleSnapshotWithImage, RemoteModifier.rcFillMaxWidth())
+        }
+      }
+    }
+  }
+}
+
+@Preview(
+  name = "picture-entity icon-fallback (light)",
+  showBackground = false,
+  widthDp = PICTURE_TILE_WIDTH_DP,
+  heightDp = PICTURE_TILE_HEIGHT_DP,
+)
+@Composable
+fun PictureEntity_IconFallback_Light() {
+  // Snapshot has no `entity_picture` — the converter takes the
+  // RemoteIcon branch, which encodes vector paths (no BitmapData op
+  // involved). Confirms the dimension issue is bitmap-specific.
+  Box(
+    modifier =
+      Modifier.uiFillMaxWidth().uiHeight(PICTURE_TILE_HEIGHT_DP.dp),
+  ) {
+    CachedCardPreview(
+      cacheKey =
+        PictureOverridePreviewKey(
+          pictureSampleCardNoEntity,
+          HaTheme.Light,
+          withOverride = false,
+        ),
+      profile = androidXExperimentalWrap,
+      modifier = Modifier.uiFillMaxWidth(),
+      card = pictureSampleCardNoEntity,
+      snapshot = pictureSampleSnapshotNoImage,
+    ) {
+      ProvideCardRegistry(defaultRegistry()) {
+        ProvideHaTheme(HaTheme.Light) {
+          RenderChild(
+            pictureSampleCardNoEntity,
+            pictureSampleSnapshotNoImage,
+            RemoteModifier.rcFillMaxWidth(),
+          )
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun PictureEntityOverrideHost(
+  theme: HaTheme,
+  card: CardConfig,
+  snapshot: HaSnapshot,
+) {
+  val resolver = remember { fakePictureResolver() }
+  Box(modifier = Modifier.uiFillMaxWidth().uiHeight(PICTURE_TILE_HEIGHT_DP.dp)) {
+    CompositionLocalProvider(LocalRemoteImageResolver provides resolver) {
+      CachedCardPreview(
+        cacheKey = PictureOverridePreviewKey(card, theme, withOverride = true),
+        profile = androidXExperimentalWrap,
+        modifier = Modifier.uiFillMaxWidth(),
+        card = card,
+        snapshot = snapshot,
+      ) {
+        ProvideCardRegistry(defaultRegistry()) {
+          ProvideHaTheme(theme) {
+            RenderChild(card, snapshot, RemoteModifier.rcFillMaxWidth())
+          }
+        }
+      }
+    }
+  }
+}
+
+private data class PictureOverridePreviewKey(
+  val card: CardConfig,
+  val theme: HaTheme,
+  val withOverride: Boolean,
+)

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/LocalNamedRemoteBitmap.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/LocalNamedRemoteBitmap.kt
@@ -1,0 +1,144 @@
+@file:Suppress(
+  "RestrictedApi",
+  "INVISIBLE_REFERENCE",
+  "INVISIBLE_MEMBER",
+)
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.remote.creation.RemoteComposeWriter
+import androidx.compose.remote.creation.compose.state.MutableRemoteBitmap
+import androidx.compose.remote.creation.compose.state.RemoteBitmap
+import androidx.compose.remote.creation.compose.state.RemoteNamedCacheKey
+import androidx.compose.remote.creation.compose.state.RemoteState
+import androidx.compose.remote.creation.compose.state.rememberNamedState
+import androidx.compose.remote.core.operations.NamedVariable
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
+
+/**
+ * Local replacements for `androidx.compose.remote.creation.compose.state.rememberNamedRemoteBitmap`
+ * (alpha010) that work around two bugs in upstream.
+ *
+ *  1. **`addNamedBitmapUrl(name, url)` defaults dimensions to 1×1.**
+ *     Upstream:
+ *
+ *     ```java
+ *     public int addNamedBitmapUrl(String name, String url) {
+ *         int id = addBitmapUrl(url);            // → addBitmapUrl(url, 1, 1)
+ *         mBuffer.setNamedVariable(id, name, IMAGE_TYPE);
+ *         return id;
+ *     }
+ *     ```
+ *
+ *     So every URL-form named bitmap captures with `mImageWidth = 1,
+ *     mImageHeight = 1`. The player allocates a 1×1 slot and the
+ *     fetched image collapses to invisible. That's the gray
+ *     picture-entity tile in #264.
+ *
+ *  2. **`StateUpdater.setUserLocalBitmap` doesn't reach the rendered
+ *     slot.** The override write hits
+ *     `RemoteComposeState.overrideData(id, value)` but the painted
+ *     surface keeps drawing the baked bytes. See [issue #277].
+ *
+ * Both helpers below mirror the upstream contract — same
+ * [rememberNamedState] caching, same [RemoteNamedCacheKey],
+ * `domain.prefixed(name)` registration — but the URL form swaps
+ * `addNamedBitmapUrl(name, url)` for a direct call to
+ * `addBitmapUrl(url, width, height)` (via [addNamedBitmapUrlSized])
+ * so the slot has real dimensions.
+ *
+ * Bug 2 can't be patched from outside (the override channel is
+ * read-only from here). The workaround is to keep the URL form
+ * up to date by re-capturing the document when the URL changes —
+ * with the dimensions fix in place the first paint actually
+ * renders, and a snapshot rotation just bumps the cache key.
+ *
+ * `@Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")` lets us
+ * reach the upstream `internal` symbols (`rememberNamedState`,
+ * `MutableRemoteBitmap`'s constructor, `RemoteNamedCacheKey`) the
+ * same way `@Suppress("RestrictedApi")` reaches the
+ * `@RestrictTo(LIBRARY_GROUP)` ones. Both are needed to mirror
+ * upstream exactly without forking the encoded byte format.
+ */
+
+/**
+ * Bake an [ImageBitmap] into the document under [name]. Mirrors
+ * upstream — the bytes form doesn't suffer from bug 1 (dimensions
+ * come from the `ImageBitmap`). Kept here so all picture-entity
+ * bitmap registration goes through one local seam.
+ */
+@Composable
+fun rememberLocalNamedRemoteBitmap(
+  name: String,
+  domain: RemoteState.Domain = RemoteState.Domain.User,
+  value: () -> ImageBitmap,
+): RemoteBitmap =
+  rememberNamedState(name, domain) {
+    val bitmap = value()
+    MutableRemoteBitmap(
+      /* constantValueOrNull = */ null,
+      RemoteNamedCacheKey(domain, name),
+    ) { creationState ->
+      creationState.document.addNamedBitmap(domain.prefixed(name), bitmap.asAndroidBitmap())
+    }
+  }
+
+/**
+ * URL-form named bitmap with explicit [width] / [height]. Replaces
+ * upstream's `rememberNamedRemoteBitmap(name, url, domain)` — that
+ * version routes through `addNamedBitmapUrl(name, url)` which is
+ * `addBitmapUrl(url, 1, 1)` underneath. This version threads the
+ * dimensions through to `addBitmapUrl(url, w, h)` so the slot has
+ * real size, then pairs it with `setNamedVariable(id, …, IMAGE_TYPE)`
+ * so the slot is still addressable by name.
+ *
+ * `RemoteBitmapDecoder.checkBounds` treats the stored width / height
+ * as a maximum on URL fetches when `CHECK_DATA_SIZE` is on, so pick
+ * a size at least as large as the largest image you expect to load.
+ * The tile's draw area is a safe default since the host can scale
+ * before pushing.
+ */
+@Composable
+fun rememberLocalNamedRemoteBitmap(
+  name: String,
+  url: String,
+  width: Int,
+  height: Int,
+  domain: RemoteState.Domain = RemoteState.Domain.User,
+): RemoteBitmap =
+  rememberNamedState(name, domain) {
+    MutableRemoteBitmap(
+      /* constantValueOrNull = */ null,
+      RemoteNamedCacheKey(domain, name),
+    ) { creationState ->
+      creationState.document.addNamedBitmapUrlSized(
+        domain.prefixed(name),
+        url,
+        width,
+        height,
+      )
+    }
+  }
+
+/**
+ * Local replacement for `RemoteComposeWriter.addNamedBitmapUrl(name,
+ * url)` that takes explicit dimensions. The upstream method delegates
+ * to `addBitmapUrl(url)` which is `addBitmapUrl(url, 1, 1)`; this
+ * uses the three-arg form `addBitmapUrl(url, w, h)` so the
+ * resulting `BitmapData` op carries real dimensions, then names the
+ * slot via `setNamedVariable(id, name, IMAGE_TYPE)` so it's still
+ * addressable. `setNamedVariable` lives on the underlying
+ * `RemoteComposeBuffer` (the writer's `getBuffer()` accessor).
+ */
+fun RemoteComposeWriter.addNamedBitmapUrlSized(
+  name: String,
+  url: String,
+  width: Int,
+  height: Int,
+): Int {
+  val id = addBitmapUrl(url, width, height)
+  buffer.setNamedVariable(id, name, NamedVariable.IMAGE_TYPE)
+  return id
+}

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/PictureImageStrategy.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/PictureImageStrategy.kt
@@ -1,0 +1,79 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.ImageBitmap
+
+/**
+ * How `picture-entity` (and other URL-bitmap cards) emit their
+ * image into the captured `.rc` document.
+ *
+ * Two production modes:
+ *
+ *  - [Url] — emit `rememberLocalNamedRemoteBitmap(name, url, w, h)`.
+ *    The player fetches the URL via the configured [BitmapLoader] at
+ *    playback. Use in the **app dashboard** where a Coil-backed
+ *    loader is wired (`HaImageStack.imageLoader` →
+ *    `CoilBitmapLoader`).
+ *
+ *  - [Inline] — emit `rememberLocalNamedRemoteBitmap(name) { bitmap }`
+ *    with the bitmap baked into the doc. Use in **widgets**, where
+ *    the runtime has no `BitmapLoader` and the doc must self-contain
+ *    every pixel. The host pre-fetches each entity's `entity_picture`
+ *    URL before capture and exposes the results through
+ *    [Inline.bitmapFor]. Falls back to the card's icon path when the
+ *    bitmap isn't ready yet (no async work inside the converter).
+ *
+ * The strategy is set by the embedding surface via
+ * [LocalPictureImageStrategy]; converters read it during capture.
+ */
+sealed interface PictureImageStrategy {
+
+  /**
+   * URL form. Captures `addBitmapUrl(url, [widthPx], [heightPx])` +
+   * `setNamedVariable(id, prefixed_name, IMAGE_TYPE)`. Player
+   * resolves the URL at playback. Dimensions are pinned because the
+   * upstream `addNamedBitmapUrl(name, url)` defaults to 1×1 and
+   * paints invisible — see #277.
+   */
+  data class Url(val widthPx: Int, val heightPx: Int) : PictureImageStrategy
+
+  /**
+   * Bytes form. The host pre-fetches the URL and exposes the
+   * resolved [ImageBitmap] through [bitmapFor]; the converter bakes
+   * it inline via `addNamedBitmap`. Use this when the embedding
+   * surface can't run a [BitmapLoader] at playback — widget cards
+   * being the primary case.
+   *
+   * Returning `null` from [bitmapFor] tells the converter to fall
+   * back to the icon path. That keeps capture synchronous and lets
+   * the host stage fetches independently.
+   */
+  fun interface Inline : PictureImageStrategy {
+    fun bitmapFor(url: String): ImageBitmap?
+  }
+
+  companion object {
+    /**
+     * Sensible app-mode default. 512×512 matches what HA's
+     * `image_proxy` serves natively for `image.*` entities; the host
+     * scales fetched camera frames before pushing so this size
+     * works for camera_proxy too.
+     */
+    val DefaultAppUrl: Url = Url(widthPx = 512, heightPx = 512)
+  }
+}
+
+/**
+ * CompositionLocal that selects which [PictureImageStrategy] the
+ * picture-entity converter uses. Defaults to
+ * [PictureImageStrategy.DefaultAppUrl] (app mode), so callers that
+ * don't override it get a URL-form doc and the existing
+ * dashboard `BitmapLoader` wiring picks the bytes up at playback.
+ *
+ * Widget hosts must explicitly provide a [PictureImageStrategy.Inline]
+ * with pre-fetched bitmaps before capture.
+ */
+val LocalPictureImageStrategy =
+  staticCompositionLocalOf<PictureImageStrategy> { PictureImageStrategy.DefaultAppUrl }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaPictureEntity.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaPictureEntity.kt
@@ -27,7 +27,6 @@ import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.remote.creation.compose.state.rsp
 import androidx.compose.remote.creation.compose.text.RemoteTextStyle
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.wear.compose.remote.material3.RemoteIcon
@@ -84,28 +83,52 @@ fun RemoteHaPictureEntity(
                 contentAlignment = RemoteAlignment.Center,
             ) {
                 if (data.imageUrl != null) {
-                    // **Size-hypothesis test.** Switch to the bytes-form
-                    // named bitmap with a fixed 100×100 placeholder so
-                    // the captured `BitmapData` op carries real
-                    // dimensions. The URL form
-                    // (`addNamedBitmapUrl(name, url)`) doesn't take
-                    // width / height; the slot's dimensions appear to
-                    // end up 0×0 and the player draws nothing even
-                    // when both `BitmapLoader.loadBitmap` and the
-                    // override pump in valid bytes — see the gray-tile
-                    // investigation in #264. The host pushes a
-                    // bitmap scaled to 100×100 via
-                    // `setUserLocalBitmap(pictureBindingName(id), …)`;
-                    // `contentScale = Fit` stretches it back to the
-                    // tile area.
+                    // The bitmap encoding form is picked by the
+                    // embedding surface via [LocalPictureImageStrategy]:
+                    // dashboards use [PictureImageStrategy.Url] so the
+                    // player fetches at playback (Coil-backed loader);
+                    // widgets use [PictureImageStrategy.Inline] with
+                    // pre-fetched bytes baked into the doc (no loader
+                    // available at widget runtime). Both go through
+                    // [rememberLocalNamedRemoteBitmap], which is the
+                    // workaround for the alpha010 1×1 default in
+                    // upstream `addNamedBitmapUrl(name, url)` — see
+                    // [LocalNamedRemoteBitmap.kt] and #277.
                     val bindingName =
                         data.entityId?.let(::pictureBindingName) ?: data.imageUrl
-                    RemoteHaImageNamed(
-                        name = bindingName,
-                        bitmap = picturePlaceholderBitmap,
-                        contentDescription = data.name.rs,
-                        modifier = RemoteModifier.fillMaxSize(),
-                    )
+                    val rb =
+                        when (val strategy = LocalPictureImageStrategy.current) {
+                            is PictureImageStrategy.Url ->
+                                rememberLocalNamedRemoteBitmap(
+                                    name = bindingName,
+                                    url = data.imageUrl,
+                                    width = strategy.widthPx,
+                                    height = strategy.heightPx,
+                                )
+                            is PictureImageStrategy.Inline ->
+                                strategy.bitmapFor(data.imageUrl)?.let { bytes ->
+                                    rememberLocalNamedRemoteBitmap(
+                                        name = bindingName,
+                                    ) { bytes }
+                                }
+                        }
+                    if (rb != null) {
+                        androidx.compose.remote.creation.compose.layout.RemoteImage(
+                            remoteBitmap = rb,
+                            contentDescription = data.name.rs,
+                            modifier = RemoteModifier.fillMaxSize(),
+                        )
+                    } else {
+                        // Inline strategy with no pre-fetched bytes for
+                        // this URL — fall back to the icon path so the
+                        // widget renders something instead of a hole.
+                        RemoteIcon(
+                            imageVector = data.icon,
+                            contentDescription = data.name.rs,
+                            modifier = RemoteModifier.size(40.rdp),
+                            tint = accent.copy(alpha = accent.alpha * 0.55f.rf),
+                        )
+                    }
                 } else {
                     RemoteIcon(
                         imageVector = data.icon,
@@ -167,21 +190,12 @@ fun RemoteHaPictureEntity(
 }
 
 /**
- * Fixed-size placeholder bitmap captured into every picture-entity
- * document so the `BitmapData` op's width / height fields are
- * non-zero. See the `RemoteHaImageNamed` call above; the host swaps
- * this for a bitmap scaled to the same 512×512 size at runtime.
- *
- * 512×512 was picked to match what HA's `image_proxy` serves natively
- * for `image.*` entities (per the gray-tile diagnostic log), so the
- * common case is a no-op resize on the override path. Camera frames
- * (typically 1680×1080) downscale to 512×288 — still better than the
- * 100×100 probe we started with. The captured PNG is one solid colour
- * so the encoded BitmapData is tiny — the dimensions are what we
- * care about, not the pixels.
+ * Default pixel size used by [PictureImageStrategy.DefaultAppUrl] and
+ * by host code that scales pre-fetched bitmaps before pushing them as
+ * an override. Matches what HA's `image_proxy` serves natively for
+ * `image.*` entities (per the gray-tile diagnostic log), so the
+ * common case is a no-op on both paths. Camera frames (typically
+ * 1680×1080) downscale to 512×288 — still well above the tile's
+ * display size.
  */
 const val PICTURE_BITMAP_SIZE_PX: Int = 512
-
-private val picturePlaceholderBitmap: ImageBitmap by lazy {
-  ImageBitmap(PICTURE_BITMAP_SIZE_PX, PICTURE_BITMAP_SIZE_PX)
-}

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaPictureEntity.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaPictureEntity.kt
@@ -27,6 +27,7 @@ import androidx.compose.remote.creation.compose.state.rs
 import androidx.compose.remote.creation.compose.state.rsp
 import androidx.compose.remote.creation.compose.text.RemoteTextStyle
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.wear.compose.remote.material3.RemoteIcon
@@ -83,19 +84,25 @@ fun RemoteHaPictureEntity(
                 contentAlignment = RemoteAlignment.Center,
             ) {
                 if (data.imageUrl != null) {
-                    // Pass a stable [name] derived from `entityId` so the host
-                    // can override the URL-fetched bytes via
-                    // `StateUpdater.setUserLocalBitmap(pictureBindingName(id), …)`.
-                    // The URL itself is still passed to the player's
-                    // `BitmapLoader` for first paint; the override stacks on
-                    // top of that for live refreshes / token rotation.
-                    // Anonymous-card fallback (no `entityId`) keeps the
-                    // default URL-as-name behaviour.
+                    // **Size-hypothesis test.** Switch to the bytes-form
+                    // named bitmap with a fixed 100×100 placeholder so
+                    // the captured `BitmapData` op carries real
+                    // dimensions. The URL form
+                    // (`addNamedBitmapUrl(name, url)`) doesn't take
+                    // width / height; the slot's dimensions appear to
+                    // end up 0×0 and the player draws nothing even
+                    // when both `BitmapLoader.loadBitmap` and the
+                    // override pump in valid bytes — see the gray-tile
+                    // investigation in #264. The host pushes a
+                    // bitmap scaled to 100×100 via
+                    // `setUserLocalBitmap(pictureBindingName(id), …)`;
+                    // `contentScale = Fit` stretches it back to the
+                    // tile area.
                     val bindingName =
                         data.entityId?.let(::pictureBindingName) ?: data.imageUrl
-                    RemoteHaImageUrl(
-                        url = data.imageUrl,
+                    RemoteHaImageNamed(
                         name = bindingName,
+                        bitmap = picturePlaceholderBitmap,
                         contentDescription = data.name.rs,
                         modifier = RemoteModifier.fillMaxSize(),
                     )
@@ -157,4 +164,16 @@ fun RemoteHaPictureEntity(
             }
         }
     }
+}
+
+/**
+ * Fixed-size placeholder bitmap captured into every picture-entity
+ * document so the `BitmapData` op's width / height fields are
+ * non-zero. See the `RemoteHaImageNamed` call above; the host swaps
+ * this for a bitmap scaled to the same 100×100 size at runtime.
+ */
+const val PICTURE_BITMAP_SIZE_PX: Int = 100
+
+private val picturePlaceholderBitmap: ImageBitmap by lazy {
+  ImageBitmap(PICTURE_BITMAP_SIZE_PX, PICTURE_BITMAP_SIZE_PX)
 }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaPictureEntity.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaPictureEntity.kt
@@ -170,9 +170,17 @@ fun RemoteHaPictureEntity(
  * Fixed-size placeholder bitmap captured into every picture-entity
  * document so the `BitmapData` op's width / height fields are
  * non-zero. See the `RemoteHaImageNamed` call above; the host swaps
- * this for a bitmap scaled to the same 100×100 size at runtime.
+ * this for a bitmap scaled to the same 512×512 size at runtime.
+ *
+ * 512×512 was picked to match what HA's `image_proxy` serves natively
+ * for `image.*` entities (per the gray-tile diagnostic log), so the
+ * common case is a no-op resize on the override path. Camera frames
+ * (typically 1680×1080) downscale to 512×288 — still better than the
+ * 100×100 probe we started with. The captured PNG is one solid colour
+ * so the encoded BitmapData is tiny — the dimensions are what we
+ * care about, not the pixels.
  */
-const val PICTURE_BITMAP_SIZE_PX: Int = 100
+const val PICTURE_BITMAP_SIZE_PX: Int = 512
 
 private val picturePlaceholderBitmap: ImageBitmap by lazy {
   ImageBitmap(PICTURE_BITMAP_SIZE_PX, PICTURE_BITMAP_SIZE_PX)

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CachedCardPreview.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CachedCardPreview.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.platform.LocalContext
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.components.HA_ACTION_NAME
+import ee.schimke.ha.rc.components.PICTURE_BITMAP_SIZE_PX
 import ee.schimke.ha.rc.components.pictureBindingName
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.contentOrNull
@@ -286,22 +287,38 @@ private suspend fun pushPictureEntityBitmaps(
             "picture entity=$entityId url=$url" +
                 if (previous != null) " (was=$previous)" else " (first push)",
         )
-        val bitmap = runCatching { resolver.resolve(url) }.getOrElse { ex ->
+        val fetched = runCatching { resolver.resolve(url) }.getOrElse { ex ->
             Log.w(TAG, "picture entity=$entityId resolve threw: ${ex.message}", ex)
             null
         }
-        if (bitmap == null) {
+        if (fetched == null) {
             Log.w(TAG, "picture entity=$entityId resolver returned null bitmap for url=$url")
             continue
         }
+        // Picture-entity documents bake a fixed-size placeholder so
+        // the named-bitmap slot has non-zero dimensions (the URL form
+        // of `addNamedBitmap*` doesn't carry width/height — see
+        // `picturePlaceholderBitmap`). Scale the override to match
+        // so the player draws into the slot at the expected size.
+        val sized =
+            if (fetched.width == PICTURE_BITMAP_SIZE_PX && fetched.height == PICTURE_BITMAP_SIZE_PX) {
+                fetched
+            } else {
+                android.graphics.Bitmap.createScaledBitmap(
+                    fetched,
+                    PICTURE_BITMAP_SIZE_PX,
+                    PICTURE_BITMAP_SIZE_PX,
+                    /* filter = */ true,
+                )
+            }
         val name = pictureBindingName(entityId)
-        runCatching { updater.setUserLocalBitmap(name, bitmap) }
+        runCatching { updater.setUserLocalBitmap(name, sized) }
             .onSuccess {
                 pushedUrls[entityId] = url
                 Log.d(
                     TAG,
                     "picture entity=$entityId pushed name=$name " +
-                        "bitmap=${bitmap.width}x${bitmap.height}",
+                        "bitmap=${sized.width}x${sized.height} (fetched=${fetched.width}x${fetched.height})",
                 )
             }
             .onFailure { ex ->

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CachedCardPreview.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CachedCardPreview.kt
@@ -140,9 +140,17 @@ fun CachedCardPreview(
             }
             ids
         }
-    // The handle survives recomposition but is replaced if the player
+    // The handles survive recomposition but get replaced if the player
     // is torn down and rebuilt (cache invalidation, theme flip).
     val updaterHolder = remember { mutableStateOf<StateUpdater?>(null) }
+    // Hold the player View so the picture-entity push can call
+    // `invalidate()` after a `setUserLocalBitmap` — that override
+    // updates the named-data map but doesn't itself mark the View
+    // dirty, so without an explicit invalidate the previous frame
+    // sticks on screen.
+    val playerHolder = remember {
+        mutableStateOf<androidx.compose.remote.player.view.RemoteComposePlayer?>(null)
+    }
     // Tracks the last value we pushed for each binding so a redundant
     // snapshot recompose doesn't re-issue identical writes. Reset when
     // [cacheKey] changes — the new document carries its own initial
@@ -176,13 +184,21 @@ fun CachedCardPreview(
     ) {
         LaunchedEffect(updaterHolder.value, snapshot) {
             val updater = updaterHolder.value ?: return@LaunchedEffect
-            pushPictureEntityBitmaps(
-                updater = updater,
-                entityIds = pictureEntityIds,
-                snapshot = snapshot,
-                pushedUrls = pushedPictureUrls,
-                resolver = imageResolver,
-            )
+            val didPush =
+                pushPictureEntityBitmaps(
+                    updater = updater,
+                    entityIds = pictureEntityIds,
+                    snapshot = snapshot,
+                    pushedUrls = pushedPictureUrls,
+                    resolver = imageResolver,
+                )
+            if (didPush) {
+                // `setUserLocalBitmap` writes through `setNamedDataOverride`
+                // which mutates the named-data map but doesn't invalidate
+                // the player View — without this call the View keeps
+                // painting the doc's baked placeholder. See #264.
+                playerHolder.value?.invalidate()
+            }
         }
     }
 
@@ -196,7 +212,10 @@ fun CachedCardPreview(
         documentBytes = cardDocument.bytes,
         modifier = modifier,
         bitmapLoader = bitmapLoader,
-        init = { player -> updaterHolder.value = player.stateUpdater },
+        init = { player ->
+            updaterHolder.value = player.stateUpdater
+            playerHolder.value = player
+        },
         onNamedAction = { name, value ->
             if (name == HA_ACTION_NAME) {
                 decodeHaAction(value)?.let(dispatcher::dispatch)
@@ -264,7 +283,8 @@ private suspend fun pushPictureEntityBitmaps(
     snapshot: HaSnapshot,
     pushedUrls: MutableMap<String, String>,
     resolver: RemoteImageResolver,
-) {
+): Boolean {
+    var pushedAny = false
     for (entityId in entityIds) {
         val url =
             snapshot.states[entityId]
@@ -315,6 +335,7 @@ private suspend fun pushPictureEntityBitmaps(
         runCatching { updater.setUserLocalBitmap(name, sized) }
             .onSuccess {
                 pushedUrls[entityId] = url
+                pushedAny = true
                 Log.d(
                     TAG,
                     "picture entity=$entityId pushed name=$name " +
@@ -325,4 +346,5 @@ private suspend fun pushPictureEntityBitmaps(
                 Log.w(TAG, "picture entity=$entityId setUserLocalBitmap failed: ${ex.message}", ex)
             }
     }
+    return pushedAny
 }


### PR DESCRIPTION
Superseded by #278 — fresh branch off main with just the final state (strategy + writer workaround), the now-redundant override-push surface removed. Carrying the earlier hypothesis-test commits in the history was making this PR harder to review than it needed to be.