### PR TITLE
feat(wear): hide large slot for low-data card types

### DIFF
--- a/docs/architecture/adaptive-card-layouts.md
+++ b/docs/architecture/adaptive-card-layouts.md
@@ -188,6 +188,133 @@ The ladder is per-card, not a fixed cascade.
 identity. Once the chrome can't fit, the next-most-useful thing is
 which-and-how-many.)
 
+## Data priorities
+
+The degradation ladder above says _what composition_ to draw at each
+canvas size. **Data priorities** answer the orthogonal question: when
+the renderer has every layout but not every field, which fields stay
+on screen?
+
+Every card's data inventory falls into five priority bands. **P1** is
+what makes the card a card — drop it and the user can't tell what
+they're looking at. **P5** is the first thing on the chopping block
+when the canvas tightens.
+
+| P | Field role | What dropping it costs |
+|---|---|---|
+| **P1** | **Identity + key value.** The visual element (icon, dial, pictogram) plus the live state that motivates the glance. | Card becomes indistinguishable from a blank chip — defeats the glance entirely. |
+| **P2** | **Disambiguating name.** Entity-specific label like "Living Room" or "Front door". | Two same-type cards look identical; the user can't tell which lamp is on. |
+| **P3** | **Unit + qualifying state.** The suffix that turns the number into a reading (°C, %, min), or the secondary value that gives the primary one intent — target temp, brightness level, track title. | The number is meaningless without context, or the user sees current state without the intent. |
+| **P4** | **Chrome and history hints.** Range labels (0–100), last-changed timestamps, severity captions, trend arrows, dividers, status sub-text. | Card loses polish but still reads. First to drop on tight surfaces. |
+| **P5** | **Bulk content.** List rows, forecast days, sparkline samples, calendar events, log entries — anything time-series or N-of-many. | Card collapses to its identity row only. List/graph cards stop _being_ list/graph cards; acceptable only if the alternative is overflow. |
+
+The ladder rungs map onto these directly:
+
+- **Full** carries P1 + P2 + P3 + P4 + P5.
+- **Reflowed** keeps P1 + P2 + P3; P4 compresses, P5 trims.
+- **Identity + value** keeps P1 + P3; P2 drops.
+- **Identity** keeps P1; everything else drops.
+- **Value** falls back to the textual P1 + P3 with no visual — last resort.
+
+**Rule of thumb:** drop priorities right-to-left as the canvas
+shrinks. Never drop P1 — if the canvas can't carry the identity,
+switch to a smaller identity (icon-only chip) before stripping it.
+
+### Per-card data inventory
+
+| Card | P1 (identity + key value) | P2 (name) | P3 (unit / secondary) | P4 (chrome) | P5 (bulk) |
+|---|---|---|---|---|---|
+| tile | tinted icon + state | name | unit | last-changed | — |
+| entity | icon + state | name | unit | — | — |
+| button | tinted icon | name | — | — | — |
+| gauge | half-arc + value | name | unit | min/max, severity | — |
+| light | tinted icon + on/off | name | brightness | colour swatch | — |
+| picture-entity | image | name | state badge | overlay scrim | — |
+| sensor | icon + state | name | unit | trend arrow | history sparkline |
+| statistic | icon + value | name | unit, period | trend | — |
+| thermostat | mode icon + current temp | room name | target temp + HVAC action | min/max range | controls strip |
+| humidifier | icon + current humidity | room name | target + action | min/max range | controls strip |
+| alarm-panel | shield icon + state | panel name | — | last-changed | keypad |
+| media-control | art + play/pause | speaker name | track title | artist, progress | seek bar |
+| bambu-spool | filament swatch + name | tray label | remaining % | material code | — |
+| heading | text | — | — | — | — |
+| markdown | text body | title | — | — | — |
+| clock | clock face | — | timezone | — | — |
+| picture | image | name (overlay) | — | — | — |
+| entities | first row | title | — | dividers | additional rows |
+| glance | first cell | title | unit chip | — | additional cells |
+| area | name + dominant entity | area name | summary count | — | per-entity grid |
+| picture-glance | image | title | — | — | entity chip strip |
+| picture-elements | image | — | — | — | positioned overlays |
+| entity-filter | matched count | filter label | — | — | matched rows |
+| vertical / horizontal / grid stacks | first child's P1 | first child's P2 | — | — | additional children |
+| weather-forecast | current icon + temp | location | unit | feels-like, humidity | forecast days |
+| logbook | latest entry | title | — | timestamps | older entries |
+| history-graph | spark + latest value | title | unit | y-axis labels | history series |
+| statistics-graph | bar + latest value | title | unit, period | y-axis labels | stat series |
+| todo-list | counter | title | — | — | item rows |
+| calendar | next event icon | title | event time | venue | additional events |
+| bambu-print-status | progress arc + % | printer name | layer x/y, time remaining | nozzle/bed temps | thumbnail, sub-stages |
+| bambu-print-control | progress + status | printer name | action buttons | — | extended controls |
+| bambu-ams | active tray colour + filament | AMS name | remaining % | tray index | per-tray rows |
+
+### Wear data-layer reality
+
+The wear data-layer proto (`LiveValues` in `WearSyncProto.kt`) carries
+**state + friendly_name + unit + device_class** per entity, and nothing
+else. Mapped onto the priority bands:
+
+- **P1** (state) ✓
+- **P2** (friendly_name) ✓
+- **P3** (unit) ✓ — _but only for cards whose P3 is the unit suffix_,
+  not those whose P3 is a secondary value (target temp, brightness,
+  track title, media position).
+- **P4** ✗ — no last-changed, no trend, no severity, no progress fields.
+- **P5** ✗ — no history, no forecast, no list payloads, no calendar
+  events, no todo items.
+
+That's the only data a Wear slot widget sees today. Two consequences
+follow.
+
+**1. Cards whose identity needs P4 / P5 advertise the small container
+only on Wear.** Their P1 is bound to a payload the data layer can't
+carry, so at the large container they would render as their stripped
+tier with a lot of empty space. The set today is **`heading`,
+`markdown`, `clock`, `weather-forecast`, `logbook`, `history-graph`,
+`statistics-graph`, `todo-list`, `calendar`**. The list lives in
+[`WearCardDataTier`](../../wear/src/main/kotlin/ee/schimke/terrazzo/wear/widget/WearCardDataTier.kt);
+[`WearSlotsController`](../../wear/src/main/kotlin/ee/schimke/terrazzo/wear/sync/WearSlotsController.kt)
+gates the large slot service on this classifier so the system widget
+picker hides large for low-data cards regardless of the phone-side
+`SlotSizePref`. (If the user explicitly chose `LargeOnly`, the
+controller falls back to the small variant rather than hiding the slot
+entirely — they wanted _some_ surfacing.)
+
+**2. Cards whose P5 is a list of additional _entities_ can fill the
+large container** by feeding more entities through the data-layer
+(each carries its own P1 + P2 + P3). `entities`, `glance`, `area`,
+`picture-glance`, `picture-elements`, `entity-filter`, and the
+`*-stack` cards all benefit from a richer fixture at the large size
+and a leaner one at the small size — same composition, different
+payload, demonstrating how the renderer's ladder picks up the
+breakpoint.
+
+The per-card preview convention in
+[`CardSlotWidgetPreviews.kt`](../../wear/src/main/kotlin/ee/schimke/terrazzo/wear/widget/CardSlotWidgetPreviews.kt)
+follows directly from those two rules:
+
+- **Small-only** `@Preview` for the low-data card types listed above.
+- **Separate `*Small` / `*Large` fixtures** (the small one stripped,
+  the large one filled) for list-shaped cards.
+- **A single shared fixture, both `@Preview` sizes**, for single-entity
+  cards (tile, button, gauge, thermostat, etc.) — the data is the
+  same; the renderer's own ladder picks the right tier.
+
+A reviewer scanning the wear preview list should see this shape
+mirrored: one small entry for each low-data card, a small+large pair
+for each multi-entity card, and a matching pair for single-entity
+cards.
+
 ## Implementation guidance
 
 ### Where the variants live

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/sync/WearSlotsController.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/sync/WearSlotsController.kt
@@ -17,6 +17,8 @@ import ee.schimke.terrazzo.wear.widget.Slot3LargeWidgetService
 import ee.schimke.terrazzo.wear.widget.Slot3SmallWidgetService
 import ee.schimke.terrazzo.wear.widget.Slot4LargeWidgetService
 import ee.schimke.terrazzo.wear.widget.Slot4SmallWidgetService
