### PR TITLE
Add debug overlays for card data changes and entity references

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,6 +106,9 @@ dependencies {
   implementation(libs.compose.ui.text.google.fonts)
   implementation(libs.compose.ui.tooling.preview)
   debugImplementation(libs.compose.ui.tooling)
+  // Debug-only: @AnimatedPreview drives the compose-preview GIF capture
+  // of the card-flash debug feature. Kept out of the release APK.
+  debugImplementation("ee.schimke.composeai:preview-annotations:0.8.12")
   implementation(libs.activity.compose)
   implementation(libs.materialkolor)
 

--- a/app/src/debug/kotlin/ee/schimke/terrazzo/previews/CardDebugPreviews.kt
+++ b/app/src/debug/kotlin/ee/schimke/terrazzo/previews/CardDebugPreviews.kt
@@ -1,0 +1,184 @@
+package ee.schimke.terrazzo.previews
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lightbulb
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import ee.schimke.composeai.preview.AnimatedPreview
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.Dashboard
+import ee.schimke.ha.model.EntityState
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.model.View
+import ee.schimke.terrazzo.dashboard.CardChangeFlash
+import ee.schimke.terrazzo.dashboard.DataGridOverlay
+import kotlin.time.Instant
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Previews for the two debug data-visualisation features
+ * (Settings → "Flash cards on data change" / "Data grid overlay").
+ * These live in `src/debug` so the `@AnimatedPreview` annotation
+ * dependency stays out of the release APK; the composables under test
+ * are `internal` to the app module and visible from here.
+ */
+
+private fun entityCard(type: String, entity: String): CardConfig =
+    CardConfig(
+        type = type,
+        raw =
+            buildJsonObject {
+                put("type", type)
+                put("entity", entity)
+            },
+    )
+
+private fun demoDashboard(): Dashboard =
+    Dashboard(
+        title = "Home",
+        views =
+            listOf(
+                View(
+                    cards =
+                        listOf(
+                            entityCard("tile", "light.living_room"),
+                            entityCard("sensor", "sensor.living_room_temperature"),
+                            entityCard("tile", "climate.thermostat"),
+                            entityCard("tile", "lock.front_door"),
+                            entityCard("entity", "binary_sensor.front_door_motion"),
+                            entityCard("tile", "switch.coffee_machine"),
+                        )
+                )
+            ),
+    )
+
+/**
+ * Static render of [DataGridOverlay] floating over a faux dashboard.
+ * `last_changed` values are stamped relative to render time so the
+ * "ago" column shows a realistic spread instead of all "—".
+ */
+@Preview(name = "Data grid overlay", widthDp = 412, heightDp = 680, showBackground = true)
+@Composable
+private fun DataGridOverlayPreview() {
+    val base = remember { System.currentTimeMillis() }
+    fun ent(id: String, state: String, agoMs: Long): EntityState =
+        EntityState(entityId = id, state = state, lastChanged = Instant.fromEpochMilliseconds(base - agoMs))
+
+    val snapshot =
+        HaSnapshot(
+            states =
+                listOf(
+                        ent("light.living_room", "on", 4_000),
+                        ent("sensor.living_room_temperature", "21.4 °C", 12_000),
+                        ent("climate.thermostat", "heat", 3_000),
+                        ent("lock.front_door", "locked", 95_000),
+                        ent("binary_sensor.front_door_motion", "off", 330_000),
+                        ent("switch.coffee_machine", "off", 61_000),
+                    )
+                    .associateBy { it.entityId }
+        )
+
+    Box(Modifier.fillMaxSize().background(Color(0xFFEFEFF3))) {
+        FauxDashboardBackdrop()
+        DataGridOverlay(dashboard = demoDashboard(), snapshot = snapshot, onClose = {})
+    }
+}
+
+/**
+ * Animated render of [CardChangeFlash]. An infinite transition sweeps a
+ * counter whose integer buckets become the card's data signature, so
+ * the slot flashes each time the bucket flips — the same path a live
+ * entity-state change drives. `@AnimatedPreview` captures the fade as a
+ * GIF.
+ */
+@Preview(name = "Card flash on data change", widthDp = 240, heightDp = 180, showBackground = true)
+@AnimatedPreview(durationMs = 2000, frameIntervalMs = 100, showCurves = false)
+@Composable
+private fun CardFlashPreview() {
+    val transition = rememberInfiniteTransition(label = "flash-demo")
+    val sweep by
+        transition.animateFloat(
+            initialValue = 0f,
+            targetValue = 3f,
+            animationSpec =
+                infiniteRepeatable(
+                    animation = tween(durationMillis = 2000, easing = LinearEasing),
+                    repeatMode = RepeatMode.Restart,
+                ),
+            label = "sweep",
+        )
+    val tick = sweep.toInt()
+    val signature = "occupancy=$tick"
+
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Box {
+            FauxTile(stateLabel = if (tick % 2 == 0) "On" else "Off")
+            CardChangeFlash(signature)
+        }
+    }
+}
+
+/** A tile-shaped placeholder so the flash highlight reads as "a card". */
+@Composable
+private fun FauxTile(stateLabel: String) {
+    Surface(
+        color = Color(0xFFE8DEF8),
+        contentColor = Color(0xFF1D1B20),
+        shape = RoundedCornerShape(16.dp),
+        modifier = Modifier.size(width = 180.dp, height = 110.dp),
+    ) {
+        Column(
+            modifier = Modifier.padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Icon(Icons.Filled.Lightbulb, contentDescription = null, modifier = Modifier.size(28.dp))
+            Text("Living room", fontSize = 14.sp, fontWeight = FontWeight.Medium)
+            Text(stateLabel, fontSize = 12.sp, color = Color(0xFF49454F))
+        }
+    }
+}
+
+/** Light grey placeholder rectangles standing in for dashboard cards. */
+@Composable
+private fun FauxDashboardBackdrop() {
+    Column(
+        modifier = Modifier.fillMaxSize().padding(top = 380.dp, start = 12.dp, end = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        repeat(3) {
+            Box(
+                Modifier.fillMaxWidth()
+                    .height(72.dp)
+                    .background(Color(0xFFD9D9E3), RoundedCornerShape(16.dp))
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -767,6 +767,8 @@ private fun SettingsScreen(
     val gridLayoutEnabled by graph.preferencesStore.experimentalGridLayout.collectAsState(initial = false)
     val collapsedModeEnabled by graph.preferencesStore.collapsedMode.collectAsState(initial = true)
     val logsViewEnabled by graph.preferencesStore.logsViewEnabled.collectAsState(initial = false)
+    val flashOnDataChange by graph.preferencesStore.flashOnDataChange.collectAsState(initial = false)
+    val dataGridOverlay by graph.preferencesStore.dataGridOverlay.collectAsState(initial = false)
     val permanentWriteEnabled by graph.preferencesStore.permanentWriteMode.collectAsState(initial = false)
 
     Scaffold(
@@ -922,6 +924,50 @@ private fun SettingsScreen(
                     checked = logsViewEnabled,
                     onCheckedChange = { enabled ->
                         scope.launch { graph.preferencesStore.setLogsViewEnabled(enabled) }
+                    },
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Debug: flash cards on data change", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        "Briefly highlight a card whenever the entity state it renders " +
+                            "changes. Handy with demo mode to see which cards are live. " +
+                            "Visual only — nothing about the rendered card changes.",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                Switch(
+                    checked = flashOnDataChange,
+                    onCheckedChange = { enabled ->
+                        scope.launch { graph.preferencesStore.setFlashOnDataChange(enabled) }
+                    },
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Debug: data grid overlay", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        "Float a grid over the dashboard listing every entity its cards " +
+                            "use — the key, current value, and how long ago it last changed. " +
+                            "Tap ✕ on the panel to dismiss.",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                Switch(
+                    checked = dataGridOverlay,
+                    onCheckedChange = { enabled ->
+                        scope.launch { graph.preferencesStore.setDataGridOverlay(enabled) }
                     },
                 )
             }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/CardDebugOverlay.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/CardDebugOverlay.kt
@@ -119,8 +119,10 @@ internal fun BoxScope.CardChangeFlash(signature: String) {
  * animates values but may not carry `last_changed`) as well as live.
  *
  * The panel floats top-centre and only intercepts touches within its own
- * bounds, so the dashboard underneath stays scrollable. [onClose] is
- * wired to the Settings toggle so the ✕ truly dismisses it.
+ * bounds, so the dashboard underneath stays scrollable. [contentPadding]
+ * is the host scaffold's inset (status bar / top app bar) so the panel
+ * lands below the chrome rather than under it. [onClose] is wired to the
+ * Settings toggle so the ✕ truly dismisses it.
  */
 @Composable
 internal fun DataGridOverlay(
@@ -128,6 +130,7 @@ internal fun DataGridOverlay(
     snapshot: HaSnapshot,
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
 ) {
     val refs = remember(dashboard) { referencedEntities(dashboard).sorted() }
     // Reset the change-tracking when the dashboard swaps so stale times
@@ -153,7 +156,7 @@ internal fun DataGridOverlay(
         }
     }
 
-    Box(modifier = modifier.fillMaxSize()) {
+    Box(modifier = modifier.fillMaxSize().padding(contentPadding)) {
         Surface(
             color = Color(0xE61C1B1F),
             contentColor = Color.White,

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/CardDebugOverlay.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/CardDebugOverlay.kt
@@ -1,0 +1,262 @@
+package ee.schimke.terrazzo.dashboard
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.Dashboard
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.terrazzo.core.logs.referencedEntities
+import kotlinx.coroutines.delay
+
+/**
+ * Debug-only host signals for the card data-visualisation features
+ * (Settings → "Flash cards on data change" / "Data grid overlay").
+ * Both read the polled [HaSnapshot] the dashboard already drives its
+ * cards from — they add no new data source and change nothing about the
+ * captured RemoteCompose documents.
+ */
+
+/**
+ * When `true`, every [CardSlot] paints a brief fading highlight each
+ * time the entity state it renders changes. Provided by [DashboardList]
+ * from [ee.schimke.terrazzo.core.prefs.PreferencesStore.flashOnDataChange];
+ * defaults to `false` so production renders untouched.
+ */
+val LocalFlashOnDataChange = staticCompositionLocalOf { false }
+
+/** Amber so the flash reads as "data" rather than an error or success. */
+private val FLASH_COLOR = Color(0xFFFFC107)
+
+/**
+ * A stable string fingerprint of the states a card depends on, used to
+ * detect "this card's data changed" across snapshots. Built from the
+ * primary `state` of each referenced entity only — deliberately not the
+ * full [ee.schimke.ha.model.EntityState], whose `lastUpdated` churns on
+ * every poll and would flash cards that didn't visibly change. Matches
+ * the change definition the debug Logs view uses.
+ */
+internal fun cardStateSignature(snapshot: HaSnapshot, refs: Set<String>): String =
+    refs.joinToString(";") { id -> "$id=${snapshot.states[id]?.state}" }
+
+/**
+ * Overlay drawn inside a [CardSlot]'s slot [Box] that flashes whenever
+ * [signature] changes. The first observed signature seeds silently (no
+ * flash on initial appearance); subsequent changes snap the highlight
+ * to full and fade it out. A no-op until a real change arrives, so it
+ * costs only a remembered [Animatable] when nothing is moving.
+ */
+@Composable
+internal fun BoxScope.CardChangeFlash(signature: String) {
+    val flash = remember { Animatable(0f) }
+    var previous by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(signature) {
+        val before = previous
+        previous = signature
+        if (before != null && before != signature) {
+            flash.snapTo(1f)
+            flash.animateTo(targetValue = 0f, animationSpec = tween(durationMillis = 850))
+        }
+    }
+    val alpha = flash.value
+    if (alpha > 0f) {
+        val shape = RoundedCornerShape(12.dp)
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .clip(shape)
+                .background(FLASH_COLOR.copy(alpha = 0.28f * alpha))
+                .border(2.dp, FLASH_COLOR.copy(alpha = alpha), shape),
+        )
+    }
+}
+
+/**
+ * Floating debug panel listing the live data the current dashboard's
+ * cards consume: one row per referenced entity with its id (key),
+ * current `state` (value), and how long ago that value last changed.
+ *
+ * Last-changed is tracked locally — the first value seen seeds silently,
+ * and the wall-clock is stamped each time a subsequent snapshot reports
+ * a different state — falling back to HA's own `last_changed` when the
+ * app hasn't yet witnessed a change. This works in demo mode (which
+ * animates values but may not carry `last_changed`) as well as live.
+ *
+ * The panel floats top-centre and only intercepts touches within its own
+ * bounds, so the dashboard underneath stays scrollable. [onClose] is
+ * wired to the Settings toggle so the ✕ truly dismisses it.
+ */
+@Composable
+internal fun DataGridOverlay(
+    dashboard: Dashboard,
+    snapshot: HaSnapshot,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val refs = remember(dashboard) { referencedEntities(dashboard).sorted() }
+    // Reset the change-tracking when the dashboard swaps so stale times
+    // from a previous board don't leak in.
+    val changeAt = remember(dashboard) { mutableStateMapOf<String, Long>() }
+    val lastValue = remember(dashboard) { HashMap<String, String>() }
+
+    LaunchedEffect(dashboard, snapshot) {
+        val now = System.currentTimeMillis()
+        refs.forEach { id ->
+            val value = snapshot.states[id]?.state ?: return@forEach
+            val prior = lastValue.put(id, value)
+            if (prior != null && prior != value) changeAt[id] = now
+        }
+    }
+
+    // 1 Hz tick so the "Xs ago" labels advance without a data change.
+    var nowMs by remember { mutableStateOf(System.currentTimeMillis()) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(1000)
+            nowMs = System.currentTimeMillis()
+        }
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        Surface(
+            color = Color(0xE61C1B1F),
+            contentColor = Color.White,
+            shape = RoundedCornerShape(12.dp),
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .fillMaxWidth()
+                .padding(8.dp)
+                .heightIn(max = 360.dp),
+        ) {
+            Column {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 12.dp, end = 4.dp, top = 4.dp, bottom = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "Card data · ${refs.size} entities",
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 13.sp,
+                        modifier = Modifier.weight(1f),
+                    )
+                    IconButton(onClick = onClose) {
+                        Icon(Icons.Filled.Close, contentDescription = "Hide data grid")
+                    }
+                }
+                if (refs.isEmpty()) {
+                    Text(
+                        text = "No entities referenced by this dashboard's cards.",
+                        fontSize = 12.sp,
+                        color = Color.White.copy(alpha = 0.7f),
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+                    )
+                } else {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxWidth(),
+                        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
+                        verticalArrangement = Arrangement.spacedBy(2.dp),
+                    ) {
+                        items(refs, key = { it }) { id ->
+                            val entity = snapshot.states[id]
+                            val changedMs = changeAt[id] ?: entity?.lastChanged?.toEpochMilliseconds()
+                            val recent = changeAt[id]?.let { nowMs - it < 1500 } ?: false
+                            DataGridRow(
+                                key = id,
+                                value = entity?.state ?: "—",
+                                ago = changedMs?.let { agoLabel(nowMs - it) } ?: "—",
+                                highlighted = recent,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DataGridRow(key: String, value: String, ago: String, highlighted: Boolean) {
+    val rowColor = if (highlighted) FLASH_COLOR.copy(alpha = 0.22f) else Color.Transparent
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(4.dp))
+            .background(rowColor)
+            .padding(horizontal = 4.dp, vertical = 2.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = key,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 11.sp,
+            color = Color.White.copy(alpha = 0.85f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1.4f),
+        )
+        Text(
+            text = value,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 11.sp,
+            color = if (highlighted) FLASH_COLOR else Color.White,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = ago,
+            fontFamily = FontFamily.Monospace,
+            fontSize = 10.sp,
+            color = Color.White.copy(alpha = 0.55f),
+            maxLines = 1,
+        )
+    }
+}
+
+private fun agoLabel(deltaMs: Long): String {
+    val seconds = (deltaMs / 1000).coerceAtLeast(0)
+    return when {
+        seconds < 60 -> "${seconds}s ago"
+        seconds < 3600 -> "${seconds / 60}m ${seconds % 60}s ago"
+        else -> "${seconds / 3600}h ${(seconds % 3600) / 60}m ago"
+    }
+}

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -59,6 +59,7 @@ import ee.schimke.terrazzo.LocalTerrazzoGraph
 import ee.schimke.terrazzo.core.pin.MobilePinnedSection
 import ee.schimke.terrazzo.core.pin.PinStore
 import ee.schimke.terrazzo.core.pin.PinnedCardData
+import ee.schimke.terrazzo.core.logs.referencedEntities
 import ee.schimke.terrazzo.core.session.DemoHaSession
 import ee.schimke.terrazzo.core.session.HaSession
 import ee.schimke.ha.rc.CachedCardPreview
@@ -246,10 +247,13 @@ private fun DashboardList(
     val cfg = rememberLayoutConfig()
     val pinStore = LocalTerrazzoGraph.current.pinStore
     val pinScope = rememberCoroutineScope()
-    val useGridLayout by LocalTerrazzoGraph.current
-        .preferencesStore.experimentalGridLayout.collectAsState(initial = false)
-    val collapsedMode by LocalTerrazzoGraph.current
-        .preferencesStore.collapsedMode.collectAsState(initial = true)
+    val preferencesStore = LocalTerrazzoGraph.current.preferencesStore
+    val useGridLayout by preferencesStore.experimentalGridLayout.collectAsState(initial = false)
+    val collapsedMode by preferencesStore.collapsedMode.collectAsState(initial = true)
+    // Debug data-visualisation toggles (Settings). Both default off so
+    // production renders are untouched; reads are cheap StateFlows.
+    val flashOnDataChange by preferencesStore.flashOnDataChange.collectAsState(initial = false)
+    val dataGridOverlay by preferencesStore.dataGridOverlay.collectAsState(initial = false)
     // Pull the process-singleton image stack (a Metro AppScope binding —
     // see AppGraph.haImageStack). Coil documents that exactly one
     // DiskCache per directory is safe; the stack owns that single
@@ -302,6 +306,7 @@ private fun DashboardList(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.TopCenter,
     ) {
+        CompositionLocalProvider(LocalFlashOnDataChange provides flashOnDataChange) {
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
@@ -339,6 +344,14 @@ private fun DashboardList(
                     ),
                 )
             }
+        }
+        }
+        if (dataGridOverlay) {
+            DataGridOverlay(
+                dashboard = dashboard,
+                snapshot = snapshot,
+                onClose = { pinScope.launch { preferencesStore.setDataGridOverlay(false) } },
+            )
         }
     }
 }
@@ -890,6 +903,13 @@ private fun CardSlot(
     val dark = LocalIsDarkTheme.current
     val captureEpoch = LocalCardCaptureEpoch.current
     val debugBorders = LocalRcDebugBorders.current
+    // Debug flash-on-change: fingerprint the entity states this card
+    // renders so the slot can flash when any of them move. Refs are
+    // resolved once per card; the signature is only built when the
+    // feature is on, so production pays a single set computation.
+    val flashOnChange = LocalFlashOnDataChange.current
+    val flashRefs = remember(card) { referencedEntities(card) }
+    val flashSignature = if (flashOnChange) cardStateSignature(snapshot, flashRefs) else null
     // The document's paint colours are baked at capture; re-encode when
     // theme flips. Snapshot is deliberately NOT in the cache key —
     // entity values flow into the running player by named binding
@@ -947,6 +967,9 @@ private fun CardSlot(
                     RenderChild(card, snapshot, RemoteModifier.fillMaxWidth())
                 }
             }
+        }
+        if (flashSignature != null) {
+            CardChangeFlash(flashSignature)
         }
     }
 }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/DashboardViewScreen.kt
@@ -351,6 +351,7 @@ private fun DashboardList(
                 dashboard = dashboard,
                 snapshot = snapshot,
                 onClose = { pinScope.launch { preferencesStore.setDataGridOverlay(false) } },
+                contentPadding = contentPadding,
             )
         }
     }

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/logs/DashboardEntityRefs.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/logs/DashboardEntityRefs.kt
@@ -1,5 +1,6 @@
 package ee.schimke.terrazzo.core.logs
 
+import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.Dashboard
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -21,13 +22,25 @@ import kotlinx.serialization.json.JsonPrimitive
  * practice — icon names use `mdi:` (colon, not dot), template strings
  * have whitespace, etc.
  */
-internal fun referencedEntities(dashboard: Dashboard): Set<String> {
+fun referencedEntities(dashboard: Dashboard): Set<String> {
     val out = mutableSetOf<String>()
     for (view in dashboard.views) {
         view.cards.forEach { walk(it.raw, out) }
         view.sections.forEach { sec -> sec.cards.forEach { walk(it.raw, out) } }
         view.badges.forEach { walk(it, out) }
     }
+    return out
+}
+
+/**
+ * Same heuristic as the dashboard-level [referencedEntities], scoped to
+ * a single card's config. Used by the per-card debug surfaces (flash on
+ * data change) that need to know which entities one card slot depends
+ * on. Returns entity ids in no particular order.
+ */
+fun referencedEntities(card: CardConfig): Set<String> {
+    val out = mutableSetOf<String>()
+    walk(card.raw, out)
     return out
 }
 

--- a/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/prefs/PreferencesStore.kt
+++ b/terrazzo-core/src/androidMain/kotlin/ee/schimke/terrazzo/core/prefs/PreferencesStore.kt
@@ -119,6 +119,38 @@ class PreferencesStore(private val context: Context) {
     }
 
     /**
+     * Debug aid: flash each dashboard card whenever the entity state it
+     * renders changes. The host watches the polled snapshot for every
+     * entity a card references (see
+     * [ee.schimke.terrazzo.core.logs.referencedEntities]) and, on a
+     * value change, paints a brief fading highlight over that card's
+     * slot. Off by default; pairs well with demo mode (which animates
+     * values every ~1s) to see which cards are live. In-memory only —
+     * it changes nothing about the rendered document.
+     */
+    val flashOnDataChange: Flow<Boolean>
+        get() = context.store.data.map { it[FLASH_ON_CHANGE_KEY] ?: false }
+
+    suspend fun setFlashOnDataChange(enabled: Boolean) {
+        context.store.edit { it[FLASH_ON_CHANGE_KEY] = enabled }
+    }
+
+    /**
+     * Debug aid: overlay a translucent grid of the live data the
+     * current dashboard's cards consume — one row per referenced
+     * entity, showing the entity id (key), its current state (value),
+     * and how long ago that value last changed. Off by default; the
+     * grid floats above the dashboard and updates in place as snapshots
+     * arrive. In-memory only.
+     */
+    val dataGridOverlay: Flow<Boolean>
+        get() = context.store.data.map { it[DATA_GRID_OVERLAY_KEY] ?: false }
+
+    suspend fun setDataGridOverlay(enabled: Boolean) {
+        context.store.edit { it[DATA_GRID_OVERLAY_KEY] = enabled }
+    }
+
+    /**
      * Permanent write mode. When off (the default), every cold start
      * seeds the dashboard write/read chip with Read, so a relaunch never
      * silently leaves the app capable of firing service calls. When on,
@@ -231,6 +263,8 @@ class PreferencesStore(private val context: Context) {
         private val GRID_LAYOUT_KEY = booleanPreferencesKey("experimental_grid_layout")
         private val COLLAPSED_MODE_KEY = booleanPreferencesKey("collapsed_mode")
         private val LOGS_VIEW_KEY = booleanPreferencesKey("logs_view_enabled")
+        private val FLASH_ON_CHANGE_KEY = booleanPreferencesKey("flash_on_data_change")
+        private val DATA_GRID_OVERLAY_KEY = booleanPreferencesKey("data_grid_overlay")
         private val PERMANENT_WRITE_KEY = booleanPreferencesKey("permanent_write_mode")
         private val SELECTED_DASHBOARDS_KEY = stringPreferencesKey("selected_dashboards")
 


### PR DESCRIPTION
## Summary
Adds two new debug-only visualization features to help developers understand which cards are live and what data they consume: a flash highlight when entity states change, and a floating data grid overlay showing all referenced entities with their current values and change timestamps.

## Key Changes

- **CardChangeFlash composable**: Renders a brief fading amber highlight over a card slot whenever the entity state it depends on changes. Uses a stable state signature to detect changes across snapshots without false positives from `lastUpdated` churn.

- **DataGridOverlay composable**: Floating debug panel listing all entities referenced by the current dashboard's cards, showing entity id, current state value, and time since last change. Tracks changes locally with fallback to HA's `last_changed` timestamp. Updates in real-time as snapshots arrive.

- **Settings toggles**: Added two new debug preferences (`flashOnDataChange` and `dataGridOverlay`) in Settings screen, both defaulting to `false` so production renders are unaffected.

- **PreferencesStore extensions**: Added `flashOnDataChange` and `dataGridOverlay` Flow properties with setter methods to persist debug preferences.

- **DashboardList integration**: Wired both debug features into the dashboard view via `CompositionLocalProvider` and conditional overlay rendering. The data grid overlay can be dismissed via its close button, which toggles the preference off.

- **Entity reference extraction**: Made `referencedEntities()` public and added a card-scoped variant to support per-card change detection. Used by both debug surfaces and the existing Logs view.

- **Preview composables**: Added comprehensive previews in `src/debug` demonstrating both features with animated GIF capture support via `@AnimatedPreview`.

## Implementation Details

- Change detection uses a fingerprint of entity `state` values only (not full `EntityState`), matching the Logs view's definition to avoid false positives from metadata churn.
- The flash animation is a 850ms fade using `Animatable` with no-op cost when idle.
- The data grid updates on a 1Hz tick so "ago" labels advance without data changes.
- Both features read the same polled `HaSnapshot` the dashboard already drives from—no new data sources.
- Debug-only dependencies (like `composeai` for `@AnimatedPreview`) are isolated to `src/debug` to keep the release APK clean.

https://claude.ai/code/session_01TpXm1nD7K27b3GXVac7iG1