### PR TITLE
feat(dashboard): add Read/Write chip next to the connection chip

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -339,10 +340,16 @@ private fun DashboardsRoot(
     var opened by rememberSaveable {
         mutableStateOf(initialDashboardToOpened(initialDashboard))
     }
-    // Safe default: button taps are ignored until the user explicitly
-    // flips the chip to Write. Survives config changes; intentionally
-    // resets on cold start so we never silently start in Write.
-    var readOnly by rememberSaveable { mutableStateOf(true) }
+    // Two-layer write-mode state:
+    //   - `permanentWriteMode` is the persisted opt-in (Settings).
+    //   - `sessionWriteMode` is a process-scoped override the chip writes
+    //     to. Null means "no override yet" — fall back to the permanent
+    //     setting, which on a fresh cold start is the read-only default.
+    val permanentWrite by graph.preferencesStore.permanentWriteMode
+        .collectAsState(initial = false)
+    val sessionWrite by graph.sessionWriteMode.writeMode.collectAsState()
+    val writeMode = sessionWrite ?: permanentWrite
+    val readOnly = !writeMode
     var installPending by remember { mutableStateOf<Pair<CardConfig, HaSnapshot>?>(null) }
     val openedValue = opened
 
@@ -431,18 +438,19 @@ private fun DashboardsRoot(
                             modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp),
                         )
                     }
