### PR TITLE
chore(deps): bump compose-ai-tools to v0.11.3

### DIFF
--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -29,7 +29,7 @@ jobs:
           # credentials persisted here.
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.11.1
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.11.3
         with:
           cli-version: catalog
           catalog-key: compose-preview-plugin

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.11.1
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.11.3
         with:
           cli-version: catalog
           catalog-key: compose-preview-plugin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ indriya = "2.2.4"
 # of the plugin marker. The preview-baselines / preview-comment GitHub
 # Actions read this key (`catalog-key: compose-preview-plugin`) to pin
 # the CLI release they install on the runner.
-compose-preview-plugin = "0.11.1"
+compose-preview-plugin = "0.11.3"
 tapmoc = "0.4.2"
 
 # Image loading (BitmapLoader / RemoteCompose named-bitmap resolution)


### PR DESCRIPTION
v0.11.1 was missing the compose-preview-0.11.1.tar.gz release asset,
so the preview-baselines and preview-comment workflows were failing at
the install step (curl exit 22). v0.11.3 publishes the tarball, so the
runner can fetch the CLI again.