### PR TITLE
fix(wear): non-flow fallback for glance / grid in Wear slots

### DIFF
--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/FlowLayoutSupport.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/FlowLayoutSupport.kt
@@ -1,0 +1,30 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * Whether the current capture profile admits the experimental
+ * `FlowLayout` op (op 240) used by `RemoteFlowRow`. Defaults to `true`:
+ * the in-app dashboard captures with `androidXExperimentalWrap` and the
+ * launcher widget with `widgetsProfile`, both of which OR in
+ * `PROFILE_EXPERIMENTAL`.
+ *
+ * Set to `false` on surfaces whose capture writer is fixed to a stable
+ * profile — notably the Glance Wear `WearWidgetDocument` capture path,
+ * which is owned by AndroidX and rejects experimental ops. HA card
+ * components that use `RemoteFlowRow` (`RemoteHaGlance`, `RemoteHaGrid`)
+ * read this local and degrade to a non-wrapping `RemoteRow` when it is
+ * `false`, so cards capture instead of throwing.
+ */
+val LocalSupportsFlowLayout = staticCompositionLocalOf { true }
+
+/** Wrap [content] so HA card components know whether they can emit
+ *  `RemoteFlowRow`. Pass `false` on Glance Wear slot surfaces. */
+@Composable
+fun ProvideFlowLayoutSupport(enabled: Boolean, content: @Composable () -> Unit) {
+    CompositionLocalProvider(LocalSupportsFlowLayout provides enabled, content = content)
+}

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaGlance.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaGlance.kt
@@ -8,6 +8,7 @@ import androidx.compose.remote.creation.compose.layout.RemoteBox
 import androidx.compose.remote.creation.compose.layout.RemoteColumn
 import androidx.compose.remote.creation.compose.layout.RemoteComposable
 import androidx.compose.remote.creation.compose.layout.RemoteFlowRow
+import androidx.compose.remote.creation.compose.layout.RemoteRow
 import androidx.compose.remote.creation.compose.layout.RemoteText
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.clickable
@@ -55,13 +56,26 @@ fun RemoteHaGlance(data: HaGlanceData, modifier: RemoteModifier = RemoteModifier
             // HA's glance spaces cells evenly across the card width.
             // FlowRow handles wrapping when more cells arrive than fit
             // the row; within each row, distribute the cells using
-            // SpaceEvenly instead of packing them to the start.
-            RemoteFlowRow(
-                modifier = RemoteModifier.fillMaxWidth(),
-                horizontalArrangement = RemoteArrangement.SpaceEvenly,
-                verticalArrangement = RemoteArrangement.spacedBy(6.rdp),
-            ) {
-                data.cells.forEach { cell -> RemoteHaGlanceCell(cell) }
+            // SpaceEvenly instead of packing them to the start. On
+            // surfaces whose capture profile rejects FlowLayout
+            // (Glance Wear), fall back to a non-wrapping RemoteRow —
+            // cells overflow visually on a narrow watch slot, but the
+            // composition captures instead of throwing.
+            if (LocalSupportsFlowLayout.current) {
+                RemoteFlowRow(
+                    modifier = RemoteModifier.fillMaxWidth(),
+                    horizontalArrangement = RemoteArrangement.SpaceEvenly,
+                    verticalArrangement = RemoteArrangement.spacedBy(6.rdp),
+                ) {
+                    data.cells.forEach { cell -> RemoteHaGlanceCell(cell) }
+                }
+            } else {
+                RemoteRow(
+                    modifier = RemoteModifier.fillMaxWidth(),
+                    horizontalArrangement = RemoteArrangement.SpaceEvenly,
+                ) {
+                    data.cells.forEach { cell -> RemoteHaGlanceCell(cell) }
+                }
             }
         }
     }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaStack.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaStack.kt
@@ -45,6 +45,11 @@ fun RemoteHaHorizontalStack(
  * HA `grid` card — N-column flow of children. Approximates `hui-grid-card.ts`;
  * actual breakpoint logic lives per-row in HA (uses CSS grid), we use
  * [RemoteFlowRow] which wraps when the row overflows.
+ *
+ * On surfaces that don't admit experimental ops (Glance Wear, gated
+ * by [LocalSupportsFlowLayout]) the grid degrades to a non-wrapping
+ * [RemoteRow]. Children overflow visually on a narrow watch slot, but
+ * the composition captures instead of throwing.
  */
 @Composable
 @RemoteComposable
@@ -52,9 +57,16 @@ fun RemoteHaGrid(
     modifier: RemoteModifier = RemoteModifier,
     content: @Composable @RemoteComposable () -> Unit,
 ) {
-    RemoteFlowRow(
-        modifier = modifier,
-        horizontalArrangement = RemoteArrangement.spacedBy(8.rdp),
-        verticalArrangement = RemoteArrangement.spacedBy(8.rdp),
-    ) { content() }
+    if (LocalSupportsFlowLayout.current) {
+        RemoteFlowRow(
+            modifier = modifier,
+            horizontalArrangement = RemoteArrangement.spacedBy(8.rdp),
+            verticalArrangement = RemoteArrangement.spacedBy(8.rdp),
+        ) { content() }
+    } else {
+        RemoteRow(
+            modifier = modifier,
+            horizontalArrangement = RemoteArrangement.spacedBy(8.rdp),
+        ) { content() }
+    }
 }

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/widget/SlotWidget.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/widget/SlotWidget.kt
@@ -27,6 +27,7 @@ import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.cards.shutter.withEnhancedShutter
 import ee.schimke.ha.rc.components.HaTheme
 import ee.schimke.ha.rc.components.ProvideCardChrome
