### PR TITLE
ci: use unified compose-preview apply action 0.11.9

### DIFF
--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -29,7 +29,7 @@ jobs:
           # credentials persisted here.
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.11.7
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-apply@v0.11.9
         with:
           cli-version: catalog
           catalog-key: compose-preview-plugin

--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -29,7 +29,7 @@ jobs:
           # credentials persisted here.
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-apply@v0.11.9
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.11.9
         with:
           cli-version: catalog
           catalog-key: compose-preview-plugin

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-apply@v0.11.9
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.11.9
         with:
           cli-version: catalog
           catalog-key: compose-preview-plugin

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.11.7
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-apply@v0.11.9
         with:
           cli-version: catalog
           catalog-key: compose-preview-plugin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ indriya = "2.2.4"
 # of the plugin marker. The preview-baselines / preview-comment GitHub
 # Actions read this key (`catalog-key: compose-preview-plugin`) to pin
 # the CLI release they install on the runner.
-compose-preview-plugin = "0.11.7"
+compose-preview-plugin = "0.11.9"
 tapmoc = "0.4.2"
 
 # Image loading (BitmapLoader / RemoteCompose named-bitmap resolution)


### PR DESCRIPTION
## Summary
Replace the split `preview-baselines` (push-to-main) and `preview-comment` (PR) actions with the unified `preview-apply@v0.11.9` action, which handles both flows. Bump the catalogued CLI / plugin version from 0.11.7 → 0.11.9 so the runner-side CLI matches the plugin auto-injected on the `:previews` module.

This restores `:integration:test` on CI: pixel-diff tests rely on PNGs produced by `composePreviewRender`, and the previous main run failed all 29 cases because that task wasn't materialised on the integration job (preview-baselines hadn't pushed renders yet on the fresh main).

## Test plan
- [ ] First push to main runs `preview-baselines` workflow → `preview-apply` updates the `compose-preview/main` branch.
- [ ] Next PR runs `preview-comment` workflow → `preview-apply` posts before/after diff comment.


---
_Generated by [Claude Code](https://claude.ai/code/session_011yq31KNJYfYivMgLoPQo5K)_