### PR TITLE
ci(preview): declare ui-tooling-preview in remaining rc modules

### DIFF
--- a/rc-card-shutter/build.gradle.kts
+++ b/rc-card-shutter/build.gradle.kts
@@ -23,6 +23,11 @@ dependencies {
 
   implementation(platform(libs.compose.bom))
   implementation(libs.compose.ui)
+  // Tooling-preview annotation jar — `compose-preview render` (0.12.0)
+  // fails fast on any Android+compose module that can't reach the
+  // @Preview annotation class, even when the module has no @Preview
+  // composables of its own.
+  implementation(libs.compose.ui.tooling.preview)
   implementation(libs.compose.foundation)
   implementation(libs.compose.material3)
   implementation(libs.compose.material.icons.extended)

--- a/rc-components-ui/build.gradle.kts
+++ b/rc-components-ui/build.gradle.kts
@@ -25,6 +25,11 @@ dependencies {
 
   implementation(platform(libs.compose.bom))
   implementation(libs.compose.ui)
+  // Tooling-preview annotation jar — `compose-preview render` (0.12.0)
+  // fails fast on any Android+compose module that can't reach the
+  // @Preview annotation class, even when the module has no @Preview
+  // composables of its own.
+  implementation(libs.compose.ui.tooling.preview)
   implementation(libs.compose.foundation)
 
   implementation(libs.remote.creation.compose)

--- a/rc-converter/build.gradle.kts
+++ b/rc-converter/build.gradle.kts
@@ -24,6 +24,11 @@ dependencies {
 
   implementation(platform(libs.compose.bom))
   implementation(libs.compose.ui)
+  // Tooling-preview annotation jar — `compose-preview render` (0.12.0)
+  // fails fast on any Android+compose module that can't reach the
+  // @Preview annotation class, even when the module has no @Preview
+  // composables of its own.
+  implementation(libs.compose.ui.tooling.preview)
   implementation(libs.compose.foundation)
   implementation(libs.compose.material3)
   implementation(libs.compose.material.icons.extended)


### PR DESCRIPTION
## Summary

Follow-up to #335. After landing the `:demo-app` fix, `compose-preview render` (0.12.0) now fails fast on the next Android+compose module without the `@Preview` annotation jar on its classpath:

```
> compose-preview: no @Preview tooling coord reachable in module ':rc-card-shutter'.
```

The CLI's discovery list is: `app, demo-app, previews, rc-card-shutter, rc-components-ui, rc-converter, tv, wear`. The first five and the last two already declare `compose.ui.tooling.preview`; this PR covers the remaining three (`:rc-card-shutter`, `:rc-components-ui`, `:rc-converter`).

None of them host `@Preview` composables, and the artifact is annotation-only (no renderer), so consumer APKs are unchanged.

## Test plan

- [ ] `compose-preview render` lists every module under "Found preview modules" without aborting on missing tooling coord
- [ ] Compose Preview workflow on `main` reaches the render stage for `app/previews/tv/wear` baselines


---
_Generated by [Claude Code](https://claude.ai/code/session_01KJgbn9qEqxUDJ5CNGpKQrr)_