### PR TITLE
Add dismiss functionality for persistent notifications

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -605,7 +605,17 @@ private fun DashboardsRoot(
                     }
                 },
                 actions = {
-                    NotificationBell(notifications = notifications)
+                    NotificationBell(
+                        notifications = notifications,
+                        onDismiss = { n ->
+                            scope.launch {
+                                runCatching { session.dismissNotification(n.notificationId) }
+                            }
+                        },
+                        onClearAll = {
+                            scope.launch { runCatching { session.dismissAllNotifications() } }
+                        },
+                    )
                     Surface(
                         onClick = onRetryConnection,
                         color = connectionStatus.color.copy(alpha = 0.16f),

--- a/app/src/main/kotlin/ee/schimke/terrazzo/notifications/NotificationBell.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/notifications/NotificationBell.kt
@@ -2,11 +2,13 @@ package ee.schimke.terrazzo.notifications
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
@@ -17,12 +19,14 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import ee.schimke.ha.model.HaNotification
@@ -33,16 +37,20 @@ import ee.schimke.ha.model.HaNotification
  * appears when the list is non-empty; tapping opens a bottom sheet
  * listing every notification with title + message + timestamp.
  *
- * Pure presentational — the source of truth is
- * `HaSession.notifications`; this composable takes the materialised
- * list and renders. New-arrival snackbars are wired separately in
- * `DashboardsRoot` so this widget stays composable in isolation.
+ * Each row carries a dismiss (X) button and the sheet header a "Clear
+ * all" action; both delegate up via [onDismiss] / [onClearAll], which
+ * `DashboardsRoot` wires to `HaSession.dismissNotification` /
+ * `dismissAllNotifications`. HA echoes the removal back over the
+ * subscription, so the list updates reactively — this composable stays
+ * presentational and never mutates the list itself.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NotificationBell(
     notifications: List<HaNotification>,
     modifier: Modifier = Modifier,
+    onDismiss: (HaNotification) -> Unit = {},
+    onClearAll: () -> Unit = {},
 ) {
     var sheetOpen by remember { mutableStateOf(false) }
     IconButton(onClick = { sheetOpen = true }, modifier = modifier) {
@@ -63,18 +71,35 @@ fun NotificationBell(
             onDismissRequest = { sheetOpen = false },
             sheetState = sheetState,
         ) {
-            NotificationSheetContent(notifications)
+            NotificationSheetContent(
+                notifications = notifications,
+                onDismiss = onDismiss,
+                onClearAll = onClearAll,
+            )
         }
     }
 }
 
 @Composable
-private fun NotificationSheetContent(notifications: List<HaNotification>) {
+private fun NotificationSheetContent(
+    notifications: List<HaNotification>,
+    onDismiss: (HaNotification) -> Unit,
+    onClearAll: () -> Unit,
+) {
     Column(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Text("Notifications", style = MaterialTheme.typography.headlineSmall)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text("Notifications", style = MaterialTheme.typography.headlineSmall)
+            if (notifications.isNotEmpty()) {
+                TextButton(onClick = onClearAll) { Text("Clear all") }
+            }
+        }
         if (notifications.isEmpty()) {
             Text(
                 "Nothing from Home Assistant right now.",
@@ -83,7 +108,7 @@ private fun NotificationSheetContent(notifications: List<HaNotification>) {
         } else {
             LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 items(notifications, key = { it.notificationId }) { n ->
-                    NotificationRow(n)
+                    NotificationRow(n, onDismiss = { onDismiss(n) })
                     HorizontalDivider()
                 }
             }
@@ -92,15 +117,27 @@ private fun NotificationSheetContent(notifications: List<HaNotification>) {
 }
 
 @Composable
-private fun NotificationRow(notification: HaNotification) {
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        val title = notification.title?.takeIf { it.isNotBlank() } ?: notification.notificationId
-        Text(title, style = MaterialTheme.typography.titleMedium)
-        if (notification.message.isNotBlank()) {
-            Text(notification.message, style = MaterialTheme.typography.bodyMedium)
+private fun NotificationRow(notification: HaNotification, onDismiss: () -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            val title = notification.title?.takeIf { it.isNotBlank() } ?: notification.notificationId
+            Text(title, style = MaterialTheme.typography.titleMedium)
+            if (notification.message.isNotBlank()) {
+                Text(notification.message, style = MaterialTheme.typography.bodyMedium)
+            }
+            notification.createdAt?.takeIf { it.isNotBlank() }?.let {
+                Text(it, style = MaterialTheme.typography.labelSmall)
+            }
         }
-        notification.createdAt?.takeIf { it.isNotBlank() }?.let {
-            Text(it, style = MaterialTheme.typography.labelSmall)
+        IconButton(onClick = onDismiss) {
+            Icon(Icons.Outlined.Close, contentDescription = "Dismiss notification")
         }
     }
 }

--- a/app/src/test/kotlin/ee/schimke/terrazzo/integration/HaClientSubscriptionTest.kt
+++ b/app/src/test/kotlin/ee/schimke/terrazzo/integration/HaClientSubscriptionTest.kt
@@ -89,6 +89,42 @@ class HaClientSubscriptionTest {
   }
 
   @Test
+  fun dismissNotification_sends_dismiss_call_service() {
+    runBlocking {
+      val client = HaClient(HaConfig(baseUrl = baseUrl, accessToken = "test-token"))
+      try {
+        client.connect()
+        client.dismissNotification("welcome")
+        val sent = withTimeout(2_000) { handler.calledServices.receive() }
+        assertEquals("persistent_notification", sent["domain"]?.jsonPrimitive?.content)
+        assertEquals("dismiss", sent["service"]?.jsonPrimitive?.content)
+        assertEquals(
+          "welcome",
+          sent["service_data"]?.jsonObject?.get("notification_id")?.jsonPrimitive?.content,
+        )
+      } finally {
+        client.close()
+      }
+    }
+  }
+
+  @Test
+  fun dismissAllNotifications_sends_dismiss_all_call_service() {
+    runBlocking {
+      val client = HaClient(HaConfig(baseUrl = baseUrl, accessToken = "test-token"))
+      try {
+        client.connect()
+        client.dismissAllNotifications()
+        val sent = withTimeout(2_000) { handler.calledServices.receive() }
+        assertEquals("persistent_notification", sent["domain"]?.jsonPrimitive?.content)
+        assertEquals("dismiss_all", sent["service"]?.jsonPrimitive?.content)
+      } finally {
+        client.close()
+      }
+    }
+  }
+
+  @Test
   fun subscribeEvents_delivers_event_frame_after_ack() {
     runBlocking {
       val client = HaClient(HaConfig(baseUrl = baseUrl, accessToken = "test-token"))
@@ -162,11 +198,18 @@ class HaClientSubscriptionTest {
     @Volatile private var subscriptionId: Int? = null
     val pushes: Channel<JsonObject> = Channel(Channel.UNLIMITED)
 
+    /** Every `call_service` frame the client sends, in arrival order, for assertions. */
+    val calledServices: Channel<JsonObject> = Channel(Channel.UNLIMITED)
+
     fun handle(msg: JsonObject): List<JsonObject> {
       val type = msg["type"]?.jsonPrimitive?.content ?: return emptyList()
       if (type == "auth") return listOf(buildJsonObject { put("type", "auth_ok") })
       val id = msg["id"]?.jsonPrimitive?.intOrNull ?: return emptyList()
       return when (type) {
+        "call_service" -> {
+          calledServices.trySend(msg)
+          listOf(result(id, JsonObject(emptyMap())))
+        }
         "persistent_notification/get" ->
           listOf(
             result(

--- a/ha-client/src/commonMain/kotlin/ee/schimke/ha/client/HaClient.kt
+++ b/ha-client/src/commonMain/kotlin/ee/schimke/ha/client/HaClient.kt
@@ -281,6 +281,28 @@ class HaClient(private val config: HaConfig, engine: HttpClientEngine? = null) {
     }
   }
 
+  /**
+   * Dismiss a single persistent notification by id — the equivalent of tapping the X next to one
+   * entry behind HA's frontend bell. Routed through the `persistent_notification.dismiss` service;
+   * HA then fires `persistent_notifications_updated` so any active subscription refetches the
+   * now-shorter list.
+   */
+  suspend fun dismissNotification(notificationId: String) {
+    callService(
+      domain = "persistent_notification",
+      service = "dismiss",
+      serviceData = buildJsonObject { put("notification_id", notificationId) },
+    )
+  }
+
+  /**
+   * Dismiss every persistent notification at once — HA's `persistent_notification.dismiss_all`
+   * service, the "clear all" affordance behind the frontend bell.
+   */
+  suspend fun dismissAllNotifications() {
+    callService(domain = "persistent_notification", service = "dismiss_all")
+  }
+
   suspend fun close() {
     val s = sessionMutex.withLock {
       val current = session

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/CachedHaSession.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/CachedHaSession.kt
@@ -7,6 +7,7 @@ import ee.schimke.ha.model.HaNotification
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.terrazzo.core.cache.OfflineCacheStorage
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.serialization.json.JsonObject
 
 /**
  * Offline-first wrapper around any [HaSession]. Every successful live
@@ -72,6 +73,22 @@ class CachedHaSession(private val delegate: HaSession, private val cache: Offlin
   }
 
   override suspend fun fetchInstanceConfig(): HaInstanceConfig? = delegate.fetchInstanceConfig()
+
+  // Writes aren't cached — forward straight to the delegate. Without this
+  // the interface's no-op default would swallow every service call when a
+  // live session is wrapped (the production path), so taps would silently
+  // do nothing.
+  override suspend fun callService(
+    domain: String,
+    service: String,
+    entityId: String?,
+    serviceData: JsonObject,
+  ) = delegate.callService(domain, service, entityId, serviceData)
+
+  override suspend fun dismissNotification(notificationId: String) =
+    delegate.dismissNotification(notificationId)
+
+  override suspend fun dismissAllNotifications() = delegate.dismissAllNotifications()
 
   override suspend fun close() {
     delegate.close()

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/HaSession.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/HaSession.kt
@@ -92,6 +92,22 @@ interface HaSession {
         serviceData: JsonObject = JsonObject(emptyMap()),
     ): Unit = Unit
 
+    /**
+     * Dismiss a single persistent notification by id — removes it from
+     * HA's bell-icon list. Live sessions round-trip
+     * `persistent_notification.dismiss`; HA then re-broadcasts the
+     * shortened list over the subscription. Sessions that can't observe
+     * notifications (demo, offline) no-op.
+     */
+    suspend fun dismissNotification(notificationId: String): Unit = Unit
+
+    /**
+     * Clear every persistent notification at once
+     * (`persistent_notification.dismiss_all`). Default no-op for sessions
+     * with nothing to clear.
+     */
+    suspend fun dismissAllNotifications(): Unit = Unit
+
     suspend fun close()
 }
 
@@ -180,6 +196,18 @@ class LiveHaSession(
         entityId: String?,
         serviceData: JsonObject,
     ) = client.callService(domain, service, entityId, serviceData)
+    override suspend fun dismissNotification(notificationId: String) {
+        // Optimistically drop it so the bell/sheet update on the tap
+        // without waiting for HA's round-trip; the
+        // `persistent_notifications_updated` refetch then confirms the
+        // authoritative list (and restores it if the dismiss failed).
+        _notifications.value = _notifications.value.filterNot { it.notificationId == notificationId }
+        client.dismissNotification(notificationId)
+    }
+    override suspend fun dismissAllNotifications() {
+        _notifications.value = emptyList()
+        client.dismissAllNotifications()
+    }
     override suspend fun close() {
         client.close()
         scope.cancel()


### PR DESCRIPTION
## Summary
Adds the ability to dismiss individual persistent notifications and clear all notifications at once in the Home Assistant client. Users can now tap an X button next to each notification or use a "Clear all" action in the notification sheet.

## Key Changes

- **UI Updates (`NotificationBell.kt`)**
  - Added dismiss (X) button to each notification row
  - Added "Clear all" button in the notification sheet header
  - Restructured layout to accommodate new dismiss controls
  - Passes `onDismiss` and `onClearAll` callbacks up to the parent

- **Client API (`HaClient.kt`)**
  - Implemented `dismissNotification(notificationId)` to dismiss a single notification via `persistent_notification.dismiss` service
  - Implemented `dismissAllNotifications()` to clear all notifications via `persistent_notification.dismiss_all` service

- **Session Layer (`HaSession.kt`, `LiveHaSession.kt`)**
  - Added interface methods for `dismissNotification()` and `dismissAllNotifications()`
  - `LiveHaSession` optimistically updates the local notifications list before sending the request to HA
  - HA's `persistent_notifications_updated` event refetches the authoritative list, confirming the dismissal

- **Cache Wrapper (`CachedHaSession.kt`)**
  - Forwards dismiss operations to the delegate session (writes aren't cached)
  - Ensures wrapped live sessions properly handle service calls instead of silently no-oping

- **Integration (`TerrazzoApp.kt`)**
  - Wired `NotificationBell` callbacks to session's dismiss methods in `DashboardsRoot`
  - Wrapped calls in error handling with `runCatching`

## Implementation Details

- Dismissals are optimistic: the UI updates immediately when the user taps the X or "Clear all"
- HA's subscription broadcasts the updated notification list, which reactively confirms the change
- The composable remains purely presentational and never mutates the list directly
- Demo and offline sessions safely no-op via interface defaults

https://claude.ai/code/session_01V6wt5WW2qxK6bEXm3TC3Mw