### PR TITLE
feat(dashboard): pick custom + built-in dashboards during signin

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -54,11 +54,13 @@ import ee.schimke.terrazzo.core.session.HaSession
 import ee.schimke.terrazzo.core.session.SessionConnectionStatus
 import ee.schimke.terrazzo.dashboard.DashboardListState
 import ee.schimke.terrazzo.dashboard.DashboardPickerScreen
+import ee.schimke.terrazzo.dashboard.DashboardSelectionScreen
 import ee.schimke.terrazzo.dashboard.DashboardSwitcher
 import ee.schimke.terrazzo.dashboard.DashboardViewScreen
 import ee.schimke.terrazzo.dashboard.ManagePinnedScreen
 import ee.schimke.terrazzo.dashboard.TopBarOverflowMenu
 import ee.schimke.terrazzo.dashboard.rememberDashboardListState
+import ee.schimke.terrazzo.dashboard.rememberSelectedDashboardListState
 import ee.schimke.terrazzo.core.network.LanConnectionPolicy
 import ee.schimke.terrazzo.discovery.DiscoveryScreen
 import ee.schimke.terrazzo.wearsync.WearWidgetsScreen
@@ -205,6 +207,11 @@ fun TerrazzoApp(
                     // jumping into a dashboard that may not exist on
                     // the new instance.
                     graph.preferencesStore.clearLastViewedDashboard()
+                    // Same reasoning for the dashboard selection set:
+                    // the new identity may expose a different set of
+                    // dashboards, so re-run selection rather than
+                    // carry over the previous instance's choices.
+                    graph.preferencesStore.clearSelectedDashboardUrls()
                     previous?.close()
                 }
                 if (enabled) {
@@ -221,6 +228,7 @@ fun TerrazzoApp(
                 scope.launch {
                     graph.preferencesStore.setDemoMode(false)
                     graph.preferencesStore.clearLastViewedDashboard()
+                    graph.preferencesStore.clearSelectedDashboardUrls()
                     // Wipe cached dashboards / snapshots and the
                     // refresh-token vault entry so the next user on
                     // this device can't read the previous account's
@@ -260,7 +268,27 @@ private fun UnauthenticatedScreen(
     )
 }
 
-private enum class AppScreen { Dashboards, Settings, Widgets, Pinned, WearWidgets, SyncDiagnostics, Logs }
+private enum class AppScreen {
+    Dashboards,
+    Settings,
+    Widgets,
+    Pinned,
+    WearWidgets,
+    SyncDiagnostics,
+    Logs,
+    ChooseDashboards,
+}
+
+/**
+ * How the user arrived on [AppScreen.ChooseDashboards]. The two paths
+ * differ in two ways:
+ *  - **Back / confirm destination** — signin-gate confirm lands on
+ *    Dashboards; settings re-edit lands on Settings.
+ *  - **Back affordance** — signin gate has no back (the user MUST
+ *    pick before getting to a dashboard); settings entry has a back
+ *    arrow that returns to Settings.
+ */
+private enum class SelectionEntry { Signin, Settings }
 
 @Composable
 private fun AuthenticatedShell(
@@ -269,18 +297,51 @@ private fun AuthenticatedShell(
     onToggleDemo: (Boolean) -> Unit,
     onSignOut: () -> Unit,
 ) {
+    val context = LocalContext.current
+    val app = remember(context) { context.applicationContext as TerrazzoApplication }
+    val graph = LocalTerrazzoGraph.current
+    val scope = rememberCoroutineScope()
+
     var screen by rememberSaveable { mutableStateOf(AppScreen.Dashboards) }
+    var selectionEntry by rememberSaveable { mutableStateOf(SelectionEntry.Signin) }
+
+    // First-run gate: if the user hasn't been through the selection
+    // screen for this session, force them onto it before opening any
+    // dashboard. We snapshot the pref once per session (rather than
+    // observing it as a Flow) so the screen doesn't auto-dismiss the
+    // moment the confirm callback writes the pref.
+    var selectionResolved by remember(session) { mutableStateOf(false) }
+    var selectionMissingAtSignin by remember(session) { mutableStateOf(false) }
+    LaunchedEffect(session) {
+        selectionMissingAtSignin = graph.preferencesStore.selectedDashboardUrlsNow() == null
+        selectionResolved = true
+    }
+    LaunchedEffect(selectionResolved, selectionMissingAtSignin) {
+        if (selectionResolved &&
+            selectionMissingAtSignin &&
+            screen != AppScreen.ChooseDashboards
+        ) {
+            selectionEntry = SelectionEntry.Signin
+            screen = AppScreen.ChooseDashboards
+        }
+    }
 
     // System-back from Settings / Widgets returns to the dashboards
     // root. Inside DashboardsRoot another BackHandler routes view →
     // picker; the platform handles back at the picker (exits app).
-    BackHandler(enabled = screen != AppScreen.Dashboards) {
-        screen = if (screen == AppScreen.SyncDiagnostics) AppScreen.Settings else AppScreen.Dashboards
+    // The signin-gate variant of ChooseDashboards swallows back (the
+    // user has to pick something before continuing); the settings
+    // re-edit variant routes back to Settings.
+    val backEnabled =
+        screen != AppScreen.Dashboards &&
+            !(screen == AppScreen.ChooseDashboards && selectionEntry == SelectionEntry.Signin)
+    BackHandler(enabled = backEnabled) {
+        screen = when (screen) {
+            AppScreen.SyncDiagnostics -> AppScreen.Settings
+            AppScreen.ChooseDashboards -> AppScreen.Settings
+            else -> AppScreen.Dashboards
+        }
     }
-
-    val context = LocalContext.current
-    val app = remember(context) { context.applicationContext as TerrazzoApplication }
-    val graph = LocalTerrazzoGraph.current
 
     when (screen) {
         AppScreen.Dashboards -> DashboardsRoot(
@@ -299,6 +360,10 @@ private fun AuthenticatedShell(
             onSignOut = onSignOut,
             onBack = { screen = AppScreen.Dashboards },
             onOpenSyncDiagnostics = { screen = AppScreen.SyncDiagnostics },
+            onManageDashboards = {
+                selectionEntry = SelectionEntry.Settings
+                screen = AppScreen.ChooseDashboards
+            },
         )
         AppScreen.Widgets -> WidgetsScreen(
             onBack = { screen = AppScreen.Dashboards },
@@ -320,6 +385,35 @@ private fun AuthenticatedShell(
         AppScreen.Logs -> ee.schimke.terrazzo.logs.LogsScreen(
             onBack = { screen = AppScreen.Dashboards },
         )
+        AppScreen.ChooseDashboards -> {
+            val rawList by rememberDashboardListState(session)
+            val currentSelection by graph.preferencesStore.selectedDashboardUrls
+                .collectAsState(initial = null)
+            DashboardSelectionScreen(
+                state = rawList,
+                initialSelection = currentSelection,
+                onConfirm = { urls ->
+                    scope.launch {
+                        graph.preferencesStore.setSelectedDashboardUrls(urls)
+                    }
+                    // Avoid stranding the user on this screen between
+                    // the pref write and the snapshot flag flipping.
+                    selectionMissingAtSignin = false
+                    screen = when (selectionEntry) {
+                        SelectionEntry.Signin -> AppScreen.Dashboards
+                        SelectionEntry.Settings -> AppScreen.Settings
+                    }
+                },
+                onBack = when (selectionEntry) {
+                    SelectionEntry.Signin -> null
+                    SelectionEntry.Settings -> { { screen = AppScreen.Settings } }
+                },
+                title = when (selectionEntry) {
+                    SelectionEntry.Signin -> "Choose dashboards"
+                    SelectionEntry.Settings -> "Manage dashboards"
+                },
+            )
+        }
     }
 }
 
@@ -342,7 +436,7 @@ private fun DashboardsRoot(
 ) {
     val graph = LocalTerrazzoGraph.current
     val scope = rememberCoroutineScope()
-    val dashboards by rememberDashboardListState(session)
+    val dashboards by rememberSelectedDashboardListState(session)
     val context = LocalContext.current
     val app = remember(context) { context.applicationContext as TerrazzoApplication }
     val wearWidgetsSupported by app.wearCapabilityProbe
@@ -587,6 +681,7 @@ private fun SettingsScreen(
     onSignOut: () -> Unit,
     onBack: () -> Unit,
     onOpenSyncDiagnostics: () -> Unit,
+    onManageDashboards: () -> Unit,
 ) {
     val isDemo = session is DemoHaSession
     val graph = LocalTerrazzoGraph.current
@@ -652,6 +747,23 @@ private fun SettingsScreen(
                     checked = isDemo,
                     onCheckedChange = onToggleDemo,
                 )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Manage dashboards", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        "Pick which custom and built-in Home Assistant dashboards " +
+                            "appear in the picker and the top-bar switcher.",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                Spacer(Modifier.width(12.dp))
+                OutlinedButton(onClick = onManageDashboards) { Text("Choose") }
             }
 
             ThemeSection(

--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -305,6 +305,16 @@ private fun AuthenticatedShell(
     var screen by rememberSaveable { mutableStateOf(AppScreen.Dashboards) }
     var selectionEntry by rememberSaveable { mutableStateOf(SelectionEntry.Signin) }
 
+    // Snapshot of the persisted selection at the moment the user
+    // entered the ChooseDashboards screen. Captured here (rather than
+    // observed via `collectAsState` inside the screen) because
+    // DataStore reads are async: a Flow-based read would start as
+    // `null`, the screen would default to "all checked", and the
+    // saved subset would silently clobber the user's existing choice
+    // when the real value arrived after composition.
+    var selectionInitial by remember { mutableStateOf<Set<String>?>(null) }
+    var selectionInitialResolved by remember { mutableStateOf(false) }
+
     // First-run gate: if the user hasn't been through the selection
     // screen for this session, force them onto it before opening any
     // dashboard. We snapshot the pref once per session (rather than
@@ -322,24 +332,31 @@ private fun AuthenticatedShell(
             screen != AppScreen.ChooseDashboards
         ) {
             selectionEntry = SelectionEntry.Signin
+            // The gate fires precisely because no selection is
+            // persisted, so the snapshot for the screen is `null`
+            // (defaults to "all checked").
+            selectionInitial = null
+            selectionInitialResolved = true
             screen = AppScreen.ChooseDashboards
         }
     }
 
-    // System-back from Settings / Widgets returns to the dashboards
-    // root. Inside DashboardsRoot another BackHandler routes view →
-    // picker; the platform handles back at the picker (exits app).
-    // The signin-gate variant of ChooseDashboards swallows back (the
-    // user has to pick something before continuing); the settings
-    // re-edit variant routes back to Settings.
-    val backEnabled =
-        screen != AppScreen.Dashboards &&
-            !(screen == AppScreen.ChooseDashboards && selectionEntry == SelectionEntry.Signin)
-    BackHandler(enabled = backEnabled) {
-        screen = when (screen) {
-            AppScreen.SyncDiagnostics -> AppScreen.Settings
-            AppScreen.ChooseDashboards -> AppScreen.Settings
-            else -> AppScreen.Dashboards
+    // System-back routing. The signin-gate variant of ChooseDashboards
+    // *swallows* back — the user has to pick at least one dashboard
+    // before continuing — so the handler stays enabled and the
+    // callback no-ops (a disabled `BackHandler` lets Android's
+    // activity-level back through, which would exit the app). The
+    // settings re-edit variant routes back to Settings. Other
+    // non-Dashboards screens follow their existing rules. Inside
+    // DashboardsRoot another BackHandler routes view → picker; the
+    // platform handles back at the picker (exits app).
+    BackHandler(enabled = screen != AppScreen.Dashboards) {
+        when {
+            screen == AppScreen.ChooseDashboards &&
+                selectionEntry == SelectionEntry.Signin -> Unit
+            screen == AppScreen.ChooseDashboards -> screen = AppScreen.Settings
+            screen == AppScreen.SyncDiagnostics -> screen = AppScreen.Settings
+            else -> screen = AppScreen.Dashboards
         }
     }
 
@@ -362,6 +379,11 @@ private fun AuthenticatedShell(
             onOpenSyncDiagnostics = { screen = AppScreen.SyncDiagnostics },
             onManageDashboards = {
                 selectionEntry = SelectionEntry.Settings
+                selectionInitialResolved = false
+                scope.launch {
+                    selectionInitial = graph.preferencesStore.selectedDashboardUrlsNow()
+                    selectionInitialResolved = true
+                }
                 screen = AppScreen.ChooseDashboards
             },
         )
@@ -387,32 +409,50 @@ private fun AuthenticatedShell(
         )
         AppScreen.ChooseDashboards -> {
             val rawList by rememberDashboardListState(session)
-            val currentSelection by graph.preferencesStore.selectedDashboardUrls
-                .collectAsState(initial = null)
-            DashboardSelectionScreen(
-                state = rawList,
-                initialSelection = currentSelection,
-                onConfirm = { urls ->
-                    scope.launch {
-                        graph.preferencesStore.setSelectedDashboardUrls(urls)
-                    }
-                    // Avoid stranding the user on this screen between
-                    // the pref write and the snapshot flag flipping.
-                    selectionMissingAtSignin = false
-                    screen = when (selectionEntry) {
-                        SelectionEntry.Signin -> AppScreen.Dashboards
-                        SelectionEntry.Settings -> AppScreen.Settings
-                    }
-                },
-                onBack = when (selectionEntry) {
-                    SelectionEntry.Signin -> null
-                    SelectionEntry.Settings -> { { screen = AppScreen.Settings } }
-                },
-                title = when (selectionEntry) {
-                    SelectionEntry.Signin -> "Choose dashboards"
-                    SelectionEntry.Settings -> "Manage dashboards"
-                },
-            )
+            // Render the screen only once we have a snapshot of the
+            // persisted selection in hand. Without the gate, the
+            // settings re-edit path would briefly mount with
+            // `initialSelection = null` (defaulting to "all checked")
+            // and the user's saved subset would only arrive after the
+            // screen's internal `selected` state was already seeded.
+            if (!selectionInitialResolved) {
+                DashboardSelectionScreen(
+                    state = DashboardListState.Loading,
+                    initialSelection = null,
+                    onConfirm = {},
+                    onBack = null,
+                    title = when (selectionEntry) {
+                        SelectionEntry.Signin -> "Choose dashboards"
+                        SelectionEntry.Settings -> "Manage dashboards"
+                    },
+                )
+            } else {
+                DashboardSelectionScreen(
+                    state = rawList,
+                    initialSelection = selectionInitial,
+                    onConfirm = { urls ->
+                        scope.launch {
+                            graph.preferencesStore.setSelectedDashboardUrls(urls)
+                        }
+                        // Avoid stranding the user on this screen
+                        // between the pref write and the snapshot
+                        // flag flipping.
+                        selectionMissingAtSignin = false
+                        screen = when (selectionEntry) {
+                            SelectionEntry.Signin -> AppScreen.Dashboards
+                            SelectionEntry.Settings -> AppScreen.Settings
+                        }
+                    },
+                    onBack = when (selectionEntry) {
+                        SelectionEntry.Signin -> null
+                        SelectionEntry.Settings -> { { screen = AppScreen.Settings } }
+                    },
+                    title = when (selectionEntry) {
+                        SelectionEntry.Signin -> "Choose dashboards"
+                        SelectionEntry.Settings -> "Manage dashboards"
+                    },
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -319,11 +319,17 @@ private fun AuthenticatedShell(
     // screen for this session, force them onto it before opening any
     // dashboard. We snapshot the pref once per session (rather than
     // observing it as a Flow) so the screen doesn't auto-dismiss the
-    // moment the confirm callback writes the pref.
+    // moment the confirm callback writes the pref. Demo mode skips
+    // the gate entirely — `DemoData.BOARDS` is a curated showcase set
+    // and there's no per-user "which of MY dashboards" question to
+    // answer, so going straight to a dashboard matches both the
+    // try-the-app intent and the instrumented test's expectations.
     var selectionResolved by remember(session) { mutableStateOf(false) }
     var selectionMissingAtSignin by remember(session) { mutableStateOf(false) }
     LaunchedEffect(session) {
-        selectionMissingAtSignin = graph.preferencesStore.selectedDashboardUrlsNow() == null
+        val isDemo = session is DemoHaSession
+        selectionMissingAtSignin =
+            !isDemo && graph.preferencesStore.selectedDashboardUrlsNow() == null
         selectionResolved = true
     }
     LaunchedEffect(selectionResolved, selectionMissingAtSignin) {

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardListState.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardListState.kt
@@ -3,12 +3,13 @@ package ee.schimke.terrazzo.dashboard
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import ee.schimke.ha.client.DashboardSummary
 import ee.schimke.terrazzo.LocalTerrazzoGraph
+import ee.schimke.terrazzo.core.prefs.PreferencesStore
 import ee.schimke.terrazzo.core.session.HaSession
 
 /**
@@ -34,10 +35,18 @@ sealed interface DashboardListState {
 }
 
 /**
- * Load + cache the dashboards list for the lifetime of [session]. A
- * new [HaSession] (sign-in / demo toggle / sign-out → sign-in) keys a
- * fresh load. Within one session this is one HTTP-equivalent call,
- * and dashboards are stable enough on the HA side that we don't poll.
+ * Load + cache the **unfiltered** dashboards list for the lifetime of
+ * [session]. A new [HaSession] (sign-in / demo toggle / sign-out →
+ * sign-in) keys a fresh load. Within one session this is one
+ * HTTP-equivalent call, and dashboards are stable enough on the HA
+ * side that we don't poll.
+ *
+ * The result is exactly what HA returned (plus a single "Home"
+ * fallback when HA returned nothing — see below). The dashboard
+ * **selection** (`PreferencesStore.selectedDashboardUrls`) is applied
+ * on top via [rememberSelectedDashboardListState]; this raw version is
+ * what the selection screen renders so the user can opt into / out of
+ * every dashboard the instance actually exposes.
  */
 @Composable
 fun rememberDashboardListState(session: HaSession): State<DashboardListState> {
@@ -69,6 +78,63 @@ fun rememberDashboardListState(session: HaSession): State<DashboardListState> {
         }
     }
     return state
+}
+
+/**
+ * Same as [rememberDashboardListState] but with the user's
+ * `selectedDashboardUrls` filter applied. The picker and the top-bar
+ * switcher both consume this so the user only ever sees the
+ * dashboards they opted into during the signin flow / Settings.
+ *
+ * Filtering rules:
+ *  - selection `null` — user hasn't been through the selection screen
+ *    yet (sign-in flow gates on this). Show the raw list unfiltered so
+ *    the brief window before the selection screen mounts doesn't blank.
+ *  - selection non-empty — keep only entries whose
+ *    [DashboardSummary.selectionKey] is in the set. If everything got
+ *    filtered out (the user removed a dashboard from HA since
+ *    choosing), fall back to the raw list so they at least see
+ *    *something* and can re-pick from Settings.
+ *  - selection empty — should not occur (the selection screen disables
+ *    the Done button on empty), but if it does we fall back to the raw
+ *    list rather than render a blank picker.
+ */
+@Composable
+fun rememberSelectedDashboardListState(session: HaSession): State<DashboardListState> {
+    val rawState = rememberDashboardListState(session)
+    val selectionState = LocalTerrazzoGraph.current.preferencesStore
+        .selectedDashboardUrls.collectAsState(initial = null)
+    return remember(rawState, selectionState) {
+        derivedStateOf { applySelection(rawState.value, selectionState.value) }
+    }
+}
+
+private fun applySelection(
+    raw: DashboardListState,
+    selection: Set<String>?,
+): DashboardListState {
+    if (raw !is DashboardListState.Ready || selection.isNullOrEmpty()) return raw
+    val filtered = raw.dashboards.filter { d ->
+        val key = d.urlPath ?: PreferencesStore.DEFAULT_DASHBOARD_SENTINEL
+        key in selection
+    }
+    // If selection includes the built-in default but HA's response
+    // didn't (it never does — HA hides the unnamed dashboard from
+    // `lovelace/dashboards/list`), stitch it in so the user can open
+    // what they picked.
+    val withDefault = if (
+        PreferencesStore.DEFAULT_DASHBOARD_SENTINEL in selection &&
+            filtered.none { it.urlPath == null }
+    ) {
+        listOf(builtInDefaultDashboard) + filtered
+    } else {
+        filtered
+    }
+    // Empty filter result: user's selection no longer matches anything
+    // the instance exposes (dashboards renamed / removed). Show the
+    // raw list so they're not stuck staring at a blank picker — they
+    // can re-run selection from Settings.
+    return if (withDefault.isEmpty()) raw else DashboardListState.Ready(withDefault)
 }
 
 private fun List<DashboardSummary>.ifNotEmptyOrHomeFallback(): List<DashboardSummary> =

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardSelectionScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardSelectionScreen.kt
@@ -1,0 +1,243 @@
+package ee.schimke.terrazzo.dashboard
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import ee.schimke.ha.client.DashboardSummary
+import ee.schimke.terrazzo.core.prefs.PreferencesStore
+
+/**
+ * Multi-select screen for the dashboards the user wants surfaced in the
+ * picker and the top-bar switcher. Shown once during the signin flow
+ * (gated by [PreferencesStore.selectedDashboardUrls] being `null`) and
+ * reachable from Settings → "Manage dashboards".
+ *
+ * Lists everything HA returned from `lovelace/dashboards/list` plus a
+ * synthetic entry for the built-in default dashboard
+ * ([builtInDefaultDashboard]) — that one isn't in HA's response but is
+ * always available at `urlPath = null`, and users invariably expect to
+ * be able to opt in to it.
+ *
+ * Selection is encoded for [PreferencesStore.setSelectedDashboardUrls]:
+ * the built-in default's `null` urlPath maps to
+ * [PreferencesStore.DEFAULT_DASHBOARD_SENTINEL]; other entries store
+ * their `urlPath` verbatim.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DashboardSelectionScreen(
+    state: DashboardListState,
+    initialSelection: Set<String>?,
+    onConfirm: (Set<String>) -> Unit,
+    onBack: (() -> Unit)? = null,
+    title: String = "Choose dashboards",
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(title) },
+                navigationIcon = {
+                    if (onBack != null) {
+                        IconButton(onClick = onBack) {
+                            Icon(
+                                Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = "Back",
+                            )
+                        }
+                    }
+                },
+            )
+        },
+        contentWindowInsets = WindowInsets.safeDrawing,
+    ) { padding ->
+        when (state) {
+            DashboardListState.Loading -> LoadingBody(padding)
+            is DashboardListState.Error -> ErrorBody(state.message, padding)
+            is DashboardListState.Ready ->
+                ReadyBody(
+                    dashboards = state.dashboards,
+                    initialSelection = initialSelection,
+                    onConfirm = onConfirm,
+                    contentPadding = padding,
+                )
+        }
+    }
+}
+
+/**
+ * Synthetic entry for HA's built-in (unnamed) dashboard. Stitched into
+ * the selection list so users can opt the default dashboard in or out
+ * the same way they do the named ones.
+ */
+val builtInDefaultDashboard: DashboardSummary =
+    DashboardSummary(urlPath = null, title = "Overview (built-in)")
+
+/**
+ * Merge HA's named dashboards with [builtInDefaultDashboard] for the
+ * selection screen. The built-in goes first so its semantics are clear
+ * even when the list is long; if HA somehow returned an entry with a
+ * `null` url_path we leave that in place and don't double up.
+ */
+fun List<DashboardSummary>.withBuiltInDefault(): List<DashboardSummary> {
+    if (any { it.urlPath == null }) return this
+    return listOf(builtInDefaultDashboard) + this
+}
+
+/**
+ * Encode a [DashboardSummary]'s `urlPath` for storage in
+ * [PreferencesStore.selectedDashboardUrls]. The built-in default's
+ * `null` becomes [PreferencesStore.DEFAULT_DASHBOARD_SENTINEL]; every
+ * other dashboard stores its `urlPath` verbatim.
+ */
+fun DashboardSummary.selectionKey(): String =
+    urlPath ?: PreferencesStore.DEFAULT_DASHBOARD_SENTINEL
+
+@Composable
+private fun LoadingBody(padding: PaddingValues) {
+    Column(
+        Modifier.fillMaxSize().padding(padding).padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        CircularProgressIndicator()
+        Text("Fetching dashboards…")
+    }
+}
+
+@Composable
+private fun ErrorBody(message: String, padding: PaddingValues) {
+    Column(Modifier.fillMaxSize().padding(padding).padding(24.dp)) {
+        Text("Couldn't load dashboards", style = MaterialTheme.typography.titleMedium)
+        Text(message)
+    }
+}
+
+@Composable
+private fun ReadyBody(
+    dashboards: List<DashboardSummary>,
+    initialSelection: Set<String>?,
+    onConfirm: (Set<String>) -> Unit,
+    contentPadding: PaddingValues,
+) {
+    val merged = remember(dashboards) { dashboards.withBuiltInDefault() }
+    // First-visit default: opt every dashboard in. Users who want a
+    // subset uncheck rather than re-checking everything, and the
+    // built-in default is always there if their only dashboard list
+    // is HA's hidden one.
+    val seed = remember(merged, initialSelection) {
+        initialSelection ?: merged.mapTo(mutableSetOf()) { it.selectionKey() }
+    }
+    var selected by remember(merged) { mutableStateOf(seed) }
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(contentPadding),
+    ) {
+        LazyColumn(
+            modifier = Modifier.weight(1f).fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(vertical = 8.dp),
+        ) {
+            item(key = "__header__") {
+                Text(
+                    text = "Pick the dashboards you want in this app. " +
+                        "You can change this later from Settings.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
+                )
+            }
+            if (merged.size > 1) {
+                item(key = "__bulk__") {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        TextButton(
+                            onClick = {
+                                selected = merged.mapTo(mutableSetOf()) { it.selectionKey() }
+                            },
+                        ) { Text("Select all") }
+                        TextButton(onClick = { selected = emptySet() }) { Text("Clear") }
+                    }
+                }
+            }
+            items(merged, key = { it.selectionKey() }) { d ->
+                val key = d.selectionKey()
+                val isChecked = key in selected
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp)
+                        .clickable {
+                            selected = if (isChecked) selected - key else selected + key
+                        },
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Checkbox(
+                            checked = isChecked,
+                            onCheckedChange = { checked ->
+                                selected = if (checked) selected + key else selected - key
+                            },
+                        )
+                        Spacer(Modifier.padding(horizontal = 4.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(d.title, style = MaterialTheme.typography.titleMedium)
+                            d.urlPath?.let {
+                                Text(it, style = MaterialTheme.typography.bodySmall)
+                            } ?: Text(
+                                "Home Assistant's default dashboard",
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            horizontalArrangement = Arrangement.End,
+        ) {
+            Button(
+                onClick = { onConfirm(selected) },
+                enabled = selected.isNotEmpty(),
+            ) { Text("Done") }
+        }
+    }
+}

--- a/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
@@ -36,6 +36,7 @@ import ee.schimke.terrazzo.core.wearsync.WearSyncManager
 import ee.schimke.terrazzo.core.widget.WidgetStore
 import ee.schimke.terrazzo.dashboard.DashboardListState
 import ee.schimke.terrazzo.dashboard.DashboardPickerScreen
+import ee.schimke.terrazzo.dashboard.DashboardSelectionScreen
 import ee.schimke.terrazzo.dashboard.DashboardViewScreen
 import ee.schimke.terrazzo.discovery.DiscoveryScreen
 import ee.schimke.terrazzo.ui.TerrazzoTheme
@@ -266,6 +267,72 @@ fun Screen_DashboardView_ThemeStyle(
         session = demoSession(),
         urlPath = null,
         onCardLongPress = {},
+    )
+}
+
+/**
+ * Sample dashboard list for the selection-screen previews: a couple of
+ * named custom dashboards (what HA actually returns from
+ * `lovelace/dashboards/list`). The screen itself stitches in the
+ * built-in "Overview" entry on top of this.
+ */
+private val SELECTION_SAMPLE_DASHBOARDS = listOf(
+    DashboardSummary(urlPath = "lovelace-mobile", title = "Living room"),
+    DashboardSummary(urlPath = "lovelace-garage", title = "Garage"),
+    DashboardSummary(urlPath = "energy", title = "Energy"),
+)
+
+@Preview(
+    name = "dashboard selection · signin",
+    showBackground = false,
+    widthDp = PHONE_WIDTH_DP,
+    heightDp = PHONE_HEIGHT_DP,
+)
+@Composable
+fun Screen_DashboardSelection_Signin() = PhoneHost {
+    DashboardSelectionScreen(
+        state = DashboardListState.Ready(SELECTION_SAMPLE_DASHBOARDS),
+        initialSelection = null,
+        onConfirm = {},
+        onBack = null,
+    )
+}
+
+@Preview(
+    name = "dashboard selection · settings",
+    showBackground = false,
+    widthDp = PHONE_WIDTH_DP,
+    heightDp = PHONE_HEIGHT_DP,
+)
+@Composable
+fun Screen_DashboardSelection_Settings() = PhoneHost {
+    DashboardSelectionScreen(
+        state = DashboardListState.Ready(SELECTION_SAMPLE_DASHBOARDS),
+        initialSelection = setOf(
+            PreferencesStore.DEFAULT_DASHBOARD_SENTINEL,
+            "lovelace-mobile",
+        ),
+        onConfirm = {},
+        onBack = {},
+        title = "Manage dashboards",
+    )
+}
+
+@Preview(
+    name = "dashboard selection · theme",
+    showBackground = false,
+    widthDp = PHONE_WIDTH_DP,
+    heightDp = PHONE_HEIGHT_DP,
+)
+@Composable
+fun Screen_DashboardSelection_ThemeStyle(
+    @PreviewParameter(ThemeStyleProvider::class) style: ThemeStyle,
+) = PhoneHost(style = style) {
+    DashboardSelectionScreen(
+        state = DashboardListState.Ready(SELECTION_SAMPLE_DASHBOARDS),
+        initialSelection = null,
+        onConfirm = {},
+        onBack = null,
     )
 }
 

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/prefs/PreferencesStore.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/prefs/PreferencesStore.kt
@@ -177,6 +177,51 @@ class PreferencesStore(private val context: Context) {
         context.store.edit { it.remove(LAST_VIEWED_KEY) }
     }
 
+    /**
+     * The set of dashboards the user has chosen to surface in the
+     * picker and the top-bar switcher. Drives signin gating: a `null`
+     * value means the user hasn't been through the selection screen
+     * yet for this instance, so the auth flow stops on the selection
+     * step before opening any dashboard. A non-null set — even an
+     * empty one — counts as "user has decided"; the empty case is
+     * handled by the picker UI rather than re-triggering selection.
+     *
+     * Encoding mirrors [lastViewedDashboard]: HA's default dashboard
+     * (`urlPath = null` over the wire) is stored as
+     * [DEFAULT_DASHBOARD_SENTINEL] so it round-trips through a
+     * `Set<String>` cleanly.
+     */
+    val selectedDashboardUrls: Flow<Set<String>?>
+        get() = context.store.data.map { prefs ->
+            if (SELECTED_DASHBOARDS_KEY !in prefs) null
+            else prefs[SELECTED_DASHBOARDS_KEY]!!
+                .split('\n')
+                .filter { it.isNotEmpty() }
+                .toSet()
+        }
+
+    suspend fun selectedDashboardUrlsNow(): Set<String>? = selectedDashboardUrls.first()
+
+    /**
+     * Persist the user's dashboard choices. Each `urlPath` is encoded
+     * as itself; the built-in (default) dashboard uses
+     * [DEFAULT_DASHBOARD_SENTINEL]. The stored string is a `\n`-joined
+     * list; HA url_paths are `[a-z0-9_-]+` so newline can't appear
+     * inside an entry.
+     */
+    suspend fun setSelectedDashboardUrls(urls: Set<String>) {
+        context.store.edit { it[SELECTED_DASHBOARDS_KEY] = urls.joinToString("\n") }
+    }
+
+    /**
+     * Forget the dashboard selection. Called on sign-out / demo toggle
+     * so the next session re-runs selection against whatever
+     * dashboards the new instance exposes.
+     */
+    suspend fun clearSelectedDashboardUrls() {
+        context.store.edit { it.remove(SELECTED_DASHBOARDS_KEY) }
+    }
+
     companion object {
         private val Context.store by preferencesDataStore(name = "terrazzo_prefs")
         private val DEMO_KEY = booleanPreferencesKey("demo_mode")
@@ -187,6 +232,7 @@ class PreferencesStore(private val context: Context) {
         private val COLLAPSED_MODE_KEY = booleanPreferencesKey("collapsed_mode")
         private val LOGS_VIEW_KEY = booleanPreferencesKey("logs_view_enabled")
         private val PERMANENT_WRITE_KEY = booleanPreferencesKey("permanent_write_mode")
+        private val SELECTED_DASHBOARDS_KEY = stringPreferencesKey("selected_dashboards")
 
         /** Stored value for HA's default (unnamed) dashboard. */
         const val DEFAULT_DASHBOARD_SENTINEL: String = "__default__"


### PR DESCRIPTION
## Summary
Implements a multi-select dashboard screen that gates the signin flow and is accessible from Settings. Users can now choose which Home Assistant dashboards (custom and the built-in default) appear in the picker and top-bar switcher.

## Key Changes

- **New `DashboardSelectionScreen` composable** — Multi-select UI for dashboard filtering with:
  - Synthetic "Overview (built-in)" entry for HA's unnamed default dashboard
  - Bulk select/clear buttons when multiple dashboards exist
  - Checkbox-based selection with card UI
  - Configurable title and back affordance for signin vs. settings contexts

- **Signin flow gating** — Selection screen is mandatory on first signin:
  - Blocks dashboard access until user makes a selection
  - Snapshot-based (not reactive) so screen doesn't auto-dismiss on pref write
  - Defaults to all dashboards selected on first visit
  - Clears selection on sign-out/demo toggle so next session re-selects against new instance's dashboards

- **Settings integration** — "Manage dashboards" button in Settings allows re-running selection:
  - Routes back to Settings on confirm
  - Shows back arrow (unlike signin variant)
  - Preserves current selection as initial state

- **Dashboard filtering** — New `rememberSelectedDashboardListState()` applies user's selection:
  - Filters raw dashboard list to only selected entries
  - Stitches in built-in default if selected but not in HA's response
  - Falls back to unfiltered list if selection becomes empty (dashboards removed from HA)
  - Picker and top-bar switcher consume filtered list

- **Preference storage** — `PreferencesStore` additions:
  - `selectedDashboardUrls` Flow for reactive selection state
  - `setSelectedDashboardUrls()` / `clearSelectedDashboardUrls()` for persistence
  - Uses `DEFAULT_DASHBOARD_SENTINEL` sentinel for HA's unnamed dashboard
  - Newline-delimited string encoding for `Set` round-trip

- **Navigation updates** — New `AppScreen.ChooseDashboards` with `SelectionEntry` enum to distinguish signin vs. settings paths:
  - Signin path: no back button, confirms to Dashboards
  - Settings path: back button, confirms to Settings
  - System back handling respects signin-gate (swallows back) vs. settings (routes to Settings)

## Open question

Currently the only "built-in" dashboard exposed is HA's unnamed `Overview` (`url_path = null`). HA also ships fixed-URL built-ins like `energy`, `map`, `logbook`, `history` — none of which are returned by `lovelace/dashboards/list`. If you want those selectable too, the selection list needs a hardcoded seed for them.

## Test plan

- [ ] Sign in to a fresh instance — selection screen appears, can pick a subset, Done lands on the chosen dashboard
- [ ] Picker and top-bar switcher only show the chosen dashboards
- [ ] Settings → "Manage dashboards" reopens the selection screen with the previous selection pre-checked
- [ ] Sign out + sign back in — selection screen re-appears (pref cleared)
- [ ] Demo-mode toggle clears selection
- [ ] Offline relaunch still shows the chosen dashboards from cache