-                    val modeColor = if (readOnly) READ_ONLY_COLOR else WRITE_COLOR
-                    Surface(
-                        onClick = { readOnly = !readOnly },
-                        color = modeColor.copy(alpha = 0.16f),
-                        shape = MaterialTheme.shapes.small,
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier.padding(end = 8.dp),
                     ) {
                         Text(
                             text = if (readOnly) "Read" else "Write",
-                            color = modeColor,
+                            color = if (readOnly) READ_ONLY_COLOR else WRITE_COLOR,
                             style = MaterialTheme.typography.labelSmall,
-                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp),
+                            modifier = Modifier.padding(end = 4.dp),
+                        )
+                        Switch(
+                            checked = writeMode,
+                            onCheckedChange = { graph.sessionWriteMode.set(it) },
                         )
                     }
                     TopBarOverflowMenu(
@@ -577,6 +585,7 @@ private fun SettingsScreen(
     val gridLayoutEnabled by graph.preferencesStore.experimentalGridLayout.collectAsState(initial = false)
     val collapsedModeEnabled by graph.preferencesStore.collapsedMode.collectAsState(initial = true)
     val logsViewEnabled by graph.preferencesStore.logsViewEnabled.collectAsState(initial = false)
+    val permanentWriteEnabled by graph.preferencesStore.permanentWriteMode.collectAsState(initial = false)
 
     Scaffold(
         topBar = {
@@ -706,6 +715,29 @@ private fun SettingsScreen(
                     checked = logsViewEnabled,
                     onCheckedChange = { enabled ->
                         scope.launch { graph.preferencesStore.setLogsViewEnabled(enabled) }
+                    },
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Permanent write mode", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        "When off, every relaunch starts in Read so taps on the dashboard " +
+                            "(and on home-screen widgets) never silently fire HA service " +
+                            "calls. Turn on if you trust this device and prefer Write by " +
+                            "default; the chip in the top bar still overrides per session.",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                Switch(
+                    checked = permanentWriteEnabled,
+                    onCheckedChange = { enabled ->
+                        scope.launch { graph.preferencesStore.setPermanentWriteMode(enabled) }
                     },
                 )
             }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -339,6 +339,10 @@ private fun DashboardsRoot(
     var opened by rememberSaveable {
         mutableStateOf(initialDashboardToOpened(initialDashboard))
     }
+    // Safe default: button taps are ignored until the user explicitly
+    // flips the chip to Write. Survives config changes; intentionally
+    // resets on cold start so we never silently start in Write.
+    var readOnly by rememberSaveable { mutableStateOf(true) }
     var installPending by remember { mutableStateOf<Pair<CardConfig, HaSnapshot>?>(null) }
     val openedValue = opened
 
@@ -427,6 +431,20 @@ private fun DashboardsRoot(
                             modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp),
                         )
                     }
+                    val modeColor = if (readOnly) READ_ONLY_COLOR else WRITE_COLOR
+                    Surface(
+                        onClick = { readOnly = !readOnly },
+                        color = modeColor.copy(alpha = 0.16f),
+                        shape = MaterialTheme.shapes.small,
+                        modifier = Modifier.padding(end = 8.dp),
+                    ) {
+                        Text(
+                            text = if (readOnly) "Read" else "Write",
+                            color = modeColor,
+                            style = MaterialTheme.typography.labelSmall,
+                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp),
+                        )
+                    }
                     TopBarOverflowMenu(
                         onOpenSettings = onOpenSettings,
                         onOpenWidgets = onOpenWidgets,
@@ -459,6 +477,7 @@ private fun DashboardsRoot(
             DashboardViewScreen(
                 session = session,
                 urlPath = openedValue,
+                readOnly = readOnly,
                 onCardLongPress = { card ->
                     // In demo mode the preview — and the installed widget —
                     // render against the current fake snapshot so values
@@ -506,6 +525,9 @@ enum class ConnectionStatus(val label: String, val color: Color) {
     Connecting("Connecting", Color(0xFF2E7D32)),
     Connected("Connected", Color(0xFF1976D2)),
 }
+
+private val READ_ONLY_COLOR = Color(0xFF455A64)
+private val WRITE_COLOR = Color(0xFFE65100)
 
 private fun SessionConnectionStatus.toUiConnectionStatus(): ConnectionStatus = when (this) {
     SessionConnectionStatus.Failed -> ConnectionStatus.Failed

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardActionDispatcher.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardActionDispatcher.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalContext
 import ee.schimke.ha.rc.AlarmKeypadCoordinator
 import ee.schimke.ha.rc.CardDocumentCache
@@ -45,13 +46,26 @@ import kotlinx.coroutines.launch
  * doesn't update.
  */
 @Composable
-fun rememberDashboardActionDispatcher(session: HaSession): HaActionDispatcher {
+fun rememberDashboardActionDispatcher(
+    session: HaSession,
+    readOnly: Boolean = true,
+): HaActionDispatcher {
     val context = LocalContext.current
     val cache = LocalCardDocumentCache.current
     val scope = rememberCoroutineScope()
     val logStore = LocalTerrazzoGraph.current.logStore
+    // Read fresh each dispatch so toggling the chip takes effect without
+    // recreating the dispatcher (and losing AlarmKeypadCoordinator state).
+    val readOnlyState = rememberUpdatedState(readOnly)
     return remember(session, context, cache, scope, logStore) {
-        val core = DashboardActionDispatcher(context.applicationContext, session, cache, scope, logStore)
+        val core = DashboardActionDispatcher(
+            context.applicationContext,
+            session,
+            cache,
+            scope,
+            logStore,
+            readOnly = { readOnlyState.value },
+        )
         // The keypad coordinator buffers per-key host actions and
         // translates ARM intents into a single `call_service` with the
         // entered code attached. Other action variants pass through.
@@ -65,6 +79,7 @@ private class DashboardActionDispatcher(
     private val cache: CardDocumentCache,
     private val scope: CoroutineScope,
     private val logStore: LogStore,
+    private val readOnly: () -> Boolean,
 ) : HaActionDispatcher {
     override fun dispatch(action: HaAction) {
         // Log every dispatched action (before any network round-trip)
@@ -74,8 +89,20 @@ private class DashboardActionDispatcher(
         recordToLog(action)
         when (action) {
             is HaAction.Url -> launchUrl(action.url)
-            is HaAction.Toggle -> handleToggle(action.entityId)
-            is HaAction.CallService -> handleCallService(action)
+            is HaAction.Toggle -> {
+                if (readOnly()) {
+                    Log.i(TAG, "Read-only mode: dropping toggle for ${action.entityId}")
+                    return
+                }
+                handleToggle(action.entityId)
+            }
+            is HaAction.CallService -> {
+                if (readOnly()) {
+                    Log.i(TAG, "Read-only mode: dropping ${action.domain}.${action.service}")
+                    return
+                }
+                handleCallService(action)
+            }
             is HaAction.MoreInfo,
             is HaAction.Navigate,
             // AlarmKey / AlarmIntent should be intercepted upstream by

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -124,6 +124,7 @@ fun DashboardViewScreen(
     urlPath: String?,
     onCardLongPress: (CardConfig) -> Unit,
     contentPadding: PaddingValues = PaddingValues(0.dp),
+    readOnly: Boolean = true,
 ) {
     val cache = LocalTerrazzoGraph.current.offlineCache
     // Seed from disk so the first composition shows the last-known
@@ -195,7 +196,7 @@ fun DashboardViewScreen(
         0L
     }
 
-    val actionDispatcher = rememberDashboardActionDispatcher(session)
+    val actionDispatcher = rememberDashboardActionDispatcher(session, readOnly = readOnly)
 
     CompositionLocalProvider(
         LocalHaActionDispatcher provides actionDispatcher,

--- a/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
@@ -113,6 +113,8 @@ private fun rememberPreviewGraph(): TerrazzoGraph {
                 get() = error("sessionFactory not wired in previews")
             override val lanConnectionPolicy: ee.schimke.terrazzo.core.network.LanConnectionPolicy
                 get() = error("lanConnectionPolicy not wired in previews")
+            override val sessionWriteMode: ee.schimke.terrazzo.core.session.SessionWriteMode =
+                ee.schimke.terrazzo.core.session.SessionWriteMode()
             override val cardMonitor: CardMonitor
                 get() = object : CardMonitor {
                     override val isEnabled: Boolean = false

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/di/TerrazzoGraph.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/di/TerrazzoGraph.kt
@@ -18,6 +18,7 @@ import ee.schimke.terrazzo.core.session.DemoHaSession
 import ee.schimke.terrazzo.core.session.HaSession
 import ee.schimke.terrazzo.core.session.LiveHaSession
 import ee.schimke.terrazzo.core.session.OfflineOnlySession
+import ee.schimke.terrazzo.core.session.SessionWriteMode
 import ee.schimke.terrazzo.core.wearsync.WearSyncManager
 import ee.schimke.terrazzo.core.widget.WidgetStore
 
@@ -42,6 +43,7 @@ interface TerrazzoGraph {
     val wearSyncManager: WearSyncManager
     val lanConnectionPolicy: LanConnectionPolicy
     val logStore: LogStore
+    val sessionWriteMode: SessionWriteMode
 
     fun interface Factory {
         fun create(context: Context): TerrazzoGraph

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/prefs/PreferencesStore.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/prefs/PreferencesStore.kt
@@ -119,6 +119,21 @@ class PreferencesStore(private val context: Context) {
     }
 
     /**
+     * Permanent write mode. When off (the default), every cold start
+     * seeds the dashboard write/read chip with Read, so a relaunch never
+     * silently leaves the app capable of firing service calls. When on,
+     * cold start seeds with Write — opt-in for users who trust their
+     * device + workflow. Independent of the in-session chip toggle:
+     * flipping the chip overrides the seed for the current process.
+     */
+    val permanentWriteMode: Flow<Boolean>
+        get() = context.store.data.map { it[PERMANENT_WRITE_KEY] ?: false }
+
+    suspend fun setPermanentWriteMode(enabled: Boolean) {
+        context.store.edit { it[PERMANENT_WRITE_KEY] = enabled }
+    }
+
+    /**
      * The dashboard the user last opened. Drives auto-launch: on cold
      * start, [ee.schimke.terrazzo.MainActivity] reads this once and
      * seeds the dashboard nav-state, so a single-dashboard or 2-3
@@ -171,6 +186,7 @@ class PreferencesStore(private val context: Context) {
         private val GRID_LAYOUT_KEY = booleanPreferencesKey("experimental_grid_layout")
         private val COLLAPSED_MODE_KEY = booleanPreferencesKey("collapsed_mode")
         private val LOGS_VIEW_KEY = booleanPreferencesKey("logs_view_enabled")
+        private val PERMANENT_WRITE_KEY = booleanPreferencesKey("permanent_write_mode")
 
         /** Stored value for HA's default (unnamed) dashboard. */
         const val DEFAULT_DASHBOARD_SENTINEL: String = "__default__"

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/SessionWriteMode.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/SessionWriteMode.kt
@@ -1,0 +1,31 @@
+package ee.schimke.terrazzo.core.session
+
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import ee.schimke.terrazzo.core.di.AppScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Process-scoped (Read | Write) holder for the dashboard chip. Survives
+ * Activity recreation (rotation, theme change) and resume, but resets
+ * on cold start so a fresh launch is gated by `PreferencesStore`'s
+ * `permanentWriteMode` — Read on the first composition unless the user
+ * has opted in to permanent Write.
+ *
+ * The state is nullable so DashboardsRoot can distinguish "the user has
+ * already chosen for this process" from "use the permanent-write-mode
+ * default". Once the chip is tapped the value is non-null and sticks
+ * for the rest of the process.
+ */
+@SingleIn(AppScope::class)
+@Inject
+class SessionWriteMode {
+    private val _writeMode = MutableStateFlow<Boolean?>(null)
+    val writeMode: StateFlow<Boolean?> = _writeMode.asStateFlow()
+
+    fun set(writeMode: Boolean) {
+        _writeMode.value = writeMode
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a labeled `Switch` (Read / Write) beside the connection chip in the dashboard `TopAppBar`. While Read is active, `HaAction.Toggle` and `HaAction.CallService` are dropped at `DashboardActionDispatcher` before any `call_service` round-trip; URL launches and as-yet-unwired actions still pass through.
- Stores the chip state in a process-scoped `SessionWriteMode` holder on the DI graph, not `rememberSaveable`. The value survives Activity recreation and resume but resets on cold start, so a restart never silently leaves the app capable of firing service calls.
- Adds a persisted **Permanent write mode** Settings toggle. When on, the cold-start seed flips to Write so the user does not have to opt in every launch; the chip still overrides per session. When off, the seed is Read.
- Threads `readOnly` through `rememberDashboardActionDispatcher` via `rememberUpdatedState` so flipping the chip takes effect without rebuilding the dispatcher (preserving `AlarmKeypadCoordinator` state).

## Test plan

- [ ] `./gradlew ktfmtCheck :app:compileDebugKotlin :app:testDebugUnitTest` is green.
- [ ] On a fresh install, cold start lands in Read; tapping a switch / button card logs `Read-only mode: dropping …` and does not call HA.
- [ ] Flipping the chip to Write makes the same tap fire `call_service` (verify against demo session and a live HA instance).
- [ ] Toggle survives rotation / theme change; cold start reverts to Read.
- [ ] Enabling **Permanent write mode** in Settings makes the next cold start seed Write.
- [ ] Alarm keypad still works — buffered digits flush via `CallService` only when in Write.