### PR TITLE
Land on default dashboard instead of picker on first launch

### DIFF
--- a/app/src/androidTest/kotlin/ee/schimke/terrazzo/dashboard/LongPressInstallTest.kt
+++ b/app/src/androidTest/kotlin/ee/schimke/terrazzo/dashboard/LongPressInstallTest.kt
@@ -52,16 +52,15 @@ class LongPressInstallTest {
             .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK)
             .putExtra(MainActivity.EXTRA_TEST_DEMO_MODE, true)
         context.startActivity(launch)
-        // Wait for the dashboard picker. The shell is now a Scaffold +
-        // TopAppBar (the old NavigationSuiteScaffold is gone), so the
-        // first stable user-visible string after demo-mode short-
-        // circuits auth is the picker's TopAppBar title. Demo-mode
-        // also clears the last-viewed-dashboard pref so we always
-        // land on the picker, never auto-resumed onto a dashboard
-        // from a previous test run.
+        // Wait for the dashboard view. Demo-mode clears the
+        // last-viewed-dashboard pref, so the app lands on HA's
+        // default dashboard (the first board in DemoData.BOARDS,
+        // "Security") rather than auto-resuming from a previous
+        // run. "Security" appears as the title in the top-bar
+        // dashboard switcher.
         assertTrue(
-            "dashboard picker did not surface within 15s",
-            device.wait(Until.hasObject(By.text("Pick a dashboard")), 15_000),
+            "Security dashboard did not surface within 15s",
+            device.wait(Until.hasObject(By.text("Security")), 15_000),
         )
     }
 
@@ -72,13 +71,10 @@ class LongPressInstallTest {
 
     @Test
     fun longPressOnDashboardCard_opensInstallSheet() {
-        // The DashboardPickerScreen lists the seven captured demo
-        // dashboards (see `DemoData.BOARDS`); the first entry is
-        // "Security". Tapping it opens the dashboard view.
-        val pickerEntry = device.wait(Until.findObject(By.text("Security")), 10_000)
-        assertNotNull("dashboard picker did not list 'Security' within 10s", pickerEntry)
-        pickerEntry!!.click()
-
+        // Demo mode lands directly on the "Security" dashboard (the
+        // first board in `DemoData.BOARDS`, exposed as HA's default
+        // dashboard); the test exercises the long-press → install
+        // sheet flow on its first card.
         val card = waitForFirstCard()
         // uiautomator's longClick uses the platform long-press timeout,
         // so this matches what a real user's finger does — and that's

--- a/app/src/main/kotlin/ee/schimke/terrazzo/MainActivity.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/MainActivity.kt
@@ -29,9 +29,9 @@ class MainActivity : ComponentActivity() {
         // the bypass even if the extra is present.
         //
         // Also clears the offline-cache instance pointer and the
-        // last-viewed-dashboard pref so the test starts on the
-        // dashboard picker every time, not auto-resumed onto a
-        // previous run's cached dashboard.
+        // last-viewed-dashboard pref so the test starts on HA's
+        // default demo dashboard every time, not auto-resumed onto
+        // a previous run's cached dashboard.
         if (BuildConfig.DEBUG && intent?.getBooleanExtra(EXTRA_TEST_DEMO_MODE, false) == true) {
             runBlocking {
                 graph.preferencesStore.setDemoMode(true)

--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -496,14 +496,15 @@ private fun SessionConnectionStatus.toUiConnectionStatus(): ConnectionStatus = w
  * Translate the persisted last-viewed-dashboard pref into the local
  * `opened` sentinel/urlPath encoding `DashboardsRoot` uses:
  *
- *   - `null` (pref absent) → [DASHBOARD_UNSET] (show picker).
+ *   - `null` (pref absent) → `null` (HA's default dashboard). First
+ *     launch lands on the default dashboard rather than the picker;
+ *     the picker stays reachable via system-back from a view.
  *   - [PreferencesStore.DEFAULT_DASHBOARD_SENTINEL] → `null`
  *     (HA's default dashboard, whose `urlPath` is null over the wire).
- *   - any other string → that `urlPath`.
+ *   - any other string — that `urlPath`.
  */
 private fun initialDashboardToOpened(stored: String?): String? = when (stored) {
-    null -> DASHBOARD_UNSET
-    PreferencesStore.DEFAULT_DASHBOARD_SENTINEL -> null
+    null, PreferencesStore.DEFAULT_DASHBOARD_SENTINEL -> null
     else -> stored
 }
 

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardPickerScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardPickerScreen.kt
@@ -23,10 +23,10 @@ import ee.schimke.ha.client.DashboardSummary
  * by the caller (`DashboardsRoot`) so the same data drives both this
  * screen and the top-bar quick-switcher dropdown without re-querying.
  *
- * The picker is the first-launch experience (when no `lastViewedDashboard`
- * pref is set) and the destination of the system-back gesture from a
- * dashboard view. With the new top-bar dropdown most users won't visit
- * this screen often once they've picked a dashboard.
+ * Reachable via the system-back gesture from a dashboard view — the
+ * app's home is the last-viewed (or HA-default) dashboard itself, so
+ * most users will use the top-bar dropdown to switch and won't visit
+ * this screen often.
  */
 @Composable
 fun DashboardPickerScreen(


### PR DESCRIPTION
## Summary
Changed the first-launch experience to open Home Assistant's default dashboard directly instead of showing the dashboard picker. The picker remains accessible via system-back from any dashboard view.

## Key Changes
- **Navigation flow**: Modified `initialDashboardToOpened()` to treat a missing `lastViewedDashboard` preference the same as the explicit default sentinel, landing on HA's default dashboard (`null` urlPath) rather than showing the picker
- **Test updates**: Updated `LongPressInstallTest` to expect the "Security" dashboard (HA's default in demo mode) to surface immediately, removing the intermediate step of tapping through the picker
- **Documentation**: Updated comments throughout the codebase to reflect the new behavior:
  - `DashboardPickerScreen`: Now describes the picker as reachable via system-back, not as the first-launch experience
  - `MainActivity`: Clarified that demo mode lands on the default dashboard
  - `TerrazzoApp`: Updated the preference translation logic documentation

## Implementation Details
The change consolidates two cases in `initialDashboardToOpened()` that now have identical behavior: both `null` (missing pref) and `PreferencesStore.DEFAULT_DASHBOARD_SENTINEL` now map to `null`, which represents HA's default dashboard. This simplifies the logic while improving the first-launch UX by showing actual content rather than a selection screen.

https://claude.ai/code/session_019cRJyaQz4JFkDewvY9nLzX