### PR TITLE
feat(auth): route token refresh through OkHttp engine

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
@@ -108,13 +108,21 @@ private fun rememberPreviewGraph(): TerrazzoGraph {
             // authService → AppAuth client config) so a real instance
             // is cheap and reaches no network until the user signs in.
             override val tokenVault: TokenVault = TokenVault(context)
-            override val authService: HaAuthService = HaAuthService(context)
-            override val sessionFactory: HaSessionFactory
-                get() = error("sessionFactory not wired in previews")
-            override val lanConnectionPolicy: ee.schimke.terrazzo.core.network.LanConnectionPolicy
-                get() = error("lanConnectionPolicy not wired in previews")
             override val remoteUrlStore: ee.schimke.terrazzo.core.network.RemoteUrlStore =
                 ee.schimke.terrazzo.core.network.RemoteUrlStore(context)
+            // Real LAN policy + engine — both are cheap (no network
+            // until something fires a request) and HaAuthService needs
+            // the engine in its constructor now.
+            override val lanConnectionPolicy: ee.schimke.terrazzo.core.network.LanConnectionPolicy =
+                ee.schimke.terrazzo.core.network.LanConnectionPolicy(context)
+            private val httpEngineFactory =
+                ee.schimke.terrazzo.core.network.HttpEngineFactory(
+                    policy = lanConnectionPolicy,
+                    remoteUrlStore = remoteUrlStore,
+                )
+            override val authService: HaAuthService = HaAuthService(context, httpEngineFactory)
+            override val sessionFactory: HaSessionFactory
+                get() = error("sessionFactory not wired in previews")
             override val sessionWriteMode: ee.schimke.terrazzo.core.session.SessionWriteMode =
                 ee.schimke.terrazzo.core.session.SessionWriteMode()
             override val cardMonitor: CardMonitor

--- a/app/src/test/kotlin/ee/schimke/terrazzo/core/auth/HaAuthServiceTokenParseTest.kt
+++ b/app/src/test/kotlin/ee/schimke/terrazzo/core/auth/HaAuthServiceTokenParseTest.kt
@@ -1,0 +1,66 @@
+package ee.schimke.terrazzo.core.auth
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+/**
+ * Unit coverage for [HaAuthService.parseTokenResponse]. The refresh call itself talks to the live
+ * OkHttp engine and gets covered end-to-end via instrumented tests; this verifies the JSON
+ * shape we expect from HA's `/auth/token` endpoint.
+ */
+class HaAuthServiceTokenParseTest {
+
+    @Test
+    fun parses_access_refresh_and_expires() {
+        val body =
+            """
+            {
+              "access_token": "abc",
+              "refresh_token": "xyz",
+              "expires_in": 1800,
+              "token_type": "Bearer"
+            }
+            """.trimIndent()
+
+        val tokens = HaAuthService.parseTokenResponse(body)
+
+        assertEquals("abc", tokens.accessToken)
+        assertEquals("xyz", tokens.refreshToken)
+        assertEquals(1800L, tokens.expiresInSeconds)
+        assertEquals("Bearer", tokens.tokenType)
+    }
+
+    @Test
+    fun missing_refresh_token_is_null() {
+        // HA usually doesn't rotate the refresh token on the
+        // `grant_type=refresh_token` exchange, so the field is often absent.
+        val body =
+            """
+            { "access_token": "abc", "expires_in": 1800, "token_type": "Bearer" }
+            """.trimIndent()
+
+        val tokens = HaAuthService.parseTokenResponse(body)
+
+        assertEquals("abc", tokens.accessToken)
+        assertNull(tokens.refreshToken)
+    }
+
+    @Test
+    fun unknown_fields_are_ignored() {
+        val body =
+            """
+            { "access_token": "abc", "ha_auth_provider": { "id": "homeassistant" } }
+            """.trimIndent()
+
+        val tokens = HaAuthService.parseTokenResponse(body)
+
+        assertEquals("abc", tokens.accessToken)
+    }
+
+    @Test
+    fun garbage_body_throws() {
+        assertFailsWith<Exception> { HaAuthService.parseTokenResponse("not json") }
+    }
+}

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/auth/HaAuthService.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/auth/HaAuthService.kt
@@ -6,21 +6,30 @@ import android.net.Uri
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import ee.schimke.terrazzo.core.di.AppScope
+import ee.schimke.terrazzo.core.network.HttpEngineFactory
+import io.ktor.client.HttpClient
+import io.ktor.client.request.forms.submitForm
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.Parameters
+import io.ktor.http.isSuccess
 import java.net.HttpURLConnection
 import java.net.URL
 import javax.net.ssl.HttpsURLConnection
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
 import net.openid.appauth.AppAuthConfiguration
 import net.openid.appauth.AuthorizationException
 import net.openid.appauth.AuthorizationRequest
 import net.openid.appauth.AuthorizationResponse
 import net.openid.appauth.AuthorizationService
 import net.openid.appauth.AuthorizationServiceConfiguration
-import net.openid.appauth.GrantTypeValues
 import net.openid.appauth.ResponseTypeValues
-import net.openid.appauth.TokenRequest
 import net.openid.appauth.TokenResponse
 import net.openid.appauth.connectivity.ConnectionBuilder
 
@@ -47,10 +56,21 @@ import net.openid.appauth.connectivity.ConnectionBuilder
  * refresh token is handed to [TokenVault] for persistence; the access
  * token is returned to the caller and held in memory for the
  * WebSocket connection lifetime.
+ *
+ * Refresh path: [refreshAccessToken] bypasses AppAuth and posts the
+ * `grant_type=refresh_token` form directly through Ktor on top of the
+ * shared [HttpEngineFactory] OkHttp engine. That means
+ * `RemoteUrlInterceptor` + `LanConnectionPolicyInterceptor` see the
+ * request and can rewrite a LAN-only base URL to the instance's public
+ * URL when the device is away from home. AppAuth's
+ * `performTokenRequest` runs on its own `HttpURLConnection` and can't
+ * be re-routed without a heavier `ConnectionBuilder` bridge — initial
+ * sign-in still uses that path, but the user is usually on the LAN
+ * they just typed the URL for, so it's not a blocker.
  */
 @SingleIn(AppScope::class)
 @Inject
-class HaAuthService(context: Context) {
+class HaAuthService(context: Context, httpEngineFactory: HttpEngineFactory) {
 
     // Allow HTTP for the integration Docker container. AppAuth's
     // default ConnectionBuilder rejects non-HTTPS endpoints at the
@@ -62,7 +82,16 @@ class HaAuthService(context: Context) {
             .build(),
     )
 
-    fun close() = appAuth.dispose()
+    // Shares the engine (and its interceptor chain) with HaClient /
+    // AddonClient so token refresh participates in the same URL-rewrite
+    // + LAN-policy gating. Cheap — Ktor reuses the OkHttp dispatcher /
+    // connection pool from the engine.
+    private val httpClient: HttpClient = HttpClient(httpEngineFactory.engine)
+
+    fun close() {
+        appAuth.dispose()
+        httpClient.close()
+    }
 
     /**
      * Build the pending-intent payload an Activity uses to launch the
@@ -106,31 +135,65 @@ class HaAuthService(context: Context) {
      * stub session to a live one without sending the user back through
      * the Custom Tab. HA usually doesn't rotate the refresh token on
      * this exchange, but if it does the response carries the new one.
+     *
+     * Goes through the shared OkHttp engine so the request is gated by
+     * `LanConnectionPolicyInterceptor` and rewritten to the public URL
+     * by `RemoteUrlInterceptor` when the device can't reach the LAN
+     * base URL (e.g. cellular, away from home).
      */
-    suspend fun refreshAccessToken(baseUrl: String, refreshToken: String): TokenResponse =
-        suspendCancellableCoroutine { cont ->
-            val config = AuthorizationServiceConfiguration(
-                Uri.parse("$baseUrl/auth/authorize"),
-                Uri.parse("$baseUrl/auth/token"),
-            )
-            val request = TokenRequest.Builder(config, CLIENT_ID)
-                .setGrantType(GrantTypeValues.REFRESH_TOKEN)
-                .setRefreshToken(refreshToken)
-                .build()
-            appAuth.performTokenRequest(request) { tokens, ex ->
-                when {
-                    tokens != null -> cont.resume(tokens)
-                    ex != null -> cont.resumeWithException(ex)
-                    else -> cont.resumeWithException(AuthorizationException.GeneralErrors.NETWORK_ERROR)
-                }
-            }
+    suspend fun refreshAccessToken(baseUrl: String, refreshToken: String): RefreshedTokens {
+        val tokenUrl = "${baseUrl.trim().removeSuffix("/")}/auth/token"
+        val response = httpClient.submitForm(
+            url = tokenUrl,
+            formParameters = Parameters.build {
+                append("grant_type", "refresh_token")
+                append("refresh_token", refreshToken)
+                append("client_id", CLIENT_ID)
+            },
+        )
+        val body = response.bodyAsText()
+        if (!response.status.isSuccess()) {
+            error("HA token refresh failed: ${response.status} $body")
         }
+        return parseTokenResponse(body)
+    }
 
     companion object {
         const val CLIENT_ID = "https://yschimke.github.io/homeassistant-remotecompose/terrazzo-auth/index.html"
         const val REDIRECT_URI = "rcha://auth-callback"
+
+        private val tokenJson = Json { ignoreUnknownKeys = true; isLenient = true }
+
+        fun parseTokenResponse(body: String): RefreshedTokens {
+            val obj: JsonObject = tokenJson.parseToJsonElement(body).jsonObject
+            return RefreshedTokens(
+                accessToken = obj.stringOrNull("access_token"),
+                refreshToken = obj.stringOrNull("refresh_token"),
+                expiresInSeconds = obj["expires_in"]?.let {
+                    (it as? JsonPrimitive)?.content?.toLongOrNull()
+                },
+                tokenType = obj.stringOrNull("token_type"),
+            )
+        }
+
+        private fun JsonObject.stringOrNull(key: String): String? = when (val v = this[key]) {
+            null, JsonNull -> null
+            is JsonPrimitive -> v.content
+            else -> null
+        }
     }
 }
+
+/**
+ * Result of a refresh-token exchange. Fields mirror the OAuth response shape so the call site
+ * can read `accessToken` and (optionally) `refreshToken` if HA rotated it.
+ */
+data class RefreshedTokens(
+    val accessToken: String?,
+    val refreshToken: String?,
+    val expiresInSeconds: Long?,
+    val tokenType: String?,
+)
 
 /**
  * AppAuth `ConnectionBuilder` that accepts both HTTPS and plain HTTP.


### PR DESCRIPTION
## Summary

`refreshAccessToken` no longer goes through AppAuth's bundled `HttpURLConnection`; instead it submits the `grant_type=refresh_token` form via a Ktor `HttpClient` built on the shared `HttpEngineFactory` OkHttp engine. That means the refresh participates in the same interceptor chain as every other HA call:

- `RemoteUrlInterceptor` (landed in #289) rewrites a LAN-only base URL to the instance's stored public URL when the device can't reach the LAN one (cellular, away from home).
- `LanConnectionPolicyInterceptor` still gates the final destination.

`HaAuthService` returns a small `RefreshedTokens` data class with the same `accessToken` / `refreshToken` field names the existing caller already uses, so `TerrazzoApp`'s cold-start auto-resume path is unchanged at the call site.

Initial sign-in (Custom Tab + code exchange) still uses AppAuth's plain-HTTP `ConnectionBuilder` — that's a one-time call against the LAN URL the user just typed, and re-routing it would mean carrying `ObsoleteUrlFactory` or a similar 800-line bridge layer just to cover a path that already works.

## Test plan

- [x] `:app:testDebugUnitTest` — new `HaAuthServiceTokenParseTest` covers the JSON shape HA returns (with rotated refresh tokens, without, unknown fields, malformed body).
- [x] `:app:assembleDebug`
- [x] `ktfmtCheck`
- [ ] Manual: cold-start on cellular with only a LAN base URL stored — refresh should now succeed by being rewritten to the public URL.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCzLwmGpCUY2rC2juQXo5v)_