### PR TITLE
test: revert from JUnit Jupiter 6 to classic JUnit 4

### DIFF
--- a/addon-server/build.gradle.kts
+++ b/addon-server/build.gradle.kts
@@ -36,9 +36,5 @@ dependencies {
 
   testImplementation(libs.kotlin.test)
   testImplementation(libs.kotlinx.coroutines.test)
-  testImplementation(platform(libs.junit.jupiter.bom))
-  testImplementation(libs.junit.jupiter)
-  testRuntimeOnly(libs.junit.platform.launcher)
+  testImplementation(libs.junit)
 }
-
-tasks.test { useJUnitPlatform() }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ kotlinx-serialization = "1.11.0"
 kotlinx-coroutines = "1.11.0"
 kotlinx-datetime = "0.8.0"
 logback = "1.5.32"
-junit-jupiter-bom = "6.0.3"
+junit = "4.13.2"
 mockserver = "6.0.0"
 indriya = "2.2.4"
 
@@ -176,9 +176,7 @@ androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", 
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
-junit-jupiter-bom = { module = "org.junit:junit-bom", version.ref = "junit-jupiter-bom" }
-junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+junit = { module = "junit:junit", version.ref = "junit" }
 mockserver-netty = { module = "org.mock-server:mockserver-netty", version.ref = "mockserver" }
 mockserver-client-java = { module = "org.mock-server:mockserver-client-java", version.ref = "mockserver" }
 

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -4,21 +4,17 @@ kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
 
 dependencies {
   testImplementation(libs.kotlin.test)
-  testImplementation(platform(libs.junit.jupiter.bom))
-  testImplementation(libs.junit.jupiter)
-  testRuntimeOnly(libs.junit.platform.launcher)
+  testImplementation(libs.junit)
 }
 
 tasks.test {
-  useJUnitPlatform()
-
   // Rendered PNGs come from the compose-preview CLI's `composePreviewRender`
   // task, which the CLI's auto-inject init script materialises on the
   // `:previews` module — run `compose-preview show` locally (or let the
   // preview-baselines / preview-comment GitHub Actions do it in CI) before
   // `./gradlew :integration:test`. The task isn't visible to a plain
   // `./gradlew` invocation, so we wire `dependsOn` only when it exists;
-  // missing PNGs are tolerated by the dynamic tests' assumeTrue skips.
+  // missing PNGs are tolerated by the parameterized tests' assumeTrue skips.
   rootProject.findProject(":previews")?.tasks?.findByName("composePreviewRender")?.let {
     dependsOn(it)
   }

--- a/integration/src/test/kotlin/ee/schimke/ha/integration/CardPixelDiffTest.kt
+++ b/integration/src/test/kotlin/ee/schimke/ha/integration/CardPixelDiffTest.kt
@@ -1,104 +1,112 @@
 package ee.schimke.ha.integration
 
 import java.io.File
-import org.junit.jupiter.api.Assumptions.assumeTrue
-import org.junit.jupiter.api.DynamicTest
-import org.junit.jupiter.api.TestFactory
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
 /**
  * Pixel-level regression tests for every HA-referenced card (not just the 4 tile variants in
  * [TileCardPixelDiffTest]). Each entry pairs an RC preview's PNG filename pattern with a committed
  * reference PNG.
  *
- * Dynamic tests so a missing reference is a single skip, not a spray of assumeTrue failures. A
+ * Parameterized so a missing reference is a single skip, not a spray of assumeTrue failures. A
  * per-test threshold lets stacks / state variants float higher than tile while we tune.
  */
-class CardPixelDiffTest {
+@RunWith(Parameterized::class)
+class CardPixelDiffTest(
+  private val previewPattern: String,
+  private val referenceRel: String,
+  private val maxPct: Double,
+) {
 
-  private data class Case(
-    val previewPattern: String,
-    val referenceRel: String,
-    val maxPct: Double = 30.0,
-  )
+  companion object {
+    @JvmStatic
+    @Parameterized.Parameters(name = "{1} <= {2}%")
+    fun cases(): Collection<Array<Any>> =
+      listOf(
+        // tile — pinned functions
+        arrayOf(
+          "Tile_TemperatureSensor_tile_sensor_temperature",
+          "tile/temperature_sensor_light.png",
+          25.0,
+        ),
+        arrayOf(
+          "Tile_TemperatureSensor_Dark_tile_sensor_temperature_dark",
+          "tile/temperature_sensor_dark.png",
+          25.0,
+        ),
+        arrayOf("Tile_LightOn_tile_light_on", "tile/light_on_light.png", 25.0),
+        arrayOf("Tile_LightOn_Dark_tile_light_on_dark", "tile/light_on_dark.png", 25.0),
 
-  private val cases =
-    listOf(
-      // tile — pinned functions
-      Case(
-        "Tile_TemperatureSensor_tile_sensor_temperature",
-        "tile/temperature_sensor_light.png",
-        25.0,
-      ),
-      Case(
-        "Tile_TemperatureSensor_Dark_tile_sensor_temperature_dark",
-        "tile/temperature_sensor_dark.png",
-        25.0,
-      ),
-      Case("Tile_LightOn_tile_light_on", "tile/light_on_light.png", 25.0),
-      Case("Tile_LightOn_Dark_tile_light_on_dark", "tile/light_on_dark.png", 25.0),
+        // tile state variants — light theme
+        arrayOf("Tile_Light_States_tile_light_light_off", "tile/light_off_light.png", 30.0),
+        arrayOf("Tile_Lock_States_tile_lock_light_locked", "tile/lock_locked_light.png", 30.0),
+        arrayOf("Tile_Cover_States_tile_cover_light_closed", "tile/cover_light.png", 40.0),
 
-      // tile state variants — light theme
-      Case("Tile_Light_States_tile_light_light_off", "tile/light_off_light.png", 30.0),
-      Case("Tile_Lock_States_tile_lock_light_locked", "tile/lock_locked_light.png", 30.0),
-      Case("Tile_Cover_States_tile_cover_light_closed", "tile/cover_light.png", 40.0),
+        // button
+        arrayOf("Button_Light_button_light_on", "button/light_on_light.png", 45.0),
+        arrayOf("Button_Light_button_light_off", "button/light_off_light.png", 45.0),
+        arrayOf("Button_Dark_button_dark_on", "button/light_on_dark.png", 45.0),
+        arrayOf("Button_Dark_button_dark_off", "button/light_off_dark.png", 45.0),
 
-      // button
-      Case("Button_Light_button_light_on", "button/light_on_light.png", 45.0),
-      Case("Button_Light_button_light_off", "button/light_off_light.png", 45.0),
-      Case("Button_Dark_button_dark_on", "button/light_on_dark.png", 45.0),
-      Case("Button_Dark_button_dark_off", "button/light_off_dark.png", 45.0),
+        // entity — TODO: HA's `entity` card is multi-row (big state,
+        // small unit, icon top-right), not a single row. Our
+        // RemoteHaEntityRow is the wrong primitive for this card.
+        // Skip for now; see docs/followups/entity-card-redesign.md.
+        //   arrayOf("Entity_Light_entity_light", "entity/temperature_sensor_light.png", 35.0),
+        //   arrayOf("Entity_Dark_entity_dark", "entity/temperature_sensor_dark.png", 35.0),
 
-      // entity — TODO: HA's `entity` card is multi-row (big state,
-      // small unit, icon top-right), not a single row. Our
-      // RemoteHaEntityRow is the wrong primitive for this card.
-      // Skip for now; see docs/followups/entity-card-redesign.md.
-      //   Case("Entity_Light_entity_light", "entity/temperature_sensor_light.png", 35.0),
-      //   Case("Entity_Dark_entity_dark", "entity/temperature_sensor_dark.png", 35.0),
+        // entities / glance / markdown
+        arrayOf("Entities_Light_entities_light", "entities/living_room_light.png", 40.0),
+        arrayOf("Entities_Dark_entities_dark", "entities/living_room_dark.png", 40.0),
+        arrayOf("Glance_Light_glance_light", "glance/overview_light.png", 40.0),
+        arrayOf("Glance_Dark_glance_dark", "glance/overview_dark.png", 40.0),
+        arrayOf("Markdown_Light_markdown_light", "markdown/notes_light.png", 40.0),
+        arrayOf("Markdown_Dark_markdown_dark", "markdown/notes_dark.png", 40.0),
 
-      // entities / glance / markdown
-      Case("Entities_Light_entities_light", "entities/living_room_light.png", 40.0),
-      Case("Entities_Dark_entities_dark", "entities/living_room_dark.png", 40.0),
-      Case("Glance_Light_glance_light", "glance/overview_light.png", 40.0),
-      Case("Glance_Dark_glance_dark", "glance/overview_dark.png", 40.0),
-      Case("Markdown_Light_markdown_light", "markdown/notes_light.png", 40.0),
-      Case("Markdown_Dark_markdown_dark", "markdown/notes_dark.png", 40.0),
+        // gauge / weather-forecast / picture-entity / logbook —
+        // converters and previews exist (see CardPreviews.kt), but no HA
+        // reference captures yet. The cases below are wired so that once
+        // `integration/scripts/capture-references.sh` is run against the
+        // seeded HA the diff pops in automatically; until then each one
+        // skips via assumeTrue.
+        arrayOf("Gauge_Light_gauge_light", "gauge/battery_light.png", 40.0),
+        arrayOf("Gauge_Dark_gauge_dark", "gauge/battery_dark.png", 40.0),
+        arrayOf(
+          "WeatherForecast_Light_weather-forecast_light",
+          "weather-forecast/forecast_home_light.png",
+          40.0,
+        ),
+        arrayOf(
+          "WeatherForecast_Dark_weather-forecast_dark",
+          "weather-forecast/forecast_home_dark.png",
+          40.0,
+        ),
+        arrayOf(
+          "PictureEntity_Light_picture-entity_light",
+          "picture-entity/driveway_light.png",
+          50.0,
+        ),
+        arrayOf("PictureEntity_Dark_picture-entity_dark", "picture-entity/driveway_dark.png", 50.0),
+        arrayOf("Logbook_Light_logbook_light", "logbook/recent_activity_light.png", 40.0),
+        arrayOf("Logbook_Dark_logbook_dark", "logbook/recent_activity_dark.png", 40.0),
+      )
+  }
 
-      // gauge / weather-forecast / picture-entity / logbook —
-      // converters and previews exist (see CardPreviews.kt), but no HA
-      // reference captures yet. The cases below are wired so that once
-      // `integration/scripts/capture-references.sh` is run against the
-      // seeded HA the diff pops in automatically; until then each one
-      // skips via assumeTrue.
-      Case("Gauge_Light_gauge_light", "gauge/battery_light.png", 40.0),
-      Case("Gauge_Dark_gauge_dark", "gauge/battery_dark.png", 40.0),
-      Case(
-        "WeatherForecast_Light_weather-forecast_light",
-        "weather-forecast/forecast_home_light.png",
-        40.0,
-      ),
-      Case(
-        "WeatherForecast_Dark_weather-forecast_dark",
-        "weather-forecast/forecast_home_dark.png",
-        40.0,
-      ),
-      Case("PictureEntity_Light_picture-entity_light", "picture-entity/driveway_light.png", 50.0),
-      Case("PictureEntity_Dark_picture-entity_dark", "picture-entity/driveway_dark.png", 50.0),
-      Case("Logbook_Light_logbook_light", "logbook/recent_activity_light.png", 40.0),
-      Case("Logbook_Dark_logbook_dark", "logbook/recent_activity_dark.png", 40.0),
+  @Test
+  fun diff() {
+    val rendered = locateRendered(previewPattern)
+    val reference = referenceFile(referenceRel)
+    assumeTrue("reference $referenceRel missing", reference.exists())
+    val report = ImageDiff.compare(rendered, reference)
+    println(report)
+    assertTrue(
+      "pixel diff above threshold: ${report.pctChanged}% > $maxPct% — $report",
+      report.pctChanged <= maxPct,
     )
-
-  @TestFactory
-  fun allCards(): List<DynamicTest> = cases.map { case ->
-    DynamicTest.dynamicTest("${case.referenceRel} <= ${case.maxPct}%") {
-      val rendered = locateRendered(case.previewPattern)
-      val reference = referenceFile(case.referenceRel)
-      assumeTrue(reference.exists(), "reference ${case.referenceRel} missing")
-      val report = ImageDiff.compare(rendered, reference)
-      println(report)
-      if (report.pctChanged > case.maxPct) {
-        error("pixel diff above threshold: ${report.pctChanged}% > ${case.maxPct}% — $report")
-      }
-    }
   }
 
   private fun locateRendered(previewName: String): File {

--- a/integration/src/test/kotlin/ee/schimke/ha/integration/TileCardPixelDiffTest.kt
+++ b/integration/src/test/kotlin/ee/schimke/ha/integration/TileCardPixelDiffTest.kt
@@ -1,9 +1,9 @@
 package ee.schimke.ha.integration
 
 import java.io.File
-import kotlin.test.assertTrue
-import org.junit.jupiter.api.Assumptions.assumeTrue
-import org.junit.jupiter.api.Test
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
 
 /**
  * Pixel-level regression tests for the `tile` converter.
@@ -50,14 +50,14 @@ class TileCardPixelDiffTest {
     val rendered = locateRendered(previewName)
     val reference = referenceFile(referenceRelPath)
     assumeTrue(
-      reference.exists(),
       "reference $referenceRelPath missing — run integration/scripts/capture-references.sh",
+      reference.exists(),
     )
     val report = ImageDiff.compare(rendered, reference)
     println(report)
     assertTrue(
-      report.pctChanged <= maxPctChanged,
       "pixel diff above threshold: ${report.pctChanged}% > $maxPctChanged% — $report",
+      report.pctChanged <= maxPctChanged,
     )
   }
 

--- a/renovate.json
+++ b/renovate.json
@@ -45,6 +45,12 @@
     {
       "matchManagers": ["github-actions"],
       "groupName": "github-actions"
+    },
+    {
+      "matchPackageNames": ["junit:junit"],
+      "description": "Stay on JUnit 4; don't auto-bump to 5.x/6.x (Jupiter is a different API).",
+      "allowedVersions": "/^4\\./",
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
We don't use Jupiter-specific features beyond `@TestFactory` / `DynamicTest` (one suite), and the BOM keeps jumping between major versions (5.x → 6.x). Pin to JUnit 4.13.2 and rewrite the one dynamic-test suite as `@RunWith(Parameterized::class)`.

- `libs.versions.toml`: drop `junit-jupiter-bom` / `-jupiter` / `-platform-launcher`; add a single `junit` → `junit:junit:4.13.2`.
- `integration` / `addon-server` build scripts: drop the platform launcher and `useJUnitPlatform()`.
- `CardPixelDiffTest`: `@TestFactory` → `@RunWith(Parameterized)` with the case table as the parameter source.
- `TileCardPixelDiffTest`: swap `org.junit.jupiter.api.*` for `org.junit.*` and flip `assumeTrue` / `assertTrue` argument order.
- `renovate.json`: pin `junit:junit` to 4.x and disable updates so the Jupiter BOM doesn't sneak back in.

## Test plan
- [x] `./gradlew :addon-server:test` (no tests yet — task is NO-SOURCE)
- [x] `./gradlew :integration:compileTestKotlin`
- [x] `./gradlew ktfmtCheck`
- [ ] `./gradlew :integration:test` — requires compose-preview renders on disk (out-of-tree CI step); unchanged from main


---
_Generated by [Claude Code](https://claude.ai/code/session_011yq31KNJYfYivMgLoPQo5K)_