### PR TITLE
Fix stale AndroidView players when switching dashboards and cards

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -663,21 +664,32 @@ private fun DashboardsRoot(
                 contentPadding = padding,
             )
         } else {
-            DashboardViewScreen(
-                session = session,
-                urlPath = openedValue,
-                readOnly = readOnly,
-                onCardLongPress = { card ->
-                    // In demo mode the preview — and the installed widget —
-                    // render against the current fake snapshot so values
-                    // aren't empty. Live mode uses an empty snapshot; the
-                    // pinned widget will refresh from HA on first tick.
-                    val previewSnapshot =
-                        if (session is DemoHaSession) DemoData.snapshot() else HaSnapshot()
-                    installPending = card to previewSnapshot
-                },
-                contentPadding = padding,
-            )
+            // Key on the opened dashboard so switching dashboards
+            // disposes the previous one's whole render subtree —
+            // crucially the per-card `AndroidView` players — instead of
+            // reusing their composition slots. The players are hosted via
+            // `AndroidView(factory = { view })`, whose factory runs once
+            // per node; without a fresh node on switch, a reused slot
+            // keeps showing the previous dashboard's view until a
+            // collapse/expand forces recreation. Re-seeding from the
+            // offline cache makes the new dashboard paint immediately.
+            key(openedValue) {
+                DashboardViewScreen(
+                    session = session,
+                    urlPath = openedValue,
+                    readOnly = readOnly,
+                    onCardLongPress = { card ->
+                        // In demo mode the preview — and the installed widget —
+                        // render against the current fake snapshot so values
+                        // aren't empty. Live mode uses an empty snapshot; the
+                        // pinned widget will refresh from HA on first tick.
+                        val previewSnapshot =
+                            if (session is DemoHaSession) DemoData.snapshot() else HaSnapshot()
+                        installPending = card to previewSnapshot
+                    },
+                    contentPadding = padding,
+                )
+            }
         }
     }
 

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -792,21 +793,26 @@ private fun SectionColumn(
             )
         }
         section.cards.forEach { card ->
-            // No `height(...)` — the wrap-adaptive player (see
-            // `CachedCardPreview` / `WrapAdaptiveRemoteDocumentPlayer`)
-            // sizes itself to the document's intrinsic content height
-            // after a paint-context warmup, so the slot wraps to the
-            // card's actual rendered height instead of pinning per-card
-            // via `naturalHeightDp`.
-            CardSlot(
-                card = card,
-                snapshot = snapshot,
-                registry = registry,
-                baseUrl = baseUrl,
-                imageLoader = imageLoader,
-                onLongPress = onLongPress,
-                modifier = Modifier.fillMaxWidth(),
-            )
+            // Key by the card config so each slot's hosted player is tied
+            // to its card identity, not its position in the section — a
+            // reused slot must not keep a previous card's `AndroidView`.
+            key(card) {
+                // No `height(...)` — the wrap-adaptive player (see
+                // `CachedCardPreview` / `WrapAdaptiveRemoteDocumentPlayer`)
+                // sizes itself to the document's intrinsic content height
+                // after a paint-context warmup, so the slot wraps to the
+                // card's actual rendered height instead of pinning per-card
+                // via `naturalHeightDp`.
+                CardSlot(
+                    card = card,
+                    snapshot = snapshot,
+                    registry = registry,
+                    baseUrl = baseUrl,
+                    imageLoader = imageLoader,
+                    onLongPress = onLongPress,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
         }
     }
 }
@@ -858,15 +864,22 @@ private fun CardRow(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         row.cards.forEach { card ->
-            CardSlot(
-                card = card,
-                snapshot = snapshot,
-                registry = registry,
-                baseUrl = baseUrl,
-                imageLoader = imageLoader,
-                onLongPress = onLongPress,
-                modifier = Modifier.weight(1f),
-            )
+            // Key by the card config so a slot never inherits an
+            // unrelated card's hosted player when repacking shifts cards
+            // between rows (e.g. a width-class change re-chunks the row).
+            // Without it the reused `AndroidView` would keep the prior
+            // card's view — the same staleness seen on dashboard switch.
+            key(card) {
+                CardSlot(
+                    card = card,
+                    snapshot = snapshot,
+                    registry = registry,
+                    baseUrl = baseUrl,
+                    imageLoader = imageLoader,
+                    onLongPress = onLongPress,
+                    modifier = Modifier.weight(1f),
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
Wraps dashboard and card compositions with `key()` blocks to ensure that `AndroidView` player instances are properly disposed and recreated when dashboards are switched or cards are repositioned, preventing stale views from persisting on screen.

## Changes
- **TerrazzoApp.kt**: Wrapped `DashboardViewScreen` with `key(openedValue)` to force recreation of the entire dashboard subtree when switching between dashboards. This ensures hosted `AndroidView` players are disposed instead of reused.

- **DashboardViewScreen.kt**: 
  - Wrapped each `CardSlot` in `SectionColumn` with `key(card)` to tie player instances to card identity rather than position
  - Wrapped each `CardSlot` in `CardRow` with `key(card)` to prevent cards from inheriting unrelated players when rows are repacked (e.g., during width-class changes)

- Added `androidx.compose.runtime.key` import to both files

## Implementation Details
The root cause was that `AndroidView(factory = { view })` only runs its factory once per composition node. When dashboards or cards were switched/repositioned without changing the node identity, the same `AndroidView` slot would be reused, keeping the previous card's view on screen until a collapse/expand forced recreation.

By keying compositions on the dashboard path and individual card configs, we ensure:
1. Dashboard switches create fresh composition nodes, disposing all previous players
2. Card repositioning within rows creates new nodes, preventing view staleness
3. The offline cache re-seeds immediately, allowing new dashboards to paint without waiting for network updates

https://claude.ai/code/session_01KjfaHnq2ximtyKBbgMyopD