### PR TITLE
ci(preview): pack portable preview bundles and show them in the terminal

### DIFF
--- a/.github/workflows/preview-bundle.yml
+++ b/.github/workflows/preview-bundle.yml
@@ -1,0 +1,129 @@
+name: Preview Bundle
+
+# Builds a portable preview bundle and prints it to the terminal.
+#
+# A "preview bundle" is the PNG+ZIP polyglot produced by
+# `compose-preview bundle pack`: the file is simultaneously a valid PNG (the
+# cover — i.e. the default preview you see when you open it) and a valid ZIP
+# whose well-known interior holds the remaining previews plus the minimal
+# classpath needed to replay them. Because everything travels inside the one
+# file it works detached from the project — drop it in Downloads, open it, and
+# the cover renders like any other PNG.
+#
+# This job packs one sample bundle for the `previews` module (cover + the other
+# previews in the ZIP) and then dumps each preview to the terminal. It prefers
+# the CLI's terminal image protocol ("the TUI") and falls back to ASCII art via
+# chafa so the previews are visible in plain CI logs. The ASCII rendering won't
+# look great, but it works on any terminal.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preview-bundle-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  BUNDLE: previews/build/compose-previews/bundle.png
+
+jobs:
+  bundle:
+    name: Pack a sample preview bundle and show it in the terminal
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup
+        with:
+          # Read-only on PRs so untrusted runs can't poison the Gradle cache.
+          cache-read-only: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+
+      # The compose-preview Gradle plugin isn't applied to any module — its
+      # render task is materialised on demand by the CLI's auto-inject init
+      # script — so install the CLI before we render/pack. Same version the
+      # other workflows pin via the catalog.
+      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.12.0
+        with:
+          version: catalog
+          catalog-key: compose-preview-plugin
+
+      # chafa is the ASCII fallback: a terminal image viewer that uses the
+      # terminal's graphics protocol when one is available and degrades to
+      # ASCII/Unicode symbols when it isn't (which is the case in CI logs).
+      - name: Install chafa (terminal image viewer / ASCII fallback)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends chafa
+
+      # `bundle pack` runs the render task itself, then packs the previews into
+      # the polyglot at $BUNDLE (the default "bundle root" output location).
+      # The first discovered preview becomes the cover (the default preview);
+      # every other preview is stored inside the ZIP. We must pass --module:
+      # bare auto-detection fans out across every module and trips on
+      # `demo-app`, which has no @Preview tooling on its classpath.
+      - name: Pack the sample preview bundle
+        run: compose-preview bundle pack --module previews -o "$BUNDLE"
+
+      - name: Inspect the bundle
+        run: compose-preview bundle inspect "$BUNDLE"
+
+      - name: Show previews in the terminal (TUI with ASCII fallback)
+        run: |
+          set -euo pipefail
+
+          # --- The TUI -----------------------------------------------------
+          # The CLI can paint rendered previews inline using the terminal's
+          # image protocol (kitty graphics). It's TTY-gated and auto-off when
+          # stdout is piped, so in CI logs it stays silent — the ASCII
+          # fallback below is what actually shows up. Kept here so a human
+          # running this locally in a capable terminal gets the real thing.
+          echo "::group::TUI — terminal image protocol (silent unless run in a graphics-capable terminal)"
+          compose-preview show --module previews --images=kitty || true
+          echo "::endgroup::"
+
+          # --- ASCII fallback ----------------------------------------------
+          # Render every preview the bundle carries. The bundle file itself is
+          # the cover (default preview); the rest live inside the ZIP, so we
+          # extract them and ASCII-print each one.
+          render_ascii() {
+            # Prefer a graphics protocol when the terminal advertises one;
+            # otherwise force plain ASCII glyphs so the output survives any
+            # log viewer. Won't look great, but it works everywhere.
+            chafa --size 100x48 "$1" 2>/dev/null \
+              || chafa -f symbols --symbols ascii --size 100x48 "$1" \
+              || echo "(could not render $1)"
+          }
+
+          echo "==> Cover (default preview): $BUNDLE"
+          render_ascii "$BUNDLE"
+
+          rm -rf bundle-extracted && mkdir -p bundle-extracted
+          compose-preview bundle extract "$BUNDLE" -o bundle-extracted
+
+          echo "==> Additional previews (well-known location inside the bundle):"
+          found=0
+          while IFS= read -r png; do
+            found=1
+            echo "── ${png#bundle-extracted/} ──"
+            render_ascii "$png"
+          done < <(find bundle-extracted -type f -name '*.png' | sort)
+          [ "$found" -eq 1 ] || echo "(no additional previews extracted)"
+
+      - name: Upload the bundle
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: preview-bundle
+          path: |
+            ${{ env.BUNDLE }}
+            bundle-extracted/**
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -131,6 +131,25 @@ compose-preview show --json        # renders and prints PNG paths
 compose-preview render --filter tile
 ```
 
+### Preview bundles
+
+`compose-preview bundle pack` packs previews into a **PNG+ZIP polyglot** — one
+file that is both the cover PNG (the default preview) and a ZIP holding the
+remaining previews plus the minimal classpath to replay them. It travels
+detached from the project: drop it in Downloads, open it, and the cover renders
+like any PNG.
+
+```sh
+compose-preview bundle pack --module previews   # -> previews/build/compose-previews/bundle.png
+compose-preview bundle inspect previews/build/compose-previews/bundle.png
+compose-preview bundle extract previews/build/compose-previews/bundle.png -o out
+```
+
+The [Preview Bundle workflow](.github/workflows/preview-bundle.yml) packs a
+sample bundle in CI and prints each preview to the terminal (graphics protocol
+when available, ASCII fallback otherwise). See
+[docs/preview-bundles.md](docs/preview-bundles.md).
+
 ## Fetching HA config
 
 `HaClient` (in `ha-client`) wraps the WebSocket commands the converter

--- a/docs/preview-bundles.md
+++ b/docs/preview-bundles.md
@@ -1,0 +1,68 @@
+# Preview bundles
+
+A **preview bundle** is the portable artifact produced by
+`compose-preview bundle pack`. It is a **PNG+ZIP polyglot**: the same bytes are
+simultaneously a valid PNG and a valid ZIP archive.
+
+```
+bundle.png
+├── (read as PNG) ── the cover: the default preview, shown by any image viewer
+└── (read as ZIP) ── manifest + the remaining previews + the minimal classpath
+```
+
+## Why a polyglot
+
+The goal is a preview you can hand to someone **detached from the project**.
+Because the cover is a normal PNG, dropping `bundle.png` into Downloads and
+opening it shows the default preview immediately — no checkout, no Gradle, no
+tooling. Anything that wants more than the cover reads the ZIP side of the same
+file.
+
+## One default, many previews
+
+- The **cover** is the single default preview — the first preview passed to
+  `--id`, or the first discovered preview when `--id` is omitted. It is the PNG
+  that the file renders as.
+- **Every other preview** is stored inside the ZIP, in its well-known interior
+  alongside the classpath needed to replay it. They never show up as the cover;
+  you reach them with `bundle extract` / `bundle inspect`.
+
+This keeps the "open it and see something useful" property (one cover) while
+still carrying the full set (the rest, inside the ZIP).
+
+## Commands
+
+```sh
+# Pack the previews module into previews/build/compose-previews/bundle.png.
+# First preview = cover; the rest go inside the ZIP.
+compose-preview bundle pack --module previews
+
+# Pick the cover (and optionally narrow the set) explicitly. First --id wins.
+compose-preview bundle pack --module previews --id Tile_TemperatureSensor -o out.png
+
+# Read the manifest without unpacking.
+compose-preview bundle inspect bundle.png
+
+# Extract the cover + every interior preview to a directory.
+compose-preview bundle extract bundle.png -o out/
+```
+
+Pass `--module` — bare auto-detection fans out across every module and trips on
+`demo-app`, which has no `@Preview` tooling on its classpath.
+
+## CI: pack + show in the terminal
+
+[`.github/workflows/preview-bundle.yml`](../.github/workflows/preview-bundle.yml)
+packs one sample bundle and dumps each preview to the terminal:
+
+- **The TUI.** `compose-preview show --images=kitty` paints previews inline
+  using the terminal's image protocol (kitty graphics). It is TTY-gated and
+  auto-off when stdout is piped, so it is silent in CI logs but works for a
+  human running it locally in a capable terminal (kitty, WezTerm, Ghostty).
+- **ASCII fallback.** [`chafa`](https://hpjansson.org/chafa/) renders each
+  preview as ASCII/Unicode art when no graphics protocol is available — which
+  is the case in CI logs. It won't look great, but every preview is visible on
+  any terminal.
+
+The packed `bundle.png` and the extracted previews are uploaded as the
+`preview-bundle` artifact.


### PR DESCRIPTION
Add a Preview Bundle workflow that packs the previews module into the
compose-preview PNG+ZIP polyglot (cover = default preview, the rest inside
the ZIP) so it works detached from the project, then prints each preview to
the terminal: the CLI's image protocol when available, ASCII via chafa as
the fallback for plain CI logs.

Document the bundle format in README and docs/preview-bundles.md.