### PR TITLE
ci: enable Crashlytics in release builds via google-services secret

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -39,6 +39,8 @@ concurrency:
 #   HARC_KEY_ALIAS                key alias inside the keystore
 #   HARC_KEY_PASSWORD             key password
 #   PLAY_SERVICE_ACCOUNT_JSON     service account JSON; presence gates Play upload
+#   GOOGLE_SERVICES_JSON          base64 of app/google-services.json; presence
+#                                 enables Firebase Crashlytics in release builds
 jobs:
   release:
     name: Build & publish release
@@ -51,6 +53,7 @@ jobs:
       TAG_NAME: ${{ github.ref_type == 'tag' && github.ref_name || inputs.tag }}
       HAS_SIGNING_KEYSTORE: ${{ secrets.SIGNING_KEYSTORE != '' }}
       HAS_PLAY_CREDENTIALS: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON != '' }}
+      HAS_GOOGLE_SERVICES: ${{ secrets.GOOGLE_SERVICES_JSON != '' }}
       PUBLISH_WEAR: ${{ inputs.publish_wear || false }}
     steps:
       - uses: actions/checkout@v6
@@ -59,6 +62,18 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: 'true'
+
+      # Must land at app/google-services.json (the path is hard-coded in the
+      # build logic) and exist before the first Gradle call — `crashlyticsEnabled`
+      # is evaluated at configuration time. Present → Crashlytics is wired into
+      # the release build; absent → the build is unchanged (no-op reporter).
+      - name: Write google-services.json (enables Crashlytics)
+        if: env.HAS_GOOGLE_SERVICES == 'true'
+        env:
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$GOOGLE_SERVICES_JSON" | base64 -d > app/google-services.json
 
       - name: Decode signing keystore
         if: env.HAS_SIGNING_KEYSTORE == 'true'
@@ -116,6 +131,7 @@ jobs:
             echo "- Tag: ${TAG_NAME}"
             echo "- Signing keystore configured: ${HAS_SIGNING_KEYSTORE}"
             echo "- Play credentials configured: ${HAS_PLAY_CREDENTIALS}"
+            echo "- Crashlytics configured: ${HAS_GOOGLE_SERVICES}"
             if [[ "${HAS_SIGNING_KEYSTORE}" == "true" && "${HAS_PLAY_CREDENTIALS}" == "true" ]]; then
               echo "- Play publish step: app attempted (internal track)"
               echo "- Wear publish enabled: ${PUBLISH_WEAR}"


### PR DESCRIPTION
Wires the opt-in Crashlytics build (added in #330) into the release workflow.

The build enables Crashlytics when `app/google-services.json` exists at Gradle configuration time. That file is `.gitignore`d, so the release job materializes it from a secret before the first Gradle call — mirroring the existing keystore-decode pattern:

- New `GOOGLE_SERVICES_JSON` secret (base64 of `app/google-services.json`), surfaced as `HAS_GOOGLE_SERVICES` in the job env.
- A decode step writes `app/google-services.json` right after setup, before any `./gradlew` invocation (the path is hard-coded in the build logic and `crashlyticsEnabled` is evaluated at configuration time).
- Documented the secret in the header and added a line to the publish summary.

Presence of the secret → Crashlytics is wired into the release build (R8 mapping auto-uploads since release is minified); absence → the build is unchanged and runs against the no-op reporter.

## Setup required (outside this PR)
Add the repo secret `GOOGLE_SERVICES_JSON`:
```
base64 -w0 google-services.json   # macOS: base64 -b0
```
for the Firebase Android app with package `ee.schimke.harc`.

## Test plan
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-build.yml'))"` — valid.
- No-secret path is a no-op (step gated on `HAS_GOOGLE_SERVICES`), so existing release builds are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFo88ftmKMzgx492LLvGMh)_