### PR TITLE
feat: capture crashes via LogStore sink and optional Crashlytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,9 @@ captures/
 */.compose-preview-history/
 */bin/
 
+# Crashlytics key — opt-in per developer; presence enables the Firebase
+# crash reporter at build time (see app/build.gradle.kts). Keep out of VCS.
+google-services.json
+*/google-services.json
+
 __pycache__/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,13 @@ android {
       if (releaseKeystorePath != null) {
         signingConfig = signingConfigs.getByName("release")
       }
+      // FirebaseCrashReporter is loaded reflectively, so R8 would strip or
+      // rename it in minified builds without an explicit keep rule. Only
+      // needed (and the class only present) when a key is configured; the
+      // experimental build type inherits this via initWith below.
+      if (crashlyticsEnabled) {
+        proguardFiles(file("crashlytics-rules.pro"))
+      }
     }
     create("experimental") {
       initWith(getByName("release"))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,6 +22,19 @@ plugins {
   alias(libs.plugins.play.publisher)
 }
 
+// Crashlytics is opt-in and gated on a real key. When
+// `app/google-services.json` is present we apply the Google Services +
+// Crashlytics Gradle plugins, compile the Firebase-backed reporter
+// (src/crashlytics), and pull in the SDK; otherwise the app builds and
+// runs unchanged against NoopCrashReporter. The matching plugin classpath
+// is added conditionally in the root build.gradle.kts.
+val crashlyticsEnabled = file("google-services.json").exists()
+
+if (crashlyticsEnabled) {
+  apply(plugin = "com.google.gms.google-services")
+  apply(plugin = "com.google.firebase.crashlytics")
+}
+
 android {
   namespace = "ee.schimke.terrazzo"
   compileSdk = libs.versions.android.compileSdk.get().toInt()
@@ -41,6 +54,10 @@ android {
     // Exposed to AndroidManifest via placeholders so the IndieAuth
     // redirect scheme is declared in one place.
     manifestPlaceholders["appAuthRedirectScheme"] = "rcha"
+
+    // Read at runtime by CrashReporter.create() to decide whether to
+    // resolve the Firebase-backed reporter or fall back to a no-op.
+    buildConfigField("boolean", "CRASHLYTICS_ENABLED", crashlyticsEnabled.toString())
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }
@@ -72,6 +89,12 @@ android {
   buildFeatures {
     compose = true
     buildConfig = true
+  }
+  // The Firebase-backed CrashReporter only joins the compilation when a
+  // key is configured; src/main stays free of any Firebase import so the
+  // no-key build needs none of the SDK.
+  if (crashlyticsEnabled) {
+    sourceSets.getByName("main").kotlin.srcDir("src/crashlytics/kotlin")
   }
   kotlin { jvmToolchain(libs.versions.java.get().toInt()) }
 }
@@ -142,6 +165,12 @@ dependencies {
 
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.kotlinx.serialization.json)
+
+  // Crashlytics SDK — only when a key is configured (see crashlyticsEnabled).
+  if (crashlyticsEnabled) {
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.crashlytics)
+  }
 
   testImplementation(libs.kotlin.test.junit)
   testImplementation(libs.kotlinx.coroutines.test)

--- a/app/crashlytics-rules.pro
+++ b/app/crashlytics-rules.pro
@@ -1,0 +1,11 @@
+# FirebaseCrashReporter is instantiated only via reflection
+# (Class.forName in CrashReporter.create), so R8 in minified
+# Crashlytics-enabled builds would otherwise strip or rename it —
+# silently falling back to NoopCrashReporter and disabling crash
+# reporting in exactly the release/experimental builds that need it.
+# Keep the class name and its no-arg constructor. This file is only
+# wired into the build when the crashlytics source set is compiled
+# (see app/build.gradle.kts `crashlyticsEnabled`).
+-keep class ee.schimke.terrazzo.crash.FirebaseCrashReporter {
+    <init>();
+}

--- a/app/src/crashlytics/kotlin/ee/schimke/terrazzo/crash/FirebaseCrashReporter.kt
+++ b/app/src/crashlytics/kotlin/ee/schimke/terrazzo/crash/FirebaseCrashReporter.kt
@@ -1,0 +1,32 @@
+package ee.schimke.terrazzo.crash
+
+import android.content.Context
+import com.google.firebase.FirebaseApp
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+
+/**
+ * Firebase Crashlytics-backed [CrashReporter]. Compiled into the app
+ * only when a Crashlytics key (`google-services.json`) is present at
+ * build time — see the `crashlyticsEnabled` source-set wiring in
+ * `app/build.gradle.kts`.
+ *
+ * Instantiated reflectively by [CrashReporter.create], so it must keep
+ * a no-arg constructor and stay `internal` to this source set.
+ *
+ * [install] initialises Firebase, which registers Crashlytics' own
+ * uncaught-exception handler — that's what reports *fatal* crashes.
+ * [recordCrash] is only for the non-fatal / handled exceptions the app
+ * forwards explicitly.
+ */
+internal class FirebaseCrashReporter : CrashReporter {
+    private val crashlytics: FirebaseCrashlytics by lazy { FirebaseCrashlytics.getInstance() }
+
+    override fun install(context: Context) {
+        FirebaseApp.initializeApp(context)
+        crashlytics.isCrashlyticsCollectionEnabled = true
+    }
+
+    override fun recordCrash(throwable: Throwable) {
+        crashlytics.recordException(throwable)
+    }
+}

--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApplication.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApplication.kt
@@ -11,11 +11,13 @@ import dev.zacsweers.metro.createGraphFactory
 import ee.schimke.ha.rc.enableRemoteComposeWrapContent
 import ee.schimke.terrazzo.core.di.TerrazzoGraph
 import ee.schimke.terrazzo.core.monitor.CardMonitor
+import ee.schimke.terrazzo.crash.CrashReporter
 import ee.schimke.terrazzo.di.AppGraph
 import ee.schimke.terrazzo.image.HaImageStack
 import ee.schimke.terrazzo.monitor.createMonitor
 import ee.schimke.terrazzo.wearsync.MobileSyncStatsStore
 import ee.schimke.terrazzo.wearsync.MobileWearSyncManager
+import kotlinx.coroutines.plus
 
 /**
  * Holds the singleton [TerrazzoGraph] so every Android entry point —
@@ -46,6 +48,10 @@ class TerrazzoApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        // Install crash logging first so anything that throws during the
+        // rest of startup is still captured (the in-app LogStore sink is
+        // always wired; Crashlytics rides along when a key is configured).
+        installCrashLogging()
         // Flip the RemoteCompose player into wrap-content sizing —
         // see enableRemoteComposeWrapContent's KDoc. Combined with the
         // wrap-friendly profile (androidXExperimentalWrap) this lets
@@ -60,13 +66,51 @@ class TerrazzoApplication : Application() {
         // demo / pinned-card updates even when the phone UI is in the
         // background). PreferencesStore + WidgetStore are read from the
         // graph; the manager owns its own lazy DataClient/MessageClient.
+        // Adopt the LogStore's CoroutineExceptionHandler on the wear-sync
+        // scope: a stray failure in background sync gets logged instead of
+        // propagating to the thread's default handler and taking the whole
+        // UI process down. The `+ handler` keeps the lifecycle Job (and its
+        // cancellation) intact.
         graph.wearSyncManager.start(
-            scope = ProcessLifecycleOwner.get().lifecycleScope,
+            scope = ProcessLifecycleOwner.get().lifecycleScope + graph.logStore.coroutineExceptionHandler,
             prefs = graph.preferencesStore,
             pinStore = graph.pinStore,
             slotsStore = graph.wearWidgetSlotsStore,
         )
     }
+
+    /**
+     * Route uncaught exceptions to the in-app [LogStore] (persisted
+     * synchronously so the trace survives the imminent process kill)
+     * and, when configured, to Crashlytics — then chain to whatever
+     * handler was already installed so the platform's default crash
+     * behaviour (dialog / process death) is preserved. Coroutine
+     * failures that escape a root scope without their own handler also
+     * land here, since they propagate to the thread's default handler.
+     */
+    private fun installCrashLogging() {
+        // install() registers Crashlytics' own uncaught handler (when a
+        // key is configured), so we capture `previous` *after* it — our
+        // handler records to the LogStore then chains through, letting
+        // Crashlytics report the fatal crash natively. We deliberately
+        // don't also call crashReporter.recordCrash here: that path is
+        // for non-fatal reports and would double-count an uncaught crash.
+        crashReporter.install(applicationContext)
+        val previous = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            runCatching { graph.logStore.recordCrash(throwable, thread, fatal = true) }
+            previous?.uncaughtException(thread, throwable)
+        }
+    }
+
+    /**
+     * Optional external crash sink. Resolves to a Firebase-backed
+     * reporter only when the app was built with a Crashlytics key
+     * (`google-services.json` present at build time); otherwise it's a
+     * no-op and the app runs crash-reporting-free off the [LogStore]
+     * sink alone.
+     */
+    private val crashReporter: CrashReporter by lazy { CrashReporter.create() }
 
     private fun registerNotificationChannels() {
         val nm = getSystemService(NotificationManager::class.java) ?: return

--- a/app/src/main/kotlin/ee/schimke/terrazzo/crash/CrashReporter.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/crash/CrashReporter.kt
@@ -1,0 +1,64 @@
+package ee.schimke.terrazzo.crash
+
+import android.content.Context
+import ee.schimke.terrazzo.BuildConfig
+
+/**
+ * Thin seam over an external crash-reporting backend so the rest of the
+ * app never imports Firebase directly. The in-app
+ * [ee.schimke.terrazzo.core.logs.LogStore] is always the primary sink;
+ * this is the *optional* off-device backend layered on top.
+ *
+ * Whether a real backend exists is a build-time decision: the Firebase
+ * implementation and its dependencies are only compiled into the app
+ * when a Crashlytics key (`google-services.json`) is present — see the
+ * `crashlyticsEnabled` wiring in `app/build.gradle.kts`. Without a key
+ * the app builds and runs exactly as before, against [NoopCrashReporter].
+ */
+interface CrashReporter {
+    /**
+     * Initialise the backend. Safe to call once, early in
+     * `Application.onCreate`. A real backend typically registers its own
+     * uncaught-exception handler here.
+     */
+    fun install(context: Context)
+
+    /**
+     * Forward a non-fatal / handled throwable to the backend. Uncaught
+     * fatal crashes are captured by the backend's own handler (installed
+     * in [install]), so this is for exceptions the app caught and
+     * recovered from but still wants reported.
+     */
+    fun recordCrash(throwable: Throwable)
+
+    companion object {
+        /**
+         * The Firebase-backed reporter when the app was built with a
+         * Crashlytics key ([BuildConfig.CRASHLYTICS_ENABLED]), otherwise
+         * a no-op.
+         *
+         * The Firebase impl lives in the `src/crashlytics` source set,
+         * compiled in only when the key is present, so it's resolved
+         * reflectively here to keep `src/main` free of any compile-time
+         * Firebase dependency. The reflection can only succeed when the
+         * source set (and thus the class) is on the classpath, and the
+         * `BuildConfig` guard short-circuits before we even try in the
+         * common no-key build.
+         */
+        fun create(): CrashReporter {
+            if (!BuildConfig.CRASHLYTICS_ENABLED) return NoopCrashReporter
+            return runCatching {
+                Class.forName("ee.schimke.terrazzo.crash.FirebaseCrashReporter")
+                    .getDeclaredConstructor()
+                    .newInstance() as CrashReporter
+            }.getOrDefault(NoopCrashReporter)
+        }
+    }
+}
+
+/** Used when no Crashlytics key is configured; the LogStore sink stands alone. */
+internal object NoopCrashReporter : CrashReporter {
+    override fun install(context: Context) = Unit
+
+    override fun recordCrash(throwable: Throwable) = Unit
+}

--- a/app/src/main/kotlin/ee/schimke/terrazzo/logs/LogsScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/logs/LogsScreen.kt
@@ -1,5 +1,6 @@
 package ee.schimke.terrazzo.logs
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -26,6 +27,9 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -40,8 +44,11 @@ import java.util.Locale
 
 /**
  * Debug surface for the [ee.schimke.terrazzo.core.logs.LogStore]
- * buffer. Three sections, reverse-chronological inside each:
+ * buffer. Four sections, reverse-chronological inside each:
  *
+ *   - **Crashes** — uncaught exceptions (and caught coroutine failures)
+ *     captured by the crash plumbing. Recorded regardless of this
+ *     screen's preference; tap a row to expand the full stack trace.
  *   - **Data updates** — entity state changes seen on the WebSocket,
  *     filtered to entities referenced by the currently-rendered
  *     dashboard so background entities don't drown the view. Kept for
@@ -60,6 +67,7 @@ fun LogsScreen(onBack: () -> Unit) {
     val store = LocalTerrazzoGraph.current.logStore
     val entries by store.flow.collectAsState()
 
+    val crashes = entries.filterIsInstance<LogEntry.Crash>().sortedByDescending { it.timestamp }
     val dataUpdates = entries.filterIsInstance<LogEntry.DataUpdate>().sortedByDescending { it.timestamp }
     val connections = entries.filterIsInstance<LogEntry.Connection>().sortedByDescending { it.timestamp }
     val actions = entries.filterIsInstance<LogEntry.LocalAction>().sortedByDescending { it.timestamp }
@@ -85,6 +93,10 @@ fun LogsScreen(onBack: () -> Unit) {
             contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
+            section("Crashes (${crashes.size})") {
+                if (crashes.isEmpty()) emptyHint("No crashes recorded. 🎉")
+                else crashes.forEach { CrashRow(it) }
+            }
             section("Connection (${connections.size})") {
                 if (connections.isEmpty()) emptyHint("No connection events yet.")
                 else connections.forEach { ConnectionRow(it) }
@@ -141,6 +153,69 @@ private fun ConnectionRow(entry: LogEntry.Connection) {
         leading = { StatusChip(entry.status) },
         primary = entry.status.label,
         secondary = entry.message,
+    )
+}
+
+@Composable
+private fun CrashRow(entry: LogEntry.Crash) {
+    var expanded by remember { mutableStateOf(false) }
+    Column(
+        modifier = Modifier.fillMaxWidth()
+            .clickable { expanded = !expanded }
+            .padding(vertical = 4.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = formatTime(entry.timestamp),
+                style = MaterialTheme.typography.labelSmall,
+                fontFamily = FontFamily.Monospace,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            CrashChip(fatal = entry.fatal)
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    entry.summary,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color(0xFFD32F2F),
+                )
+                Text(
+                    "thread: ${entry.threadName}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        if (expanded) {
+            Text(
+                text = entry.stackTrace,
+                style = MaterialTheme.typography.labelSmall,
+                fontFamily = FontFamily.Monospace,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun CrashChip(fatal: Boolean) {
+    val color = if (fatal) Color(0xFFD32F2F) else Color(0xFFF57C00)
+    AssistChip(
+        onClick = {},
+        enabled = false,
+        label = {
+            Text(
+                if (fatal) "FATAL" else "CAUGHT",
+                style = MaterialTheme.typography.labelSmall,
+            )
+        },
+        colors = AssistChipDefaults.assistChipColors(
+            disabledContainerColor = color.copy(alpha = 0.16f),
+            disabledLabelColor = color,
+        ),
     )
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,25 @@
 import com.ncorti.ktfmt.gradle.KtfmtExtension
 
+buildscript {
+  // Crashlytics is opt-in. Only put the Google Services / Crashlytics
+  // Gradle plugins on the buildscript classpath when an
+  // `app/google-services.json` is present — without it nothing here
+  // resolves, so the default build is byte-for-byte unaffected and pulls
+  // in no Firebase tooling. The path is resolved relative to the root
+  // project dir (Gradle's working directory). Versions are only fetched
+  // by developers who have configured a key; bump as needed.
+  if (java.io.File("app/google-services.json").exists()) {
+    repositories {
+      google()
+      mavenCentral()
+    }
+    dependencies {
+      classpath("com.google.gms:google-services:4.4.4")
+      classpath("com.google.firebase:firebase-crashlytics-gradle:3.0.6")
+    }
+  }
+}
+
 plugins {
   alias(libs.plugins.android.application) apply false
   alias(libs.plugins.android.library) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,10 @@ jetbrains-markdown = "0.7.3"
 horologist = "0.8.3-alpha"
 play-services-wearable = "20.0.1"
 
+# Firebase Crashlytics (opt-in — only resolved when a google-services.json
+# key is configured; see app/build.gradle.kts `crashlyticsEnabled`).
+firebase-bom = "34.4.0"
+
 [libraries]
 # RemoteCompose authoring / playback
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
@@ -182,6 +186,11 @@ mockserver-client-java = { module = "org.mock-server:mockserver-client-java", ve
 
 jetbrains-markdown = { module = "org.jetbrains:markdown", version.ref = "jetbrains-markdown" }
 indriya = { module = "tech.units:indriya", version.ref = "indriya" }
+
+# Firebase Crashlytics — pulled into :app only when a Crashlytics key is
+# configured (the BoM aligns the Crashlytics + analytics artifact versions).
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
+firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/logs/LogStore.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/logs/LogStore.kt
@@ -8,6 +8,7 @@ import dev.zacsweers.metro.SingleIn
 import ee.schimke.ha.model.Dashboard
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.terrazzo.core.di.AppScope
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -17,6 +18,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Persistent log buffer for the debug Logs view. Hidden behind a
@@ -35,6 +38,10 @@ import kotlinx.coroutines.launch
  *  - **Local actions** — button taps, toggles, service calls dispatched
  *    by the dashboard's action dispatcher. Captured *before* the
  *    network round-trip so a failed send is still visible.
+ *  - **Crashes** — uncaught exceptions (persisted synchronously so the
+ *    trace survives the process kill) and caught coroutine failures fed
+ *    via [recordCrash]. Unlike the streams above these are recorded
+ *    even when the debug-logs preference is off.
  *
  * Persisted to disk via a Proto DataStore so events survive process
  * death. The in-memory ring is the source of truth for reads / the
@@ -127,6 +134,54 @@ class LogStore(context: Context) {
     }
 
     /**
+     * Record an exception in the buffer. Unlike the other feeders this
+     * is *not* gated on the debug-logs preference — a crash is worth
+     * keeping even if the user never opened the Logs screen, so the
+     * trace is there the moment they flip the toggle to diagnose.
+     *
+     * [fatal] marks an uncaught crash that's about to take the process
+     * down (the uncaught-exception handler). Those persist
+     * *synchronously* via [persistBlocking] because the async IO scope
+     * wouldn't survive the imminent kill. Non-fatal reports — a caught
+     * coroutine failure routed through [coroutineExceptionHandler] —
+     * ride the normal async path.
+     */
+    fun recordCrash(
+        throwable: Throwable,
+        thread: Thread = Thread.currentThread(),
+        fatal: Boolean = true,
+    ) {
+        val entry = LogEntry.Crash(
+            timestamp = clock(),
+            threadName = thread.name,
+            summary = throwable.summarize(),
+            stackTrace = throwable.stackTraceToString(),
+            fatal = fatal,
+        )
+        synchronized(lock) {
+            entries.addLast(entry)
+            prune(entry.timestamp)
+        }
+        publish()
+        if (fatal) persistBlocking() else persistAsync()
+    }
+
+    /**
+     * Drop-in [CoroutineExceptionHandler] for the app's top-level
+     * scopes (e.g. the process-lifecycle wear-sync scope). An exception
+     * that escapes a root `launch` lands here and is recorded as a
+     * non-fatal crash; the scope is already torn down by the time the
+     * handler runs. Adopting this on a background scope keeps a stray
+     * failure there from propagating to the thread's default handler
+     * and killing the whole UI process — while still capturing the
+     * trace in the in-app log.
+     */
+    val coroutineExceptionHandler: CoroutineExceptionHandler =
+        CoroutineExceptionHandler { _, throwable ->
+            recordCrash(throwable, fatal = false)
+        }
+
+    /**
      * Diff [snapshot] against the last recorded snapshot for any
      * entity referenced by [dashboard], emitting one
      * [LogEntry.DataUpdate] per changed entity. First call after
@@ -216,12 +271,38 @@ class LogStore(context: Context) {
         }
     }
 
+    /**
+     * Synchronous sibling of [persistAsync] for the fatal-crash path.
+     * Blocks the calling thread until the ring is on disk because the
+     * uncaught-exception handler runs microseconds before the default
+     * handler kills the process — a write dispatched to [scope] would
+     * never flush. Time-boxed by [PERSIST_BLOCKING_TIMEOUT_MS] so a
+     * wedged DataStore write can't hang the dying process, and wrapped
+     * in `runCatching` for the same reason [persistAsync] is: a missed
+     * write on the debug surface mustn't mask the original crash.
+     */
+    private fun persistBlocking() {
+        runCatching {
+            runBlocking {
+                withTimeoutOrNull(PERSIST_BLOCKING_TIMEOUT_MS) {
+                    dataStore.updateData {
+                        val snapshot = synchronized(lock) { entries.map { it.toPersisted() } }
+                        PersistedLogBuffer(entries = snapshot)
+                    }
+                }
+            }
+        }
+    }
+
     companion object {
         /** Data updates older than this are dropped on every write. */
         const val DATA_UPDATE_RETENTION_MS: Long = 5 * 60 * 1000L
 
         /** Hard cap so a chatty session can't grow the buffer without bound. */
         const val MAX_ENTRIES: Int = 500
+
+        /** Upper bound on the blocking disk flush in the crash path. */
+        const val PERSIST_BLOCKING_TIMEOUT_MS: Long = 1_000L
 
         private val Context.logStore: DataStore<PersistedLogBuffer> by dataStore(
             fileName = "terrazzo_logs.pb",
@@ -254,4 +335,24 @@ sealed interface LogEntry {
         val summary: String,
         val entityId: String? = null,
     ) : LogEntry
+
+    /**
+     * An exception captured by the crash plumbing. [fatal] distinguishes
+     * an uncaught crash that took the process down from a non-fatal
+     * report (a coroutine failure that was logged but recovered).
+     */
+    data class Crash(
+        override val timestamp: Long,
+        val threadName: String,
+        val summary: String,
+        val stackTrace: String,
+        val fatal: Boolean,
+    ) : LogEntry
+}
+
+/** `ClassName: message`, or just the class name when there's no message. */
+private fun Throwable.summarize(): String {
+    val name = this::class.qualifiedName ?: this::class.simpleName ?: "Throwable"
+    val msg = message
+    return if (msg.isNullOrBlank()) name else "$name: $msg"
 }

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/logs/LogStorePersistence.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/logs/LogStorePersistence.kt
@@ -31,7 +31,7 @@ internal data class PersistedLogBuffer(
 @Serializable
 internal data class PersistedLogEntry(
     @ProtoNumber(1) val timestamp: Long = 0L,
-    /** 0 = connection · 1 = local action · 2 = data update. */
+    /** 0 = connection · 1 = local action · 2 = data update · 3 = crash. */
     @ProtoNumber(2) val kind: Int = 0,
     /** Ordinal of [LogConnectionStatus]; -1 when [kind] != 0. */
     @ProtoNumber(3) val connectionStatus: Int = -1,
@@ -40,11 +40,15 @@ internal data class PersistedLogEntry(
     @ProtoNumber(6) val entityId: String = "",
     @ProtoNumber(7) val fromState: String = "",
     @ProtoNumber(8) val toState: String = "",
+    @ProtoNumber(9) val stackTrace: String = "",
+    @ProtoNumber(10) val threadName: String = "",
+    @ProtoNumber(11) val fatal: Boolean = false,
 )
 
 internal const val KIND_CONNECTION: Int = 0
 internal const val KIND_LOCAL_ACTION: Int = 1
 internal const val KIND_DATA_UPDATE: Int = 2
+internal const val KIND_CRASH: Int = 3
 
 internal fun LogEntry.toPersisted(): PersistedLogEntry = when (this) {
     is LogEntry.Connection -> PersistedLogEntry(
@@ -65,6 +69,14 @@ internal fun LogEntry.toPersisted(): PersistedLogEntry = when (this) {
         entityId = entityId,
         fromState = fromState,
         toState = toState,
+    )
+    is LogEntry.Crash -> PersistedLogEntry(
+        timestamp = timestamp,
+        kind = KIND_CRASH,
+        summary = summary,
+        stackTrace = stackTrace,
+        threadName = threadName,
+        fatal = fatal,
     )
 }
 
@@ -87,6 +99,13 @@ internal fun PersistedLogEntry.toModel(): LogEntry? = when (kind) {
         entityId = entityId,
         fromState = fromState,
         toState = toState,
+    )
+    KIND_CRASH -> LogEntry.Crash(
+        timestamp = timestamp,
+        threadName = threadName,
+        summary = summary,
+        stackTrace = stackTrace,
+        fatal = fatal,
     )
     else -> null
 }


### PR DESCRIPTION
Capture crashes that previously vanished — there was no uncaught-exception
handler and no crash-reporting backend, so a crash left no trace beyond
adb logcat.

Internal (always on, no new dependencies):
- LogStore gains a Crash entry type and recordCrash(). Fatal crashes are
  persisted synchronously (the async IO scope wouldn't survive the
  imminent process kill), time-boxed so a wedged write can't hang the
  dying process. Recorded regardless of the debug-logs preference.
- TerrazzoApplication installs a default uncaught-exception handler that
  records to LogStore then chains to the previous handler, preserving the
  platform's crash behaviour. Coroutine failures that escape a root scope
  land here too.
- LogStore exposes a CoroutineExceptionHandler, adopted on the wear-sync
  process-lifecycle scope so a background-sync failure is logged instead
  of taking the whole UI process down.
- LogsScreen shows a Crashes section with expandable stack traces.

Crashlytics (opt-in, gated on a key):
- Present only when app/google-services.json exists at build time: the
  Google Services + Crashlytics Gradle plugins are applied, the Firebase
  SDK is pulled in, and the FirebaseCrashReporter source set is compiled.
  Without a key the build is unchanged and runs against a no-op reporter.
- CrashReporter seam keeps src/main free of any Firebase import; the
  Firebase impl is resolved reflectively behind a BuildConfig flag.