### PR TITLE
chore(deps): drop default compose-preview plugin application; bump compose-ai-tools to v0.11.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,12 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
       # `test` fans out to every module: Android library / app modules get
       # their `testDebugUnitTest`, JVM modules (`:integration`, KMP common)
-      # get plain `test`. `:integration:test` also depends on
-      # `:previews:renderAllPreviews`, which runs the Robolectric-backed
-      # pixel-parity renders.
+      # get plain `test`. The compose-preview Gradle plugin is no longer
+      # applied to any module — its `composePreviewRender` task is
+      # materialised by the CLI's auto-inject init script on demand, so the
+      # Robolectric-backed pixel renders are produced by the preview-baselines
+      # / preview-comment workflows (not this job). `:integration:test`
+      # tolerates missing PNGs via assumeTrue skips.
       - run: ./gradlew test --stacktrace
       - name: Upload test reports
         if: always()

--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -29,7 +29,7 @@ jobs:
           # credentials persisted here.
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.10.16
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.11.1
         with:
           cli-version: catalog
           catalog-key: compose-preview-plugin

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.10.16
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.11.1
         with:
           cli-version: catalog
           catalog-key: compose-preview-plugin

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,6 @@ val appVersionCode: Int =
 plugins {
   alias(libs.plugins.android.application)
   alias(libs.plugins.compose.compiler)
-  alias(libs.plugins.compose.preview)
   alias(libs.plugins.metro)
   alias(libs.plugins.tapmoc)
   alias(libs.plugins.kotlin.serialization)
@@ -31,9 +30,9 @@ android {
     // Widget playback via RemoteViews.DrawInstructions needs API 35+
     // (VANILLA_ICE_CREAM). We still compile / target the newest
     // available SDK via `compileSdk` / `targetSdk`. Keeping minSdk
-    // at 35 (not 36) lets Robolectric's SDK-35 framework — which
-    // compose-preview 0.7.8 tops out at — parse this module's
-    // apk-for-local-test during renderPreviews.
+    // at 35 (not 36) lets the Robolectric framework the compose-preview
+    // CLI ships with parse this module's apk-for-local-test during
+    // composePreviewRender.
     minSdk = 35
     targetSdk = libs.versions.android.targetSdk.get().toInt()
     versionCode = appVersionCode
@@ -80,12 +79,6 @@ android {
 tapmoc {
   java(libs.versions.java.get().toInt())
   kotlin(libs.versions.kotlin.get())
-}
-
-composePreview {
-  variant.set("debug")
-  sdkVersion.set(35)
-  enabled.set(true)
 }
 
 play {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,8 +36,16 @@ junit-jupiter-bom = "6.0.3"
 mockserver = "5.15.0"
 indriya = "2.2.4"
 
-# Preview tooling
-compose-preview-plugin = "0.10.16"
+# Preview tooling — pinned compose-ai-tools release. The CLI and the
+# `ee.schimke.composeai.preview` Gradle plugin ship as a single release,
+# so one version covers both. We no longer apply the plugin from any
+# module — the CLI auto-injects it via `--init-script` on every
+# invocation — but the [plugins] alias below still references this
+# version key so Renovate's gradle manager keeps tracking new releases
+# of the plugin marker. The preview-baselines / preview-comment GitHub
+# Actions read this key (`catalog-key: compose-preview-plugin`) to pin
+# the CLI release they install on the runner.
+compose-preview-plugin = "0.11.1"
 tapmoc = "0.4.2"
 
 # Image loading (BitmapLoader / RemoteCompose named-bitmap resolution)
@@ -185,6 +193,10 @@ kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref 
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+# Renovate tracking hook for compose-ai-tools. The CLI auto-injects this
+# plugin via `--init-script`, so no module applies the alias directly —
+# keeping the [plugins] entry lets Renovate's gradle manager continue
+# proposing version bumps against the plugin marker.
 compose-preview = { id = "ee.schimke.composeai.preview", version.ref = "compose-preview-plugin" }
 metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 tapmoc = { id = "com.gradleup.tapmoc", version.ref = "tapmoc" }

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -12,9 +12,16 @@ dependencies {
 tasks.test {
   useJUnitPlatform()
 
-  // Our rendered PNGs come from `:previews:renderAllPreviews`. Wire it so
-  // `./gradlew :integration:test` is a single command.
-  dependsOn(":previews:renderAllPreviews")
+  // Rendered PNGs come from the compose-preview CLI's `composePreviewRender`
+  // task, which the CLI's auto-inject init script materialises on the
+  // `:previews` module — run `compose-preview show` locally (or let the
+  // preview-baselines / preview-comment GitHub Actions do it in CI) before
+  // `./gradlew :integration:test`. The task isn't visible to a plain
+  // `./gradlew` invocation, so we wire `dependsOn` only when it exists;
+  // missing PNGs are tolerated by the dynamic tests' assumeTrue skips.
+  rootProject.findProject(":previews")?.tasks?.findByName("composePreviewRender")?.let {
+    dependsOn(it)
+  }
 
   systemProperty(
     "ha.rendered.dir",

--- a/previews/build.gradle.kts
+++ b/previews/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
-  alias(libs.plugins.compose.preview)
 }
 
 android {
@@ -14,12 +13,6 @@ android {
     targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
   }
   kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
-}
-
-composePreview {
-  variant.set("debug")
-  sdkVersion.set(35)
-  enabled.set(true)
 }
 
 dependencies {

--- a/tv/build.gradle.kts
+++ b/tv/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
   alias(libs.plugins.android.application)
   alias(libs.plugins.compose.compiler)
-  alias(libs.plugins.compose.preview)
 }
 
 android {
@@ -23,12 +22,6 @@ android {
     targetCompatibility = JavaVersion.toVersion(libs.versions.java.get())
   }
   kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
-}
-
-composePreview {
-  variant.set("debug")
-  sdkVersion.set(34)
-  enabled.set(true)
 }
 
 dependencies {

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -15,7 +15,6 @@ val wearVersionCode: Int =
 plugins {
   alias(libs.plugins.android.application)
   alias(libs.plugins.compose.compiler)
-  alias(libs.plugins.compose.preview)
   alias(libs.plugins.kotlin.serialization)
   alias(libs.plugins.play.publisher)
 }
@@ -43,12 +42,6 @@ android {
     // source lint checks for this module.
     checkGeneratedSources = false
   }
-}
-
-composePreview {
-  variant.set("debug")
-  sdkVersion.set(34)
-  enabled.set(true)
 }
 
 play {


### PR DESCRIPTION
The compose-ai-tools v0.11.1 CLI auto-injects `ee.schimke.composeai.preview`
into every consuming project via `--init-script`, so we no longer need to
apply the plugin alias from individual module build files. The
`composePreview { ... }` configuration blocks went with it — the CLI uses
its own defaults, which match what we were setting (debug variant, sdk
matching compileSdk, enabled). The [plugins] catalog alias is kept solely
as a Renovate tracking hook for the plugin marker.

Preview rendering moves entirely to the v0.11.1 preview-baselines /
preview-comment GitHub Actions, which drive the CLI and therefore pick
up the auto-inject. The `:integration:test` dependsOn `:previews:
renderAllPreviews` is replaced with a conditional wire-up against the
CLI-created `composePreviewRender` task so a plain `./gradlew test`
doesn't fail at task-graph time; the existing assumeTrue skips handle
the missing-PNG case.