### PR TITLE
Tie HA connection lifecycle to app foreground state

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -74,9 +74,11 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * Root composable. Two phases:
@@ -545,19 +547,40 @@ private fun DashboardsRoot(
         }
     }
 
-    // Keep the HA connection alive while the user has the app open.
-    // While the activity is RESUMED, watch for a Failed status and
-    // retry with a short backoff. Each retry either lands at Connected
-    // (loop idles) or at Failed (StateFlow re-emits and we retry
-    // again). When the activity is paused the [repeatOnLifecycle] scope
-    // cancels, so we stop poking the network in the background.
+    // Tie the HA connection to the foreground. We hold the socket open
+    // only while the activity is RESUMED:
+    //
+    //  - On entering the foreground, if we parked the socket on the way
+    //    out (or a prior attempt failed), reconnect now so the user sees
+    //    "Connecting" immediately instead of a stale status.
+    //  - While foregrounded, watch for a Failed status and retry with a
+    //    short backoff. Each retry lands at Connected (loop idles) or at
+    //    Failed (StateFlow re-emits and we retry again).
+    //  - On leaving the foreground, cleanly disconnect. Without this the
+    //    OS tears the idle socket down in the background and the next
+    //    read-loop failure logs a spurious Error; a clean disconnect logs
+    //    a neutral "Disconnected" instead.
     LaunchedEffect(session, lifecycleOwner) {
         lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
-            while (true) {
-                session.connectionStatus.first { it == SessionConnectionStatus.Failed }
-                delay(RECONNECT_BACKOFF_MS)
-                if (session.connectionStatus.value == SessionConnectionStatus.Failed) {
-                    runCatching { session.connect() }
+            val status = session.connectionStatus.value
+            if (status == SessionConnectionStatus.Disconnected ||
+                status == SessionConnectionStatus.Failed
+            ) {
+                runCatching { session.connect() }
+            }
+            try {
+                while (true) {
+                    session.connectionStatus.first { it == SessionConnectionStatus.Failed }
+                    delay(RECONNECT_BACKOFF_MS)
+                    if (session.connectionStatus.value == SessionConnectionStatus.Failed) {
+                        runCatching { session.connect() }
+                    }
+                }
+            } finally {
+                // repeatOnLifecycle has cancelled us; close the socket
+                // outside the cancelled scope so the suspend call runs.
+                withContext(NonCancellable) {
+                    runCatching { session.disconnect() }
                 }
             }
         }
@@ -735,6 +758,7 @@ enum class ConnectionStatus(val label: String, val color: Color) {
     Failed("Failed", Color(0xFFD32F2F)),
     Connecting("Connecting", Color(0xFF2E7D32)),
     Connected("Connected", Color(0xFF1976D2)),
+    Disconnected("Paused", Color(0xFF757575)),
 }
 
 private val READ_ONLY_COLOR = Color(0xFF455A64)
@@ -744,6 +768,7 @@ private fun SessionConnectionStatus.toUiConnectionStatus(): ConnectionStatus = w
     SessionConnectionStatus.Failed -> ConnectionStatus.Failed
     SessionConnectionStatus.Connecting -> ConnectionStatus.Connecting
     SessionConnectionStatus.Connected -> ConnectionStatus.Connected
+    SessionConnectionStatus.Disconnected -> ConnectionStatus.Disconnected
 }
 
 private fun SessionConnectionStatus.toLogStatus(): ee.schimke.terrazzo.core.logs.LogConnectionStatus =
@@ -751,6 +776,7 @@ private fun SessionConnectionStatus.toLogStatus(): ee.schimke.terrazzo.core.logs
         SessionConnectionStatus.Failed -> ee.schimke.terrazzo.core.logs.LogConnectionStatus.Error
         SessionConnectionStatus.Connecting -> ee.schimke.terrazzo.core.logs.LogConnectionStatus.Connecting
         SessionConnectionStatus.Connected -> ee.schimke.terrazzo.core.logs.LogConnectionStatus.Connected
+        SessionConnectionStatus.Disconnected -> ee.schimke.terrazzo.core.logs.LogConnectionStatus.Disconnected
     }
 
 /**

--- a/app/src/test/kotlin/ee/schimke/terrazzo/integration/LiveHaSessionReconnectTest.kt
+++ b/app/src/test/kotlin/ee/schimke/terrazzo/integration/LiveHaSessionReconnectTest.kt
@@ -139,6 +139,41 @@ class LiveHaSessionReconnectTest {
     }
   }
 
+  @Test
+  fun disconnect_parks_cleanly_as_disconnected_not_failed() {
+    runBlocking {
+      val session = LiveHaSession(baseUrl = baseUrl, accessToken = "test-token")
+      try {
+        session.connect()
+        assertEquals(SessionConnectionStatus.Connected, session.connectionStatus.value)
+
+        // Backgrounding: park the socket. This must read as a clean
+        // Disconnected, not Failed — otherwise the log paints it red as
+        // an "Error" on every app switch (the bug this fixes) and the
+        // reconnect loop treats an intentional park as a fault.
+        session.disconnect()
+        assertEquals(SessionConnectionStatus.Disconnected, session.connectionStatus.value)
+
+        // The HaClient.Disconnected that the socket close emits behind us
+        // must not flip the bridge back to Failed. Settle, then assert we
+        // held Disconnected.
+        withTimeout(3_000) {
+          session.connectionStatus.filter { it == SessionConnectionStatus.Disconnected }.first()
+        }
+        assertEquals(SessionConnectionStatus.Disconnected, session.connectionStatus.value)
+
+        // Foregrounding: reconnect restores a live, usable session.
+        session.connect()
+        withTimeout(3_000) {
+          session.connectionStatus.filter { it == SessionConnectionStatus.Connected }.first()
+        }
+        assertEquals("Home", session.loadDashboard(null).first.title)
+      } finally {
+        session.close()
+      }
+    }
+  }
+
   private fun newServer(port: Int): EmbeddedServer<*, *> =
     embeddedServer(CIO, port = port, host = "127.0.0.1") {
         install(WebSockets)

--- a/ha-client/src/commonMain/kotlin/ee/schimke/ha/client/HaClient.kt
+++ b/ha-client/src/commonMain/kotlin/ee/schimke/ha/client/HaClient.kt
@@ -303,6 +303,25 @@ class HaClient(private val config: HaConfig, engine: HttpClientEngine? = null) {
     callService(domain = "persistent_notification", service = "dismiss_all")
   }
 
+  /**
+   * Gracefully tear down the live WebSocket but keep the client reusable — unlike [close], which
+   * also cancels the client scope and the HTTP engine. Used when the app goes to the background: we
+   * close the socket with a NORMAL reason and reset to [ConnectionState.Disconnected], ready for a
+   * fresh [connect] when the app returns to the foreground. Cancelling [receiveJob] also runs its
+   * cleanup (failing in-flight commands, clearing subscriptions), same as a peer-side close.
+   */
+  suspend fun disconnect() {
+    val s = sessionMutex.withLock {
+      val current = session
+      session = null
+      receiveJob?.cancel()
+      receiveJob = null
+      current
+    }
+    runCatching { s?.close(CloseReason(CloseReason.Codes.NORMAL, "background")) }
+    _state.value = ConnectionState.Disconnected
+  }
+
   suspend fun close() {
     val s = sessionMutex.withLock {
       val current = session

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/CachedHaSession.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/CachedHaSession.kt
@@ -90,6 +90,10 @@ class CachedHaSession(private val delegate: HaSession, private val cache: Offlin
 
   override suspend fun dismissAllNotifications() = delegate.dismissAllNotifications()
 
+  override suspend fun disconnect() {
+    delegate.disconnect()
+  }
+
   override suspend fun close() {
     delegate.close()
   }

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/HaSession.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/session/HaSession.kt
@@ -69,6 +69,20 @@ interface HaSession {
     }
 
     suspend fun connect()
+
+    /**
+     * Gracefully park the live connection without tearing the session
+     * down (unlike [close], which makes it unusable). Sessions holding a
+     * socket close it with a clean reason and move to
+     * [SessionConnectionStatus.Disconnected]; sessions with nothing to
+     * disconnect (demo, offline) no-op. Pair with [connect] to resume.
+     *
+     * Driven by the app-lifecycle hook: when the app backgrounds we drop
+     * the WebSocket here so the OS tearing it down later doesn't surface
+     * as a spurious Error, and reopen it via [connect] on return.
+     */
+    suspend fun disconnect() {}
+
     suspend fun listDashboards(): List<DashboardSummary>
     suspend fun loadDashboard(urlPath: String?): Pair<Dashboard, HaSnapshot>
 
@@ -115,6 +129,14 @@ enum class SessionConnectionStatus {
     Failed,
     Connecting,
     Connected,
+
+    /**
+     * Intentionally parked — the app backgrounded and we closed the
+     * socket cleanly. Distinct from [Failed] so the log paints it as a
+     * neutral "Disconnected" rather than a red "Error", and so the
+     * foreground reconnect hook knows to reopen it.
+     */
+    Disconnected,
 }
 
 /** Live session backed by an HA WebSocket. */
@@ -130,6 +152,13 @@ class LiveHaSession(
     private val _notifications = MutableStateFlow<List<HaNotification>>(emptyList())
     override val notifications: StateFlow<List<HaNotification>> = _notifications.asStateFlow()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    // True while we've intentionally parked the socket (app backgrounded
+    // via [disconnect]). Gates the state bridge so the HaClient.Disconnected
+    // that follows surfaces as a clean [SessionConnectionStatus.Disconnected]
+    // rather than [Failed] — an *unexpected* mid-flight death (parked ==
+    // false) still maps to Failed so the reconnect loop wakes up.
+    @Volatile private var parked = false
 
     init {
         // Bridge the underlying socket's state into our session status so
@@ -147,7 +176,10 @@ class LiveHaSession(
                     HaClient.ConnectionState.Connecting,
                     HaClient.ConnectionState.Authenticating ->
                         _connectionStatus.value = SessionConnectionStatus.Connecting
-                    HaClient.ConnectionState.Disconnected,
+                    HaClient.ConnectionState.Disconnected ->
+                        _connectionStatus.value =
+                            if (parked) SessionConnectionStatus.Disconnected
+                            else SessionConnectionStatus.Failed
                     HaClient.ConnectionState.Error ->
                         _connectionStatus.value = SessionConnectionStatus.Failed
                 }
@@ -178,10 +210,17 @@ class LiveHaSession(
     }
 
     override suspend fun connect() {
+        parked = false
         _connectionStatus.value = SessionConnectionStatus.Connecting
         runCatching { client.connect() }
             .onSuccess { _connectionStatus.value = SessionConnectionStatus.Connected }
             .onFailure { _connectionStatus.value = SessionConnectionStatus.Failed; throw it }
+    }
+
+    override suspend fun disconnect() {
+        parked = true
+        runCatching { client.disconnect() }
+        _connectionStatus.value = SessionConnectionStatus.Disconnected
     }
     override suspend fun listDashboards(): List<DashboardSummary> = client.listDashboards()
     override suspend fun loadDashboard(urlPath: String?): Pair<Dashboard, HaSnapshot> {


### PR DESCRIPTION
## Summary
This change implements graceful socket management tied to the app lifecycle. When the app backgrounds, the WebSocket is cleanly disconnected instead of being left idle for the OS to tear down. When the app returns to the foreground, the connection is re-established. This prevents spurious error logs on app backgrounding and ensures users see an accurate connection status.

## Key Changes

- **New `disconnect()` method**: Added to `HaSession` interface and `LiveHaSession` to gracefully park the WebSocket without fully closing the session. This allows reconnection via `connect()` without recreating the session.

- **New `Disconnected` connection status**: Added `SessionConnectionStatus.Disconnected` to distinguish intentional disconnections (app backgrounded) from unexpected failures. Maps to a neutral "Paused" UI status instead of red "Error".

- **Lifecycle-aware reconnection**: Modified `DashboardsRoot` to:
  - Reconnect immediately when entering foreground if the socket was parked or failed
  - Retry on `Failed` status with backoff while foregrounded
  - Cleanly disconnect when leaving foreground using `withContext(NonCancellable)` to ensure the suspend call completes even as the lifecycle scope cancels

- **State bridge logic**: Updated `LiveHaSession` to track whether a disconnect was intentional (`parked` flag). When `HaClient.Disconnected` is received:
  - If `parked == true`: surface as `SessionConnectionStatus.Disconnected` (clean)
  - If `parked == false`: surface as `SessionConnectionStatus.Failed` (unexpected, triggers reconnect)

- **HaClient disconnect**: Added `disconnect()` method to cleanly close the WebSocket with a NORMAL close reason while keeping the client reusable, unlike `close()` which fully tears down the client.

- **Wrapper support**: Updated `CachedHaSession` to delegate the new `disconnect()` method.

## Implementation Details

- The `parked` volatile flag in `LiveHaSession` gates the state bridge to ensure intentional disconnections don't trigger the reconnect loop
- Uses `withContext(NonCancellable)` in the finally block to guarantee the disconnect suspend call completes even after the lifecycle scope cancels
- Includes comprehensive test coverage for the disconnect-reconnect cycle

https://claude.ai/code/session_01XiN1Kr9Yn8D8PkXVb9ueuH