### PR TITLE
ci: render previews in unit-test job so pixel-diff tests find PNGs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       # local to the test job and doesn't push anything.)
       - uses: yschimke/compose-ai-tools/.github/actions/install@v0.11.10
         with:
-          cli-version: catalog
+          version: catalog
           catalog-key: compose-preview-plugin
       - name: Render @Preview composables
         run: compose-preview show --json > /dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,14 +39,23 @@ jobs:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@v6
+      # `:integration:test`'s pixel-diff suites require rendered PNGs
+      # under `previews/build/compose-previews/renders/`. The
+      # compose-preview Gradle plugin isn't applied to any module — its
+      # `composePreviewRender` task is materialised by the CLI's
+      # auto-inject init script on demand — so we install the CLI and
+      # render before `./gradlew test`. (The `compose-preview` workflow
+      # still publishes baselines / PR comments separately; this step is
+      # local to the test job and doesn't push anything.)
+      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.11.10
+        with:
+          cli-version: catalog
+          catalog-key: compose-preview-plugin
+      - name: Render @Preview composables
+        run: compose-preview show --json > /dev/null
       # `test` fans out to every module: Android library / app modules get
       # their `testDebugUnitTest`, JVM modules (`:integration`, KMP common)
-      # get plain `test`. The compose-preview Gradle plugin is no longer
-      # applied to any module — its `composePreviewRender` task is
-      # materialised by the CLI's auto-inject init script on demand, so the
-      # Robolectric-backed pixel renders are produced by the preview-baselines
-      # / preview-comment workflows (not this job). `:integration:test`
-      # tolerates missing PNGs via assumeTrue skips.
+      # get plain `test`.
       - run: ./gradlew test --stacktrace
       - name: Upload test reports
         if: always()

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -10,11 +10,11 @@ dependencies {
 tasks.test {
   // Rendered PNGs come from the compose-preview CLI's `composePreviewRender`
   // task, which the CLI's auto-inject init script materialises on the
-  // `:previews` module — run `compose-preview show` locally (or let the
-  // preview-baselines / preview-comment GitHub Actions do it in CI) before
-  // `./gradlew :integration:test`. The task isn't visible to a plain
+  // `:previews` module — run `compose-preview show` locally (CI does this
+  // in the `test` job before `./gradlew test`) so the renders exist before
+  // the pixel-diff suites run. The task isn't visible to a plain
   // `./gradlew` invocation, so we wire `dependsOn` only when it exists;
-  // missing PNGs are tolerated by the parameterized tests' assumeTrue skips.
+  // the pixel-diff tests hard-fail when the renders are missing.
   rootProject.findProject(":previews")?.tasks?.findByName("composePreviewRender")?.let {
     dependsOn(it)
   }


### PR DESCRIPTION
## Summary
- `:integration:test`'s pixel-diff suites (`CardPixelDiffTest`, `TileCardPixelDiffTest`) call `require(!exact.isNullOrEmpty())` in `locateRendered`, which throws `IllegalArgumentException` before the `assumeTrue(reference.exists())` skip can run. The CI `test` job runs plain `./gradlew test`, which leaves `previews/build/compose-previews/renders/` empty because the `composePreviewRender` task is only materialised by the compose-preview CLI's auto-inject init script — so every pixel-diff case fails.
- Install the CLI via `yschimke/compose-ai-tools/.github/actions/install@v0.11.10` and run `compose-preview show --json` before `./gradlew test` in the `test` job. Renders aren't published from this job; the separate `compose-preview` workflow still owns baselines and PR comments.
- Refresh the now-stale "missing PNGs tolerated via `assumeTrue` skips" comment in `integration/build.gradle.kts`.

## Test plan
- [ ] CI `Unit tests` job passes (pixel-diff suites find renders instead of throwing `IllegalArgumentException at CardPixelDiffTest.kt:116` / `TileCardPixelDiffTest.kt:68`).
- [ ] `Render previews (baseline or PR comment, auto-selected)` job still passes (unchanged).
- [ ] Other CI jobs (`Assemble (debug)`, `Android lint`, `Instrumented tests`, `ktfmt check`) unaffected.