### PR TITLE
feat: forward non-fatal coroutine crashes to Crashlytics

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApplication.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApplication.kt
@@ -96,16 +96,19 @@ class TerrazzoApplication : Application() {
         // don't also call crashReporter.recordCrash here: that path is
         // for non-fatal reports and would double-count an uncaught crash.
         crashReporter.install(applicationContext)
-        // Forward caught/non-fatal crashes (e.g. coroutine failures routed
-        // through the LogStore's CoroutineExceptionHandler) to the backend
-        // as non-fatals. Fatal crashes aren't routed here — they're already
-        // reported by the backend's own uncaught handler via the chain below.
-        graph.logStore.nonFatalSink = crashReporter::recordCrash
         val previous = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
             runCatching { graph.logStore.recordCrash(throwable, thread, fatal = true) }
             previous?.uncaughtException(thread, throwable)
         }
+        // Forward caught/non-fatal crashes (e.g. coroutine failures routed
+        // through the LogStore's CoroutineExceptionHandler) to the backend
+        // as non-fatals. Fatal crashes aren't routed here — they're already
+        // reported by the backend's own uncaught handler via the chain above.
+        // This is the first `graph` access, which triggers graph init; we do
+        // it *after* installing the handler so a failure during init is still
+        // captured rather than escaping uncovered.
+        graph.logStore.nonFatalSink = crashReporter::recordCrash
     }
 
     /**

--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApplication.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApplication.kt
@@ -96,6 +96,11 @@ class TerrazzoApplication : Application() {
         // don't also call crashReporter.recordCrash here: that path is
         // for non-fatal reports and would double-count an uncaught crash.
         crashReporter.install(applicationContext)
+        // Forward caught/non-fatal crashes (e.g. coroutine failures routed
+        // through the LogStore's CoroutineExceptionHandler) to the backend
+        // as non-fatals. Fatal crashes aren't routed here — they're already
+        // reported by the backend's own uncaught handler via the chain below.
+        graph.logStore.nonFatalSink = crashReporter::recordCrash
         val previous = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
             runCatching { graph.logStore.recordCrash(throwable, thread, fatal = true) }

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/logs/LogStore.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/logs/LogStore.kt
@@ -134,6 +134,17 @@ class LogStore(context: Context) {
     }
 
     /**
+     * Forwards *non-fatal* crashes to an external backend (Crashlytics)
+     * when one is configured. terrazzo-core carries no Firebase
+     * dependency, so the app installs the bridge here once its reporter
+     * is up; until then it's a no-op and only the in-app buffer is
+     * written. Fatal crashes are deliberately *not* routed through this:
+     * the backend's own uncaught-exception handler already reports those,
+     * and forwarding would double-count them.
+     */
+    var nonFatalSink: (Throwable) -> Unit = {}
+
+    /**
      * Record an exception in the buffer. Unlike the other feeders this
      * is *not* gated on the debug-logs preference — a crash is worth
      * keeping even if the user never opened the Logs screen, so the
@@ -144,7 +155,8 @@ class LogStore(context: Context) {
      * *synchronously* via [persistBlocking] because the async IO scope
      * wouldn't survive the imminent kill. Non-fatal reports — a caught
      * coroutine failure routed through [coroutineExceptionHandler] —
-     * ride the normal async path.
+     * ride the normal async path and are additionally forwarded to
+     * [nonFatalSink].
      */
     fun recordCrash(
         throwable: Throwable,
@@ -163,7 +175,13 @@ class LogStore(context: Context) {
             prune(entry.timestamp)
         }
         publish()
-        if (fatal) persistBlocking() else persistAsync()
+        if (fatal) {
+            persistBlocking()
+        } else {
+            persistAsync()
+            // Best-effort: a failing backend mustn't mask the original error.
+            runCatching { nonFatalSink(throwable) }
+        }
     }
 
     /**


### PR DESCRIPTION
Follow-up to #330. The crash-logging PR added a `LogStore` CoroutineExceptionHandler that records caught coroutine failures to the in-app buffer, but those never reached the external backend — so in Crashlytics-enabled builds a handled coroutine failure was visible only locally. (Raised in review on #330.)

- `LogStore` gains a `nonFatalSink` seam. terrazzo-core carries no Firebase dependency, so the app installs the bridge; until then it's a no-op and only the in-app buffer is written. `recordCrash` forwards non-fatal crashes through it, best-effort (a failing backend can't mask the original error).
- `TerrazzoApplication` wires the sink to `CrashReporter::recordCrash`. Fatal crashes are deliberately **not** routed here — the backend's own uncaught handler already reports those via the handler chain, so forwarding would double-count them.

## Test plan
- `./gradlew :app:compileDebugKotlin` — passes (no-key build, no-op sink).
- `./gradlew :app:ktfmtCheck :terrazzo-core:ktfmtCheck` — passes.
- Crashlytics-enabled path is build-time gated on `google-services.json`; unchanged from #330's wiring.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFo88ftmKMzgx492LLvGMh)_