### PR TITLE
feat: add Firebase Analytics alongside Crashlytics

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -173,10 +173,14 @@ dependencies {
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.kotlinx.serialization.json)
 
-  // Crashlytics SDK — only when a key is configured (see crashlyticsEnabled).
+  // Firebase SDK — only when a google-services.json key is configured (see
+  // crashlyticsEnabled). Analytics rides alongside Crashlytics: it auto-inits
+  // via the google-services-generated config and gives Crashlytics richer
+  // breadcrumb / user-velocity data; no app code needed.
   if (crashlyticsEnabled) {
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.crashlytics)
+    implementation(libs.firebase.analytics)
   }
 
   testImplementation(libs.kotlin.test.junit)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,7 +63,7 @@ play-services-wearable = "20.0.1"
 
 # Firebase Crashlytics (opt-in — only resolved when a google-services.json
 # key is configured; see app/build.gradle.kts `crashlyticsEnabled`).
-firebase-bom = "34.4.0"
+firebase-bom = "34.14.0"
 
 [libraries]
 # RemoteCompose authoring / playback
@@ -187,10 +187,12 @@ mockserver-client-java = { module = "org.mock-server:mockserver-client-java", ve
 jetbrains-markdown = { module = "org.jetbrains:markdown", version.ref = "jetbrains-markdown" }
 indriya = { module = "tech.units:indriya", version.ref = "indriya" }
 
-# Firebase Crashlytics — pulled into :app only when a Crashlytics key is
-# configured (the BoM aligns the Crashlytics + analytics artifact versions).
+# Firebase — pulled into :app only when a google-services.json key is
+# configured (the BoM aligns the Crashlytics + analytics artifact versions,
+# so these carry no explicit version).
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
+firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Adds Firebase Analytics to the existing opt-in Firebase setup (from the standard Firebase console "add Analytics" snippet).

- `firebase-analytics` added to the key-gated Firebase dependency block in `:app` (alongside `firebase-crashlytics`).
- Firebase BoM bumped `34.4.0` → `34.14.0`.

Analytics auto-initializes from the google-services-generated config — no app code — and gives Crashlytics richer breadcrumb / user-velocity data.

Everything stays gated on `google-services.json` presence via the existing `crashlyticsEnabled` flag, so **the no-key build is unchanged** and pulls in no Firebase artifacts.

### Note on the google-services plugin
The console snippet declares `id("com.google.gms.google-services") version "4.4.4" apply false` in the root `plugins {}` block. I kept the plugin on the **conditional buildscript classpath** (already wired in the crash-logging change) instead: the plugins-DSL `apply false` form resolves the plugin marker unconditionally even with no key, which would break the "no-key build needs no Firebase tooling" guarantee. The applied plugin is identical when the key is present.

## Test plan
- With a dummy `google-services.json`: `./gradlew :app:help` configures cleanly — the `firebase-analytics` catalog accessor resolves and both Firebase plugins apply.
- `./gradlew ktfmtCheckScripts` — passes.
- No-key path unchanged (dependency block gated on `crashlyticsEnabled`).
- Full artifact resolution / `assembleRelease` requires a real key + network and is exercised by the release workflow.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RFo88ftmKMzgx492LLvGMh)_