### PR TITLE
feat(discovery): mDNS scan in Discovery screen with click-to-pick

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -146,6 +146,18 @@ fun TerrazzoApp(
     // can render dashboards / live values from whatever's current.
     LaunchedEffect(session) { wearSync.setSession(session) }
 
+    // Once a live session has finished connecting, ask HA for its
+    // config and stash the `external_url` so the OkHttp interceptor
+    // can swap in the public host when LAN isn't reachable
+    // (e.g. on cellular). A demo / offline session returns null
+    // from [fetchInstanceConfig], so this no-ops there.
+    LaunchedEffect(session) {
+        val s = session ?: return@LaunchedEffect
+        s.connectionStatus.first { it == SessionConnectionStatus.Connected }
+        val config = runCatching { s.fetchInstanceConfig() }.getOrNull() ?: return@LaunchedEffect
+        graph.remoteUrlStore.setExternalUrl(s.baseUrl, config.externalUrl)
+    }
+
     // Plumb session credentials into the process-wide image stack so
     // the singleton OkHttp client adds `Authorization: Bearer …` to
     // same-host fetches without rebuilding the loader. Demo / null
@@ -216,6 +228,7 @@ fun TerrazzoApp(
                     if (previousBaseUrl != null) {
                         graph.offlineCache.clearInstance(previousBaseUrl)
                         runCatching { graph.tokenVault.clear(previousBaseUrl) }
+                        graph.remoteUrlStore.clear(previousBaseUrl)
                     }
                     previous?.close()
                 }
@@ -613,6 +626,14 @@ private fun SettingsScreen(
                 if (isDemo) "Demo mode — offline fake data" else session.baseUrl,
                 style = MaterialTheme.typography.bodyMedium,
             )
+            if (!isDemo) {
+                val externalUrl by graph.remoteUrlStore.externalUrl(session.baseUrl)
+                    .collectAsState(initial = null)
+                externalUrl?.let { url ->
+                    Text("Public URL (away from home)", style = MaterialTheme.typography.labelMedium)
+                    Text(url, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
 
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/kotlin/ee/schimke/terrazzo/discovery/DiscoveryScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/discovery/DiscoveryScreen.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,13 +13,17 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -31,15 +36,23 @@ import ee.schimke.terrazzo.core.network.LanConnectionPolicy
 import java.net.URI
 
 /**
- * First-run screen: ask for the HA base URL.
+ * First-run screen: discover Home Assistant instances on the LAN over mDNS, with a manual URL
+ * entry as a fallback.
  *
- * Default-filled with `http://homeassistant:8123` — the hostname HAOS /
- * supervisor publish on the LAN, and what the official companion app
- * defaults to. A real (on-LAN) hostname or IP can be typed in.
+ * Behaviour:
+ *  * On entry, requests the `ACCESS_LOCAL_NETWORK` runtime permission (Android 16+ only —
+ *    pre-Baklava devices inherit network access from the install-time permissions). The mDNS
+ *    scanner starts as soon as the permission resolves (or immediately on older devices).
+ *  * Discovered instances appear as cards above the URL field. Tapping a card runs the same
+ *    `onInstancePicked` callback the manual flow would call, so login proceeds against the
+ *    resolved `base_url` (HA's zeroconf TXT) or the resolved `host:port` if that record is
+ *    absent.
+ *  * The URL field stays available — defaulted to `http://homeassistant:8123`, the same hostname
+ *    HAOS / supervisor publish on the LAN and the HA companion app uses — for users on networks
+ *    where mDNS doesn't propagate (some enterprise APs, mesh setups with multicast disabled).
  *
- * A previous version scanned `_home-assistant._tcp` via mDNS; removed
- * by request — the app only needs to talk to the one known instance.
- * `HaDiscovery` stays in the module for future reuse.
+ * The mDNS scan is cold: scrolling away from the screen / login completing cancels the discovery
+ * via the underlying `NsdManager.stopServiceDiscovery` call in [HaDiscovery.scan].
  */
 @Composable
 fun DiscoveryScreen(
@@ -51,16 +64,32 @@ fun DiscoveryScreen(
     val context = LocalContext.current
 
     // ACCESS_LOCAL_NETWORK is a runtime permission on Android 16+. Surface
-    // the system dialog before login when the entered URL points at a LAN
-    // host so the post-OAuth API calls aren't blocked. The pending URL
-    // crosses the dialog so the launcher's result handler can forward it.
+    // the system dialog before any LAN traffic — both the mDNS scan and
+    // the post-OAuth API calls need it. The pending base URL crosses the
+    // dialog so the launcher's result handler can forward it to login.
     var pendingBaseUrl by remember { mutableStateOf<String?>(null) }
+    var localNetworkGranted by remember {
+        mutableStateOf(!needsLocalNetworkRuntime() || hasLocalNetwork(context))
+    }
     val permissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
-    ) { _ ->
-        pendingBaseUrl?.let(onInstancePicked)
+    ) { granted ->
+        if (granted) localNetworkGranted = true
+        pendingBaseUrl?.let { onInstancePicked(it) }
         pendingBaseUrl = null
     }
+
+    // Ask for the permission on first composition rather than waiting
+    // for Connect / mDNS-tap — the scan can't start without it on
+    // Android 16+ and we want results before the user reaches the URL
+    // field.
+    LaunchedEffect(Unit) {
+        if (needsLocalNetworkRuntime() && !hasLocalNetwork(context)) {
+            permissionLauncher.launch(ACCESS_LOCAL_NETWORK)
+        }
+    }
+
+    val instances = rememberDiscoveredInstances(enabled = localNetworkGranted)
 
     Scaffold(snackbarHost = snackbarHost) { innerPadding ->
         Column(
@@ -72,12 +101,34 @@ fun DiscoveryScreen(
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             Text("Connect to Home Assistant", style = MaterialTheme.typography.headlineMedium)
-            Text(
-                "Defaulted to the standard Home Assistant LAN hostname. " +
-                    "Edit to point at your own instance if needed.",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+
+            if (instances.isNotEmpty()) {
+                Text(
+                    "Found on this network — tap to connect:",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                instances.forEach { instance ->
+                    DiscoveredInstanceCard(
+                        instance = instance,
+                        onClick = { onInstancePicked(instance.baseUrl) },
+                    )
+                }
+                HorizontalDivider()
+                Text(
+                    "Or enter a URL manually:",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                Text(
+                    "Looking for Home Assistant on this network. " +
+                        "If nothing shows up, enter the URL manually.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
             OutlinedTextField(
                 value = host,
                 onValueChange = { host = it },
@@ -104,12 +155,67 @@ fun DiscoveryScreen(
     }
 }
 
+@Composable
+private fun DiscoveredInstanceCard(
+    instance: HaInstance,
+    onClick: () -> Unit,
+) {
+    OutlinedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text(instance.name, style = MaterialTheme.typography.titleMedium)
+            Text(
+                instance.baseUrl,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            instance.version?.let {
+                Text(
+                    "HA $it",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Subscribes to [HaDiscovery.scan] while [enabled] is true and deduplicates by `baseUrl` (a
+ * single HA may advertise multiple times — once per network interface, once per cluster member).
+ * Returns a sorted list so the rendered order is stable across recompositions.
+ */
+@Composable
+private fun rememberDiscoveredInstances(enabled: Boolean): List<HaInstance> {
+    val context = LocalContext.current
+    val discovery = remember(context) { HaDiscovery(context.applicationContext) }
+    val byBaseUrl = remember { mutableStateMapOf<String, HaInstance>() }
+
+    LaunchedEffect(enabled) {
+        if (!enabled) return@LaunchedEffect
+        discovery.scan().collect { instance ->
+            byBaseUrl[instance.baseUrl] = instance
+        }
+    }
+    return byBaseUrl.values.sortedBy { it.name.lowercase() }
+}
+
+private fun needsLocalNetworkRuntime(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA
+
+private fun hasLocalNetwork(context: Context): Boolean =
+    ContextCompat.checkSelfPermission(context, ACCESS_LOCAL_NETWORK) == PackageManager.PERMISSION_GRANTED
+
 private fun needsLocalNetworkPermission(context: Context, baseUrl: String): Boolean {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.BAKLAVA) return false
+    if (!needsLocalNetworkRuntime()) return false
     val host = runCatching { URI(baseUrl).host }.getOrNull() ?: return false
     if (!LanConnectionPolicy.isLanHost(host)) return false
-    return ContextCompat.checkSelfPermission(context, ACCESS_LOCAL_NETWORK) !=
-        PackageManager.PERMISSION_GRANTED
+    return !hasLocalNetwork(context)
 }
 
 // String literal so we can reference it on devices below API 36 without

--- a/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
@@ -113,6 +113,8 @@ private fun rememberPreviewGraph(): TerrazzoGraph {
                 get() = error("sessionFactory not wired in previews")
             override val lanConnectionPolicy: ee.schimke.terrazzo.core.network.LanConnectionPolicy
                 get() = error("lanConnectionPolicy not wired in previews")
+            override val remoteUrlStore: ee.schimke.terrazzo.core.network.RemoteUrlStore =
+                ee.schimke.terrazzo.core.network.RemoteUrlStore(context)
             override val sessionWriteMode: ee.schimke.terrazzo.core.session.SessionWriteMode =
                 ee.schimke.terrazzo.core.session.SessionWriteMode()
             override val cardMonitor: CardMonitor

--- a/app/src/test/kotlin/ee/schimke/terrazzo/core/network/RemoteUrlInterceptorTest.kt
+++ b/app/src/test/kotlin/ee/schimke/terrazzo/core/network/RemoteUrlInterceptorTest.kt
@@ -1,0 +1,111 @@
+package ee.schimke.terrazzo.core.network
+
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RemoteUrlInterceptorTest {
+
+    @Test
+    fun allow_passes_request_through_unchanged() {
+        val interceptor =
+            RemoteUrlInterceptor(
+                check = { LanConnectionPolicy.Verdict.Allow },
+                externalFor = { error("should not be consulted when LAN is allowed") },
+            )
+        val original = Request.Builder().url("http://homeassistant.local:8123/api").build()
+        val chain = FakeChain(original)
+
+        interceptor.intercept(chain)
+
+        assertEquals("http://homeassistant.local:8123/api", chain.lastUrl)
+    }
+
+    @Test
+    fun deny_with_external_target_rewrites_scheme_host_and_port() {
+        val target =
+            RemoteUrlStore.ExternalTarget(scheme = "https", host = "abc.ui.nabu.casa", port = 443)
+        val interceptor =
+            RemoteUrlInterceptor(
+                check = { LanConnectionPolicy.Verdict.Deny("cellular") },
+                externalFor = { host ->
+                    assertEquals("homeassistant.local", host)
+                    target
+                },
+            )
+        val original = Request.Builder().url("http://homeassistant.local:8123/api/x").build()
+        val chain = FakeChain(original)
+
+        interceptor.intercept(chain)
+
+        assertEquals("https://abc.ui.nabu.casa/api/x", chain.lastUrl)
+    }
+
+    @Test
+    fun deny_without_external_target_passes_through_for_lan_gate_to_reject() {
+        // No public URL on file → leave the request as-is. The downstream
+        // [LanConnectionPolicyInterceptor] is responsible for failing
+        // closed; this interceptor only rewrites when it has a target.
+        val interceptor =
+            RemoteUrlInterceptor(
+                check = { LanConnectionPolicy.Verdict.Deny("cellular") },
+                externalFor = { null },
+            )
+        val original = Request.Builder().url("http://homeassistant.local:8123/api/x").build()
+        val chain = FakeChain(original)
+
+        interceptor.intercept(chain)
+
+        assertEquals("http://homeassistant.local:8123/api/x", chain.lastUrl)
+    }
+
+    @Test
+    fun rewrite_preserves_path_and_query() {
+        val target =
+            RemoteUrlStore.ExternalTarget(scheme = "https", host = "remote.example", port = 8443)
+        val interceptor =
+            RemoteUrlInterceptor(
+                check = { LanConnectionPolicy.Verdict.Deny("cellular") },
+                externalFor = { target },
+            )
+        val original =
+            Request.Builder().url("http://192.168.1.5:8123/api/states?domain=light").build()
+        val chain = FakeChain(original)
+
+        interceptor.intercept(chain)
+
+        assertEquals("https://remote.example:8443/api/states?domain=light", chain.lastUrl)
+    }
+
+    private class FakeChain(private val request: Request) : Interceptor.Chain {
+        var lastUrl: String? = null
+            private set
+
+        override fun request(): Request = request
+
+        override fun proceed(request: Request): Response {
+            lastUrl = request.url.toString()
+            return Response.Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body("".toResponseBody("text/plain".toMediaType()))
+                .build()
+        }
+
+        override fun call(): okhttp3.Call = error("not used")
+        override fun connectTimeoutMillis(): Int = 0
+        override fun connection(): okhttp3.Connection? = null
+        override fun readTimeoutMillis(): Int = 0
+        override fun withConnectTimeout(timeout: Int, unit: java.util.concurrent.TimeUnit) = this
+        override fun withReadTimeout(timeout: Int, unit: java.util.concurrent.TimeUnit) = this
+        override fun withWriteTimeout(timeout: Int, unit: java.util.concurrent.TimeUnit) = this
+        override fun writeTimeoutMillis(): Int = 0
+    }
+}

--- a/ha-client/src/commonMain/kotlin/ee/schimke/ha/client/HaClient.kt
+++ b/ha-client/src/commonMain/kotlin/ee/schimke/ha/client/HaClient.kt
@@ -134,6 +134,22 @@ class HaClient(private val config: HaConfig, engine: HttpClientEngine? = null) {
     return json.decodeFromJsonElement(Dashboard.serializer(), result)
   }
 
+  /**
+   * Fetch the HA instance's `config` payload — same shape `GET /api/config` returns over REST,
+   * exposed here over the already-open WebSocket so we don't pay a separate TCP/TLS handshake. Used
+   * to pick up the user's configured `external_url` (Nabu Casa / reverse-proxy hostname) so the app
+   * can route over the public URL when away from the LAN.
+   */
+  suspend fun fetchConfig(): HaInstanceConfig {
+    val result = runCommand("get_config")
+    return HaInstanceConfig(
+      version = result["version"]?.jsonPrimitive?.content,
+      locationName = result["location_name"]?.jsonPrimitive?.content,
+      internalUrl = result["internal_url"]?.nullableString(),
+      externalUrl = result["external_url"]?.nullableString(),
+    )
+  }
+
   /** Top-level Lovelace dashboards registered in `lovelace/dashboards`. */
   suspend fun listDashboards(): List<DashboardSummary> {
     val result = runCommandArray("lovelace/dashboards/list")
@@ -324,3 +340,23 @@ private fun String.toWsUrl(): String =
 
 @Serializable
 data class DashboardSummary(val urlPath: String?, val title: String, val icon: String? = null)
+
+/**
+ * Subset of HA's `config` payload we care about. HA's `external_url` is set when the user has
+ * configured remote access (Nabu Casa, reverse proxy, etc.); `internal_url` is what the user
+ * configured for LAN access. Either may be null if the user hasn't set them.
+ */
+@Serializable
+data class HaInstanceConfig(
+  val version: String? = null,
+  val locationName: String? = null,
+  val internalUrl: String? = null,
+  val externalUrl: String? = null,
+)
+
+private fun kotlinx.serialization.json.JsonElement.nullableString(): String? =
+  when (this) {
+    is kotlinx.serialization.json.JsonNull -> null
+    is kotlinx.serialization.json.JsonPrimitive -> content
+    else -> null
+  }

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/di/TerrazzoGraph.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/di/TerrazzoGraph.kt
@@ -10,6 +10,7 @@ import ee.schimke.terrazzo.core.logs.LogStore
 import ee.schimke.terrazzo.core.monitor.CardMonitor
 import ee.schimke.terrazzo.core.network.HttpEngineFactory
 import ee.schimke.terrazzo.core.network.LanConnectionPolicy
+import ee.schimke.terrazzo.core.network.RemoteUrlStore
 import ee.schimke.terrazzo.core.pin.PinStore
 import ee.schimke.terrazzo.core.pin.WearWidgetSlotsStore
 import ee.schimke.terrazzo.core.prefs.PreferencesStore
@@ -42,6 +43,7 @@ interface TerrazzoGraph {
     val cardMonitor: CardMonitor
     val wearSyncManager: WearSyncManager
     val lanConnectionPolicy: LanConnectionPolicy
+    val remoteUrlStore: RemoteUrlStore
     val logStore: LogStore
     val sessionWriteMode: SessionWriteMode
 

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/network/HttpEngineFactory.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/network/HttpEngineFactory.kt
@@ -7,14 +7,27 @@ import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.okhttp.OkHttp
 
 /**
- * Builds a Ktor [HttpClientEngine] with the LAN connection policy installed as an OkHttp
- * interceptor. Singleton so the underlying OkHttp connection pool / dispatcher is shared across
- * `HaClient` and `AddonClient` instances.
+ * Builds a Ktor [HttpClientEngine] for HA / addon traffic with two interceptors:
+ *
+ *  1. [RemoteUrlInterceptor] — rewrites requests aimed at the LAN base URL onto the instance's
+ *     public ("external") URL when the current network can't reach the LAN one. Only applies if
+ *     we've previously read `external_url` from HA via `get_config`.
+ *  2. [LanConnectionPolicyInterceptor] — final gate: rejects requests still aimed at a private /
+ *     plaintext destination the current network can't safely reach.
+ *
+ * Singleton so the underlying OkHttp connection pool / dispatcher is shared across `HaClient` and
+ * `AddonClient` instances.
  */
 @SingleIn(AppScope::class)
 @Inject
-class HttpEngineFactory(private val policy: LanConnectionPolicy) {
+class HttpEngineFactory(
+  private val policy: LanConnectionPolicy,
+  private val remoteUrlStore: RemoteUrlStore,
+) {
 
   val engine: HttpClientEngine =
-    OkHttp.create { addInterceptor(LanConnectionPolicyInterceptor(policy)) }
+    OkHttp.create {
+      addInterceptor(RemoteUrlInterceptor(policy, remoteUrlStore))
+      addInterceptor(LanConnectionPolicyInterceptor(policy))
+    }
 }

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/network/RemoteUrlInterceptor.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/network/RemoteUrlInterceptor.kt
@@ -1,0 +1,56 @@
+package ee.schimke.terrazzo.core.network
+
+import okhttp3.HttpUrl
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * Rewrites outgoing requests from an HA instance's internal (LAN) URL to its public
+ * (`external_url`) URL when the LAN destination isn't usable from the current network.
+ *
+ * Examples:
+ *  * On home Wi-Fi, the session base is `http://homeassistant.local:8123`.
+ *    [LanConnectionPolicy] allows it → request goes through unchanged.
+ *  * On cellular, the same `http://homeassistant.local:8123` is denied (plaintext
+ *    LAN over cellular). If the store knows the public URL HA reports
+ *    (`https://abc.ui.nabu.casa`), this interceptor rewrites the request to
+ *    `https://abc.ui.nabu.casa/...`. HA accepts the same OAuth bearer over either
+ *    URL, so headers (including `Authorization`) ride along unchanged.
+ *
+ * Sits before [LanConnectionPolicyInterceptor] so the rewrite happens first and the
+ * downstream policy gate sees an already-public, allow-listed URL.
+ *
+ * Does nothing when:
+ *  * The request URL is already on the public host (e.g. the user manually entered the
+ *    Nabu Casa URL at login).
+ *  * No public URL is on file for the request host.
+ *  * The LAN policy would already allow the request.
+ */
+class RemoteUrlInterceptor(
+  private val check: (String) -> LanConnectionPolicy.Verdict,
+  private val externalFor: (host: String) -> RemoteUrlStore.ExternalTarget?,
+) : Interceptor {
+
+  constructor(
+    policy: LanConnectionPolicy,
+    store: RemoteUrlStore,
+  ) : this(policy::check, store::externalHostFor)
+
+  override fun intercept(chain: Interceptor.Chain): Response {
+    val request = chain.request()
+    val url = request.url
+    if (check(url.toString()) is LanConnectionPolicy.Verdict.Allow) {
+      return chain.proceed(request)
+    }
+    val target = externalFor(url.host) ?: return chain.proceed(request)
+    val rewritten = url.rewriteTo(target)
+    return chain.proceed(request.newBuilder().url(rewritten).build())
+  }
+
+  private fun HttpUrl.rewriteTo(target: RemoteUrlStore.ExternalTarget): HttpUrl =
+    newBuilder()
+      .scheme(target.scheme)
+      .host(target.host)
+      .port(target.port)
+      .build()
+}

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/network/RemoteUrlStore.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/network/RemoteUrlStore.kt
@@ -1,0 +1,121 @@
+package ee.schimke.terrazzo.core.network
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import ee.schimke.terrazzo.core.di.AppScope
+import java.net.URI
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+/**
+ * Per-instance public ("external") URL persisted after we read HA's
+ * `get_config` payload. Pairs the URL the user logged in with (their LAN
+ * baseUrl) to the public URL HA exposes for remote access — usually a
+ * Nabu Casa hostname under `ui.nabu.casa` or a self-hosted reverse
+ * proxy.
+ *
+ * Two access paths:
+ *   - `Flow` / suspend reads for UI surfaces (Settings).
+ *   - Synchronous lookup via [externalHostFor] for the OkHttp interceptor
+ *     that rewrites outgoing requests to the public host when the LAN
+ *     destination isn't reachable from the current network. The
+ *     interceptor runs on the network thread and can't suspend, so the
+ *     store keeps a process-local map mirrored to disk.
+ */
+@SingleIn(AppScope::class)
+@Inject
+class RemoteUrlStore(private val context: Context) {
+
+    // Mirrors disk into an O(1) lookup the interceptor can consult per
+    // request without touching DataStore. Keys are the *host* of the
+    // login baseUrl; lookup is per outgoing request host.
+    private val cache = ConcurrentHashMap<String, ExternalTarget>()
+
+    private val hydrateScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    init {
+        // Background-hydrate so the interceptor sees mapped hosts ASAP
+        // without blocking app start on a DataStore read. Until this
+        // completes the interceptor returns null (= "no rewrite"),
+        // which is the same behaviour as a fresh install.
+        hydrateScope.launch {
+            context.store.data.first().asMap().forEach { (key, value) ->
+                val baseUrl = key.name.removePrefix(KEY_PREFIX)
+                val host = uriHost(baseUrl) ?: return@forEach
+                val target = parseTarget(value as? String ?: return@forEach) ?: return@forEach
+                cache[host] = target
+            }
+        }
+    }
+
+    /**
+     * Persist the external URL HA reports for [baseUrl]. Pass null to clear (the user removed
+     * their `external_url` in HA, or sign-out wiped the slot).
+     */
+    suspend fun setExternalUrl(baseUrl: String, externalUrl: String?) {
+        val host = uriHost(baseUrl) ?: return
+        val target = externalUrl?.let(::parseTarget)
+        context.store.edit { prefs ->
+            val key = keyOf(baseUrl)
+            if (externalUrl.isNullOrBlank()) prefs.remove(key) else prefs[key] = externalUrl
+        }
+        if (target != null) cache[host] = target else cache.remove(host)
+    }
+
+    fun externalUrl(baseUrl: String): Flow<String?> =
+        context.store.data.map { it[keyOf(baseUrl)] }
+
+    suspend fun externalUrlNow(baseUrl: String): String? =
+        context.store.data.first()[keyOf(baseUrl)]
+
+    /**
+     * Cached lookup keyed by request host. Returns the parsed `scheme/host/port` for the public
+     * URL the interceptor should rewrite to, or null if we have no public URL on file for that
+     * host. Runs in O(1) on the network thread.
+     */
+    fun externalHostFor(internalHost: String): ExternalTarget? =
+        cache[internalHost.lowercase()]
+
+    /** Wipe a single instance's public URL — called from sign-out. */
+    suspend fun clear(baseUrl: String) {
+        setExternalUrl(baseUrl, null)
+    }
+
+    data class ExternalTarget(val scheme: String, val host: String, val port: Int)
+
+    private fun keyOf(baseUrl: String) = stringPreferencesKey("$KEY_PREFIX${normalize(baseUrl)}")
+
+    private companion object {
+        private val Context.store by preferencesDataStore(name = "terrazzo_remote_urls")
+        const val KEY_PREFIX = "external_url."
+
+        fun normalize(baseUrl: String): String = baseUrl.trim().removeSuffix("/")
+
+        fun uriHost(url: String): String? =
+            runCatching { URI(normalize(url)).host?.lowercase() }.getOrNull()
+
+        fun parseTarget(url: String): ExternalTarget? = runCatching {
+            val u = URI(url.trim())
+            val scheme = u.scheme?.lowercase() ?: return@runCatching null
+            val host = u.host?.lowercase() ?: return@runCatching null
+            val port = if (u.port == -1) defaultPort(scheme) else u.port
+            ExternalTarget(scheme, host, port)
+        }.getOrNull()
+
+        fun defaultPort(scheme: String): Int = when (scheme) {
+            "https" -> 443
+            "http" -> 80
+            else -> -1
+        }
+    }
+}

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/CachedHaSession.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/CachedHaSession.kt
@@ -1,6 +1,7 @@
 package ee.schimke.terrazzo.core.session
 
 import ee.schimke.ha.client.DashboardSummary
+import ee.schimke.ha.client.HaInstanceConfig
 import ee.schimke.ha.model.Dashboard
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.terrazzo.core.cache.OfflineCacheStorage
@@ -65,6 +66,8 @@ class CachedHaSession(private val delegate: HaSession, private val cache: Offlin
       }
       .getOrElse { ex -> cached ?: throw ex }
   }
+
+  override suspend fun fetchInstanceConfig(): HaInstanceConfig? = delegate.fetchInstanceConfig()
 
   override suspend fun close() {
     delegate.close()

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/HaSession.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/HaSession.kt
@@ -3,6 +3,7 @@ package ee.schimke.terrazzo.core.session
 import ee.schimke.ha.client.DashboardSummary
 import ee.schimke.ha.client.HaClient
 import ee.schimke.ha.client.HaConfig
+import ee.schimke.ha.client.HaInstanceConfig
 import ee.schimke.ha.model.Dashboard
 import ee.schimke.ha.model.HaSnapshot
 import io.ktor.client.engine.HttpClientEngine
@@ -47,6 +48,13 @@ interface HaSession {
     suspend fun connect()
     suspend fun listDashboards(): List<DashboardSummary>
     suspend fun loadDashboard(urlPath: String?): Pair<Dashboard, HaSnapshot>
+
+    /**
+     * Fetch HA's `get_config` payload — version + `internal_url` / `external_url`. Live sessions
+     * round-trip the WebSocket; demo / offline sessions return null so callers can skip the
+     * persist-public-URL side effect.
+     */
+    suspend fun fetchInstanceConfig(): HaInstanceConfig? = null
 
     /**
      * Fire-and-await an HA service call. The dashboard's
@@ -118,6 +126,7 @@ class LiveHaSession(
         val snapshot = client.snapshot()
         return dashboard to snapshot
     }
+    override suspend fun fetchInstanceConfig(): HaInstanceConfig = client.fetchConfig()
     override suspend fun callService(
         domain: String,
         service: String,


### PR DESCRIPTION
Re-enables the `HaDiscovery` mDNS scanner on first launch so users can tap a
discovered instance instead of typing the URL. ACCESS_LOCAL_NETWORK is requested
on screen entry on Android 16+ so the scan and the post-OAuth API calls have
permission upfront. Manual URL entry stays as fallback.

Also lays the groundwork for routing to HA over its public URL when away from
home: HaClient gains `fetchConfig()` to read HA's `internal_url` / `external_url`
from `get_config`; a new `RemoteUrlStore` persists the public URL per instance;
`RemoteUrlInterceptor` rewrites outgoing OkHttp requests to that host whenever
`LanConnectionPolicy` denies the LAN destination (cellular, captive Wi-Fi, etc.)
so the same OAuth bearer rides over to the public hostname. Settings now shows
the public URL when known.