### PR TITLE
feat(app): add hidden logs view for WS data, connection events, local actions

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -246,7 +246,7 @@ private fun UnauthenticatedScreen(
     )
 }
 
-private enum class AppScreen { Dashboards, Settings, Widgets, Pinned, WearWidgets, SyncDiagnostics }
+private enum class AppScreen { Dashboards, Settings, Widgets, Pinned, WearWidgets, SyncDiagnostics, Logs }
 
 @Composable
 private fun AuthenticatedShell(
@@ -276,6 +276,7 @@ private fun AuthenticatedShell(
             onOpenWidgets = { screen = AppScreen.Widgets },
             onOpenPinned = { screen = AppScreen.Pinned },
             onOpenWearWidgets = { screen = AppScreen.WearWidgets },
+            onOpenLogs = { screen = AppScreen.Logs },
             onSignOut = onSignOut,
         )
         AppScreen.Settings -> SettingsScreen(
@@ -302,6 +303,9 @@ private fun AuthenticatedShell(
                 onBack = { screen = AppScreen.Settings },
             )
         }
+        AppScreen.Logs -> ee.schimke.terrazzo.logs.LogsScreen(
+            onBack = { screen = AppScreen.Dashboards },
+        )
     }
 }
 
@@ -319,6 +323,7 @@ private fun DashboardsRoot(
     onOpenWidgets: () -> Unit,
     onOpenPinned: () -> Unit,
     onOpenWearWidgets: () -> Unit,
+    onOpenLogs: () -> Unit,
     onSignOut: () -> Unit,
 ) {
     val graph = LocalTerrazzoGraph.current
@@ -329,6 +334,7 @@ private fun DashboardsRoot(
     val wearWidgetsSupported by app.wearCapabilityProbe
         .stateFlow(scope)
         .collectAsState()
+    val logsViewEnabled by graph.preferencesStore.logsViewEnabled.collectAsState(initial = false)
 
     var opened by rememberSaveable {
         mutableStateOf(initialDashboardToOpened(initialDashboard))
@@ -362,6 +368,20 @@ private fun DashboardsRoot(
                     runCatching { session.connect() }
                 }
             }
+        }
+    }
+
+    // Mirror live connection-status transitions into the debug log
+    // buffer so the Logs view (when enabled) shows reconnect timing.
+    // StateFlow already de-duplicates identical emissions, so each
+    // entry here corresponds to a real transition.
+    val logStore = graph.logStore
+    LaunchedEffect(session, logStore) {
+        session.connectionStatus.collect { status ->
+            logStore.recordConnection(
+                status = status.toLogStatus(),
+                message = session.baseUrl,
+            )
         }
     }
 
@@ -412,6 +432,7 @@ private fun DashboardsRoot(
                         onOpenWidgets = onOpenWidgets,
                         onOpenPinned = onOpenPinned,
                         onOpenWearWidgets = if (wearWidgetsSupported) onOpenWearWidgets else null,
+                        onOpenLogs = if (logsViewEnabled) onOpenLogs else null,
                         onSignOut = onSignOut,
                     )
                 },
@@ -492,6 +513,13 @@ private fun SessionConnectionStatus.toUiConnectionStatus(): ConnectionStatus = w
     SessionConnectionStatus.Connected -> ConnectionStatus.Connected
 }
 
