### PR TITLE
fix(deps): align with remote-compose alpha11 API changes

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/AnimationPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/AnimationPreviews.kt
@@ -7,7 +7,7 @@ import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
 import androidx.compose.remote.creation.compose.state.RemoteBoolean
 import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.remote.creation.compose.state.rf
-import androidx.compose.remote.tooling.preview.RemotePreview
+import androidx.compose.remote.tooling.preview.RemoteContentPreview
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.graphics.Color
@@ -77,7 +77,7 @@ class ToggleProgressFramesProvider : PreviewParameterProvider<Pair<String, Float
 fun Toggle_Animation_Light(
     @PreviewParameter(ToggleProgressFramesProvider::class) frame: Pair<String, Float>,
 ) {
-    RemotePreview(profile = androidXExperimental) {
+    RemoteContentPreview(profile = androidXExperimental) {
         ProvideHaTheme(HaTheme.Light) {
             RemoteHaToggleSwitchByProgress(
                 progress = frame.second.rf,
@@ -93,7 +93,7 @@ fun Toggle_Animation_Light(
 fun Toggle_Animation_Dark(
     @PreviewParameter(ToggleProgressFramesProvider::class) frame: Pair<String, Float>,
 ) {
-    RemotePreview(profile = androidXExperimental) {
+    RemoteContentPreview(profile = androidXExperimental) {
         ProvideHaTheme(HaTheme.Dark) {
             RemoteHaToggleSwitchByProgress(
                 progress = frame.second.rf,
@@ -114,7 +114,7 @@ fun Toggle_Animation_Dark(
 @Preview(name = "toggle-animated (light)", showBackground = false, widthDp = 40, heightDp = 24)
 @Composable
 fun Toggle_Animated_Light() {
-    RemotePreview(profile = androidXExperimental) {
+    RemoteContentPreview(profile = androidXExperimental) {
         ProvideHaTheme(HaTheme.Light) {
             RemoteHaToggleSwitch(
                 isOn = RemoteBoolean(false),
@@ -128,7 +128,7 @@ fun Toggle_Animated_Light() {
 @Preview(name = "toggle-animated (dark)", showBackground = false, widthDp = 40, heightDp = 24)
 @Composable
 fun Toggle_Animated_Dark() {
-    RemotePreview(profile = androidXExperimental) {
+    RemoteContentPreview(profile = androidXExperimental) {
         ProvideHaTheme(HaTheme.Dark) {
             RemoteHaToggleSwitch(
                 isOn = RemoteBoolean(false),
@@ -178,7 +178,7 @@ private fun gaugeFrameCardJson(): String =
 
 @Composable
 private fun GaugeFrameHost(theme: HaTheme, content: @Composable () -> Unit) {
-    RemotePreview(profile = androidXExperimental) {
+    RemoteContentPreview(profile = androidXExperimental) {
         CompositionLocalProvider(LocalHaClock provides FixedHaClock(PreviewNow)) {
             ProvideCardRegistry(defaultRegistry()) {
                 ProvideHaTheme(theme) { content() }

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.remote.creation.compose.layout.RemoteComposable
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
-import androidx.compose.remote.tooling.preview.RemotePreview
+import androidx.compose.remote.tooling.preview.RemoteContentPreview
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
@@ -96,7 +96,7 @@ private val PreviewNow: ZonedDateTime =
 
 @Composable
 internal fun CardHost(theme: HaTheme, content: @Composable () -> Unit) {
-    RemotePreview(profile = androidXExperimental) {
+    RemoteContentPreview(profile = androidXExperimental) {
         CompositionLocalProvider(LocalHaClock provides FixedHaClock(PreviewNow)) {
             ProvideCardRegistry(defaultRegistry()) {
                 ProvideHaTheme(theme) { content() }
@@ -389,7 +389,7 @@ private fun PlayerSlot(
     content: @Composable @RemoteComposable () -> Unit,
 ) {
     Box(modifier = Modifier.uiFillMaxWidth().height(heightDp.dp)) {
-        RemotePreview(profile = androidXExperimental) {
+        RemoteContentPreview(profile = androidXExperimental) {
             CompositionLocalProvider(LocalHaClock provides FixedHaClock(PreviewNow)) {
                 ProvideCardRegistry(defaultRegistry()) {
                     ProvideHaTheme(theme) { content() }

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/DashboardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/DashboardPreviews.kt
@@ -19,7 +19,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
 import androidx.compose.remote.player.core.platform.BitmapLoader
-import androidx.compose.remote.tooling.preview.RemotePreview
+import androidx.compose.remote.tooling.preview.RemoteContentPreview
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/GarageShutterCardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/GarageShutterCardPreviews.kt
@@ -2,7 +2,7 @@
 
 package ee.schimke.ha.previews
 
-import androidx.compose.remote.tooling.preview.RemotePreview
+import androidx.compose.remote.tooling.preview.RemoteContentPreview
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -49,7 +49,7 @@ private const val SINGLE_HEIGHT_DP = 172
 
 @Composable
 private fun GarageHost(theme: HaTheme, content: @Composable () -> Unit) {
-    RemotePreview(profile = androidXExperimental) {
+    RemoteContentPreview(profile = androidXExperimental) {
         ProvideCardRegistry(defaultRegistry().withGarageShutter()) {
             ProvideHaTheme(theme) { content() }
         }

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/ImagePreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/ImagePreviews.kt
@@ -11,7 +11,7 @@ import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
 import androidx.compose.remote.creation.compose.modifier.height
 import androidx.compose.remote.creation.compose.state.rdp
 import androidx.compose.remote.creation.compose.state.rs
-import androidx.compose.remote.tooling.preview.RemotePreview
+import androidx.compose.remote.tooling.preview.RemoteContentPreview
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -250,7 +250,7 @@ private fun ProbeUrlHost(theme: HaTheme, url: String) {
 @Composable
 private fun ImageHost(theme: HaTheme, content: @Composable @RemoteComposable () -> Unit) {
     Box(modifier = Modifier.uiFillMaxWidth().uiHeight(IMAGE_BOX_HEIGHT_DP.dp)) {
-        RemotePreview(profile = androidXExperimental) {
+        RemoteContentPreview(profile = androidXExperimental) {
             ProvideHaTheme(theme) { content() }
         }
     }

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/ShutterCardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/ShutterCardPreviews.kt
@@ -2,7 +2,7 @@
 
 package ee.schimke.ha.previews
 
-import androidx.compose.remote.tooling.preview.RemotePreview
+import androidx.compose.remote.tooling.preview.RemoteContentPreview
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import ee.schimke.ha.model.EntityState
@@ -31,7 +31,7 @@ private const val CARD_HEIGHT_DP = 300
 
 @Composable
 private fun ShutterHost(theme: HaTheme, content: @Composable () -> Unit) {
-    RemotePreview(profile = androidXExperimental) {
+    RemoteContentPreview(profile = androidXExperimental) {
         ProvideCardRegistry(defaultRegistry().withEnhancedShutter()) {
             ProvideHaTheme(theme) { content() }
         }

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/ThemePreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/ThemePreviews.kt
@@ -19,7 +19,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
-import androidx.compose.remote.tooling.preview.RemotePreview
+import androidx.compose.remote.tooling.preview.RemoteContentPreview
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -183,7 +183,7 @@ private fun ThemeShowcase(style: ThemeStyle, darkTheme: Boolean) {
                             .clip(RoundedCornerShape(12.dp))
                             .background(haTheme.cardBackground),
                     ) {
-                        RemotePreview(profile = androidXExperimental) {
+                        RemoteContentPreview(profile = androidXExperimental) {
                             ProvideCardRegistry(defaultRegistry()) {
                                 ProvideHaTheme(haTheme) {
                                     RenderChild(
@@ -202,7 +202,7 @@ private fun ThemeShowcase(style: ThemeStyle, darkTheme: Boolean) {
                             .clip(RoundedCornerShape(12.dp))
                             .background(haTheme.cardBackground),
                     ) {
-                        RemotePreview(profile = androidXExperimental) {
+                        RemoteContentPreview(profile = androidXExperimental) {
                             ProvideCardRegistry(defaultRegistry()) {
                                 ProvideHaTheme(haTheme) {
                                     RenderChild(

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/TileCardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/TileCardPreviews.kt
@@ -2,7 +2,7 @@
 
 package ee.schimke.ha.previews
 
-import androidx.compose.remote.tooling.preview.RemotePreview
+import androidx.compose.remote.tooling.preview.RemoteContentPreview
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import ee.schimke.ha.rc.ProvideCardRegistry
@@ -26,7 +26,7 @@ private const val TILE_HEIGHT_DP = 43
 
 @Composable
 private fun TileHost(theme: HaTheme, content: @Composable () -> Unit) {
-    RemotePreview(profile = androidXExperimental) {
+    RemoteContentPreview(profile = androidXExperimental) {
         ProvideCardRegistry(defaultRegistry()) {
             ProvideHaTheme(theme) { content() }
         }

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/ToggleSwitchPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/ToggleSwitchPreviews.kt
@@ -5,7 +5,7 @@ package ee.schimke.ha.previews
 import androidx.compose.remote.creation.compose.state.RemoteBoolean
 import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.remote.creation.compose.state.rf
-import androidx.compose.remote.tooling.preview.RemotePreview
+import androidx.compose.remote.tooling.preview.RemoteContentPreview
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
@@ -33,7 +33,7 @@ private val PreviewInactiveAccent = Color(0xFFB0B0B0)
 
 @Composable
 private fun SwitchHost(theme: HaTheme, content: @Composable () -> Unit) {
-    RemotePreview(profile = androidXExperimental) {
+    RemoteContentPreview(profile = androidXExperimental) {
         ProvideHaTheme(theme) { content() }
     }
 }

--- a/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaUiHost.kt
+++ b/rc-components-ui/src/main/kotlin/ee/schimke/ha/rc/ui/HaUiHost.kt
@@ -2,9 +2,8 @@
 
 package ee.schimke.ha.rc.ui
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.remote.creation.compose.layout.RemoteComposable
-import androidx.compose.remote.tooling.preview.RemotePreview
+import androidx.compose.remote.tooling.preview.RemoteContentPreview
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import ee.schimke.ha.rc.components.HaTheme
@@ -26,9 +25,9 @@ import ee.schimke.ha.rc.components.ProvideHaTheme
  *    provide is a passthrough when no override is set.
  *
  * Action callbacks: the embedded RemoteCompose document delivers
- * `HostAction`s at playback time. `RemotePreview` doesn't expose the
- * named-action stream, so apps that want HA service dispatch must drop
- * to Tier-1 (use `RemoteHa*` directly inside their own
+ * `HostAction`s at playback time. `RemoteContentPreview` doesn't expose
+ * the named-action stream, so apps that want HA service dispatch must
+ * drop to Tier-1 (use `RemoteHa*` directly inside their own
  * `RemoteDocumentPlayer(onNamedAction = …)`). Tier-2 is for
  * visual embedding.
  */
@@ -38,9 +37,7 @@ internal fun HaUiHost(
     theme: HaTheme = LocalHaTheme.current,
     content: @Composable @RemoteComposable () -> Unit,
 ) {
-    Box(modifier) {
-        RemotePreview(profile = haUiEmbedProfile) {
-            ProvideHaTheme(theme) { content() }
-        }
+    RemoteContentPreview(modifier = modifier, profile = haUiEmbedProfile) {
+        ProvideHaTheme(theme) { content() }
     }
 }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/HaAction.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/HaAction.kt
@@ -2,7 +2,7 @@ package ee.schimke.ha.rc.components
 
 import androidx.annotation.RestrictTo
 import androidx.compose.remote.creation.compose.action.Action
-import androidx.compose.remote.creation.compose.action.HostAction
+import androidx.compose.remote.creation.compose.action.hostAction
 import androidx.compose.remote.creation.compose.state.rs
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -107,5 +107,5 @@ private val json = Json { ignoreUnknownKeys = true }
 fun HaAction.toRemoteAction(): Action? {
     if (this is HaAction.None) return null
     val payload = json.encodeToString(HaAction.serializer(), this)
-    return HostAction(name = HA_ACTION_NAME.rs, value = payload.rs)
+    return hostAction(HA_ACTION_NAME.rs, payload.rs)
 }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaImage.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaImage.kt
@@ -78,7 +78,7 @@ fun RemoteHaImageNamed(
     contentScale: ContentScale = ContentScale.Fit,
     domain: RemoteState.Domain = RemoteState.Domain.User,
 ) {
-    val rb = rememberNamedRemoteBitmap(name = name, domain = domain, content = { bitmap })
+    val rb = rememberNamedRemoteBitmap(name = name, domain = domain, value = { bitmap })
     RemoteImage(
         remoteBitmap = rb,
         contentDescription = contentDescription,

--- a/wear/src/main/kotlin/androidx/glance/wear/tooling/preview/WearWidgetPreview.kt
+++ b/wear/src/main/kotlin/androidx/glance/wear/tooling/preview/WearWidgetPreview.kt
@@ -27,7 +27,7 @@ package androidx.glance.wear.tooling.preview
 import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
-import androidx.compose.remote.tooling.preview.RemoteDocPreview
+import androidx.compose.remote.tooling.preview.RemoteDocumentPreview
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -41,7 +41,7 @@ import kotlinx.coroutines.runBlocking
  * Previews a [GlanceWearWidget] within a widget container in the Android Studio Preview.
  *
  * This utility function calls [GlanceWearWidget.provideWidgetData] to get the widget's layout,
- * captures it into a Remote Compose document, and displays it using [RemoteDocPreview]. This
+ * captures it into a Remote Compose document, and displays it using [RemoteDocumentPreview]. This
  * ensures the preview accurately reflects how the widget will appear to users, including
  * container-specific properties like padding and corner radius.
  *
@@ -66,7 +66,7 @@ public fun WearWidgetPreview(
             }
         }
 
-    RemoteDocPreview(
+    RemoteDocumentPreview(
         document,
         modifier =
             modifier

--- a/wear/src/main/kotlin/androidx/glance/wear/tooling/preview/WearWidgetPreviewSnapshot.kt
+++ b/wear/src/main/kotlin/androidx/glance/wear/tooling/preview/WearWidgetPreviewSnapshot.kt
@@ -39,7 +39,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.remote.tooling.preview.RemoteDocPreview
+import androidx.compose.remote.tooling.preview.RemoteDocumentPreview
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -96,7 +96,7 @@ public fun WearWidgetPreviewSnapshot(
         modifier = Modifier.size(227.dp).clip(CircleShape).background(Color.Black),
         contentAlignment = Alignment.Center,
     ) {
-        RemoteDocPreview(
+        RemoteDocumentPreview(
             document,
             modifier =
                 modifier


### PR DESCRIPTION
## Summary
Unbreak the build after the remote-compose alpha10 → alpha11 bump (#318):

- **HaAction**: `HostAction(name, value)` constructor is now `internal`. Switch to the public `hostAction(name, value)` factory in `HostActionKt`.
- **RemoteHaImage**: `rememberNamedRemoteBitmap`'s lambda parameter was renamed `content` → `value`.
- **HaUiHost** / `previews/*`: `RemotePreview` was renamed to `RemoteContentPreview`. Same signature `(modifier, profile, content)`.
- **wear** vendored `WearWidgetPreview` / `WearWidgetPreviewSnapshot`: `RemoteDocPreview` is now `RemoteDocumentPreview`.

`RemoteContentPreview` / `RemotePreviewWrapper` are `@RestrictTo(LIBRARY_GROUP)` in alpha11 — the existing `@file:Suppress("RestrictedApi")` on the relevant files still applies. A follow-up could swap to `@PreviewWrapper(wrapper = RemotePreviewWrapper::class)` for the `previews/` module, but the wrapper takes no `profile` argument, so the explicit `androidXExperimental` profile would be lost.

## Test plan
- [x] `./gradlew assemble`
- [x] `./gradlew ktfmtCheck`