+import ee.schimke.ha.rc.components.ProvideFlowLayoutSupport
 import ee.schimke.ha.rc.components.ProvideHaTheme
 import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.ha.rc.components.haThemeFor
@@ -105,11 +106,24 @@ abstract class SlotWidget(internal val slotIndex: Int) : GlanceWearWidget() {
                             // own shape + brush via WearWidgetBrush, so
                             // suppress the per-card rounded clip + divider
                             // border that would otherwise double up.
+                            //
+                            // Glance Wear's capture profile is fixed by
+                            // AndroidX to a stable op set that rejects
+                            // FlowLayout (op 240). Tell HA card components
+                            // to use a non-wrapping row fallback so cards
+                            // that lean on `RemoteFlowRow` (glance / grid /
+                            // entity-filter) capture instead of throwing.
                             ProvideCardChrome(enabled = false) {
-                                if (card != null) {
-                                    RenderChild(card, snapshot, RemoteModifier.fillMaxWidth())
-                                } else {
-                                    EmptySlotPlaceholder(slotIndex, theme)
+                                ProvideFlowLayoutSupport(enabled = false) {
+                                    if (card != null) {
+                                        RenderChild(
+                                            card,
+                                            snapshot,
+                                            RemoteModifier.fillMaxWidth(),
+                                        )
+                                    } else {
+                                        EmptySlotPlaceholder(slotIndex, theme)
+                                    }
                                 }
                             }
                         }

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/widget/SlotWidgetPreviews.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/widget/SlotWidgetPreviews.kt
@@ -29,6 +29,7 @@ import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.cards.shutter.withEnhancedShutter
 import ee.schimke.ha.rc.components.HaTheme
 import ee.schimke.ha.rc.components.ProvideCardChrome
+import ee.schimke.ha.rc.components.ProvideFlowLayoutSupport
 import ee.schimke.ha.rc.components.ProvideHaTheme
 import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.ha.rc.components.haThemeFor
@@ -72,12 +73,22 @@ internal class PreviewSlotWidget(
                         ProvideCardSizeMode(CardSizeMode.Fixed) {
                             // Match the runtime SlotWidget: the wear
                             // container already paints the shape + brush, so
-                            // skip the per-card chrome to avoid doubling up.
+                            // skip the per-card chrome to avoid doubling up;
+                            // and tell HA card components to use the
+                            // non-wrapping fallback for `RemoteFlowRow`
+                            // since Glance Wear's capture profile rejects
+                            // FlowLayout (op 240).
                             ProvideCardChrome(enabled = false) {
-                                if (card != null) {
-                                    RenderChild(card, snapshot, RemoteModifier.fillMaxWidth())
-                                } else {
-                                    PreviewEmptyPlaceholder(slotIndex, theme)
+                                ProvideFlowLayoutSupport(enabled = false) {
+                                    if (card != null) {
+                                        RenderChild(
+                                            card,
+                                            snapshot,
+                                            RemoteModifier.fillMaxWidth(),
+                                        )
+                                    } else {
+                                        PreviewEmptyPlaceholder(slotIndex, theme)
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary

Glance Wear's `WearWidgetDocument` capture path is owned by AndroidX and uses a stable RC profile that rejects experimental ops, including FlowLayout (op 240). `RemoteHaGlance` and `RemoteHaGrid` both emit `RemoteFlowRow`, so the matching wear slot previews (`glance`, `grid`, `entity-filter` — the last renders as `glance` internally) failed to capture, produced no PNG, and broke Preview Baselines once the install step was unblocked on `v0.11.3` (run [26343606137](https://github.com/yschimke/homeassistant-remotecompose/actions/runs/26343606137), 6 of 73 previews missing).

- New `LocalSupportsFlowLayout` composition local (default `true`, matching the phone widget's `widgetsProfile` and the dashboard's `androidXExperimentalWrap` — both OR in `PROFILE_EXPERIMENTAL`). Mirrors the existing `LocalCardChromeEnabled` pattern.
- `RemoteHaGlance` / `RemoteHaGrid` read the local and degrade to a non-wrapping `RemoteRow` when `false`. Cells overflow visually on a 200 dp watch slot, but the composition captures instead of throwing.
- Production `SlotWidget` and `PreviewSlotWidget` wrap their content in `ProvideFlowLayoutSupport(enabled = false)`.

Phone widget, in-app dashboard and `CardPreviewMatrix` are unchanged — they leave the local at the default and continue to wrap via `RemoteFlowRow`.

## Test plan

- [ ] Preview Comment workflow on this PR renders all 73 wear previews successfully (the 6 previously-failing previews — `WearGlanceSmall`, `WearGlanceLarge`, `WearEntityFilterSmall`, `WearEntityFilterLarge`, `WearGridSmall`, `WearGridLarge` — now produce PNGs).
- [ ] After merge, Preview Baselines updates `compose-preview/main` + `compose-preview/resources/main` for the first time since 2026-05-16.
- [ ] Eyeball the new `glance` / `grid` / `entity-filter` PNGs on the watch slot to confirm the non-wrap fallback looks acceptable (some cell overflow expected; not a crash).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRRyhvMtFiHJTmVivtmK8e)_