+private fun SessionConnectionStatus.toLogStatus(): ee.schimke.terrazzo.core.logs.LogConnectionStatus =
+    when (this) {
+        SessionConnectionStatus.Failed -> ee.schimke.terrazzo.core.logs.LogConnectionStatus.Error
+        SessionConnectionStatus.Connecting -> ee.schimke.terrazzo.core.logs.LogConnectionStatus.Connecting
+        SessionConnectionStatus.Connected -> ee.schimke.terrazzo.core.logs.LogConnectionStatus.Connected
+    }
+
 /**
  * Translate the persisted last-viewed-dashboard pref into the local
  * `opened` sentinel/urlPath encoding `DashboardsRoot` uses:
@@ -526,6 +554,7 @@ private fun SettingsScreen(
     val darkPref by graph.preferencesStore.darkMode.collectAsState(initial = DarkModePref.Follow)
     val gridLayoutEnabled by graph.preferencesStore.experimentalGridLayout.collectAsState(initial = false)
     val collapsedModeEnabled by graph.preferencesStore.collapsedMode.collectAsState(initial = true)
+    val logsViewEnabled by graph.preferencesStore.logsViewEnabled.collectAsState(initial = false)
 
     Scaffold(
         topBar = {
@@ -633,6 +662,28 @@ private fun SettingsScreen(
                     checked = collapsedModeEnabled,
                     onCheckedChange = { enabled ->
                         scope.launch { graph.preferencesStore.setCollapsedMode(enabled) }
+                    },
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Show logs view", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        "Exposes a debug screen via the overflow menu listing recent " +
+                            "dashboard-entity updates, connect / disconnect events, and " +
+                            "locally-dispatched service calls. In-memory only.",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                Switch(
+                    checked = logsViewEnabled,
+                    onCheckedChange = { enabled ->
+                        scope.launch { graph.preferencesStore.setLogsViewEnabled(enabled) }
                     },
                 )
             }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardActionDispatcher.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardActionDispatcher.kt
@@ -14,6 +14,8 @@ import ee.schimke.ha.rc.CardDocumentCache
 import ee.schimke.ha.rc.HaActionDispatcher
 import ee.schimke.ha.rc.LocalCardDocumentCache
 import ee.schimke.ha.rc.components.HaAction
+import ee.schimke.terrazzo.LocalTerrazzoGraph
+import ee.schimke.terrazzo.core.logs.LogStore
 import ee.schimke.terrazzo.core.session.CoverCommand
 import ee.schimke.terrazzo.core.session.DemoData
 import ee.schimke.terrazzo.core.session.DemoHaSession
@@ -47,8 +49,9 @@ fun rememberDashboardActionDispatcher(session: HaSession): HaActionDispatcher {
     val context = LocalContext.current
     val cache = LocalCardDocumentCache.current
     val scope = rememberCoroutineScope()
-    return remember(session, context, cache, scope) {
-        val core = DashboardActionDispatcher(context.applicationContext, session, cache, scope)
+    val logStore = LocalTerrazzoGraph.current.logStore
+    return remember(session, context, cache, scope, logStore) {
+        val core = DashboardActionDispatcher(context.applicationContext, session, cache, scope, logStore)
         // The keypad coordinator buffers per-key host actions and
         // translates ARM intents into a single `call_service` with the
         // entered code attached. Other action variants pass through.
@@ -61,8 +64,14 @@ private class DashboardActionDispatcher(
     private val session: HaSession,
     private val cache: CardDocumentCache,
     private val scope: CoroutineScope,
+    private val logStore: LogStore,
 ) : HaActionDispatcher {
     override fun dispatch(action: HaAction) {
+        // Log every dispatched action (before any network round-trip)
+        // so the debug Logs view sees the tap even if the call fails.
+        // Unwired variants are still recorded so the screen reflects
+        // that the tap landed.
+        recordToLog(action)
         when (action) {
             is HaAction.Url -> launchUrl(action.url)
             is HaAction.Toggle -> handleToggle(action.entityId)
@@ -76,6 +85,21 @@ private class DashboardActionDispatcher(
             is HaAction.AlarmIntent,
             HaAction.None -> Log.i(TAG, "Action not yet wired: $action")
         }
+    }
+
+    private fun recordToLog(action: HaAction) {
+        val (summary, entityId) = when (action) {
+            is HaAction.Url -> "Open URL: ${action.url}" to null
+            is HaAction.Toggle -> "Toggle" to action.entityId
+            is HaAction.CallService ->
+                "Call ${action.domain}.${action.service}" to action.entityId
+            is HaAction.MoreInfo -> "More info" to action.entityId
+            is HaAction.Navigate -> "Navigate to ${action.path}" to null
+            is HaAction.AlarmKey -> "Alarm key ${action.key}" to action.entityId
+            is HaAction.AlarmIntent -> "Alarm ${action.service}" to action.entityId
+            HaAction.None -> return
+        }
+        logStore.recordLocalAction(summary = summary, entityId = entityId)
     }
 
     private fun launchUrl(url: String) {

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -139,6 +139,7 @@ fun DashboardViewScreen(
         mutableStateOf(seed)
     }
 
+    val logStore = LocalTerrazzoGraph.current.logStore
     LaunchedEffect(session, urlPath) {
         // Poll when the session opts in (demo mode does, at ~1s) so
         // values visibly change; a one-shot fetch otherwise.
@@ -146,6 +147,11 @@ fun DashboardViewScreen(
             try {
                 val (dashboard, snapshot) = session.loadDashboard(urlPath)
                 state = DashboardState.Ready(dashboard, snapshot)
+                // Feed the debug log buffer. The store diffs each
+                // snapshot against the previous one and emits a
+                // DataUpdate per changed entity, filtered to entities
+                // this dashboard actually references.
+                logStore.recordDashboardSnapshot(dashboard, snapshot)
             } catch (ce: CancellationException) {
                 // Dashboard switch or composition leaving — let the new
                 // LaunchedEffect take over. `runCatching` used to absorb
@@ -180,6 +186,7 @@ fun DashboardViewScreen(
                 runCatching { session.loadDashboard(urlPath) }
                     .onSuccess { (dashboard, snapshot) ->
                         state = DashboardState.Ready(dashboard, snapshot)
+                        logStore.recordDashboardSnapshot(dashboard, snapshot)
                     }
             }
         }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/TopBarOverflowMenu.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/TopBarOverflowMenu.kt
@@ -27,6 +27,7 @@ fun TopBarOverflowMenu(
     onOpenWidgets: () -> Unit,
     onOpenPinned: () -> Unit,
     onOpenWearWidgets: (() -> Unit)?,
+    onOpenLogs: (() -> Unit)?,
     onSignOut: () -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
@@ -54,6 +55,13 @@ fun TopBarOverflowMenu(
             DropdownMenuItem(
                 text = { Text("Wear widgets") },
                 onClick = { expanded = false; onOpenWearWidgets() },
+            )
+        }
+        // Hidden unless the user enabled the logs view in Settings.
+        if (onOpenLogs != null) {
+            DropdownMenuItem(
+                text = { Text("Logs") },
+                onClick = { expanded = false; onOpenLogs() },
             )
         }
         DropdownMenuItem(

--- a/app/src/main/kotlin/ee/schimke/terrazzo/logs/LogsScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/logs/LogsScreen.kt
@@ -1,0 +1,228 @@
+package ee.schimke.terrazzo.logs
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import ee.schimke.terrazzo.LocalTerrazzoGraph
+import ee.schimke.terrazzo.core.logs.LogConnectionStatus
+import ee.schimke.terrazzo.core.logs.LogEntry
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Debug surface for the [ee.schimke.terrazzo.core.logs.LogStore]
+ * buffer. Three sections, reverse-chronological inside each:
+ *
+ *   - **Data updates** — entity state changes seen on the WebSocket,
+ *     filtered to entities referenced by the currently-rendered
+ *     dashboard so background entities don't drown the view. Kept for
+ *     5 minutes.
+ *   - **Connection** — connect / disconnect / error transitions on
+ *     the live HA session.
+ *   - **Actions** — local taps that fan out to `call_service` /
+ *     `homeassistant.toggle`. Logged before the network round-trip.
+ *
+ * Hidden behind `PreferencesStore.logsViewEnabled` — the overflow menu
+ * doesn't show the entry until the user flips the toggle in Settings.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LogsScreen(onBack: () -> Unit) {
+    val store = LocalTerrazzoGraph.current.logStore
+    val entries by store.flow.collectAsState()
+
+    val dataUpdates = entries.filterIsInstance<LogEntry.DataUpdate>().sortedByDescending { it.timestamp }
+    val connections = entries.filterIsInstance<LogEntry.Connection>().sortedByDescending { it.timestamp }
+    val actions = entries.filterIsInstance<LogEntry.LocalAction>().sortedByDescending { it.timestamp }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Logs") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+                actions = {
+                    TextButton(onClick = { store.clear() }) { Text("Clear") }
+                },
+            )
+        },
+        contentWindowInsets = WindowInsets.safeDrawing,
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(padding),
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            section("Connection (${connections.size})") {
+                if (connections.isEmpty()) emptyHint("No connection events yet.")
+                else connections.forEach { ConnectionRow(it) }
+            }
+            section("Local actions (${actions.size})") {
+                if (actions.isEmpty()) emptyHint("Tap a dashboard button to see it here.")
+                else actions.forEach { ActionRow(it) }
+            }
+            section("Data updates · last 5 min (${dataUpdates.size})") {
+                if (dataUpdates.isEmpty()) {
+                    emptyHint(
+                        "No dashboard-entity updates yet. Only entities rendered on " +
+                            "the current dashboard are tracked.",
+                    )
+                } else {
+                    dataUpdates.forEach { DataUpdateRow(it) }
+                }
+            }
+        }
+    }
+}
+
+private fun androidx.compose.foundation.lazy.LazyListScope.section(
+    title: String,
+    content: @Composable () -> Unit,
+) {
+    item(key = "header:$title") {
+        Column {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+                modifier = Modifier.padding(top = 16.dp, bottom = 4.dp),
+            )
+            HorizontalDivider()
+        }
+    }
+    item(key = "body:$title") { Column { content() } }
+}
+
+@Composable
+private fun emptyHint(text: String) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.padding(vertical = 8.dp),
+    )
+}
+
+@Composable
+private fun ConnectionRow(entry: LogEntry.Connection) {
+    LogRow(
+        timestamp = entry.timestamp,
+        leading = { StatusChip(entry.status) },
+        primary = entry.status.label,
+        secondary = entry.message,
+    )
+}
+
+@Composable
+private fun ActionRow(entry: LogEntry.LocalAction) {
+    LogRow(
+        timestamp = entry.timestamp,
+        leading = null,
+        primary = entry.summary,
+        secondary = entry.entityId,
+    )
+}
+
+@Composable
+private fun DataUpdateRow(entry: LogEntry.DataUpdate) {
+    LogRow(
+        timestamp = entry.timestamp,
+        leading = null,
+        primary = entry.entityId,
+        secondary = "${entry.fromState} → ${entry.toState}",
+    )
+}
+
+@Composable
+private fun LogRow(
+    timestamp: Long,
+    leading: (@Composable () -> Unit)?,
+    primary: String,
+    secondary: String?,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = formatTime(timestamp),
+            style = MaterialTheme.typography.labelSmall,
+            fontFamily = FontFamily.Monospace,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        if (leading != null) leading()
+        Column(modifier = Modifier.weight(1f)) {
+            Text(primary, style = MaterialTheme.typography.bodyMedium)
+            if (!secondary.isNullOrBlank()) {
+                Text(
+                    secondary,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusChip(status: LogConnectionStatus) {
+    val color = when (status) {
+        LogConnectionStatus.Connected -> Color(0xFF1976D2)
+        LogConnectionStatus.Connecting -> Color(0xFF2E7D32)
+        LogConnectionStatus.Disconnected -> Color(0xFF757575)
+        LogConnectionStatus.Error -> Color(0xFFD32F2F)
+    }
+    AssistChip(
+        onClick = {},
+        enabled = false,
+        label = { Text(status.label, style = MaterialTheme.typography.labelSmall) },
+        colors = AssistChipDefaults.assistChipColors(
+            disabledContainerColor = color.copy(alpha = 0.16f),
+            disabledLabelColor = color,
+        ),
+    )
+}
+
+private val LogConnectionStatus.label: String
+    get() = when (this) {
+        LogConnectionStatus.Connected -> "Connected"
+        LogConnectionStatus.Connecting -> "Connecting"
+        LogConnectionStatus.Disconnected -> "Disconnected"
+        LogConnectionStatus.Error -> "Error"
+    }
+
+private val timeFormat by lazy { SimpleDateFormat("HH:mm:ss", Locale.getDefault()) }
+
+private fun formatTime(ts: Long): String = timeFormat.format(Date(ts))

--- a/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
@@ -119,6 +119,8 @@ private fun rememberPreviewGraph(): TerrazzoGraph {
                     override fun start(card: CardConfig, durationMinutes: Int) {}
                 }
             override val wearSyncManager: WearSyncManager = NoOpWearSyncManager()
+            override val logStore: ee.schimke.terrazzo.core.logs.LogStore =
+                ee.schimke.terrazzo.core.logs.LogStore()
         }
     }
 }

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/di/TerrazzoGraph.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/di/TerrazzoGraph.kt
@@ -6,6 +6,7 @@ import dev.zacsweers.metro.SingleIn
 import ee.schimke.terrazzo.core.auth.HaAuthService
 import ee.schimke.terrazzo.core.auth.TokenVault
 import ee.schimke.terrazzo.core.cache.OfflineCache
+import ee.schimke.terrazzo.core.logs.LogStore
 import ee.schimke.terrazzo.core.monitor.CardMonitor
 import ee.schimke.terrazzo.core.network.HttpEngineFactory
 import ee.schimke.terrazzo.core.network.LanConnectionPolicy
@@ -40,6 +41,7 @@ interface TerrazzoGraph {
     val cardMonitor: CardMonitor
     val wearSyncManager: WearSyncManager
     val lanConnectionPolicy: LanConnectionPolicy
+    val logStore: LogStore
 
     fun interface Factory {
         fun create(context: Context): TerrazzoGraph

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/logs/DashboardEntityRefs.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/logs/DashboardEntityRefs.kt
@@ -1,0 +1,45 @@
+package ee.schimke.terrazzo.core.logs
+
+import ee.schimke.ha.model.Dashboard
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Heuristic entity-id extractor for dashboard configs.
+ *
+ * Lovelace card schemas don't share a single field for "the entities I
+ * use" — most cards put one or more `entity` / `entities` keys at the
+ * top level, but custom cards bury entity refs anywhere in their JSON
+ * (e.g. `triggers[].entity_id`, `tap_action.entity_id`). Walking the
+ * full card tree and picking out strings that look like an HA entity id
+ * covers the long tail without us hardcoding per-card knowledge.
+ *
+ * The HA entity-id grammar is restrictive enough
+ * (`^[a-z0-9_]+\.[a-z0-9_]+$`) that false positives are rare in
+ * practice — icon names use `mdi:` (colon, not dot), template strings
+ * have whitespace, etc.
+ */
+internal fun referencedEntities(dashboard: Dashboard): Set<String> {
+    val out = mutableSetOf<String>()
+    for (view in dashboard.views) {
+        view.cards.forEach { walk(it.raw, out) }
+        view.sections.forEach { sec -> sec.cards.forEach { walk(it.raw, out) } }
+        view.badges.forEach { walk(it, out) }
+    }
+    return out
+}
+
+private fun walk(el: JsonElement, out: MutableSet<String>) {
+    when (el) {
+        is JsonObject -> el.values.forEach { walk(it, out) }
+        is JsonArray -> el.forEach { walk(it, out) }
+        is JsonPrimitive -> if (el.isString) {
+            val s = el.content
+            if (ENTITY_ID_REGEX.matches(s)) out.add(s)
+        }
+    }
+}
+
+private val ENTITY_ID_REGEX = Regex("^[a-z0-9_]+\\.[a-z0-9_]+$")

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/logs/LogStore.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/logs/LogStore.kt
@@ -1,0 +1,168 @@
+package ee.schimke.terrazzo.core.logs
+
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import ee.schimke.ha.model.Dashboard
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.terrazzo.core.di.AppScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * In-memory log buffer for the debug Logs view. Hidden behind a
+ * preference (default off); when enabled the app feeds three event
+ * streams here:
+ *
+ *  - **Data updates** — emitted by [recordDashboardSnapshot] when a
+ *    dashboard fetch returns a different state for an entity that the
+ *    *currently rendered* dashboard references. Entities that aren't
+ *    on any dashboard never enter the buffer, so a `get_states` snapshot
+ *    covering thousands of unused entities doesn't drown the view.
+ *    Retained for [DATA_UPDATE_RETENTION_MS] (5 minutes) so the screen
+ *    can show "what changed recently" without unbounded growth.
+ *  - **Connection events** — connect / disconnect / error transitions
+ *    sourced from [ee.schimke.terrazzo.core.session.HaSession.connectionStatus].
+ *  - **Local actions** — button taps, toggles, service calls dispatched
+ *    by the dashboard's action dispatcher. Captured *before* the
+ *    network round-trip so a failed send is still visible.
+ *
+ * The store is process-singleton: all hooks share the same buffer
+ * regardless of which dashboard / session is active. A single
+ * [clear] empties everything; useful from the screen itself.
+ */
+@SingleIn(AppScope::class)
+@Inject
+class LogStore {
+
+    private val lock = Any()
+    private val entries: ArrayDeque<LogEntry> = ArrayDeque()
+    private val lastSeenStates: MutableMap<String, String> = mutableMapOf()
+    private val _flow = MutableStateFlow<List<LogEntry>>(emptyList())
+    val flow: StateFlow<List<LogEntry>> = _flow.asStateFlow()
+
+    /**
+     * Pluggable so tests can drive time. Production uses
+     * [System.currentTimeMillis] via the default constructor.
+     */
+    var clock: () -> Long = { System.currentTimeMillis() }
+
+    fun recordConnection(status: LogConnectionStatus, message: String? = null) {
+        addEntry(
+            LogEntry.Connection(
+                timestamp = clock(),
+                status = status,
+                message = message,
+            )
+        )
+    }
+
+    fun recordLocalAction(summary: String, entityId: String? = null) {
+        addEntry(
+            LogEntry.LocalAction(
+                timestamp = clock(),
+                summary = summary,
+                entityId = entityId,
+            )
+        )
+    }
+
+    /**
+     * Diff [snapshot] against the last recorded snapshot for any
+     * entity referenced by [dashboard], emitting one
+     * [LogEntry.DataUpdate] per changed entity. First call after
+     * [clear] (or for newly-referenced entities) just seeds the
+     * baseline silently — without that, opening the app would log
+     * every entity once.
+     */
+    fun recordDashboardSnapshot(dashboard: Dashboard, snapshot: HaSnapshot) {
+        val refs = referencedEntities(dashboard)
+        if (refs.isEmpty()) return
+        val now = clock()
+        val updates = mutableListOf<LogEntry>()
+        synchronized(lock) {
+            for (id in refs) {
+                val current = snapshot.states[id]?.state ?: continue
+                val prior = lastSeenStates[id]
+                lastSeenStates[id] = current
+                if (prior != null && prior != current) {
+                    updates += LogEntry.DataUpdate(
+                        timestamp = now,
+                        entityId = id,
+                        fromState = prior,
+                        toState = current,
+                    )
+                }
+            }
+            if (updates.isNotEmpty()) {
+                entries.addAll(updates)
+                prune(now)
+            }
+        }
+        if (updates.isNotEmpty()) publish()
+    }
+
+    fun clear() {
+        synchronized(lock) {
+            entries.clear()
+            lastSeenStates.clear()
+        }
+        _flow.value = emptyList()
+    }
+
+    private fun addEntry(entry: LogEntry) {
+        synchronized(lock) {
+            entries.addLast(entry)
+            prune(entry.timestamp)
+        }
+        publish()
+    }
+
+    private fun prune(now: Long) {
+        val cutoff = now - DATA_UPDATE_RETENTION_MS
+        val iterator = entries.iterator()
+        while (iterator.hasNext()) {
+            val e = iterator.next()
+            if (e is LogEntry.DataUpdate && e.timestamp < cutoff) iterator.remove()
+        }
+        while (entries.size > MAX_ENTRIES) entries.removeFirst()
+    }
+
+    private fun publish() {
+        _flow.value = synchronized(lock) { entries.toList() }
+    }
+
+    companion object {
+        /** Data updates older than this are dropped on every write. */
+        const val DATA_UPDATE_RETENTION_MS: Long = 5 * 60 * 1000L
+
+        /** Hard cap so a chatty session can't grow the buffer without bound. */
+        const val MAX_ENTRIES: Int = 500
+    }
+}
+
+/** Categorised connection lifecycle, decoupled from the session enum. */
+enum class LogConnectionStatus { Connected, Connecting, Disconnected, Error }
+
+sealed interface LogEntry {
+    val timestamp: Long
+
+    data class DataUpdate(
+        override val timestamp: Long,
+        val entityId: String,
+        val fromState: String,
+        val toState: String,
+    ) : LogEntry
+
+    data class Connection(
+        override val timestamp: Long,
+        val status: LogConnectionStatus,
+        val message: String? = null,
+    ) : LogEntry
+
+    data class LocalAction(
+        override val timestamp: Long,
+        val summary: String,
+        val entityId: String? = null,
+    ) : LogEntry
+}

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/prefs/PreferencesStore.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/prefs/PreferencesStore.kt
@@ -104,6 +104,21 @@ class PreferencesStore(private val context: Context) {
     }
 
     /**
+     * Hidden debug surface that exposes the in-memory
+     * [ee.schimke.terrazzo.core.logs.LogStore] buffer (WebSocket data
+     * updates touching dashboard entities, connect / disconnect
+     * events, locally-dispatched service calls). Off by default; the
+     * toggle lives in Settings and the corresponding overflow-menu
+     * entry only appears while it's on.
+     */
+    val logsViewEnabled: Flow<Boolean>
+        get() = context.store.data.map { it[LOGS_VIEW_KEY] ?: false }
+
+    suspend fun setLogsViewEnabled(enabled: Boolean) {
+        context.store.edit { it[LOGS_VIEW_KEY] = enabled }
+    }
+
+    /**
      * The dashboard the user last opened. Drives auto-launch: on cold
      * start, [ee.schimke.terrazzo.MainActivity] reads this once and
      * seeds the dashboard nav-state, so a single-dashboard or 2-3
@@ -155,6 +170,7 @@ class PreferencesStore(private val context: Context) {
         private val LAST_VIEWED_KEY = stringPreferencesKey("last_viewed_dashboard")
         private val GRID_LAYOUT_KEY = booleanPreferencesKey("experimental_grid_layout")
         private val COLLAPSED_MODE_KEY = booleanPreferencesKey("collapsed_mode")
+        private val LOGS_VIEW_KEY = booleanPreferencesKey("logs_view_enabled")
 
         /** Stored value for HA's default (unnamed) dashboard. */
         const val DEFAULT_DASHBOARD_SENTINEL: String = "__default__"


