### PR TITLE
Add compose-ui-tooling-preview dependency to demo-app

### DIFF
--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -32,6 +32,14 @@ dependencies {
   implementation(libs.compose.foundation)
   implementation(libs.compose.material3)
   implementation(libs.activity.compose)
+  // No @Preview composables in :demo-app, but the compose-preview CLI's
+  // 0.12.0 module auto-detection treats "annotation class not on the
+  // ClassGraph classpath" as a hard error (rc=2) instead of a silent
+  // "0 previews here, skip", aborting the workflow before the modules
+  // that do contribute baselines are rendered. The annotation-only
+  // artifact is tiny and ships no renderer, so it stays out of the
+  // release APK while satisfying discovery.
+  implementation(libs.compose.ui.tooling.preview)
 
   implementation(libs.remote.player.compose)
   implementation(libs.remote.player.view)


### PR DESCRIPTION
## Summary
Added the `compose-ui-tooling-preview` annotation-only dependency to the demo-app module to resolve issues with the compose-preview CLI's module auto-detection.

## Key Changes
- Added `implementation(libs.compose.ui.tooling.preview)` to demo-app's build.gradle.kts

## Implementation Details
The compose-preview CLI (v0.12.0+) treats missing `@Preview` annotation classes as a hard error during module auto-detection, causing the workflow to abort before modules with actual preview composables can be rendered. By including the annotation-only artifact in demo-app:
- The CLI's auto-detection succeeds without errors
- The dependency is lightweight and ships no renderer code
- It remains excluded from the release APK while satisfying the CLI's discovery requirements

https://claude.ai/code/session_01KJgbn9qEqxUDJ5CNGpKQrr