### PR TITLE
feat(logs): persist log buffer via Proto DataStore

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
@@ -120,7 +120,7 @@ private fun rememberPreviewGraph(): TerrazzoGraph {
                 }
             override val wearSyncManager: WearSyncManager = NoOpWearSyncManager()
             override val logStore: ee.schimke.terrazzo.core.logs.LogStore =
-                ee.schimke.terrazzo.core.logs.LogStore()
+                ee.schimke.terrazzo.core.logs.LogStore(context)
         }
     }
 }

--- a/terrazzo-core/build.gradle.kts
+++ b/terrazzo-core/build.gradle.kts
@@ -24,8 +24,10 @@ kotlin {
       implementation(project(":ha-client"))
       implementation(libs.kotlinx.coroutines.core)
       implementation(libs.kotlinx.serialization.json)
+      implementation(libs.kotlinx.serialization.protobuf)
     }
     androidMain.dependencies {
+      implementation(libs.androidx.datastore)
       implementation(libs.androidx.datastore.preferences)
       implementation(libs.appauth)
       implementation(libs.ktor.client.okhttp)

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/logs/LogStore.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/logs/LogStore.kt
@@ -84,12 +84,26 @@ class LogStore(context: Context) {
         val persisted = dataStore.data.first()
         val loaded = persisted.entries.mapNotNull { it.toModel() }
         val now = clock()
+        val merged: Boolean
         synchronized(lock) {
+            // Merge — do NOT replace. Events recorded while this
+            // suspending load is in flight (e.g. the connection
+            // observer firing during boot) live in `entries` already;
+            // a naive `clear() + addAll(loaded)` would drop them.
+            // Loaded entries are older by construction, so prepend
+            // and sort to keep the chronological order the UI relies
+            // on. `distinct()` guards against a clean restart where
+            // an entry could in principle land twice.
+            val current = entries.toList()
             entries.clear()
-            entries.addAll(loaded)
+            entries.addAll((loaded + current).distinct().sortedBy { it.timestamp })
             prune(now)
+            merged = current.isNotEmpty()
         }
         publish()
+        // Anything recorded during the load gap was only in memory;
+        // flush so disk reflects the merged ring.
+        if (merged) persistAsync()
     }
 
     fun recordConnection(status: LogConnectionStatus, message: String? = null) {
@@ -183,17 +197,21 @@ class LogStore(context: Context) {
     }
 
     /**
-     * Fire a write of the current ring to disk. Writes queue inside
-     * DataStore (`updateData` is sequential), so a burst of events
-     * coalesces naturally without us tracking versions. The
-     * `runCatching` swallows IO errors — a missed write on the debug
-     * surface isn't worth crashing the app.
+     * Fire a write of the current ring to disk. The snapshot is read
+     * *inside* [DataStore.updateData] so its sequential transform
+     * mutex orders writes by completion, not by launch — otherwise
+     * two concurrent `persistAsync` calls could land on disk in the
+     * opposite order from their in-memory ordering, leaving disk
+     * state stale. The `runCatching` swallows IO errors — a missed
+     * write on the debug surface isn't worth crashing the app.
      */
     private fun persistAsync() {
-        val snapshot = synchronized(lock) { entries.map { it.toPersisted() } }
         scope.launch {
             runCatching {
-                dataStore.updateData { PersistedLogBuffer(entries = snapshot) }
+                dataStore.updateData {
+                    val snapshot = synchronized(lock) { entries.map { it.toPersisted() } }
+                    PersistedLogBuffer(entries = snapshot)
+                }
             }
         }
     }

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/logs/LogStore.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/logs/LogStore.kt
@@ -1,16 +1,25 @@
 package ee.schimke.terrazzo.core.logs
 
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.dataStore
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import ee.schimke.ha.model.Dashboard
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.terrazzo.core.di.AppScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 
 /**
- * In-memory log buffer for the debug Logs view. Hidden behind a
+ * Persistent log buffer for the debug Logs view. Hidden behind a
  * preference (default off); when enabled the app feeds three event
  * streams here:
  *
@@ -27,13 +36,26 @@ import kotlinx.coroutines.flow.asStateFlow
  *    by the dashboard's action dispatcher. Captured *before* the
  *    network round-trip so a failed send is still visible.
  *
+ * Persisted to disk via a Proto DataStore so events survive process
+ * death. The in-memory ring is the source of truth for reads / the
+ * UI flow; writes are mirrored to disk asynchronously on the store's
+ * own IO scope so callers never block on the file. On cold start the
+ * file is loaded once and pruned against the current clock — old
+ * data updates age out automatically.
+ *
  * The store is process-singleton: all hooks share the same buffer
- * regardless of which dashboard / session is active. A single
- * [clear] empties everything; useful from the screen itself.
+ * regardless of which dashboard / session is active. [clear] empties
+ * both the in-memory ring and the persisted copy.
  */
 @SingleIn(AppScope::class)
 @Inject
-class LogStore {
+class LogStore(context: Context) {
+
+    private val dataStore: DataStore<PersistedLogBuffer> = context.logStore
+    // Owns disk reads / writes; SupervisorJob so one failure doesn't
+    // kill the rest. Lives for the process — LogStore is AppScope so
+    // never cancelled.
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     private val lock = Any()
     private val entries: ArrayDeque<LogEntry> = ArrayDeque()
@@ -43,9 +65,32 @@ class LogStore {
 
     /**
      * Pluggable so tests can drive time. Production uses
-     * [System.currentTimeMillis] via the default constructor.
+     * [System.currentTimeMillis].
      */
     var clock: () -> Long = { System.currentTimeMillis() }
+
+    /**
+     * Suspend until the persisted buffer has been loaded into memory.
+     * Tests use this to deterministically read state that was written
+     * to disk in a prior run; production callers (the LogsScreen
+     * `collectAsState`) just observe [flow] and see entries appear
+     * when load finishes.
+     */
+    suspend fun awaitInitialLoad() {
+        loadJob.join()
+    }
+
+    private val loadJob: Job = scope.launch {
+        val persisted = dataStore.data.first()
+        val loaded = persisted.entries.mapNotNull { it.toModel() }
+        val now = clock()
+        synchronized(lock) {
+            entries.clear()
+            entries.addAll(loaded)
+            prune(now)
+        }
+        publish()
+    }
 
     fun recordConnection(status: LogConnectionStatus, message: String? = null) {
         addEntry(
@@ -99,7 +144,10 @@ class LogStore {
                 prune(now)
             }
         }
-        if (updates.isNotEmpty()) publish()
+        if (updates.isNotEmpty()) {
+            publish()
+            persistAsync()
+        }
     }
 
     fun clear() {
@@ -108,6 +156,7 @@ class LogStore {
             lastSeenStates.clear()
         }
         _flow.value = emptyList()
+        persistAsync()
     }
 
     private fun addEntry(entry: LogEntry) {
@@ -116,6 +165,7 @@ class LogStore {
             prune(entry.timestamp)
         }
         publish()
+        persistAsync()
     }
 
     private fun prune(now: Long) {
@@ -132,12 +182,33 @@ class LogStore {
         _flow.value = synchronized(lock) { entries.toList() }
     }
 
+    /**
+     * Fire a write of the current ring to disk. Writes queue inside
+     * DataStore (`updateData` is sequential), so a burst of events
+     * coalesces naturally without us tracking versions. The
+     * `runCatching` swallows IO errors — a missed write on the debug
+     * surface isn't worth crashing the app.
+     */
+    private fun persistAsync() {
+        val snapshot = synchronized(lock) { entries.map { it.toPersisted() } }
+        scope.launch {
+            runCatching {
+                dataStore.updateData { PersistedLogBuffer(entries = snapshot) }
+            }
+        }
+    }
+
     companion object {
         /** Data updates older than this are dropped on every write. */
         const val DATA_UPDATE_RETENTION_MS: Long = 5 * 60 * 1000L
 
         /** Hard cap so a chatty session can't grow the buffer without bound. */
         const val MAX_ENTRIES: Int = 500
+
+        private val Context.logStore: DataStore<PersistedLogBuffer> by dataStore(
+            fileName = "terrazzo_logs.pb",
+            serializer = protoBufStoreSerializer(PersistedLogBuffer()),
+        )
     }
 }
 

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/logs/LogStorePersistence.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/logs/LogStorePersistence.kt
@@ -1,0 +1,123 @@
+@file:OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+
+package ee.schimke.terrazzo.core.logs
+
+import androidx.datastore.core.Serializer
+import java.io.InputStream
+import java.io.OutputStream
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoBuf
+import kotlinx.serialization.protobuf.ProtoNumber
+import kotlinx.serialization.serializer
+
+/**
+ * Persisted form of the [LogStore] ring. Flat shape with a [kind] tag
+ * (rather than polymorphic serialisation over the sealed [LogEntry])
+ * because proto-wire polymorphism wants a `SerializersModule`
+ * registration we'd otherwise carry just for this one store. Empty
+ * strings stand in for nulls — proto3 has no `optional` so a missing
+ * field reads as an empty string anyway.
+ *
+ * Wire numbers are stable; do not reorder. Adding new fields is fine
+ * as long as they get a fresh number.
+ */
+@Serializable
+internal data class PersistedLogBuffer(
+    @ProtoNumber(1) val entries: List<PersistedLogEntry> = emptyList(),
+)
+
+@Serializable
+internal data class PersistedLogEntry(
+    @ProtoNumber(1) val timestamp: Long = 0L,
+    /** 0 = connection · 1 = local action · 2 = data update. */
+    @ProtoNumber(2) val kind: Int = 0,
+    /** Ordinal of [LogConnectionStatus]; -1 when [kind] != 0. */
+    @ProtoNumber(3) val connectionStatus: Int = -1,
+    @ProtoNumber(4) val message: String = "",
+    @ProtoNumber(5) val summary: String = "",
+    @ProtoNumber(6) val entityId: String = "",
+    @ProtoNumber(7) val fromState: String = "",
+    @ProtoNumber(8) val toState: String = "",
+)
+
+internal const val KIND_CONNECTION: Int = 0
+internal const val KIND_LOCAL_ACTION: Int = 1
+internal const val KIND_DATA_UPDATE: Int = 2
+
+internal fun LogEntry.toPersisted(): PersistedLogEntry = when (this) {
+    is LogEntry.Connection -> PersistedLogEntry(
+        timestamp = timestamp,
+        kind = KIND_CONNECTION,
+        connectionStatus = status.ordinal,
+        message = message.orEmpty(),
+    )
+    is LogEntry.LocalAction -> PersistedLogEntry(
+        timestamp = timestamp,
+        kind = KIND_LOCAL_ACTION,
+        summary = summary,
+        entityId = entityId.orEmpty(),
+    )
+    is LogEntry.DataUpdate -> PersistedLogEntry(
+        timestamp = timestamp,
+        kind = KIND_DATA_UPDATE,
+        entityId = entityId,
+        fromState = fromState,
+        toState = toState,
+    )
+}
+
+internal fun PersistedLogEntry.toModel(): LogEntry? = when (kind) {
+    KIND_CONNECTION -> {
+        val status = LogConnectionStatus.entries.getOrNull(connectionStatus) ?: return null
+        LogEntry.Connection(
+            timestamp = timestamp,
+            status = status,
+            message = message.takeIf { it.isNotEmpty() },
+        )
+    }
+    KIND_LOCAL_ACTION -> LogEntry.LocalAction(
+        timestamp = timestamp,
+        summary = summary,
+        entityId = entityId.takeIf { it.isNotEmpty() },
+    )
+    KIND_DATA_UPDATE -> LogEntry.DataUpdate(
+        timestamp = timestamp,
+        entityId = entityId,
+        fromState = fromState,
+        toState = toState,
+    )
+    else -> null
+}
+
+/**
+ * Bridges `androidx.datastore.core.Serializer<T>` to
+ * `kotlinx-serialization-protobuf`. Defensive read: empty file (first
+ * run) or corrupt bytes fall back to [defaultValue] rather than
+ * propagating a `CorruptionException` that would crash the activity.
+ *
+ * Mirrors the same adapter in `app/wearsync/proto/ProtoSerializers.kt`
+ * — kept duplicated to avoid pulling :app's wearsync module into
+ * :terrazzo-core.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+internal class ProtoBufStoreSerializer<T : Any>(
+    private val ksz: KSerializer<T>,
+    override val defaultValue: T,
+) : Serializer<T> {
+    override suspend fun readFrom(input: InputStream): T {
+        val bytes = input.readBytes()
+        if (bytes.isEmpty()) return defaultValue
+        return runCatching { ProtoBuf.decodeFromByteArray(ksz, bytes) }
+            .getOrDefault(defaultValue)
+    }
+
+    override suspend fun writeTo(t: T, output: OutputStream) {
+        output.write(ProtoBuf.encodeToByteArray(ksz, t))
+    }
+}
+
+@OptIn(ExperimentalSerializationApi::class)
+internal inline fun <reified T : Any> protoBufStoreSerializer(default: T): ProtoBufStoreSerializer<T> =
+    ProtoBufStoreSerializer(serializer(), default)


### PR DESCRIPTION
## Summary
Converts the LogStore from an in-memory-only buffer to a persistent store that survives process death. Events are now written to disk asynchronously using Protocol Buffers and DataStore, while maintaining the in-memory ring as the source of truth for UI reads.

## Key Changes
- **New persistence layer**: Added `LogStorePersistence.kt` with:
  - `PersistedLogBuffer` and `PersistedLogEntry` data classes using `@Serializable` for proto encoding
  - Conversion functions `toPersisted()` and `toModel()` to bridge between domain and persisted models
  - `ProtoBufStoreSerializer` adapter to bridge kotlinx-serialization-protobuf with androidx.datastore
  - Flat schema with `kind` tags instead of polymorphic serialization to avoid SerializersModule overhead

- **LogStore initialization**:
  - Now accepts `Context` parameter for DataStore access
  - Loads persisted events on startup via `loadJob`, pruning old data against current clock
  - Added `awaitInitialLoad()` suspend function for deterministic testing

- **Async persistence**:
  - Writes are mirrored to disk asynchronously on a dedicated IO scope (`SupervisorJob + Dispatchers.IO`)
  - Errors are caught and swallowed to prevent crashes on the debug surface
  - DataStore's sequential `updateData` naturally coalesces burst writes

- **Updated callers**: Preview code updated to pass `Context` to LogStore constructor

## Notable Details
- Wire numbers in proto messages are stable; new fields can be added with fresh numbers
- Empty strings represent nulls since proto3 has no `optional` keyword
- The in-memory ring remains the source of truth; disk is a write-through cache
- Data updates older than 5 minutes are automatically pruned on every write
- Hard cap of 500 entries prevents unbounded growth in chatty sessions

## Test plan
- [ ] Enable the Logs view, generate a few entries (connect/disconnect, taps, refreshes)
- [ ] Kill the process; relaunch and confirm prior entries reappear, with stale data updates aged out
- [ ] Tap "Clear" and confirm the on-disk file is also emptied (no entries on next launch)