+import ee.schimke.terrazzo.wear.widget.WearCardDataTier
+import ee.schimke.terrazzo.wear.widget.wearCardDataTier
 import ee.schimke.terrazzo.wearsync.proto.SlotSizePref
 import ee.schimke.terrazzo.wearsync.proto.WearWidgetSlots
 import kotlinx.coroutines.CoroutineScope
@@ -35,6 +37,13 @@ import kotlinx.coroutines.launch
  *     decides which subset is enabled. Disabled services don't appear
  *     in the picker, so the user's "Small only" choice on the phone
  *     genuinely hides the large variant.
+ *   - **Low-data card type** ([WearCardDataTier.SmallOnly]) — large
+ *     is force-disabled regardless of `SlotSizePref`. Cards whose
+ *     identity depends on payloads the wear sync proto can't carry
+ *     (forecast, history, calendar events, …) render as an
+ *     under-filled chip at the large container, so the picker hides
+ *     that variant. See `docs/architecture/adaptive-card-layouts.md`
+ *     § "Wear data-layer reality".
  *
  * Below [WEAR_WIDGETS_MIN_SDK] every component stays disabled
  * regardless of phone-side assignment; the alpha library short-circuits
@@ -81,16 +90,38 @@ class WearSlotsController(
 
     private fun applySlots(slots: WearWidgetSlots) {
         val pm = context.packageManager
+        // Per-cardKey type lookup so we can gate the large variant on
+        // the card's data tier. A null lookup (slot assigned but the
+        // pinned card hasn't synced yet) defaults to Both — we don't
+        // know what type it is, so don't pre-emptively hide the large
+        // service; the next slots update will revisit.
+        val typeByKey = readPinnedTypeByKey()
         for (i in 0 until SLOT_COUNT) {
             val slot = slots.slots.firstOrNull { it.slotIndex == i }
             val assigned = slot?.cardKey?.isNotEmpty() == true
             val sizePref = SlotSizePref.fromWire(slot?.size ?: SlotSizePref.Both.wireValue)
-            val enableSmall = assigned && sizePref.advertisesSmall
-            val enableLarge = assigned && sizePref.advertisesLarge
+            val tier = slot?.cardKey?.let { typeByKey[it] }
+                ?.let { wearCardDataTier(it) }
+                ?: WearCardDataTier.Both
+            // If the user asked for LargeOnly but the card type can't
+            // fill the large container, fall back to small rather than
+            // hiding the slot entirely — the user explicitly chose to
+            // surface this slot in the picker.
+            val largeFallback = sizePref.advertisesLarge && !tier.supportsLarge
+            val enableSmall = assigned && (sizePref.advertisesSmall || largeFallback)
+            val enableLarge = assigned && sizePref.advertisesLarge && tier.supportsLarge
             applyComponent(pm, SLOT_SMALL_COMPONENTS[i], enableSmall)
             applyComponent(pm, SLOT_LARGE_COMPONENTS[i], enableLarge)
         }
     }
+
+    private fun readPinnedTypeByKey(): Map<String, String> =
+        runCatching { WearOfflineStore(context).readPinned() }
+            .getOrNull()
+            ?.cards
+            ?.filter { it.cardKey.isNotEmpty() && it.card.type.isNotEmpty() }
+            ?.associate { it.cardKey to it.card.type }
+            ?: emptyMap()
 
     private fun applyComponent(pm: PackageManager, component: Class<*>, enabled: Boolean) {
         val name = ComponentName(context, component)

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/sync/WearSlotsController.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/sync/WearSlotsController.kt
@@ -19,15 +19,21 @@ import ee.schimke.terrazzo.wear.widget.Slot4LargeWidgetService
 import ee.schimke.terrazzo.wear.widget.Slot4SmallWidgetService
 import ee.schimke.terrazzo.wear.widget.WearCardDataTier
 import ee.schimke.terrazzo.wear.widget.wearCardDataTier
+import ee.schimke.terrazzo.wearsync.proto.PinnedCardSet
 import ee.schimke.terrazzo.wearsync.proto.SlotSizePref
 import ee.schimke.terrazzo.wearsync.proto.WearWidgetSlots
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
 /**
- * Watches [WearSyncRepository.slots] and keeps the 10 slot widget
- * services in sync with the user's mobile-side assignments. Each slot
+ * Watches [WearSyncRepository.slots] + [WearSyncRepository.pinned] and
+ * keeps the 10 slot widget services in sync with the user's
+ * mobile-side assignments. Both flows are combined so the tier gate
+ * (see below) recomputes whenever either changes — pinned-card
+ * metadata edits and the `/wear/slots` ↔ `/wear/pinned` arrival race
+ * both need a re-apply, not just slot edits. Each slot
  * has two services (small + large) so the system widget picker can
  * filter by container type:
  *
@@ -74,7 +80,13 @@ class WearSlotsController(
             return
         }
         scope.launch {
-            repo.slots.collectLatest { applySlots(it) }
+            // Combine slots + pinned so tier gating recomputes whenever
+            // either flow emits. Pinned-only changes (same cardKey, new
+            // card.type) and the init race where /wear/slots arrives
+            // before /wear/pinned both need a re-apply, not just slot
+            // edits. `combine` emits on every change of either source.
+            combine(repo.slots, repo.pinned) { slots, pinned -> slots to pinned }
+                .collectLatest { (slots, pinned) -> applySlots(slots, pinned) }
         }
     }
 
@@ -88,14 +100,16 @@ class WearSlotsController(
         }
     }
 
-    private fun applySlots(slots: WearWidgetSlots) {
+    private fun applySlots(slots: WearWidgetSlots, pinned: PinnedCardSet) {
         val pm = context.packageManager
         // Per-cardKey type lookup so we can gate the large variant on
         // the card's data tier. A null lookup (slot assigned but the
         // pinned card hasn't synced yet) defaults to Both — we don't
         // know what type it is, so don't pre-emptively hide the large
-        // service; the next slots update will revisit.
-        val typeByKey = readPinnedTypeByKey()
+        // service; the next pinned emission will revisit.
+        val typeByKey = pinned.cards
+            .filter { it.cardKey.isNotEmpty() && it.card.type.isNotEmpty() }
+            .associate { it.cardKey to it.card.type }
         for (i in 0 until SLOT_COUNT) {
             val slot = slots.slots.firstOrNull { it.slotIndex == i }
             val assigned = slot?.cardKey?.isNotEmpty() == true
@@ -114,14 +128,6 @@ class WearSlotsController(
             applyComponent(pm, SLOT_LARGE_COMPONENTS[i], enableLarge)
         }
     }
-
-    private fun readPinnedTypeByKey(): Map<String, String> =
-        runCatching { WearOfflineStore(context).readPinned() }
-            .getOrNull()
-            ?.cards
-            ?.filter { it.cardKey.isNotEmpty() && it.card.type.isNotEmpty() }
-            ?.associate { it.cardKey to it.card.type }
-            ?: emptyMap()
 
     private fun applyComponent(pm: PackageManager, component: Class<*>, enabled: Boolean) {
         val name = ComponentName(context, component)

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/widget/CardSlotWidgetPreviews.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/widget/CardSlotWidgetPreviews.kt
@@ -7,13 +7,32 @@ import androidx.compose.ui.tooling.preview.Preview
 import ee.schimke.ha.model.HaSnapshot
 
 /**
- * One @Preview pair (small + large slot container) per card template.
- * These run the card through the wear capture path
- * ([SlotWidgetPreviewFixture]) so the rendered preview matches what the
+ * One @Preview entry per card template, grouped by data tier (see
+ * `docs/architecture/adaptive-card-layouts.md` § "Wear data-layer
+ * reality" and [WearCardDataTier]):
+ *
+ *   - **Small-only.** Card has hardly any live data on Wear — either
+ *     because its config is static (`heading`, `markdown`, `clock`) or
+ *     because its identity needs P4 / P5 payloads the wear sync proto
+ *     doesn't carry (`weather-forecast`, `logbook`, `history-graph`,
+ *     `statistics-graph`, `todo-list`, `calendar`). At the large
+ *     container these would render as their stripped tier with a lot
+ *     of empty space, so we don't advertise large.
+ *   - **Single-entity (small + large, shared fixture).** Card carries
+ *     one entity's P1 + P2 + P3 at any size; the renderer's own ladder
+ *     picks the right tier. Same fixture feeds both previews.
+ *   - **Multi-entity (small + large, separate fixtures).** Card's P5
+ *     is a list of additional entities. Small fixture is stripped to
+ *     one entity (no title) so the preview shows the collapsed tier;
+ *     large fixture carries the full multi-entity payload so the
+ *     preview shows the filled tier.
+ *
+ * Each preview runs the card through the wear capture path
+ * ([SlotWidgetPreviewFixture]) so the rendered output matches what the
  * watch will actually draw — including the `ProvideCardChrome(false)`
- * suppression that strips each card's own rounded-clip + divider border,
- * since the Glance Wear container already supplies the slot's shape and
- * brush.
+ * suppression that strips each card's own rounded-clip + divider
+ * border, since the Glance Wear container already supplies the slot's
+ * shape and brush.
  *
  * Card configs are kept minimal — just enough to exercise the rendered
  * layout. Snapshots use the same shape as runtime values flowing over
@@ -23,6 +42,51 @@ import ee.schimke.ha.model.HaSnapshot
  * (app preferred + launcher widget sizes alongside wear), see
  * `ee.schimke.ha.previews.CardPreviewMatrix` in the previews module.
  */
+
+// ── Small-only previews ─────────────────────────────────────────────
+// Low-data card types. See WearCardDataTier.SmallOnly.
+
+@Preview(name = "wear · heading (small)")
+@Composable
+fun WearHeadingSmall() = wearCardPreview(headingFixture(), ContainerType.Small)
+
+@Preview(name = "wear · markdown (small)")
+@Composable
+fun WearMarkdownSmall() = wearCardPreview(markdownFixture(), ContainerType.Small)
+
+@Preview(name = "wear · clock (small)")
+@Composable
+fun WearClockSmall() = wearCardPreview(clockFixture(), ContainerType.Small)
+
+@Preview(name = "wear · weather-forecast (small)")
+@Composable
+fun WearWeatherForecastSmall() =
+    wearCardPreview(weatherForecastFixture(), ContainerType.Small)
+
+@Preview(name = "wear · logbook (small)")
+@Composable
+fun WearLogbookSmall() = wearCardPreview(logbookFixture(), ContainerType.Small)
+
+@Preview(name = "wear · history-graph (small)")
+@Composable
+fun WearHistoryGraphSmall() = wearCardPreview(historyGraphFixture(), ContainerType.Small)
+
+@Preview(name = "wear · statistics-graph (small)")
+@Composable
+fun WearStatisticsGraphSmall() =
+    wearCardPreview(statisticsGraphFixture(), ContainerType.Small)
+
+@Preview(name = "wear · todo-list (small)")
+@Composable
+fun WearTodoListSmall() = wearCardPreview(todoListFixture(), ContainerType.Small)
+
+@Preview(name = "wear · calendar (small)")
+@Composable
+fun WearCalendarSmall() = wearCardPreview(calendarFixture(), ContainerType.Small)
+
+// ── Single-entity previews (shared fixture, small + large) ──────────
+// One entity's worth of P1 + P2 + P3 at any canvas size. The
+// renderer's per-card ladder picks the right tier.
 
 @Preview(name = "wear · tile (small)")
 @Composable
@@ -48,62 +112,6 @@ fun WearEntitySmall() = wearCardPreview(entityFixture(), ContainerType.Small)
 @Composable
 fun WearEntityLarge() = wearCardPreview(entityFixture(), ContainerType.Large)
 
-@Preview(name = "wear · entities (small)")
-@Composable
-fun WearEntitiesSmall() = wearCardPreview(entitiesFixture(), ContainerType.Small)
-
-@Preview(name = "wear · entities (large)")
-@Composable
-fun WearEntitiesLarge() = wearCardPreview(entitiesFixture(), ContainerType.Large)
-
-@Preview(name = "wear · glance (small)")
-@Composable
-fun WearGlanceSmall() = wearCardPreview(glanceFixture(), ContainerType.Small)
-
-@Preview(name = "wear · glance (large)")
-@Composable
-fun WearGlanceLarge() = wearCardPreview(glanceFixture(), ContainerType.Large)
-
-@Preview(name = "wear · heading (small)")
-@Composable
-fun WearHeadingSmall() = wearCardPreview(headingFixture(), ContainerType.Small)
-
-@Preview(name = "wear · heading (large)")
-@Composable
-fun WearHeadingLarge() = wearCardPreview(headingFixture(), ContainerType.Large)
-
-@Preview(name = "wear · markdown (small)")
-@Composable
-fun WearMarkdownSmall() = wearCardPreview(markdownFixture(), ContainerType.Small)
-
-@Preview(name = "wear · markdown (large)")
-@Composable
-fun WearMarkdownLarge() = wearCardPreview(markdownFixture(), ContainerType.Large)
-
-@Preview(name = "wear · vertical-stack (small)")
-@Composable
-fun WearVerticalStackSmall() = wearCardPreview(verticalStackFixture(), ContainerType.Small)
-
-@Preview(name = "wear · vertical-stack (large)")
-@Composable
-fun WearVerticalStackLarge() = wearCardPreview(verticalStackFixture(), ContainerType.Large)
-
-@Preview(name = "wear · horizontal-stack (small)")
-@Composable
-fun WearHorizontalStackSmall() = wearCardPreview(horizontalStackFixture(), ContainerType.Small)
-
-@Preview(name = "wear · horizontal-stack (large)")
-@Composable
-fun WearHorizontalStackLarge() = wearCardPreview(horizontalStackFixture(), ContainerType.Large)
-
-@Preview(name = "wear · grid (small)")
-@Composable
-fun WearGridSmall() = wearCardPreview(gridFixture(), ContainerType.Small)
-
-@Preview(name = "wear · grid (large)")
-@Composable
-fun WearGridLarge() = wearCardPreview(gridFixture(), ContainerType.Large)
-
 @Preview(name = "wear · gauge (small)")
 @Composable
 fun WearGaugeSmall() = wearCardPreview(gaugeFixture(), ContainerType.Small)
@@ -112,29 +120,47 @@ fun WearGaugeSmall() = wearCardPreview(gaugeFixture(), ContainerType.Small)
 @Composable
 fun WearGaugeLarge() = wearCardPreview(gaugeFixture(), ContainerType.Large)
 
+@Preview(name = "wear · light (small)")
+@Composable
+fun WearLightSmall() = wearCardPreview(lightFixture(), ContainerType.Small)
+
+@Preview(name = "wear · light (large)")
+@Composable
+fun WearLightLarge() = wearCardPreview(lightFixture(), ContainerType.Large)
+
 @Preview(name = "wear · picture-entity (small)")
 @Composable
-fun WearPictureEntitySmall() = wearCardPreview(pictureEntityFixture(), ContainerType.Small)
+fun WearPictureEntitySmall() =
+    wearCardPreview(pictureEntityFixture(), ContainerType.Small)
 
 @Preview(name = "wear · picture-entity (large)")
 @Composable
-fun WearPictureEntityLarge() = wearCardPreview(pictureEntityFixture(), ContainerType.Large)
+fun WearPictureEntityLarge() =
+    wearCardPreview(pictureEntityFixture(), ContainerType.Large)
 
-@Preview(name = "wear · weather-forecast (small)")
+@Preview(name = "wear · picture (small)")
 @Composable
-fun WearWeatherForecastSmall() = wearCardPreview(weatherForecastFixture(), ContainerType.Small)
+fun WearPictureSmall() = wearCardPreview(pictureFixture(), ContainerType.Small)
 
-@Preview(name = "wear · weather-forecast (large)")
+@Preview(name = "wear · picture (large)")
 @Composable
-fun WearWeatherForecastLarge() = wearCardPreview(weatherForecastFixture(), ContainerType.Large)
+fun WearPictureLarge() = wearCardPreview(pictureFixture(), ContainerType.Large)
 
-@Preview(name = "wear · logbook (small)")
+@Preview(name = "wear · sensor (small)")
 @Composable
-fun WearLogbookSmall() = wearCardPreview(logbookFixture(), ContainerType.Small)
+fun WearSensorSmall() = wearCardPreview(sensorFixture(), ContainerType.Small)
 
-@Preview(name = "wear · logbook (large)")
+@Preview(name = "wear · sensor (large)")
 @Composable
-fun WearLogbookLarge() = wearCardPreview(logbookFixture(), ContainerType.Large)
+fun WearSensorLarge() = wearCardPreview(sensorFixture(), ContainerType.Large)
+
+@Preview(name = "wear · statistic (small)")
+@Composable
+fun WearStatisticSmall() = wearCardPreview(statisticFixture(), ContainerType.Small)
+
+@Preview(name = "wear · statistic (large)")
+@Composable
+fun WearStatisticLarge() = wearCardPreview(statisticFixture(), ContainerType.Large)
 
 @Preview(name = "wear · thermostat (small)")
 @Composable
@@ -152,54 +178,6 @@ fun WearHumidifierSmall() = wearCardPreview(humidifierFixture(), ContainerType.S
 @Composable
 fun WearHumidifierLarge() = wearCardPreview(humidifierFixture(), ContainerType.Large)
 
-@Preview(name = "wear · light (small)")
-@Composable
-fun WearLightSmall() = wearCardPreview(lightFixture(), ContainerType.Small)
-
-@Preview(name = "wear · light (large)")
-@Composable
-fun WearLightLarge() = wearCardPreview(lightFixture(), ContainerType.Large)
-
-@Preview(name = "wear · clock (small)")
-@Composable
-fun WearClockSmall() = wearCardPreview(clockFixture(), ContainerType.Small)
-
-@Preview(name = "wear · clock (large)")
-@Composable
-fun WearClockLarge() = wearCardPreview(clockFixture(), ContainerType.Large)
-
-@Preview(name = "wear · history-graph (small)")
-@Composable
-fun WearHistoryGraphSmall() = wearCardPreview(historyGraphFixture(), ContainerType.Small)
-
-@Preview(name = "wear · history-graph (large)")
-@Composable
-fun WearHistoryGraphLarge() = wearCardPreview(historyGraphFixture(), ContainerType.Large)
-
-@Preview(name = "wear · statistics-graph (small)")
-@Composable
-fun WearStatisticsGraphSmall() = wearCardPreview(statisticsGraphFixture(), ContainerType.Small)
-
-@Preview(name = "wear · statistics-graph (large)")
-@Composable
-fun WearStatisticsGraphLarge() = wearCardPreview(statisticsGraphFixture(), ContainerType.Large)
-
-@Preview(name = "wear · statistic (small)")
-@Composable
-fun WearStatisticSmall() = wearCardPreview(statisticFixture(), ContainerType.Small)
-
-@Preview(name = "wear · statistic (large)")
-@Composable
-fun WearStatisticLarge() = wearCardPreview(statisticFixture(), ContainerType.Large)
-
-@Preview(name = "wear · sensor (small)")
-@Composable
-fun WearSensorSmall() = wearCardPreview(sensorFixture(), ContainerType.Small)
-
-@Preview(name = "wear · sensor (large)")
-@Composable
-fun WearSensorLarge() = wearCardPreview(sensorFixture(), ContainerType.Large)
-
 @Preview(name = "wear · alarm-panel (small)")
 @Composable
 fun WearAlarmPanelSmall() = wearCardPreview(alarmPanelFixture(), ContainerType.Small)
@@ -210,91 +188,13 @@ fun WearAlarmPanelLarge() = wearCardPreview(alarmPanelFixture(), ContainerType.L
 
 @Preview(name = "wear · media-control (small)")
 @Composable
-fun WearMediaControlSmall() = wearCardPreview(mediaControlFixture(), ContainerType.Small)
+fun WearMediaControlSmall() =
+    wearCardPreview(mediaControlFixture(), ContainerType.Small)
 
 @Preview(name = "wear · media-control (large)")
 @Composable
-fun WearMediaControlLarge() = wearCardPreview(mediaControlFixture(), ContainerType.Large)
-
-@Preview(name = "wear · todo-list (small)")
-@Composable
-fun WearTodoListSmall() = wearCardPreview(todoListFixture(), ContainerType.Small)
-
-@Preview(name = "wear · todo-list (large)")
-@Composable
-fun WearTodoListLarge() = wearCardPreview(todoListFixture(), ContainerType.Large)
-
-@Preview(name = "wear · calendar (small)")
-@Composable
-fun WearCalendarSmall() = wearCardPreview(calendarFixture(), ContainerType.Small)
-
-@Preview(name = "wear · calendar (large)")
-@Composable
-fun WearCalendarLarge() = wearCardPreview(calendarFixture(), ContainerType.Large)
-
-@Preview(name = "wear · area (small)")
-@Composable
-fun WearAreaSmall() = wearCardPreview(areaFixture(), ContainerType.Small)
-
-@Preview(name = "wear · area (large)")
-@Composable
-fun WearAreaLarge() = wearCardPreview(areaFixture(), ContainerType.Large)
-
-@Preview(name = "wear · picture (small)")
-@Composable
-fun WearPictureSmall() = wearCardPreview(pictureFixture(), ContainerType.Small)
-
-@Preview(name = "wear · picture (large)")
-@Composable
-fun WearPictureLarge() = wearCardPreview(pictureFixture(), ContainerType.Large)
-
-@Preview(name = "wear · picture-glance (small)")
-@Composable
-fun WearPictureGlanceSmall() = wearCardPreview(pictureGlanceFixture(), ContainerType.Small)
-
-@Preview(name = "wear · picture-glance (large)")
-@Composable
-fun WearPictureGlanceLarge() = wearCardPreview(pictureGlanceFixture(), ContainerType.Large)
-
-@Preview(name = "wear · picture-elements (small)")
-@Composable
-fun WearPictureElementsSmall() = wearCardPreview(pictureElementsFixture(), ContainerType.Small)
-
-@Preview(name = "wear · picture-elements (large)")
-@Composable
-fun WearPictureElementsLarge() = wearCardPreview(pictureElementsFixture(), ContainerType.Large)
-
-@Preview(name = "wear · entity-filter (small)")
-@Composable
-fun WearEntityFilterSmall() = wearCardPreview(entityFilterFixture(), ContainerType.Small)
-
-@Preview(name = "wear · entity-filter (large)")
-@Composable
-fun WearEntityFilterLarge() = wearCardPreview(entityFilterFixture(), ContainerType.Large)
-
-@Preview(name = "wear · bambu print-status (small)")
-@Composable
-fun WearBambuPrintStatusSmall() = wearCardPreview(bambuPrintStatusFixture(), ContainerType.Small)
-
-@Preview(name = "wear · bambu print-status (large)")
-@Composable
-fun WearBambuPrintStatusLarge() = wearCardPreview(bambuPrintStatusFixture(), ContainerType.Large)
-
-@Preview(name = "wear · bambu print-control (small)")
-@Composable
-fun WearBambuPrintControlSmall() = wearCardPreview(bambuPrintControlFixture(), ContainerType.Small)
-
-@Preview(name = "wear · bambu print-control (large)")
-@Composable
-fun WearBambuPrintControlLarge() = wearCardPreview(bambuPrintControlFixture(), ContainerType.Large)
-
-@Preview(name = "wear · bambu ams (small)")
-@Composable
-fun WearBambuAmsSmall() = wearCardPreview(bambuAmsFixture(), ContainerType.Small)
-
-@Preview(name = "wear · bambu ams (large)")
-@Composable
-fun WearBambuAmsLarge() = wearCardPreview(bambuAmsFixture(), ContainerType.Large)
+fun WearMediaControlLarge() =
+    wearCardPreview(mediaControlFixture(), ContainerType.Large)
 
 @Preview(name = "wear · bambu spool (small)")
 @Composable
@@ -312,6 +212,124 @@ fun WearUnsupportedSmall() = wearCardPreview(unsupportedFixture(), ContainerType
 @Composable
 fun WearUnsupportedLarge() = wearCardPreview(unsupportedFixture(), ContainerType.Large)
 
+// ── Multi-entity previews (stripped small + filled large) ───────────
+// P5 is a list of additional entities — the small fixture is stripped
+// to one row / cell so the preview shows the collapsed tier; the
+// large fixture carries the full multi-entity payload so the preview
+// shows the filled tier.
+
+@Preview(name = "wear · entities (small)")
+@Composable
+fun WearEntitiesSmall() =
+    wearCardPreview(entitiesSmallFixture(), ContainerType.Small)
+
+@Preview(name = "wear · entities (large)")
+@Composable
+fun WearEntitiesLarge() =
+    wearCardPreview(entitiesLargeFixture(), ContainerType.Large)
+
+@Preview(name = "wear · glance (small)")
+@Composable
+fun WearGlanceSmall() = wearCardPreview(glanceSmallFixture(), ContainerType.Small)
+
+@Preview(name = "wear · glance (large)")
+@Composable
+fun WearGlanceLarge() = wearCardPreview(glanceLargeFixture(), ContainerType.Large)
+
+@Preview(name = "wear · area (small)")
+@Composable
+fun WearAreaSmall() = wearCardPreview(areaSmallFixture(), ContainerType.Small)
+
+@Preview(name = "wear · area (large)")
+@Composable
+fun WearAreaLarge() = wearCardPreview(areaLargeFixture(), ContainerType.Large)
+
+@Preview(name = "wear · picture-glance (small)")
+@Composable
+fun WearPictureGlanceSmall() =
+    wearCardPreview(pictureGlanceSmallFixture(), ContainerType.Small)
+
+@Preview(name = "wear · picture-glance (large)")
+@Composable
+fun WearPictureGlanceLarge() =
+    wearCardPreview(pictureGlanceLargeFixture(), ContainerType.Large)
+
+@Preview(name = "wear · picture-elements (small)")
+@Composable
+fun WearPictureElementsSmall() =
+    wearCardPreview(pictureElementsSmallFixture(), ContainerType.Small)
+
+@Preview(name = "wear · picture-elements (large)")
+@Composable
+fun WearPictureElementsLarge() =
+    wearCardPreview(pictureElementsLargeFixture(), ContainerType.Large)
+
+@Preview(name = "wear · entity-filter (small)")
+@Composable
+fun WearEntityFilterSmall() =
+    wearCardPreview(entityFilterSmallFixture(), ContainerType.Small)
+
+@Preview(name = "wear · entity-filter (large)")
+@Composable
+fun WearEntityFilterLarge() =
+    wearCardPreview(entityFilterLargeFixture(), ContainerType.Large)
+
+@Preview(name = "wear · vertical-stack (small)")
+@Composable
+fun WearVerticalStackSmall() =
+    wearCardPreview(verticalStackSmallFixture(), ContainerType.Small)
+
+@Preview(name = "wear · vertical-stack (large)")
+@Composable
+fun WearVerticalStackLarge() =
+    wearCardPreview(verticalStackLargeFixture(), ContainerType.Large)
+
+@Preview(name = "wear · horizontal-stack (small)")
+@Composable
+fun WearHorizontalStackSmall() =
+    wearCardPreview(horizontalStackSmallFixture(), ContainerType.Small)
+
+@Preview(name = "wear · horizontal-stack (large)")
+@Composable
+fun WearHorizontalStackLarge() =
+    wearCardPreview(horizontalStackLargeFixture(), ContainerType.Large)
+
+@Preview(name = "wear · grid (small)")
+@Composable
+fun WearGridSmall() = wearCardPreview(gridSmallFixture(), ContainerType.Small)
+
+@Preview(name = "wear · grid (large)")
+@Composable
+fun WearGridLarge() = wearCardPreview(gridLargeFixture(), ContainerType.Large)
+
+@Preview(name = "wear · bambu print-status (small)")
+@Composable
+fun WearBambuPrintStatusSmall() =
+    wearCardPreview(bambuPrintStatusFixture(), ContainerType.Small)
+
+@Preview(name = "wear · bambu print-status (large)")
+@Composable
+fun WearBambuPrintStatusLarge() =
+    wearCardPreview(bambuPrintStatusFixture(), ContainerType.Large)
+
+@Preview(name = "wear · bambu print-control (small)")
+@Composable
+fun WearBambuPrintControlSmall() =
+    wearCardPreview(bambuPrintControlFixture(), ContainerType.Small)
+
+@Preview(name = "wear · bambu print-control (large)")
+@Composable
+fun WearBambuPrintControlLarge() =
+    wearCardPreview(bambuPrintControlFixture(), ContainerType.Large)
+
+@Preview(name = "wear · bambu ams (small)")
+@Composable
+fun WearBambuAmsSmall() = wearCardPreview(bambuAmsSmallFixture(), ContainerType.Small)
+
+@Preview(name = "wear · bambu ams (large)")
+@Composable
+fun WearBambuAmsLarge() = wearCardPreview(bambuAmsLargeFixture(), ContainerType.Large)
+
 // ── helpers ──────────────────────────────────────────────────────────
 
 private data class CardFixture(val json: String, val snapshot: HaSnapshot)
@@ -325,119 +343,27 @@ private fun wearCardPreview(fixture: CardFixture, container: ContainerType) {
     )
 }
 
-// ── fixtures ────────────────────────────────────────────────────────
+// ── single-entity fixtures ──────────────────────────────────────────
 //
-// Each fixture pairs a card-config JSON snippet with the matching entity
-// snapshot so the preview can resolve live bindings. Mirrors the canonical
-// shapes in ee.schimke.ha.previews.CardPreviews / Fixtures — the wear
-// previews intentionally bake their own copies to keep the wear module
-// free of a previews-module dependency.
+// Each fixture pairs a card-config JSON snippet with the matching
+// entity snapshot so the preview can resolve live bindings. Mirrors
+// the canonical shapes in ee.schimke.ha.previews.CardPreviews /
+// Fixtures — the wear previews intentionally bake their own copies to
+// keep the wear module free of a previews-module dependency.
 
 private fun tileFixture() = CardFixture(
     json = """{"type":"tile","entity":"sensor.living_room","name":"Living Room"}""",
-    snapshot = snapshotOf(
-        entityState(
-            id = "sensor.living_room",
-            state = "21.5",
-            friendlyName = "Living Room",
-            unit = "°C",
-            deviceClass = "temperature",
-        ),
-    ),
+    snapshot = snapshotOf(livingRoomTempState()),
 )
 
 private fun buttonFixture() = CardFixture(
     json = """{"type":"button","entity":"light.kitchen","name":"Kitchen","show_name":true}""",
-    snapshot = snapshotOf(
-        entityState(id = "light.kitchen", state = "on", friendlyName = "Kitchen"),
-    ),
+    snapshot = snapshotOf(kitchenLightState()),
 )
 
 private fun entityFixture() = CardFixture(
     json = """{"type":"entity","entity":"sensor.living_room"}""",
-    snapshot = snapshotOf(
-        entityState(
-            id = "sensor.living_room",
-            state = "21.5",
-            friendlyName = "Living Room",
-            unit = "°C",
-            deviceClass = "temperature",
-        ),
-    ),
-)
-
-private fun entitiesFixture() = CardFixture(
-    json = """{"type":"entities","title":"Living Room","entities":["sensor.living_room","light.kitchen"]}""",
-    snapshot = snapshotOf(
-        entityState(
-            id = "sensor.living_room",
-            state = "21.5",
-            friendlyName = "Living Room",
-            unit = "°C",
-            deviceClass = "temperature",
-        ),
-        entityState(id = "light.kitchen", state = "on", friendlyName = "Kitchen"),
-    ),
-)
-
-private fun glanceFixture() = CardFixture(
-    json = """{"type":"glance","title":"Overview","entities":["sensor.living_room","light.kitchen","lock.front_door"]}""",
-    snapshot = snapshotOf(
-        entityState(
-            id = "sensor.living_room",
-            state = "21.5",
-            friendlyName = "Living Room",
-            unit = "°C",
-            deviceClass = "temperature",
-        ),
-        entityState(id = "light.kitchen", state = "on", friendlyName = "Kitchen"),
-        entityState(id = "lock.front_door", state = "locked", friendlyName = "Front door"),
-    ),
-)
-
-private fun headingFixture() = CardFixture(
-    json = """{"type":"heading","heading":"Downstairs"}""",
-    snapshot = HaSnapshot(),
-)
-
-private fun markdownFixture() = CardFixture(
-    json = """{"type":"markdown","title":"Notes","content":"Welcome home."}""",
-    snapshot = HaSnapshot(),
-)
-
-private fun verticalStackFixture() = CardFixture(
-    json = """{"type":"vertical-stack","cards":[{"type":"tile","entity":"sensor.living_room"},{"type":"tile","entity":"light.kitchen"}]}""",
-    snapshot = snapshotOf(
-        entityState(
-            id = "sensor.living_room",
-            state = "21.5",
-            friendlyName = "Living Room",
-            unit = "°C",
-            deviceClass = "temperature",
-        ),
-        entityState(id = "light.kitchen", state = "on", friendlyName = "Kitchen"),
-    ),
-)
-
-private fun horizontalStackFixture() = CardFixture(
-    json = """{"type":"horizontal-stack","cards":[{"type":"button","entity":"light.kitchen","name":"Kitchen"},{"type":"button","entity":"sensor.living_room","name":"Temp"}]}""",
-    snapshot = snapshotOf(
-        entityState(id = "light.kitchen", state = "on", friendlyName = "Kitchen"),
-        entityState(
-            id = "sensor.living_room",
-            state = "21.5",
-            friendlyName = "Living Room",
-            unit = "°C",
-            deviceClass = "temperature",
-        ),
-    ),
-)
-
-private fun gridFixture() = CardFixture(
-    json = """{"type":"grid","cards":[{"type":"button","entity":"light.kitchen","name":"Kitchen"},{"type":"button","entity":"light.kitchen","name":"Office"}]}""",
-    snapshot = snapshotOf(
-        entityState(id = "light.kitchen", state = "on", friendlyName = "Kitchen"),
-    ),
+    snapshot = snapshotOf(livingRoomTempState()),
 )
 
 private fun gaugeFixture() = CardFixture(
@@ -453,11 +379,100 @@ private fun gaugeFixture() = CardFixture(
     ),
 )
 
+private fun lightFixture() = CardFixture(
+    json = """{"type":"light","entity":"light.kitchen"}""",
+    snapshot = snapshotOf(kitchenLightState()),
+)
+
 private fun pictureEntityFixture() = CardFixture(
     json = """{"type":"picture-entity","entity":"camera.driveway","name":"Driveway","show_name":true}""",
     snapshot = snapshotOf(
         entityState(id = "camera.driveway", state = "idle", friendlyName = "Driveway"),
     ),
+)
+
+private fun pictureFixture() = CardFixture(
+    json = """{"type":"picture","image":"/local/floorplan.png","name":"Floor plan"}""",
+    snapshot = HaSnapshot(),
+)
+
+private fun sensorFixture() = CardFixture(
+    json = """{"type":"sensor","entity":"sensor.outside_temp","hours_to_show":24}""",
+    snapshot = snapshotOf(outsideTempState()),
+)
+
+private fun statisticFixture() = CardFixture(
+    json = """{"type":"statistic","entity":"sensor.house_power","stat_type":"mean","period":"day"}""",
+    snapshot = snapshotOf(housePowerState()),
+)
+
+private fun thermostatFixture() = CardFixture(
+    json = """{"type":"thermostat","entity":"climate.living_room"}""",
+    snapshot = snapshotOf(
+        entityState(id = "climate.living_room", state = "heat", friendlyName = "Living Room"),
+    ),
+)
+
+private fun humidifierFixture() = CardFixture(
+    json = """{"type":"humidifier","entity":"humidifier.bedroom"}""",
+    snapshot = snapshotOf(
+        entityState(id = "humidifier.bedroom", state = "on", friendlyName = "Bedroom"),
+    ),
+)
+
+private fun alarmPanelFixture() = CardFixture(
+    json = """{"type":"alarm-panel","entity":"alarm_control_panel.house","states":["arm_away","arm_home"]}""",
+    snapshot = snapshotOf(
+        entityState(
+            id = "alarm_control_panel.house",
+            state = "disarmed",
+            friendlyName = "House",
+        ),
+    ),
+)
+
+private fun mediaControlFixture() = CardFixture(
+    json = """{"type":"media-control","entity":"media_player.office_speaker"}""",
+    snapshot = snapshotOf(
+        entityState(
+            id = "media_player.office_speaker",
+            state = "playing",
+            friendlyName = "Office speaker",
+        ),
+    ),
+)
+
+private fun bambuSpoolFixture() = CardFixture(
+    json = """{"type":"custom:ha-bambulab-spool-card","spool":"<spool-id-placeholder>"}""",
+    snapshot = HaSnapshot(),
+)
+
+private fun unsupportedFixture() = CardFixture(
+    json = """{"type":"iframe","url":"https://example.com"}""",
+    snapshot = HaSnapshot(),
+)
+
+// ── small-only fixtures ─────────────────────────────────────────────
+//
+// These cards have hardly any live data on Wear. Their fixtures
+// reflect what the watch will actually see — no forecast arrays, no
+// list items, no event payloads — so the rendered preview matches
+// the production stripped tier rather than the full HA-dashboard
+// rendering.
+
+private fun headingFixture() = CardFixture(
+    json = """{"type":"heading","heading":"Downstairs"}""",
+    snapshot = HaSnapshot(),
+)
+
+private fun markdownFixture() = CardFixture(
+    json = """{"type":"markdown","title":"Notes","content":"Welcome home."}""",
+    snapshot = HaSnapshot(),
+)
+
+private fun clockFixture() = CardFixture(
+    json = """{"type":"clock","clock_size":"medium","time_format":"24"}""",
+    snapshot = HaSnapshot(),
 )
 
 private fun weatherForecastFixture() = CardFixture(
@@ -478,96 +493,14 @@ private fun logbookFixture() = CardFixture(
     ),
 )
 
-private fun thermostatFixture() = CardFixture(
-    json = """{"type":"thermostat","entity":"climate.living_room"}""",
-    snapshot = snapshotOf(
-        entityState(id = "climate.living_room", state = "heat", friendlyName = "Living Room"),
-    ),
-)
-
-private fun humidifierFixture() = CardFixture(
-    json = """{"type":"humidifier","entity":"humidifier.bedroom"}""",
-    snapshot = snapshotOf(
-        entityState(id = "humidifier.bedroom", state = "on", friendlyName = "Bedroom"),
-    ),
-)
-
-private fun lightFixture() = CardFixture(
-    json = """{"type":"light","entity":"light.kitchen"}""",
-    snapshot = snapshotOf(
-        entityState(id = "light.kitchen", state = "on", friendlyName = "Kitchen"),
-    ),
-)
-
-private fun clockFixture() = CardFixture(
-    json = """{"type":"clock","clock_size":"medium","time_format":"24"}""",
-    snapshot = HaSnapshot(),
-)
-
 private fun historyGraphFixture() = CardFixture(
     json = """{"type":"history-graph","title":"Temperature","hours_to_show":24,"entities":["sensor.outside_temp"]}""",
-    snapshot = snapshotOf(
-        entityState(
-            id = "sensor.outside_temp",
-            state = "8.2",
-            friendlyName = "Outside",
-            unit = "°C",
-            deviceClass = "temperature",
-        ),
-    ),
+    snapshot = snapshotOf(outsideTempState()),
 )
 
 private fun statisticsGraphFixture() = CardFixture(
     json = """{"type":"statistics-graph","title":"Power","period":"hour","stat_types":["mean"],"entities":["sensor.house_power"]}""",
-    snapshot = snapshotOf(
-        entityState(
-            id = "sensor.house_power",
-            state = "412",
-            friendlyName = "House power",
-            unit = "W",
-            deviceClass = "power",
-        ),
-    ),
-)
-
-private fun statisticFixture() = CardFixture(
-    json = """{"type":"statistic","entity":"sensor.house_power","stat_type":"mean","period":"day"}""",
-    snapshot = snapshotOf(
-        entityState(
-            id = "sensor.house_power",
-            state = "412",
-            friendlyName = "House power",
-            unit = "W",
-            deviceClass = "power",
-        ),
-    ),
-)
-
-private fun sensorFixture() = CardFixture(
-    json = """{"type":"sensor","entity":"sensor.outside_temp","hours_to_show":24}""",
-    snapshot = snapshotOf(
-        entityState(
-            id = "sensor.outside_temp",
-            state = "8.2",
-            friendlyName = "Outside",
-            unit = "°C",
-            deviceClass = "temperature",
-        ),
-    ),
-)
-
-private fun alarmPanelFixture() = CardFixture(
-    json = """{"type":"alarm-panel","entity":"alarm_control_panel.house","states":["arm_away","arm_home"]}""",
-    snapshot = snapshotOf(
-        entityState(id = "alarm_control_panel.house", state = "disarmed", friendlyName = "House"),
-    ),
-)
-
-private fun mediaControlFixture() = CardFixture(
-    json = """{"type":"media-control","entity":"media_player.office_speaker"}""",
-    snapshot = snapshotOf(
-        entityState(id = "media_player.office_speaker", state = "playing", friendlyName = "Office speaker"),
-    ),
+    snapshot = snapshotOf(housePowerState()),
 )
 
 private fun todoListFixture() = CardFixture(
@@ -584,43 +517,140 @@ private fun calendarFixture() = CardFixture(
     ),
 )
 
-private fun areaFixture() = CardFixture(
-    json = """{"type":"area","name":"Living room","entities":["sensor.living_room","light.kitchen"]}""",
+// ── multi-entity fixtures ───────────────────────────────────────────
+//
+// Paired Small / Large versions. The Small fixture is deliberately
+// stripped (one entity, no title) so the preview shows the collapsed
+// row; the Large fixture carries the full multi-entity payload so the
+// preview shows the filled tier.
+
+private fun entitiesSmallFixture() = CardFixture(
+    json = """{"type":"entities","entities":["sensor.living_room"]}""",
+    snapshot = snapshotOf(livingRoomTempState()),
+)
+
+private fun entitiesLargeFixture() = CardFixture(
+    json = """{"type":"entities","title":"Living Room","entities":["sensor.living_room","light.kitchen","switch.coffee_maker","lock.front_door"]}""",
     snapshot = snapshotOf(
-        entityState(
-            id = "sensor.living_room",
-            state = "21.5",
-            friendlyName = "Living Room",
-            unit = "°C",
-            deviceClass = "temperature",
-        ),
-        entityState(id = "light.kitchen", state = "on", friendlyName = "Kitchen"),
+        livingRoomTempState(),
+        kitchenLightState(),
+        entityState(id = "switch.coffee_maker", state = "on", friendlyName = "Coffee maker"),
+        entityState(id = "lock.front_door", state = "locked", friendlyName = "Front door"),
     ),
 )
 
-private fun pictureFixture() = CardFixture(
-    json = """{"type":"picture","image":"/local/floorplan.png","name":"Floor plan"}""",
-    snapshot = HaSnapshot(),
+private fun glanceSmallFixture() = CardFixture(
+    json = """{"type":"glance","entities":["light.kitchen"]}""",
+    snapshot = snapshotOf(kitchenLightState()),
 )
 
-private fun pictureGlanceFixture() = CardFixture(
-    json = """{"type":"picture-glance","title":"Living room","image":"/local/lr.png","entities":["light.kitchen"]}""",
+private fun glanceLargeFixture() = CardFixture(
+    json = """{"type":"glance","title":"Overview","entities":["sensor.living_room","light.kitchen","lock.front_door","switch.coffee_maker"]}""",
     snapshot = snapshotOf(
-        entityState(id = "light.kitchen", state = "on", friendlyName = "Kitchen"),
+        livingRoomTempState(),
+        kitchenLightState(),
+        entityState(id = "lock.front_door", state = "locked", friendlyName = "Front door"),
+        entityState(id = "switch.coffee_maker", state = "on", friendlyName = "Coffee maker"),
     ),
 )
 
-private fun pictureElementsFixture() = CardFixture(
-    json = """{"type":"picture-elements","image":"/local/floorplan.png","elements":[{"type":"state-icon","entity":"light.kitchen","style":{"left":"30%","top":"40%"}}]}""",
+private fun areaSmallFixture() = CardFixture(
+    json = """{"type":"area","name":"Living room","entities":["sensor.living_room"]}""",
+    snapshot = snapshotOf(livingRoomTempState()),
+)
+
+private fun areaLargeFixture() = CardFixture(
+    json = """{"type":"area","name":"Living room","entities":["sensor.living_room","light.kitchen","switch.coffee_maker","lock.front_door"]}""",
     snapshot = snapshotOf(
-        entityState(id = "light.kitchen", state = "on", friendlyName = "Kitchen"),
+        livingRoomTempState(),
+        kitchenLightState(),
+        entityState(id = "switch.coffee_maker", state = "on", friendlyName = "Coffee maker"),
+        entityState(id = "lock.front_door", state = "locked", friendlyName = "Front door"),
     ),
 )
 
-private fun entityFilterFixture() = CardFixture(
-    json = """{"type":"entity-filter","state_filter":["on"],"entities":["light.kitchen"],"card":{"type":"glance","title":"On now"}}""",
+private fun pictureGlanceSmallFixture() = CardFixture(
+    json = """{"type":"picture-glance","image":"/local/lr.png","entities":["light.kitchen"]}""",
+    snapshot = snapshotOf(kitchenLightState()),
+)
+
+private fun pictureGlanceLargeFixture() = CardFixture(
+    json = """{"type":"picture-glance","title":"Living room","image":"/local/lr.png","entities":["light.kitchen","switch.coffee_maker","lock.front_door"]}""",
     snapshot = snapshotOf(
-        entityState(id = "light.kitchen", state = "on", friendlyName = "Kitchen"),
+        kitchenLightState(),
+        entityState(id = "switch.coffee_maker", state = "on", friendlyName = "Coffee maker"),
+        entityState(id = "lock.front_door", state = "locked", friendlyName = "Front door"),
+    ),
+)
+
+private fun pictureElementsSmallFixture() = CardFixture(
+    json = """{"type":"picture-elements","image":"/local/floorplan.png","elements":[{"type":"state-icon","entity":"light.kitchen","style":{"left":"50%","top":"50%"}}]}""",
+    snapshot = snapshotOf(kitchenLightState()),
+)
+
+private fun pictureElementsLargeFixture() = CardFixture(
+    json = """{"type":"picture-elements","image":"/local/floorplan.png","elements":[{"type":"state-icon","entity":"light.kitchen","style":{"left":"25%","top":"40%"}},{"type":"state-icon","entity":"lock.front_door","style":{"left":"60%","top":"30%"}},{"type":"state-icon","entity":"switch.coffee_maker","style":{"left":"75%","top":"70%"}}]}""",
+    snapshot = snapshotOf(
+        kitchenLightState(),
+        entityState(id = "lock.front_door", state = "locked", friendlyName = "Front door"),
+        entityState(id = "switch.coffee_maker", state = "on", friendlyName = "Coffee maker"),
+    ),
+)
+
+private fun entityFilterSmallFixture() = CardFixture(
+    json = """{"type":"entity-filter","state_filter":["on"],"entities":["light.kitchen"]}""",
+    snapshot = snapshotOf(kitchenLightState()),
+)
+
+private fun entityFilterLargeFixture() = CardFixture(
+    json = """{"type":"entity-filter","state_filter":["on"],"entities":["light.kitchen","switch.coffee_maker","switch.office_lamp"],"card":{"type":"glance","title":"On now"}}""",
+    snapshot = snapshotOf(
+        kitchenLightState(),
+        entityState(id = "switch.coffee_maker", state = "on", friendlyName = "Coffee maker"),
+        entityState(id = "switch.office_lamp", state = "on", friendlyName = "Office lamp"),
+    ),
+)
+
+private fun verticalStackSmallFixture() = CardFixture(
+    json = """{"type":"vertical-stack","cards":[{"type":"tile","entity":"sensor.living_room"}]}""",
+    snapshot = snapshotOf(livingRoomTempState()),
+)
+
+private fun verticalStackLargeFixture() = CardFixture(
+    json = """{"type":"vertical-stack","cards":[{"type":"tile","entity":"sensor.living_room"},{"type":"tile","entity":"light.kitchen"},{"type":"tile","entity":"lock.front_door"}]}""",
+    snapshot = snapshotOf(
+        livingRoomTempState(),
+        kitchenLightState(),
+        entityState(id = "lock.front_door", state = "locked", friendlyName = "Front door"),
+    ),
+)
+
+private fun horizontalStackSmallFixture() = CardFixture(
+    json = """{"type":"horizontal-stack","cards":[{"type":"button","entity":"light.kitchen","name":"Kitchen"}]}""",
+    snapshot = snapshotOf(kitchenLightState()),
+)
+
+private fun horizontalStackLargeFixture() = CardFixture(
+    json = """{"type":"horizontal-stack","cards":[{"type":"button","entity":"light.kitchen","name":"Kitchen"},{"type":"button","entity":"sensor.living_room","name":"Temp"},{"type":"button","entity":"lock.front_door","name":"Door"}]}""",
+    snapshot = snapshotOf(
+        kitchenLightState(),
+        livingRoomTempState(),
+        entityState(id = "lock.front_door", state = "locked", friendlyName = "Front door"),
+    ),
+)
+
+private fun gridSmallFixture() = CardFixture(
+    json = """{"type":"grid","cards":[{"type":"button","entity":"light.kitchen","name":"Kitchen"}]}""",
+    snapshot = snapshotOf(kitchenLightState()),
+)
+
+private fun gridLargeFixture() = CardFixture(
+    json = """{"type":"grid","cards":[{"type":"button","entity":"light.kitchen","name":"Kitchen"},{"type":"button","entity":"light.office_lamp","name":"Office"},{"type":"button","entity":"switch.coffee_maker","name":"Coffee"},{"type":"button","entity":"lock.front_door","name":"Door"}]}""",
+    snapshot = snapshotOf(
+        kitchenLightState(),
+        entityState(id = "light.office_lamp", state = "off", friendlyName = "Office lamp"),
+        entityState(id = "switch.coffee_maker", state = "on", friendlyName = "Coffee maker"),
+        entityState(id = "lock.front_door", state = "locked", friendlyName = "Front door"),
     ),
 )
 
@@ -634,17 +664,44 @@ private fun bambuPrintControlFixture() = CardFixture(
     snapshot = HaSnapshot(),
 )
 
-private fun bambuAmsFixture() = CardFixture(
+private fun bambuAmsSmallFixture() = CardFixture(
+    json = """{"type":"custom:ha-bambulab-ams-card","ams":"<device-id-placeholder>","style":"compact"}""",
+    snapshot = HaSnapshot(),
+)
+
+private fun bambuAmsLargeFixture() = CardFixture(
     json = """{"type":"custom:ha-bambulab-ams-card","ams":"<device-id-placeholder>","style":"full"}""",
     snapshot = HaSnapshot(),
 )
 
-private fun bambuSpoolFixture() = CardFixture(
-    json = """{"type":"custom:ha-bambulab-spool-card","spool":"<spool-id-placeholder>"}""",
-    snapshot = HaSnapshot(),
+// ── shared entity-state shorthands ──────────────────────────────────
+
+private fun livingRoomTempState() = entityState(
+    id = "sensor.living_room",
+    state = "21.5",
+    friendlyName = "Living Room",
+    unit = "°C",
+    deviceClass = "temperature",
 )
 
-private fun unsupportedFixture() = CardFixture(
-    json = """{"type":"iframe","url":"https://example.com"}""",
-    snapshot = HaSnapshot(),
+private fun kitchenLightState() = entityState(
+    id = "light.kitchen",
+    state = "on",
+    friendlyName = "Kitchen",
+)
+
+private fun outsideTempState() = entityState(
+    id = "sensor.outside_temp",
+    state = "8.2",
+    friendlyName = "Outside",
+    unit = "°C",
+    deviceClass = "temperature",
+)
+
+private fun housePowerState() = entityState(
+    id = "sensor.house_power",
+    state = "412",
+    friendlyName = "House power",
+    unit = "W",
+    deviceClass = "power",
 )

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/widget/WearCardDataTier.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/widget/WearCardDataTier.kt
@@ -1,0 +1,80 @@
+package ee.schimke.terrazzo.wear.widget
+
+/**
+ * Per-card-type classification of how much of a card's data hierarchy
+ * can survive the wear sync proto and the slot widget canvas.
+ *
+ * See `docs/architecture/adaptive-card-layouts.md` § "Wear data-layer
+ * reality" for the motivation. In short: `LiveValues` carries
+ * state + friendly_name + unit + device_class per entity — P1 + P2 +
+ * (unit-only) P3 in priority terms. Cards whose identity depends on
+ * P4 / P5 data (forecast arrays, history series, list payloads, log
+ * entries, calendar events) cannot fill the large slot container; at
+ * 200×112 dp they would render as their stripped tier with a lot of
+ * empty space. For those, advertising the large slot service is just
+ * noise in the system widget picker.
+ *
+ * Drives two things:
+ *   - [WearSlotsController][ee.schimke.terrazzo.wear.sync.WearSlotsController.applySlots]
+ *     gates `enableLarge` on this classifier so the picker hides the
+ *     large variant for low-data card types regardless of the
+ *     phone-side `SlotSizePref`.
+ *   - The `@Preview` convention in
+ *     [CardSlotWidgetPreviews][CardSlotWidgetPreviews_kt]: small-only
+ *     for [SmallOnly] types; small + large for [Both] types.
+ *
+ * Unknown / future card types default to [Both]: safer to advertise
+ * both and let the renderer's ladder pick the right tier than to
+ * silently hide the large variant for a card that could fill it.
+ */
+internal enum class WearCardDataTier {
+    /**
+     * Card needs only what fits at the small (200×60 dp) slot
+     * container. Includes both cards with hardly any live data
+     * (`heading`, `markdown`, `clock`) and cards whose identity
+     * depends on payloads the wear sync proto doesn't carry
+     * (`weather-forecast`, `logbook`, `history-graph`,
+     * `statistics-graph`, `todo-list`, `calendar`).
+     */
+    SmallOnly,
+
+    /**
+     * Card renders meaningfully at both small (200×60 dp) and large
+     * (200×112 dp) slot containers, either because it's a single-entity
+     * card that scales its own tier (tile, gauge, thermostat) or
+     * because it's a multi-entity card whose extra rows / cells fill
+     * the large canvas (entities, glance, area, *-stack).
+     */
+    Both;
+
+    val supportsLarge: Boolean get() = this == Both
+}
+
+/**
+ * Classify a card-config `type` string. Type strings come straight
+ * from the lovelace card config (`"tile"`, `"weather-forecast"`,
+ * `"custom:ha-bambulab-print_status-card"`, …); this function returns
+ * [WearCardDataTier.Both] for any type not explicitly listed so a new
+ * card never silently loses its large slot.
+ */
+internal fun wearCardDataTier(cardType: String): WearCardDataTier =
+    when (cardType) {
+        // Static / config-only content — nothing for the large canvas
+        // to fill with.
+        "heading",
+        "markdown",
+        "clock",
+        // Identity depends on P4 / P5 payloads the wear sync proto
+        // doesn't carry (forecast array, history points, statistics
+        // series, log entries, todo items, calendar events). At the
+        // large container these render as their stripped tier with a
+        // lot of empty space.
+        "weather-forecast",
+        "logbook",
+        "history-graph",
+        "statistics-graph",
+        "todo-list",
+        "calendar" -> WearCardDataTier.SmallOnly
+
+        else -> WearCardDataTier.Both
+    }


### PR DESCRIPTION
A wear slot widget only sees state + friendly_name + unit + device_class
per entity — the data layer can't carry forecast arrays, history points,
list items, or calendar events. Cards whose identity depends on those
P4/P5 payloads (heading, markdown, clock, weather-forecast, logbook,
history-graph, statistics-graph, todo-list, calendar) render as a
stripped chip with a lot of empty space at the 200x112 dp large
container, so the system widget picker should not surface that variant.

Adds WearCardDataTier as the per-type classifier. WearSlotsController
ANDs the large slot service enable against tier.supportsLarge — for a
LargeOnly user pref on a SmallOnly card type, the controller falls back
to enabling small rather than hiding the slot entirely.

Restructures CardSlotWidgetPreviews.kt to mirror the same convention:
small-only @Preview for low-data cards; small + large with a shared
fixture for single-entity cards; small + large with separate stripped
vs filled fixtures for multi-entity cards (entities, glance, area,
picture-glance, picture-elements, entity-filter, *-stacks, bambu-ams).

Extends docs/architecture/adaptive-card-layouts.md with a P1-P5 data
priority hierarchy, a per-card data inventory table, and a "Wear
data-layer reality" section that maps the proto fields onto the
priority bands and motivates the small-only set.