### PR DESCRIPTION
## Summary
Adds a hidden debug surface that exposes an in-memory log buffer tracking WebSocket data updates, connection lifecycle events, and locally-dispatched service calls. The feature is gated behind a preference toggle in Settings and only appears in the overflow menu when enabled.

## Key Changes

- **New `LogStore` class** (`terrazzo-core/logs/LogStore.kt`): Process-singleton in-memory buffer that tracks three event streams:
  - Data updates for entities referenced by the currently-rendered dashboard (retained for 5 minutes)
  - Connection status transitions (connected/connecting/disconnected/error)
  - Local action dispatches (button taps, toggles, service calls) logged before network round-trips
  - Hard cap of 500 entries with automatic pruning of stale data updates

- **New `LogsScreen` composable** (`app/logs/LogsScreen.kt`): Debug UI displaying logs in three reverse-chronological sections with timestamps, status chips for connection events, and state transition details for data updates

- **Entity reference extraction** (`terrazzo-core/logs/DashboardEntityRefs.kt`): Heuristic walker that extracts entity IDs from dashboard JSON configs to filter which entities are tracked (prevents unbounded growth from unused entities)

- **Integration points**:
  - `DashboardActionDispatcher`: Records all dispatched actions to the log store before execution
  - `DashboardViewScreen`: Feeds dashboard snapshots to the log store for change tracking
  - `TerrazzoApp`: Mirrors WebSocket connection status transitions into the log buffer
  - `PreferencesStore`: New `logsViewEnabled` preference to control visibility

- **UI integration**:
  - New "Logs" entry in overflow menu (conditionally shown when preference is enabled)
  - Settings screen toggle to enable/disable the logs view
  - Navigation wiring in `TerrazzoApp` to route to the logs screen

## Implementation Details

- Thread-safe with synchronized access to the entry buffer and state tracking
- Pluggable clock for testability
- Entity ID validation using regex (`^[a-z0-9_]+\.[a-z0-9_]+$`) to minimize false positives when walking dashboard JSON
- Connection events and local actions are retained indefinitely (up to the 500-entry cap); only data updates are time-pruned
- Preference defaults to off to avoid overhead in production builds

## Test plan
- [ ] Toggle "Show logs view" in Settings, confirm the overflow menu entry appears/disappears
- [ ] Open the Logs screen; tap a dashboard button and confirm the action lands under "Local actions"
- [ ] Force a disconnect and confirm connection transitions show under "Connection"
- [ ] Let a dashboard refresh and confirm changed entity states show under "Data updates"; confirm older-than-5-min data updates drop off