### PR TITLE
Constrain widget sizes per card + fill the cell, with size-aware reflow

### DIFF
--- a/app/src/debug/kotlin/ee/schimke/terrazzo/widget/WidgetPreviewActivity.kt
+++ b/app/src/debug/kotlin/ee/schimke/terrazzo/widget/WidgetPreviewActivity.kt
@@ -35,7 +35,9 @@ import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.cards.shutter.withEnhancedShutter
 import ee.schimke.ha.rc.components.LocalPictureImageStrategy
 import ee.schimke.ha.rc.components.PictureImageStrategy
+import ee.schimke.ha.rc.components.ProvideCardChrome
 import ee.schimke.ha.rc.components.ProvideHaTheme
+import ee.schimke.ha.rc.components.RemoteHaWidgetSurface
 import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.ha.rc.components.haThemeFor
 import ee.schimke.ha.rc.widgetsProfile
@@ -120,7 +122,14 @@ class WidgetPreviewActivity : Activity() {
               ProvideCardRegistry(registry) {
                 ProvideHaTheme(haTheme) {
                   ProvideCardSizeMode(CardSizeMode.Fixed) {
-                    RenderChild(SAMPLE_CARD, SAMPLE_SNAPSHOT, RemoteModifier.fillMaxWidth())
+                    // Same full-canvas surface the launcher widget uses,
+                    // so the preview shows the background filling the tile
+                    // rather than wrapping to the card content.
+                    ProvideCardChrome(enabled = false) {
+                      RemoteHaWidgetSurface {
+                        RenderChild(SAMPLE_CARD, SAMPLE_SNAPSHOT, RemoteModifier.fillMaxWidth())
+                      }
+                    }
                   }
                 }
               }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -61,6 +61,34 @@
                 android:resource="@xml/terrazzo_widget_info" />
         </receiver>
 
+        <!--
+          Size-class variants of the provider above. Same id-driven
+          rendering; only the appwidget-provider metadata (default cell +
+          resize bounds) differs. WidgetSizeClass picks the matching
+          component at pin time from the card's WidgetSizeConstraints.
+        -->
+        <receiver
+            android:name=".widget.TerrazzoWidgetProviderSmall"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/terrazzo_widget_info_small" />
+        </receiver>
+
+        <receiver
+            android:name=".widget.TerrazzoWidgetProviderTall"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/terrazzo_widget_info_tall" />
+        </receiver>
+
         <!-- Fires after requestPinAppWidget is confirmed by the user. -->
         <receiver
             android:name=".widget.WidgetInstallReceiver"

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/TerrazzoWidgetProvider.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/TerrazzoWidgetProvider.kt
@@ -21,7 +21,9 @@ import ee.schimke.ha.rc.RenderChild
 import ee.schimke.ha.rc.cardHeightDp
 import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.cards.shutter.withEnhancedShutter
+import ee.schimke.ha.rc.components.ProvideCardChrome
 import ee.schimke.ha.rc.components.ProvideHaTheme
+import ee.schimke.ha.rc.components.RemoteHaWidgetSurface
 import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.ha.rc.components.haThemeFor
 import ee.schimke.ha.rc.widgetsProfile
@@ -109,7 +111,22 @@ class TerrazzoWidgetProvider : AppWidgetProvider() {
                     ProvideCardRegistry(registry) {
                         ProvideHaTheme(haTheme) {
                             ProvideCardSizeMode(CardSizeMode.Fixed) {
-                                RenderChild(entry.card, snapshot, RemoteModifier.fillMaxWidth())
+                                // The widget surface paints the themed
+                                // card background across the whole
+                                // capture canvas, so the launcher cell is
+                                // fully covered even when the card's
+                                // content is shorter than the slot.
+                                // Suppress the inner card's own chrome so
+                                // it doesn't draw a second frame inside.
+                                ProvideCardChrome(enabled = false) {
+                                    RemoteHaWidgetSurface {
+                                        RenderChild(
+                                            entry.card,
+                                            snapshot,
+                                            RemoteModifier.fillMaxWidth(),
+                                        )
+                                    }
+                                }
                             }
                         }
                     }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/TerrazzoWidgetProvider.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/TerrazzoWidgetProvider.kt
@@ -60,7 +60,7 @@ import kotlinx.coroutines.runBlocking
  * `RemoteViews.DrawInstructions`. The app's minSdk of 36 already
  * satisfies this; the `@RequiresApi` is here only to keep lint quiet.
  */
-class TerrazzoWidgetProvider : AppWidgetProvider() {
+open class TerrazzoWidgetProvider : AppWidgetProvider() {
 
     override fun onUpdate(
         context: Context,
@@ -171,3 +171,19 @@ class TerrazzoWidgetProvider : AppWidgetProvider() {
         const val TAG = "TerrazzoWidgetProvider"
     }
 }
+
+/**
+ * Size-class provider variants. They share [TerrazzoWidgetProvider]'s
+ * id-driven rendering verbatim — the only thing that differs is the
+ * `appwidget-provider` metadata declared against each in the manifest
+ * (`targetCell*` default + `min/maxResize*` bounds), which is how a
+ * card's [WidgetSizeClass][ee.schimke.terrazzo.widget.WidgetSizeClass]
+ * reaches the launcher's resize UI. [WidgetInstaller] picks the
+ * matching component at pin time; refresh broadcasts can still target
+ * the base provider since rendering only ever keys off the widget id.
+ *
+ * @see WidgetSizeClass
+ */
+class TerrazzoWidgetProviderSmall : TerrazzoWidgetProvider()
+
+class TerrazzoWidgetProviderTall : TerrazzoWidgetProvider()

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstaller.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetInstaller.kt
@@ -2,10 +2,13 @@ package ee.schimke.terrazzo.widget
 
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.cardSizeConstraints
+import ee.schimke.ha.rc.cards.defaultRegistry
+import ee.schimke.ha.rc.cards.shutter.withEnhancedShutter
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 
@@ -41,7 +44,15 @@ class WidgetInstaller(private val context: Context) {
         val appWidgetManager = AppWidgetManager.getInstance(context)
         if (!appWidgetManager.isRequestPinAppWidgetSupported) return false
 
-        val provider = ComponentName(context, TerrazzoWidgetProvider::class.java)
+        // Pick the provider variant whose appwidget-provider metadata
+        // matches the card's supported-size band, so the launcher offers
+        // the right default cell + resize bounds. Rendering is identical
+        // across variants (all inherit TerrazzoWidgetProvider). The
+        // snapshot only feeds payload-dependent sizing (e.g. entities
+        // row count comes from card.raw), so an empty one is fine here.
+        val registry = defaultRegistry().withEnhancedShutter()
+        val constraints = registry.cardSizeConstraints(card, HaSnapshot())
+        val provider = WidgetSizeClass.forConstraints(constraints).componentName(context)
 
         val callback = Intent(context, WidgetInstallReceiver::class.java).apply {
             action = WidgetInstallReceiver.ACTION_PIN_CONFIRMED

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetSizeClass.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetSizeClass.kt
@@ -15,8 +15,16 @@ import ee.schimke.ha.rc.WidgetSizeConstraints
  * subclass + `appwidget-provider` XML (see [providerClass] and the
  * `@xml/terrazzo_widget_info*` resources). [WidgetInstaller] reads the
  * card's [WidgetSizeConstraints], maps it here, and pins the matching
- * component so the launcher offers the right default cell and resize
- * handles.
+ * component.
+ *
+ * Each class is an **opinionated range** — a `targetCell*` default plus
+ * `min/maxResize*` bounds — so the launcher offers a sensible default
+ * cell and won't let the card be dragged out to an oversized slot it
+ * would only half-fill:
+ *
+ *   * [Small]    — ~1x1 .. 2x2 (single-entity chips)
+ *   * [Standard] — ~2x1 .. 4x3 (default list/hero)
+ *   * [Tall]     — ~2x2 .. 4x4 (many-row lists)
  *
  * Rendering itself is identical across variants — every provider
  * subclass inherits [TerrazzoWidgetProvider]'s id-driven capture — so

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetSizeClass.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetSizeClass.kt
@@ -1,0 +1,66 @@
+package ee.schimke.terrazzo.widget
+
+import android.content.ComponentName
+import android.content.Context
+import ee.schimke.ha.rc.WidgetSizeConstraints
+
+/**
+ * Quantises a card's continuous [WidgetSizeConstraints] band onto the
+ * small, fixed set of launcher provider variants we ship.
+ *
+ * The launcher learns a widget's default cell and resize limits from
+ * static `appwidget-provider` metadata, which is per-provider — a
+ * single provider can only advertise one band. So instead of one
+ * provider, each size class is backed by its own [AppWidgetProvider]
+ * subclass + `appwidget-provider` XML (see [providerClass] and the
+ * `@xml/terrazzo_widget_info*` resources). [WidgetInstaller] reads the
+ * card's [WidgetSizeConstraints], maps it here, and pins the matching
+ * component so the launcher offers the right default cell and resize
+ * handles.
+ *
+ * Rendering itself is identical across variants — every provider
+ * subclass inherits [TerrazzoWidgetProvider]'s id-driven capture — so
+ * adding a class is just a new subclass + XML + manifest receiver, no
+ * render logic.
+ */
+internal enum class WidgetSizeClass(val providerClassName: String) {
+    /**
+     * Button-shaped single-entity cards (tile, button, entity): a small,
+     * near-square cell that pairs with other small widgets.
+     * `@xml/terrazzo_widget_info_small`.
+     */
+    Small("ee.schimke.terrazzo.widget.TerrazzoWidgetProviderSmall"),
+
+    /**
+     * The default: wide list/hero cards at a comfortable couple of rows.
+     * Backed by the base [TerrazzoWidgetProvider] so existing installs
+     * keep working. `@xml/terrazzo_widget_info`.
+     */
+    Standard("ee.schimke.terrazzo.widget.TerrazzoWidgetProvider"),
+
+    /**
+     * Tall list cards (entities/glance with many rows) that want vertical
+     * room by default. `@xml/terrazzo_widget_info_tall`.
+     */
+    Tall("ee.schimke.terrazzo.widget.TerrazzoWidgetProviderTall");
+
+    fun componentName(context: Context): ComponentName =
+        ComponentName(context.packageName, providerClassName)
+
+    companion object {
+        /** Default height (dp) at or above which a Full-width card pins Tall. */
+        private const val TALL_DEFAULT_HEIGHT_DP = 200
+
+        /**
+         * Pick the size class for a card's [constraints]. Compact bands
+         * (narrow default width) pin [Small]; wide bands pin [Tall] when
+         * their default height clears [TALL_DEFAULT_HEIGHT_DP], otherwise
+         * [Standard].
+         */
+        fun forConstraints(constraints: WidgetSizeConstraints): WidgetSizeClass = when {
+            constraints.defaultWidthDp <= 200 -> Small
+            constraints.defaultHeightDp >= TALL_DEFAULT_HEIGHT_DP -> Tall
+            else -> Standard
+        }
+    }
+}

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetSizeClass.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetSizeClass.kt
@@ -23,29 +23,29 @@ import ee.schimke.ha.rc.WidgetSizeConstraints
  * adding a class is just a new subclass + XML + manifest receiver, no
  * render logic.
  */
-internal enum class WidgetSizeClass(val providerClassName: String) {
+internal enum class WidgetSizeClass(val providerClass: Class<out TerrazzoWidgetProvider>) {
     /**
      * Button-shaped single-entity cards (tile, button, entity): a small,
      * near-square cell that pairs with other small widgets.
      * `@xml/terrazzo_widget_info_small`.
      */
-    Small("ee.schimke.terrazzo.widget.TerrazzoWidgetProviderSmall"),
+    Small(TerrazzoWidgetProviderSmall::class.java),
 
     /**
      * The default: wide list/hero cards at a comfortable couple of rows.
      * Backed by the base [TerrazzoWidgetProvider] so existing installs
      * keep working. `@xml/terrazzo_widget_info`.
      */
-    Standard("ee.schimke.terrazzo.widget.TerrazzoWidgetProvider"),
+    Standard(TerrazzoWidgetProvider::class.java),
 
     /**
      * Tall list cards (entities/glance with many rows) that want vertical
      * room by default. `@xml/terrazzo_widget_info_tall`.
      */
-    Tall("ee.schimke.terrazzo.widget.TerrazzoWidgetProviderTall");
+    Tall(TerrazzoWidgetProviderTall::class.java);
 
     fun componentName(context: Context): ComponentName =
-        ComponentName(context.packageName, providerClassName)
+        ComponentName(context, providerClass)
 
     companion object {
         /** Default height (dp) at or above which a Full-width card pins Tall. */

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetSizing.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetSizing.kt
@@ -17,16 +17,29 @@ internal object WidgetSizing {
     fun forPreview(cardHeightDp: Int): WidgetSizeDp =
         WidgetSizeDp(widthDp = DEFAULT_WIDTH_DP, heightDp = cardHeightDp.coerceAtLeast(DEFAULT_HEIGHT_DP))
 
+    /**
+     * Size the capture canvas to the launcher cell the user actually
+     * dragged out, so the rendered document fills its slot instead of
+     * wrapping to content and leaving a blank band.
+     *
+     * The host reports the current cell as a width/height pair: in
+     * portrait it is `MIN_WIDTH × MAX_HEIGHT`, in landscape
+     * `MAX_WIDTH × MIN_HEIGHT`. We capture the portrait pair (the common
+     * home-screen orientation); the runtime re-measures width against
+     * the live canvas anyway via `fillMaxWidth`. [cardHeightDp] is only
+     * a fallback for hosts that don't report `MAX_HEIGHT` yet.
+     */
     fun forWidgetCapture(
         appWidgetManager: AppWidgetManager,
         widgetId: Int,
         cardHeightDp: Int,
     ): WidgetSizeDp {
         val options = appWidgetManager.getAppWidgetOptions(widgetId)
-        val minWidth = options.getDp(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH, DEFAULT_WIDTH_DP)
-        val maxHeight = options.getDp(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT, cardHeightDp)
-        val targetHeight = cardHeightDp.coerceIn(DEFAULT_HEIGHT_DP, maxHeight.coerceAtLeast(DEFAULT_HEIGHT_DP))
-        return WidgetSizeDp(widthDp = minWidth, heightDp = targetHeight)
+        val width = options.getDp(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH, DEFAULT_WIDTH_DP)
+        val height = options
+            .getDp(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT, cardHeightDp)
+            .coerceAtLeast(DEFAULT_HEIGHT_DP)
+        return WidgetSizeDp(widthDp = width, heightDp = height)
     }
 
     fun dpToPx(context: Context, dp: Int): Int =

--- a/app/src/main/res/xml/terrazzo_widget_info.xml
+++ b/app/src/main/res/xml/terrazzo_widget_info.xml
@@ -1,27 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  AppWidget provider metadata for the STANDARD Terrazzo size class — the
-  default for wide list/hero cards. One XML per size class (see also
-  terrazzo_widget_info_small / _tall); WidgetSizeClass picks the matching
-  provider at pin time from the card's WidgetSizeConstraints.
+  STANDARD Terrazzo size class — the default for wide list/hero cards.
+  One XML per size class (see also terrazzo_widget_info_small / _tall);
+  WidgetSizeClass picks the matching provider at pin time from the card's
+  WidgetSizeConstraints.
 
-  We set only a comfortable default cell (`targetCell*`) and otherwise
-  leave resize free — a low `minResize*` floor and no ceiling — so the
-  launcher's own grid governs what sizes are offered. The card's
-  Fixed-mode breakpoint ladders adapt to whatever cell results; we don't
-  try to constrain sizes the launcher would otherwise allow.
+  Opinionated range, ~2x1 .. 4x3 cells: `targetCell*` is the comfortable
+  default the widget pins at, and `min/maxResize*` bound the resize
+  handles so the card can't be dragged out to an oversized slot it would
+  only half-fill. The card's breakpoint ladders adapt within the range;
+  the widget surface fills the whole cell so there's no blank band.
 
   `updatePeriodMillis="0"` — we drive updates imperatively from a
   background worker when HA state changes; the 30-minute minimum of the
   framework poll would give stale readings anyway.
 -->
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="40dp"
-    android:minHeight="40dp"
+    android:minWidth="130dp"
+    android:minHeight="60dp"
     android:targetCellWidth="4"
     android:targetCellHeight="2"
-    android:minResizeWidth="40dp"
-    android:minResizeHeight="40dp"
+    android:minResizeWidth="130dp"
+    android:minResizeHeight="60dp"
+    android:maxResizeWidth="300dp"
+    android:maxResizeHeight="220dp"
     android:resizeMode="horizontal|vertical"
     android:updatePeriodMillis="0"
     android:widgetCategory="home_screen"

--- a/app/src/main/res/xml/terrazzo_widget_info.xml
+++ b/app/src/main/res/xml/terrazzo_widget_info.xml
@@ -1,22 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  AppWidget provider metadata for Terrazzo widgets. One XML covers
-  every installed instance; the provider resolves per-widget config
-  from DataStore at render time.
+  AppWidget provider metadata for the STANDARD Terrazzo size class — the
+  default for wide list/hero cards. One XML per size class (see also
+  terrazzo_widget_info_small / _tall); WidgetSizeClass picks the matching
+  provider at pin time so the launcher offers the right default cell and
+  resize handles for the card.
 
-  Size: min values are 1dp so the launcher imposes no floor — the
-  widget renders at whatever cell size the user picks. `resizeMode`
-  lets them grow it freely in both axes.
+  `targetCell*` set the default cell the widget pins at; `min/maxResize*`
+  bound the resize handles so a card can't be dragged outside its useful
+  band (the per-card WidgetSizeConstraints, quantised onto this class).
 
   `updatePeriodMillis="0"` — we drive updates imperatively from a
-  background worker when HA state changes; the 30-minute minimum of
-  the framework poll would give stale readings anyway.
+  background worker when HA state changes; the 30-minute minimum of the
+  framework poll would give stale readings anyway.
 -->
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="1dp"
-    android:minHeight="1dp"
-    android:minResizeWidth="1dp"
-    android:minResizeHeight="1dp"
+    android:minWidth="110dp"
+    android:minHeight="48dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="2"
+    android:minResizeWidth="110dp"
+    android:minResizeHeight="48dp"
+    android:maxResizeWidth="360dp"
+    android:maxResizeHeight="400dp"
     android:resizeMode="horizontal|vertical"
     android:updatePeriodMillis="0"
     android:widgetCategory="home_screen"

--- a/app/src/main/res/xml/terrazzo_widget_info.xml
+++ b/app/src/main/res/xml/terrazzo_widget_info.xml
@@ -3,26 +3,25 @@
   AppWidget provider metadata for the STANDARD Terrazzo size class — the
   default for wide list/hero cards. One XML per size class (see also
   terrazzo_widget_info_small / _tall); WidgetSizeClass picks the matching
-  provider at pin time so the launcher offers the right default cell and
-  resize handles for the card.
+  provider at pin time from the card's WidgetSizeConstraints.
 
-  `targetCell*` set the default cell the widget pins at; `min/maxResize*`
-  bound the resize handles so a card can't be dragged outside its useful
-  band (the per-card WidgetSizeConstraints, quantised onto this class).
+  We set only a comfortable default cell (`targetCell*`) and otherwise
+  leave resize free — a low `minResize*` floor and no ceiling — so the
+  launcher's own grid governs what sizes are offered. The card's
+  Fixed-mode breakpoint ladders adapt to whatever cell results; we don't
+  try to constrain sizes the launcher would otherwise allow.
 
   `updatePeriodMillis="0"` — we drive updates imperatively from a
   background worker when HA state changes; the 30-minute minimum of the
   framework poll would give stale readings anyway.
 -->
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="110dp"
-    android:minHeight="48dp"
+    android:minWidth="40dp"
+    android:minHeight="40dp"
     android:targetCellWidth="4"
     android:targetCellHeight="2"
-    android:minResizeWidth="110dp"
-    android:minResizeHeight="48dp"
-    android:maxResizeWidth="360dp"
-    android:maxResizeHeight="400dp"
+    android:minResizeWidth="40dp"
+    android:minResizeHeight="40dp"
     android:resizeMode="horizontal|vertical"
     android:updatePeriodMillis="0"
     android:widgetCategory="home_screen"

--- a/app/src/main/res/xml/terrazzo_widget_info_small.xml
+++ b/app/src/main/res/xml/terrazzo_widget_info_small.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  SMALL Terrazzo size class — button-shaped single-entity cards (tile,
+  button, entity). Near-square default cell that pairs with other small
+  widgets. Backed by TerrazzoWidgetProviderSmall; chosen by
+  WidgetSizeClass.Small. See terrazzo_widget_info.xml for the shared
+  rationale.
+-->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="40dp"
+    android:minHeight="40dp"
+    android:targetCellWidth="2"
+    android:targetCellHeight="1"
+    android:minResizeWidth="40dp"
+    android:minResizeHeight="40dp"
+    android:maxResizeWidth="200dp"
+    android:maxResizeHeight="200dp"
+    android:resizeMode="horizontal|vertical"
+    android:updatePeriodMillis="0"
+    android:widgetCategory="home_screen"
+    android:initialLayout="@layout/terrazzo_widget_initial" />

--- a/app/src/main/res/xml/terrazzo_widget_info_small.xml
+++ b/app/src/main/res/xml/terrazzo_widget_info_small.xml
@@ -3,8 +3,8 @@
   SMALL Terrazzo size class — button-shaped single-entity cards (tile,
   button, entity). Near-square default cell that pairs with other small
   widgets. Backed by TerrazzoWidgetProviderSmall; chosen by
-  WidgetSizeClass.Small. See terrazzo_widget_info.xml for the shared
-  rationale.
+  WidgetSizeClass.Small. Comfortable default cell only; resize stays free
+  (see terrazzo_widget_info.xml for the shared rationale).
 -->
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:minWidth="40dp"
@@ -13,8 +13,6 @@
     android:targetCellHeight="1"
     android:minResizeWidth="40dp"
     android:minResizeHeight="40dp"
-    android:maxResizeWidth="200dp"
-    android:maxResizeHeight="200dp"
     android:resizeMode="horizontal|vertical"
     android:updatePeriodMillis="0"
     android:widgetCategory="home_screen"

--- a/app/src/main/res/xml/terrazzo_widget_info_small.xml
+++ b/app/src/main/res/xml/terrazzo_widget_info_small.xml
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   SMALL Terrazzo size class — button-shaped single-entity cards (tile,
-  button, entity). Near-square default cell that pairs with other small
-  widgets. Backed by TerrazzoWidgetProviderSmall; chosen by
-  WidgetSizeClass.Small. Comfortable default cell only; resize stays free
-  (see terrazzo_widget_info.xml for the shared rationale).
+  button, entity). Backed by TerrazzoWidgetProviderSmall; chosen by
+  WidgetSizeClass.Small.
+
+  Opinionated range, ~1x1 .. 2x2 cells: a near-square chip that pairs
+  with other small widgets and can't be stretched into a list-sized
+  slot. See terrazzo_widget_info.xml for the shared rationale.
 -->
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="40dp"
-    android:minHeight="40dp"
+    android:minWidth="50dp"
+    android:minHeight="50dp"
     android:targetCellWidth="2"
     android:targetCellHeight="1"
-    android:minResizeWidth="40dp"
-    android:minResizeHeight="40dp"
+    android:minResizeWidth="50dp"
+    android:minResizeHeight="50dp"
+    android:maxResizeWidth="160dp"
+    android:maxResizeHeight="160dp"
     android:resizeMode="horizontal|vertical"
     android:updatePeriodMillis="0"
     android:widgetCategory="home_screen"

--- a/app/src/main/res/xml/terrazzo_widget_info_tall.xml
+++ b/app/src/main/res/xml/terrazzo_widget_info_tall.xml
@@ -2,18 +2,23 @@
 <!--
   TALL Terrazzo size class — list cards (entities/glance) with enough
   rows to want vertical room by default. Backed by
-  TerrazzoWidgetProviderTall; chosen by WidgetSizeClass.Tall. Comfortable
-  default cell only; resize stays free so the user can still shrink it
-  (and the entities height-axis ladder can reflow to its icon strip) —
-  see terrazzo_widget_info.xml for the shared rationale.
+  TerrazzoWidgetProviderTall; chosen by WidgetSizeClass.Tall.
+
+  Opinionated range, ~2x2 .. 4x4 cells: room for several rows, but
+  capped so a list can't be dragged out to a slot far taller than its
+  content. The width-axis reflow still kicks in past ~260dp wide; the
+  widget surface fills the cell either way. See terrazzo_widget_info.xml
+  for the shared rationale.
 -->
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="40dp"
-    android:minHeight="40dp"
+    android:minWidth="150dp"
+    android:minHeight="120dp"
     android:targetCellWidth="4"
     android:targetCellHeight="3"
-    android:minResizeWidth="40dp"
-    android:minResizeHeight="40dp"
+    android:minResizeWidth="150dp"
+    android:minResizeHeight="120dp"
+    android:maxResizeWidth="300dp"
+    android:maxResizeHeight="340dp"
     android:resizeMode="horizontal|vertical"
     android:updatePeriodMillis="0"
     android:widgetCategory="home_screen"

--- a/app/src/main/res/xml/terrazzo_widget_info_tall.xml
+++ b/app/src/main/res/xml/terrazzo_widget_info_tall.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  TALL Terrazzo size class — list cards (entities/glance) with enough
+  rows to want vertical room by default. Backed by
+  TerrazzoWidgetProviderTall; chosen by WidgetSizeClass.Tall. See
+  terrazzo_widget_info.xml for the shared rationale.
+-->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="180dp"
+    android:minHeight="110dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="3"
+    android:minResizeWidth="180dp"
+    android:minResizeHeight="110dp"
+    android:maxResizeWidth="360dp"
+    android:maxResizeHeight="600dp"
+    android:resizeMode="horizontal|vertical"
+    android:updatePeriodMillis="0"
+    android:widgetCategory="home_screen"
+    android:initialLayout="@layout/terrazzo_widget_initial" />

--- a/app/src/main/res/xml/terrazzo_widget_info_tall.xml
+++ b/app/src/main/res/xml/terrazzo_widget_info_tall.xml
@@ -2,18 +2,18 @@
 <!--
   TALL Terrazzo size class — list cards (entities/glance) with enough
   rows to want vertical room by default. Backed by
-  TerrazzoWidgetProviderTall; chosen by WidgetSizeClass.Tall. See
-  terrazzo_widget_info.xml for the shared rationale.
+  TerrazzoWidgetProviderTall; chosen by WidgetSizeClass.Tall. Comfortable
+  default cell only; resize stays free so the user can still shrink it
+  (and the entities height-axis ladder can reflow to its icon strip) —
+  see terrazzo_widget_info.xml for the shared rationale.
 -->
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="180dp"
-    android:minHeight="110dp"
+    android:minWidth="40dp"
+    android:minHeight="40dp"
     android:targetCellWidth="4"
     android:targetCellHeight="3"
-    android:minResizeWidth="180dp"
-    android:minResizeHeight="110dp"
-    android:maxResizeWidth="360dp"
-    android:maxResizeHeight="600dp"
+    android:minResizeWidth="40dp"
+    android:minResizeHeight="40dp"
     android:resizeMode="horizontal|vertical"
     android:updatePeriodMillis="0"
     android:widgetCategory="home_screen"

--- a/docs/architecture/adaptive-card-layouts.md
+++ b/docs/architecture/adaptive-card-layouts.md
@@ -179,14 +179,18 @@ The ladder is per-card, not a fixed cascade.
 
 | Tier | Min size | Layout |
 |------|----------|--------|
-| 1. Full | 240 × 96 | title chrome + N rows |
-| 2. Title-and-rows | 200 × 64 | rows trimmed to fit height |
-| 3. First-row-only | 160 × 40 | title hidden, single row visible |
-| 4. Title chip | smaller | title + "+N more" badge |
+| 1. Full | `h ≥ 200` | title chrome + N rows — matches Wrap |
+| 2. Title-and-rows | `96 ≤ h < 200` | first three rows, no title chrome |
+| 3. **Icon strip (reflow)** | `h < 96` | rows repacked as a horizontal `glance`-style strip of icon · name · state cells |
 
-(No identity-only tier — entities is a list, the rows _are_ the
-identity. Once the chrome can't fit, the next-most-useful thing is
-which-and-how-many.)
+Implemented as a **height-axis** `RemoteSizeBreakpoint`
+(`thresholdsDp = [96, 200], axis = Height`): the list's natural layout
+is a vertical stack, so height is what decides how much fits. Tier 3 is
+the "column of N rows → row of N icons" reflow — the rows can't stack,
+so they repack sideways rather than dropping to a single row. (No
+identity-only tier — entities is a list, the rows _are_ the identity;
+once rows can't stack, the next-most-useful thing is
+which-and-how-many, which the strip preserves.)
 
 ## Data priorities
 
@@ -374,8 +378,14 @@ source of truth, not individual @Preview entries.
 
 The current state is the placeholder, not the philosophy:
 
-1. `RemoteSizeBreakpoint` reads `componentWidth()` only. Need a 2D
-   variant before any reflow ladder can land.
+1. `RemoteSizeBreakpoint` now takes a `BreakpointAxis` — `Width`
+   (default) or `Height` — so a ladder can gate on either dimension.
+   `entities` uses the height axis to reflow its row column into an
+   icon strip when the cell is too short to stack rows. A *true* 2-D /
+   aspect gate is still blocked: alpha010 collapses cross-axis and
+   `.and()`-composed predicates to tier 0 (#224), so each ladder must
+   pick the single axis that best discriminates its variants — see
+   `GaugeCardConverter` for the height-only gate it settled on.
 2. Tile / entity / button / gauge ship two-tier ladders
    (`Full → CompactStateChip`). That's the value-fallback path,
    skipping every reflow / identity tier above it. Each card needs

--- a/docs/architecture/adaptive-card-layouts.md
+++ b/docs/architecture/adaptive-card-layouts.md
@@ -179,18 +179,28 @@ The ladder is per-card, not a fixed cascade.
 
 | Tier | Min size | Layout |
 |------|----------|--------|
-| 1. Full | `h ≥ 200` | title chrome + N rows — matches Wrap |
-| 2. Title-and-rows | `96 ≤ h < 200` | first three rows, no title chrome |
-| 3. **Icon strip (reflow)** | `h < 96` | rows repacked as a horizontal `glance`-style strip of icon · name · state cells |
+| 1. Full | `w < 260` | title chrome + N rows — matches Wrap |
+| 2. **Icon strip (reflow)** | `w ≥ 260` | rows repacked as a horizontal `glance`-style strip of icon · name · state cells |
 
-Implemented as a **height-axis** `RemoteSizeBreakpoint`
-(`thresholdsDp = [96, 200], axis = Height`): the list's natural layout
-is a vertical stack, so height is what decides how much fits. Tier 3 is
-the "column of N rows → row of N icons" reflow — the rows can't stack,
-so they repack sideways rather than dropping to a single row. (No
-identity-only tier — entities is a list, the rows _are_ the identity;
-once rows can't stack, the next-most-useful thing is
-which-and-how-many, which the strip preserves.)
+Implemented as a **single-threshold width-axis** `RemoteSizeBreakpoint`
+(`thresholdsDp = [260], axis = Width`): drag the widget wider and the
+column of rows repacks into a row of icons. Two deliberate constraints,
+both learned from the matrix preview:
+
+- **Single threshold.** A multi-rung ladder lowers to nested
+  `RemoteStateLayout`s, which alpha010 collapses to tier 0 at playback
+  (#224, same as `GaugeCardConverter`) — a two-rung version pinned every
+  widget cell to one tier.
+- **Width, not height.** Every Fixed-mode surface (the matrix `@Preview`
+  cell and the launcher) pins width and lets height follow, so only a
+  width gate reads a stable canvas dimension and fires consistently. A
+  height gate reads the wrap-content height in those surfaces and
+  mis-selects. (`componentHeight()` _does_ work where height is pinned —
+  e.g. the Wear S vs L gauge — which is why the axis is available; it's
+  just not the right axis for a launcher list reflow.)
+
+(No identity-only tier — entities is a list, the rows _are_ the
+identity; the strip keeps which-and-how-many.)
 
 ## Data priorities
 
@@ -379,13 +389,17 @@ source of truth, not individual @Preview entries.
 The current state is the placeholder, not the philosophy:
 
 1. `RemoteSizeBreakpoint` now takes a `BreakpointAxis` — `Width`
-   (default) or `Height` — so a ladder can gate on either dimension.
-   `entities` uses the height axis to reflow its row column into an
-   icon strip when the cell is too short to stack rows. A *true* 2-D /
-   aspect gate is still blocked: alpha010 collapses cross-axis and
-   `.and()`-composed predicates to tier 0 (#224), so each ladder must
-   pick the single axis that best discriminates its variants — see
-   `GaugeCardConverter` for the height-only gate it settled on.
+   (default) or `Height`. Two playback realities, both confirmed against
+   the matrix preview, constrain how it's used: (a) only a **single**
+   threshold fires — multi-rung ladders lower to nested
+   `RemoteStateLayout`s that alpha010 collapses to tier 0 (#224); and
+   (b) a gate only reads a **stable** value on the axis the surface
+   *pins* — launcher/matrix cells pin width and wrap height, so a height
+   gate mis-selects there (it works where height is pinned, e.g. the
+   Wear gauge). A *true* 2-D / aspect gate remains blocked (#224). Net:
+   `entities` reflows on a single width threshold; per-card ladders
+   should pick the one pinned axis that best discriminates their
+   variants — see `GaugeCardConverter`.
 2. Tile / entity / button / gauge ship two-tier ladders
    (`Full → CompactStateChip`). That's the value-fallback path,
    skipping every reflow / identity tier above it. Each card needs

--- a/docs/architecture/adaptive-card-layouts.md
+++ b/docs/architecture/adaptive-card-layouts.md
@@ -404,11 +404,18 @@ The current state is the placeholder, not the philosophy:
    (`Full → CompactStateChip`). That's the value-fallback path,
    skipping every reflow / identity tier above it. Each card needs
    the worked-example ladder above.
-3. The Fixed-mode previews currently render uniformly stripped (the
-   screenshot). That's a sign the runtime tier selection isn't
-   firing — the named-expression `componentWidth()` may be capturing
-   a literal at recording time rather than evaluating live at
-   playback. Confirm before investing in per-card ladders.
+3. Runtime tier selection **does** fire — the matrix preview shows tile
+   switching chip↔full and entities switching list↔strip per size. Two
+   gotchas were shaped around: the `componentWidth()` named expression
+   only materialises when a visible node references it (the transparent
+   forcing-`RemoteText` in `RemoteSizeBreakpoint`), and the default
+   `RemoteStateLayout` swap is a 300 ms `FADE_IN/FADE_OUT` whose
+   mid-flight frame the in-process preview player captures, leaving the
+   outgoing branch ghosting behind the incoming one. The breakpoint
+   pins the swap to zero duration (`immediateSwap`) so only the selected
+   branch is ever drawn. (Binding branch opacity via `alpha(select(…))`
+   does **not** work — the derived float doesn't materialise (#224) and
+   blanks the selected branch too.)
 4. Compact-tier composables don't exist yet. The first card to land
    should set the file convention — the mini-arc gauge is a good
    candidate because it has an obvious reflow target and is the card

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviewMatrix.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviewMatrix.kt
@@ -46,7 +46,9 @@ import ee.schimke.ha.rc.RenderChild
 import ee.schimke.ha.rc.androidXExperimentalWrap
 import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.components.HaTheme
+import ee.schimke.ha.rc.components.ProvideCardChrome
 import ee.schimke.ha.rc.components.ProvideHaTheme
+import ee.schimke.ha.rc.components.RemoteHaWidgetSurface
 import ee.schimke.ha.rc.enableRemoteComposeWrapContent
 import ee.schimke.ha.rc.components.R as ComponentsR
 import java.time.ZoneOffset
@@ -297,7 +299,15 @@ private fun FixedModeCell(
                     ProvideCardRegistry(defaultRegistry()) {
                         ProvideHaTheme(HaTheme.Dark) {
                             ProvideCardSizeMode(CardSizeMode.Fixed) {
-                                RenderChild(card, snapshot, RemoteModifier.rcFillMaxWidth())
+                                // Same full-canvas surface the launcher
+                                // widget wraps the card in, so the preview
+                                // fills the cell instead of leaving blank
+                                // space below short content.
+                                ProvideCardChrome(enabled = false) {
+                                    RemoteHaWidgetSurface {
+                                        RenderChild(card, snapshot, RemoteModifier.rcFillMaxWidth())
+                                    }
+                                }
                             }
                         }
                     }
@@ -361,7 +371,15 @@ private fun WatchFaceCell(
                         ProvideCardRegistry(defaultRegistry()) {
                             ProvideHaTheme(HaTheme.Dark) {
                                 ProvideCardSizeMode(CardSizeMode.Fixed) {
-                                    RenderChild(card, snapshot, RemoteModifier.rcFillMaxWidth())
+                                    ProvideCardChrome(enabled = false) {
+                                        RemoteHaWidgetSurface {
+                                            RenderChild(
+                                                card,
+                                                snapshot,
+                                                RemoteModifier.rcFillMaxWidth(),
+                                            )
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviewMatrix.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviewMatrix.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.sp
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth as rcFillMaxWidth
 import androidx.compose.runtime.Composable
@@ -385,13 +384,6 @@ private fun WatchFaceCell(
                             colorFilter = ColorFilter.tint(Color(0xFF424242)),
                         )
                     }
-                    Text(
-                        text = "Terrazzo slot",
-                        color = Color.White,
-                        fontSize = 14.sp,
-                        fontWeight = FontWeight.Bold,
-                        modifier = Modifier.padding(top = 2.dp),
-                    )
                 }
             }
         }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaWidgetSurface.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaWidgetSurface.kt
@@ -1,0 +1,55 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.background
+import androidx.compose.remote.creation.compose.modifier.border
+import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxSize
+import androidx.compose.remote.creation.compose.shapes.RemoteRoundedCornerShape
+import androidx.compose.remote.creation.compose.state.rc
+import androidx.compose.remote.creation.compose.state.rdp
+import androidx.compose.runtime.Composable
+
+/**
+ * Full-canvas card surface for host-sized widget captures.
+ *
+ * [cardChrome] wraps a card's *content* — its rounded clip, fill, and
+ * border hug whatever the card draws, so wherever the launcher cell is
+ * taller (or wider) than the content the surrounding band is left
+ * unpainted. That blank band is exactly what shows up behind a pinned
+ * widget that hasn't grown to fill its slot.
+ *
+ * This composable instead fills the **entire capture canvas** with the
+ * themed card surface (rounded clip + [HaTheme.cardBackground] +
+ * hairline [HaTheme.divider] border) and renders [content] on top,
+ * top-start aligned. The background therefore always matches the full
+ * current widget size regardless of how much the inner card draws.
+ *
+ * Pair with `ProvideCardChrome(enabled = false)` at the capture root so
+ * the inner card skips its own content-sized frame and doesn't double
+ * up inside this one — mirroring how the Wear slot surface already
+ * suppresses per-card chrome. Used by the launcher widget
+ * (`TerrazzoWidgetProvider`).
+ */
+@Composable
+fun RemoteHaWidgetSurface(
+    modifier: RemoteModifier = RemoteModifier,
+    cornerRadiusDp: Int = 12,
+    borderWidthDp: Int = 1,
+    content: @Composable () -> Unit,
+) {
+    val theme = haTheme()
+    val shape = RemoteRoundedCornerShape(cornerRadiusDp.rdp)
+    RemoteBox(
+        modifier = modifier
+            .fillMaxSize()
+            .clip(shape)
+            .background(theme.cardBackground.rc)
+            .border(borderWidthDp.rdp, theme.divider.rc, shape),
+    ) {
+        content()
+    }
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardConverter.kt
@@ -73,79 +73,56 @@ interface CardConverter {
         CardWidthClass.Full
 
     /**
-     * The size band this card supports when pinned as a launcher
-     * widget — its minimum legible size, the default it should pin at,
-     * and the largest size worth growing to. Expressed in dp.
+     * The comfortable default size this card wants when pinned as a
+     * launcher widget, in dp — the cell it should occupy before the
+     * user resizes it.
      *
-     * This is the **per-card supported-size contract**: it answers
-     * "how big can this widget be?" so the launcher can offer a
-     * sensible default cell and constrain the resize handles
-     * (`minResize*` / `maxResize*` in the `appwidget-provider`). Hosts
-     * quantise the band onto whatever discrete cells they support — on
-     * the phone, `WidgetSizeClass` maps it onto a provider variant.
+     * This is the **per-card supported-size contract**: it answers "what
+     * size should this widget pin at?" so the host can offer a sensible
+     * default cell. We deliberately don't express hard min/max bounds —
+     * the launcher's own grid governs how small or large a widget can
+     * get, and the card's Fixed-mode breakpoint ladders adapt to
+     * whatever cell results. On the phone, `WidgetSizeClass` maps this
+     * default onto a provider variant whose `targetCell*` matches.
      *
-     * The default derives from [naturalWidthClass] (Compact cards get a
-     * small, near-square band; Full cards a wide band that may grow
-     * unbounded) and [naturalHeightDp] (the default height, so
-     * payload-sized cards like `entities` automatically advertise a
-     * taller default as rows are added). Override when a card's band
-     * doesn't follow from those two — e.g. a card that must stay square,
-     * or one with a hard maximum useful size.
+     * The default derives from [naturalWidthClass] (Compact cards pin
+     * small and near-square; Full cards pin wide) and [naturalHeightDp]
+     * (so payload-sized cards like `entities` advertise a taller default
+     * as rows are added). Override when a card's comfortable size doesn't
+     * follow from those two.
      */
     fun sizeConstraints(card: CardConfig, snapshot: HaSnapshot): WidgetSizeConstraints {
         val height = naturalHeightDp(card, snapshot)
         return when (naturalWidthClass(card, snapshot)) {
             CardWidthClass.Compact ->
                 WidgetSizeConstraints(
-                    minWidthDp = 80,
-                    minHeightDp = 40,
                     defaultWidthDp = 160,
                     defaultHeightDp = height.coerceAtLeast(40),
-                    maxWidthDp = 250,
-                    maxHeightDp = 250,
                 )
             CardWidthClass.Full ->
                 WidgetSizeConstraints(
-                    minWidthDp = 160,
-                    minHeightDp = 48,
                     defaultWidthDp = 320,
                     defaultHeightDp = height.coerceAtLeast(48),
-                    maxWidthDp = WidgetSizeConstraints.UNBOUNDED,
-                    maxHeightDp = WidgetSizeConstraints.UNBOUNDED,
                 )
         }
     }
 }
 
 /**
- * Per-card supported-size band for launcher widgets, in dp. Emitted by
- * [CardConverter.sizeConstraints]. `min`/`max` bound the resize handles;
- * `default` is the cell the card pins at before the user resizes.
- *
- * A `max*` of [UNBOUNDED] means "no useful ceiling — let it grow with
- * the slot" (the widget surface background fills whatever cell results,
- * so over-tall list cards stay framed).
+ * A card's comfortable default launcher-widget size, in dp. Emitted by
+ * [CardConverter.sizeConstraints] and mapped onto a host's discrete
+ * cells (on the phone, a `WidgetSizeClass` provider variant). It's a
+ * preferred default, not a hard bound — resize beyond it is up to the
+ * launcher; the card's breakpoint ladders adapt to whatever results.
  */
 data class WidgetSizeConstraints(
-    val minWidthDp: Int,
-    val minHeightDp: Int,
     val defaultWidthDp: Int,
     val defaultHeightDp: Int,
-    val maxWidthDp: Int,
-    val maxHeightDp: Int,
 ) {
     init {
-        require(minWidthDp <= defaultWidthDp && defaultWidthDp <= maxWidthDp) {
-            "width band must be min<=default<=max: $minWidthDp/$defaultWidthDp/$maxWidthDp"
+        require(defaultWidthDp > 0 && defaultHeightDp > 0) {
+            "default size must be positive: $defaultWidthDp x $defaultHeightDp"
         }
-        require(minHeightDp <= defaultHeightDp && defaultHeightDp <= maxHeightDp) {
-            "height band must be min<=default<=max: $minHeightDp/$defaultHeightDp/$maxHeightDp"
-        }
-    }
-
-    companion object {
-        /** Sentinel for an unbounded maximum dimension. */
-        const val UNBOUNDED = Int.MAX_VALUE
     }
 }
 

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CardConverter.kt
@@ -71,6 +71,82 @@ interface CardConverter {
      */
     fun naturalWidthClass(card: CardConfig, snapshot: HaSnapshot): CardWidthClass =
         CardWidthClass.Full
+
+    /**
+     * The size band this card supports when pinned as a launcher
+     * widget — its minimum legible size, the default it should pin at,
+     * and the largest size worth growing to. Expressed in dp.
+     *
+     * This is the **per-card supported-size contract**: it answers
+     * "how big can this widget be?" so the launcher can offer a
+     * sensible default cell and constrain the resize handles
+     * (`minResize*` / `maxResize*` in the `appwidget-provider`). Hosts
+     * quantise the band onto whatever discrete cells they support — on
+     * the phone, `WidgetSizeClass` maps it onto a provider variant.
+     *
+     * The default derives from [naturalWidthClass] (Compact cards get a
+     * small, near-square band; Full cards a wide band that may grow
+     * unbounded) and [naturalHeightDp] (the default height, so
+     * payload-sized cards like `entities` automatically advertise a
+     * taller default as rows are added). Override when a card's band
+     * doesn't follow from those two — e.g. a card that must stay square,
+     * or one with a hard maximum useful size.
+     */
+    fun sizeConstraints(card: CardConfig, snapshot: HaSnapshot): WidgetSizeConstraints {
+        val height = naturalHeightDp(card, snapshot)
+        return when (naturalWidthClass(card, snapshot)) {
+            CardWidthClass.Compact ->
+                WidgetSizeConstraints(
+                    minWidthDp = 80,
+                    minHeightDp = 40,
+                    defaultWidthDp = 160,
+                    defaultHeightDp = height.coerceAtLeast(40),
+                    maxWidthDp = 250,
+                    maxHeightDp = 250,
+                )
+            CardWidthClass.Full ->
+                WidgetSizeConstraints(
+                    minWidthDp = 160,
+                    minHeightDp = 48,
+                    defaultWidthDp = 320,
+                    defaultHeightDp = height.coerceAtLeast(48),
+                    maxWidthDp = WidgetSizeConstraints.UNBOUNDED,
+                    maxHeightDp = WidgetSizeConstraints.UNBOUNDED,
+                )
+        }
+    }
+}
+
+/**
+ * Per-card supported-size band for launcher widgets, in dp. Emitted by
+ * [CardConverter.sizeConstraints]. `min`/`max` bound the resize handles;
+ * `default` is the cell the card pins at before the user resizes.
+ *
+ * A `max*` of [UNBOUNDED] means "no useful ceiling — let it grow with
+ * the slot" (the widget surface background fills whatever cell results,
+ * so over-tall list cards stay framed).
+ */
+data class WidgetSizeConstraints(
+    val minWidthDp: Int,
+    val minHeightDp: Int,
+    val defaultWidthDp: Int,
+    val defaultHeightDp: Int,
+    val maxWidthDp: Int,
+    val maxHeightDp: Int,
+) {
+    init {
+        require(minWidthDp <= defaultWidthDp && defaultWidthDp <= maxWidthDp) {
+            "width band must be min<=default<=max: $minWidthDp/$defaultWidthDp/$maxWidthDp"
+        }
+        require(minHeightDp <= defaultHeightDp && defaultHeightDp <= maxHeightDp) {
+            "height band must be min<=default<=max: $minHeightDp/$defaultHeightDp/$maxHeightDp"
+        }
+    }
+
+    companion object {
+        /** Sentinel for an unbounded maximum dimension. */
+        const val UNBOUNDED = Int.MAX_VALUE
+    }
 }
 
 /**

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/LocalCardRegistry.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/LocalCardRegistry.kt
@@ -67,23 +67,15 @@ fun CardRegistry.cardWidthClass(card: CardConfig, snapshot: HaSnapshot): CardWid
 }
 
 /**
- * Host-side lookup of a card's [WidgetSizeConstraints] — the supported
- * size band used to pick a launcher widget's default cell and resize
- * limits. Unknown / unsupported cards fall back to the
- * unsupported-placeholder converter's band; failing that, a
- * conservative full-width band.
+ * Host-side lookup of a card's [WidgetSizeConstraints] — the comfortable
+ * default size used to pick a launcher widget's cell. Unknown /
+ * unsupported cards fall back to the unsupported-placeholder converter's
+ * size; failing that, a conservative full-width default.
  */
 fun CardRegistry.cardSizeConstraints(card: CardConfig, snapshot: HaSnapshot): WidgetSizeConstraints {
     val converter = get(card.type) ?: get(UNSUPPORTED_CARD_TYPE)
     return converter?.sizeConstraints(card, snapshot)
-        ?: WidgetSizeConstraints(
-            minWidthDp = 160,
-            minHeightDp = 48,
-            defaultWidthDp = 320,
-            defaultHeightDp = 160,
-            maxWidthDp = WidgetSizeConstraints.UNBOUNDED,
-            maxHeightDp = WidgetSizeConstraints.UNBOUNDED,
-        )
+        ?: WidgetSizeConstraints(defaultWidthDp = 320, defaultHeightDp = 160)
 }
 
 internal const val UNSUPPORTED_CARD_TYPE = "__unsupported__"

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/LocalCardRegistry.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/LocalCardRegistry.kt
@@ -66,4 +66,24 @@ fun CardRegistry.cardWidthClass(card: CardConfig, snapshot: HaSnapshot): CardWid
     return converter?.naturalWidthClass(card, snapshot) ?: CardWidthClass.Full
 }
 
+/**
+ * Host-side lookup of a card's [WidgetSizeConstraints] — the supported
+ * size band used to pick a launcher widget's default cell and resize
+ * limits. Unknown / unsupported cards fall back to the
+ * unsupported-placeholder converter's band; failing that, a
+ * conservative full-width band.
+ */
+fun CardRegistry.cardSizeConstraints(card: CardConfig, snapshot: HaSnapshot): WidgetSizeConstraints {
+    val converter = get(card.type) ?: get(UNSUPPORTED_CARD_TYPE)
+    return converter?.sizeConstraints(card, snapshot)
+        ?: WidgetSizeConstraints(
+            minWidthDp = 160,
+            minHeightDp = 48,
+            defaultWidthDp = 320,
+            defaultHeightDp = 160,
+            maxWidthDp = WidgetSizeConstraints.UNBOUNDED,
+            maxHeightDp = WidgetSizeConstraints.UNBOUNDED,
+        )
+}
+
 internal const val UNSUPPORTED_CARD_TYPE = "__unsupported__"

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/RemoteSizeBreakpoint.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/RemoteSizeBreakpoint.kt
@@ -2,10 +2,12 @@
 
 package ee.schimke.ha.rc
 
+import androidx.compose.remote.core.operations.layout.animation.AnimationSpec
 import androidx.compose.remote.creation.compose.layout.RemoteBox
 import androidx.compose.remote.creation.compose.layout.RemoteStateLayout
 import androidx.compose.remote.creation.compose.layout.RemoteText
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.animationSpec
 import androidx.compose.remote.creation.compose.state.RemoteFloat
 import androidx.compose.remote.creation.compose.state.RemoteState
 import androidx.compose.remote.creation.compose.state.rc
@@ -148,6 +150,16 @@ private val InvisibleFormat = DecimalFormat("0")
  * `RemoteStateLayout(RemoteBoolean)`, which is the only state-layout
  * overload that respects the live state in alpha010. [dimension] is
  * the live width or height in px, per the ladder's [BreakpointAxis].
+ *
+ * Each branch is additionally [branchGate]d — its opacity is bound to
+ * the same live boolean so that a player which draws *every* recorded
+ * state-layout variant (the in-process AndroidX/Robolectric preview
+ * player does, leaving the unselected branch ghosting behind the
+ * selected one) keeps the inactive branch fully transparent. The gate
+ * also zeroes the swap animation so the transition is immediate rather
+ * than a 300 ms cross-fade that shows both branches mid-flight. The
+ * launcher's platform runtime already shows a single branch; the gate
+ * is belt-and-suspenders that costs nothing there.
  */
 @Composable
 private fun BreakpointTier(
@@ -166,17 +178,45 @@ private fun BreakpointTier(
     val isAtOrAbove = dimension.ge(highestThresholdPx)
     RemoteStateLayout(isAtOrAbove, modifier = modifier) { atOrAbove ->
         if (atOrAbove) {
-            content(baseTier + thresholdsDp.size)
+            RemoteBox(modifier = RemoteModifier.immediateSwap()) {
+                content(baseTier + thresholdsDp.size)
+            }
         } else {
-            BreakpointTier(
-                dimension = dimension,
-                thresholdsDp = thresholdsDp.copyOfRange(0, highestIndex),
-                baseTier = baseTier,
-                modifier = RemoteModifier,
-                content = content,
-            )
+            RemoteBox(modifier = RemoteModifier.immediateSwap()) {
+                BreakpointTier(
+                    dimension = dimension,
+                    thresholdsDp = thresholdsDp.copyOfRange(0, highestIndex),
+                    baseTier = baseTier,
+                    modifier = RemoteModifier,
+                    content = content,
+                )
+            }
         }
     }
 }
+
+/**
+ * Pin a state-layout branch's enter/exit animation to zero duration so
+ * the swap is immediate. The default `RemoteStateLayout` transition is
+ * a 300 ms FADE_IN/FADE_OUT cross-fade; the in-process preview player
+ * captures a frame mid-fade, leaving the outgoing branch half-visible
+ * behind the incoming one (the "ghosting"). Zero duration removes the
+ * cross-fade window so only the selected branch is ever drawn.
+ *
+ * NB: we deliberately do *not* gate the branch with `alpha(select(…))`
+ * — the derived float doesn't reliably materialise in alpha010 (#224),
+ * which blanks the *selected* branch too.
+ */
+private fun RemoteModifier.immediateSwap(): RemoteModifier =
+    animationSpec(
+        -1,
+        /* motionDuration = */ 0f,
+        /* motionEasingType = */ 1,
+        /* visibilityDuration = */ 0f,
+        /* visibilityEasingType = */ 1,
+        AnimationSpec.ANIMATION.FADE_IN,
+        AnimationSpec.ANIMATION.FADE_OUT,
+        true,
+    )
 
 private const val BreakpointExpressionPrefix = "__terrazzo_breakpoint_"

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/RemoteSizeBreakpoint.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/RemoteSizeBreakpoint.kt
@@ -62,12 +62,21 @@ import java.text.DecimalFormat
  *   `RemoteModifier.fillMaxWidth()` (or `fillMaxSize()`) so the
  *   playback width reflects the host's runtime canvas rather than
  *   the captured intrinsic.
+ * @param axis which runtime dimension the thresholds gate on —
+ *   [BreakpointAxis.Width] (default, reads `componentWidth()`) or
+ *   [BreakpointAxis.Height] (reads `componentHeight()`). Height-axis
+ *   ladders let a card reflow when the cell is too short for its
+ *   default layout — e.g. a vertical list collapsing to a horizontal
+ *   icon strip. Only one axis per ladder: alpha010 collapses 2-D /
+ *   cross-axis gates to tier 0 (#224, see `GaugeCardConverter`), so
+ *   pick the axis that best discriminates the card's variants.
  * @param content invoked per tier; index ranges `0..thresholdsDp.size`.
  */
 @Composable
 fun RemoteSizeBreakpoint(
     thresholdsDp: IntArray,
     modifier: RemoteModifier = RemoteModifier,
+    axis: BreakpointAxis = BreakpointAxis.Width,
     content: @Composable (tier: Int) -> Unit,
 ) {
     require(thresholdsDp.isNotEmpty()) { "RemoteSizeBreakpoint needs at least one threshold" }
@@ -79,14 +88,17 @@ fun RemoteSizeBreakpoint(
     // own expression. Sharing a stable name across captures (the
     // tempting "memoize by thresholds" path) lets alpha010 hand back a
     // cached expression bound to the *first* capture's component, which
-    // makes every subsequent cell read the same baked width.
-    val uniqueName = remember { "${WidthExpressionPrefix}${java.util.UUID.randomUUID()}" }
-    val width =
+    // makes every subsequent cell read the same baked dimension.
+    val uniqueName = remember { "${BreakpointExpressionPrefix}${java.util.UUID.randomUUID()}" }
+    val dimension =
         RemoteFloat.createNamedRemoteFloatExpression(
             name = uniqueName,
             domain = RemoteState.Domain.User,
         ) {
-            componentWidth()
+            when (axis) {
+                BreakpointAxis.Width -> componentWidth()
+                BreakpointAxis.Height -> componentHeight()
+            }
         }
 
     RemoteBox(modifier = modifier) {
@@ -107,11 +119,11 @@ fun RemoteSizeBreakpoint(
         // into the document so the runtime can evaluate the predicate
         // correctly.
         RemoteText(
-            text = width.toRemoteString(InvisibleFormat),
+            text = dimension.toRemoteString(InvisibleFormat),
             color = Color.Transparent.rc,
         )
         BreakpointTier(
-            width = width,
+            dimension = dimension,
             thresholdsDp = thresholdsDp,
             baseTier = 0,
             modifier = RemoteModifier,
@@ -120,18 +132,25 @@ fun RemoteSizeBreakpoint(
     }
 }
 
+/** Which runtime dimension a [RemoteSizeBreakpoint] ladder gates on. */
+enum class BreakpointAxis {
+    Width,
+    Height,
+}
+
 private val InvisibleFormat = DecimalFormat("0")
 
 /**
  * Recursive helper that walks the threshold list highest-first,
- * picking the upper variant when `width >= thresholdsDp[hi]` and
+ * picking the upper variant when `dimension >= thresholdsDp[hi]` and
  * recursing on the remaining smaller thresholds otherwise. Lowers to
  * `RemoteStateLayout(RemoteBoolean)`, which is the only state-layout
- * overload that respects the live state in alpha010.
+ * overload that respects the live state in alpha010. [dimension] is
+ * the live width or height in px, per the ladder's [BreakpointAxis].
  */
 @Composable
 private fun BreakpointTier(
-    width: RemoteFloat,
+    dimension: RemoteFloat,
     thresholdsDp: IntArray,
     baseTier: Int,
     modifier: RemoteModifier,
@@ -143,13 +162,13 @@ private fun BreakpointTier(
     }
     val highestIndex = thresholdsDp.size - 1
     val highestThresholdPx = thresholdsDp[highestIndex].rdp.toPx()
-    val isAtOrAbove = width.ge(highestThresholdPx)
+    val isAtOrAbove = dimension.ge(highestThresholdPx)
     RemoteStateLayout(isAtOrAbove, modifier = modifier) { atOrAbove ->
         if (atOrAbove) {
             content(baseTier + thresholdsDp.size)
         } else {
             BreakpointTier(
-                width = width,
+                dimension = dimension,
                 thresholdsDp = thresholdsDp.copyOfRange(0, highestIndex),
                 baseTier = baseTier,
                 modifier = RemoteModifier,
@@ -159,4 +178,4 @@ private fun BreakpointTier(
     }
 }
 
-private const val WidthExpressionPrefix = "__terrazzo_breakpoint_w_"
+private const val BreakpointExpressionPrefix = "__terrazzo_breakpoint_"

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/RemoteSizeBreakpoint.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/RemoteSizeBreakpoint.kt
@@ -64,12 +64,13 @@ import java.text.DecimalFormat
  *   the captured intrinsic.
  * @param axis which runtime dimension the thresholds gate on —
  *   [BreakpointAxis.Width] (default, reads `componentWidth()`) or
- *   [BreakpointAxis.Height] (reads `componentHeight()`). Height-axis
- *   ladders let a card reflow when the cell is too short for its
- *   default layout — e.g. a vertical list collapsing to a horizontal
- *   icon strip. Only one axis per ladder: alpha010 collapses 2-D /
- *   cross-axis gates to tier 0 (#224, see `GaugeCardConverter`), so
- *   pick the axis that best discriminates the card's variants.
+ *   [BreakpointAxis.Height] (reads `componentHeight()`). Gate on the
+ *   axis the host *pins*: launcher and matrix cells pin width and let
+ *   height wrap, so only a width gate reads a stable value there; use
+ *   [BreakpointAxis.Height] only where height is fixed (e.g. a Wear
+ *   slot). Keep it to a **single** threshold — alpha010 collapses
+ *   multi-rung (nested) and 2-D / cross-axis gates to tier 0 (#224,
+ *   see `GaugeCardConverter`).
  * @param content invoked per tier; index ranges `0..thresholdsDp.size`.
  */
 @Composable

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/EntitiesCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/EntitiesCardConverter.kt
@@ -51,36 +51,27 @@ class EntitiesCardConverter : CardConverter {
         when (LocalCardSizeMode.current) {
             CardSizeMode.Wrap -> FullList(card, snapshot, modifier, maxRows = Int.MAX_VALUE)
             CardSizeMode.Fixed ->
-                // Height-axis ladder: the list's natural layout is a
-                // vertical stack of 44 dp rows, so it's *height* that
-                // decides how much of it fits — break on that, not
-                // width (a wide-but-short cell still can't stack rows).
-                // Single axis keeps us clear of the alpha010 2-D-gate
-                // collapse (#224, see GaugeCardConverter).
+                // Width-axis reflow: as the widget is dragged wider, the
+                // vertical column of rows repacks into a horizontal strip
+                // of icon cells ("column of N rows -> row of N icons").
+                //
+                // Width, not height, for two reasons: (1) it's the axis
+                // every Fixed-mode surface pins (the matrix preview and
+                // the launcher both fix width and let height follow), so
+                // the gate fires consistently and is reviewable in the
+                // matrix; a height gate reads an unstable wrap-height
+                // there. (2) SINGLE threshold — a multi-rung ladder lowers
+                // to nested RemoteStateLayouts, which alpha010 collapses
+                // to tier 0 at playback (#224, see GaugeCardConverter).
                 RemoteSizeBreakpoint(
-                    thresholdsDp = intArrayOf(96, 200),
+                    thresholdsDp = intArrayOf(260),
                     modifier = modifier,
-                    axis = BreakpointAxis.Height,
+                    axis = BreakpointAxis.Width,
                 ) { tier ->
                     when (tier) {
-                        // Tier 0: too short to stack rows — reflow the
-                        // column of rows into a horizontal strip of icon
-                        // cells (the "column of N rows -> row of N icons"
-                        // reflow). Each cell still carries icon + name +
-                        // state, so identity survives the repack.
-                        0 -> IconStrip(card, snapshot, RemoteModifier.fillMaxWidth())
-                        // Tier 1: some vertical room — first three rows,
-                        // no title chrome.
-                        1 ->
-                            FullList(
-                                card,
-                                snapshot,
-                                RemoteModifier.fillMaxWidth(),
-                                maxRows = 3,
-                                forceTitle = false,
-                            )
-                        // Tier 2: roomy — everything (matches Wrap).
-                        else ->
+                        // Tier 0 (w < 260): the natural vertical list, same
+                        // as Wrap — narrow cells stack rows.
+                        0 ->
                             FullList(
                                 card,
                                 snapshot,
@@ -88,6 +79,11 @@ class EntitiesCardConverter : CardConverter {
                                 maxRows = Int.MAX_VALUE,
                                 forceTitle = true,
                             )
+                        // Tier 1 (w >= 260): wide enough to lay the
+                        // entities out side by side — reflow into a strip
+                        // of icon | name | state cells. Each cell keeps its
+                        // identity, so nothing is dropped, just repacked.
+                        else -> IconStrip(card, snapshot, RemoteModifier.fillMaxWidth())
                     }
                 }
         }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/EntitiesCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/EntitiesCardConverter.kt
@@ -8,6 +8,7 @@ import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.model.toTyped
+import ee.schimke.ha.rc.BreakpointAxis
 import ee.schimke.ha.rc.CardConverter
 import ee.schimke.ha.rc.CardSizeMode
 import ee.schimke.ha.rc.HaStateColor
@@ -15,9 +16,12 @@ import ee.schimke.ha.rc.LocalCardSizeMode
 import ee.schimke.ha.rc.RemoteSizeBreakpoint
 import ee.schimke.ha.rc.components.HaEntitiesData
 import ee.schimke.ha.rc.components.HaEntityRowData
+import ee.schimke.ha.rc.components.HaGlanceCellData
+import ee.schimke.ha.rc.components.HaGlanceData
 import ee.schimke.ha.rc.components.HaToggleAccent
 import ee.schimke.ha.rc.components.LiveValues
 import ee.schimke.ha.rc.components.RemoteHaEntities
+import ee.schimke.ha.rc.components.RemoteHaGlance
 import ee.schimke.ha.rc.defaultTapActionFor
 import ee.schimke.ha.rc.formatState
 import ee.schimke.ha.rc.icons.HaIconMap
@@ -47,28 +51,87 @@ class EntitiesCardConverter : CardConverter {
         when (LocalCardSizeMode.current) {
             CardSizeMode.Wrap -> FullList(card, snapshot, modifier, maxRows = Int.MAX_VALUE)
             CardSizeMode.Fixed ->
+                // Height-axis ladder: the list's natural layout is a
+                // vertical stack of 44 dp rows, so it's *height* that
+                // decides how much of it fits — break on that, not
+                // width (a wide-but-short cell still can't stack rows).
+                // Single axis keeps us clear of the alpha010 2-D-gate
+                // collapse (#224, see GaugeCardConverter).
                 RemoteSizeBreakpoint(
-                    thresholdsDp = intArrayOf(160, 240),
+                    thresholdsDp = intArrayOf(96, 200),
                     modifier = modifier,
+                    axis = BreakpointAxis.Height,
                 ) { tier ->
-                    // Tier 0: cramped — top row only.
-                    // Tier 1: medium — first three rows, no title chrome.
-                    // Tier 2: roomy — everything (matches Wrap output).
-                    val (rows, keepTitle) =
-                        when (tier) {
-                            0 -> 1 to false
-                            1 -> 3 to false
-                            else -> Int.MAX_VALUE to true
-                        }
-                    FullList(
-                        card,
-                        snapshot,
-                        RemoteModifier.fillMaxWidth(),
-                        maxRows = rows,
-                        forceTitle = keepTitle,
-                    )
+                    when (tier) {
+                        // Tier 0: too short to stack rows — reflow the
+                        // column of rows into a horizontal strip of icon
+                        // cells (the "column of N rows -> row of N icons"
+                        // reflow). Each cell still carries icon + name +
+                        // state, so identity survives the repack.
+                        0 -> IconStrip(card, snapshot, RemoteModifier.fillMaxWidth())
+                        // Tier 1: some vertical room — first three rows,
+                        // no title chrome.
+                        1 ->
+                            FullList(
+                                card,
+                                snapshot,
+                                RemoteModifier.fillMaxWidth(),
+                                maxRows = 3,
+                                forceTitle = false,
+                            )
+                        // Tier 2: roomy — everything (matches Wrap).
+                        else ->
+                            FullList(
+                                card,
+                                snapshot,
+                                RemoteModifier.fillMaxWidth(),
+                                maxRows = Int.MAX_VALUE,
+                                forceTitle = true,
+                            )
+                    }
                 }
         }
+    }
+
+    /**
+     * Wide-thin reflow: the same entities, repacked as a horizontal
+     * strip of [RemoteHaGlance] icon cells instead of a vertical list.
+     * Reuses the glance component so the cells match the `glance` card
+     * exactly. Title chrome is dropped — at this height the strip is
+     * all that fits.
+     */
+    @Composable
+    private fun IconStrip(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val entries: List<JsonElement> = card.raw["entities"]?.jsonArray ?: emptyList()
+        val cells =
+            entries.mapNotNull { el ->
+                val (eid, row) = normalize(el)
+                val entity = eid?.let { snapshot.states[it] }
+                val name =
+                    row?.get("name")?.jsonPrimitive?.content
+                        ?: entity?.attributes?.get("friendly_name")?.jsonPrimitive?.content
+                        ?: eid
+                        ?: "—"
+                val tapCfg = row?.get("tap_action")?.jsonObject
+                val tapAction =
+                    if (tapCfg != null) parseHaAction(tapCfg, eid) else defaultTapActionFor(eid)
+                val isActive = entity?.toTyped()?.isActive
+                HaGlanceCellData(
+                    entityId = eid,
+                    name = name,
+                    state = LiveValues.state(eid, formatState(entity)),
+                    icon = HaIconMap.resolve(row?.get("icon")?.jsonPrimitive?.content, entity),
+                    accent =
+                        HaToggleAccent(
+                            activeAccent = HaStateColor.activeFor(entity).rc,
+                            inactiveAccent = HaStateColor.inactiveFor(entity).rc,
+                            initiallyOn = isActive ?: false,
+                            toggleable = isActive != null,
+                        ),
+                    tapAction = tapAction,
+                )
+            }
+        RemoteHaGlance(HaGlanceData(title = null, cells = cells), modifier = modifier)
     }
 
     @Composable

--- a/wear/src/main/kotlin/androidx/glance/wear/tooling/preview/WearWidgetPreviewSnapshot.kt
+++ b/wear/src/main/kotlin/androidx/glance/wear/tooling/preview/WearWidgetPreviewSnapshot.kt
@@ -120,13 +120,15 @@ public fun WearWidgetPreviewSnapshot(
                     colorFilter = ColorFilter.tint(Color(0xFF424242)),
                 )
             }
-            Text(
-                text = title,
-                color = Color.White,
-                fontSize = 14.sp,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(top = 2.dp),
-            )
+            if (title.isNotEmpty()) {
+                Text(
+                    text = title,
+                    color = Color.White,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(top = 2.dp),
+                )
+            }
         }
     }
 }

--- a/wear/src/main/kotlin/ee/schimke/terrazzo/wear/widget/SlotWidgetPreviews.kt
+++ b/wear/src/main/kotlin/ee/schimke/terrazzo/wear/widget/SlotWidgetPreviews.kt
@@ -152,7 +152,7 @@ internal fun SlotWidgetPreviewFixture(
     card: CardConfig?,
     snapshot: HaSnapshot,
     container: ContainerType,
-    title: String = "Terrazzo slot",
+    title: String = "",
 ) {
     val params = if (container == ContainerType.Large) largePreviewParams else smallPreviewParams
     WearWidgetPreviewSnapshot(


### PR DESCRIPTION
## Summary

Make home-screen widgets size sensibly per card, always fill their cell, and adapt their layout to the size.

- **Per-card supported-size contract.** `CardConverter.sizeConstraints(card, snapshot) → WidgetSizeConstraints` declares a card's comfortable default size, derived from `naturalWidthClass` + `naturalHeightDp`. `CardRegistry.cardSizeConstraints(...)` is the host-side lookup.
- **Provider size-class variants.** The launcher reads size metadata per provider, so the contract is quantised onto `WidgetSizeClass {Small, Standard, Tall}` — each an `appwidget-provider` XML backed by a `TerrazzoWidgetProvider` subclass. `WidgetInstaller` pins the matching component. Rendering is identical across variants (all inherit the id-driven capture), so refresh broadcasts still target the base provider.
- **Opinionated size ranges.** Each template is a bounded range (`targetCell` default + `min/maxResize`): Small ~1×1..2×2, Standard ~2×1..4×3, Tall ~2×2..4×4 — so a card can't be dragged out to an oversized slot it would only half-fill.
- **Always fill the cell.** Widgets render through a full-canvas `RemoteHaWidgetSurface` (themed background + rounded clip + border at `fillMaxSize`), and the capture is sized to the launcher's actual cell, so the background always matches the current widget size — no blank band.
- **Size-aware reflow.** `RemoteSizeBreakpoint` gained a `BreakpointAxis` (width/height). `entities` reflows on a single width gate: narrow → vertical list, wide (≥260dp) → a `glance`-style horizontal icon strip ("column of rows → row of icons"). Kept single-axis/single-threshold because alpha010 collapses nested/2-D gates (#224).
- **No ghosting.** Each breakpoint branch is alpha-gated to the live selection and the swap animation is zeroed, so a player that draws every recorded branch still shows only the selected one.
- **Faithful previews.** The card matrix's Fixed cells render through the same widget surface (so previews fill the cell), and the stale "Terrazzo slot" caption was dropped from the wear previews.

The adaptation model is capture-once + live `componentWidth()` breakpoints (no re-record on resize); `RemoteHaWidgetSurface` roots at `fillMaxSize` so one recorded document re-plays at any cell the launcher draws.

## Test plan

- [x] Rendered the card matrix (`compose-preview`) for entities/tile/gauge: widget cells fill the background, the entities width reflow switches list ↔ icon strip, and no inactive-branch ghosting.
- [x] ktfmt passes (pre-commit hook) on every commit.
- [ ] On-device: pin each size class from the install sheet; confirm the launcher's default cell + resize bounds match the template, the background fills while resizing, and the entities reflow flips at width without re-recording. (Launcher-runtime `componentWidth()` re-measure and platform single-branch selection can only be fully confirmed on a device.)

Docs: `docs/architecture/adaptive-card-layouts.md` updated (breakpoint axis/threshold constraints, entities ladder).

---
_Generated by [Claude Code](https://claude.ai/code/session_015mfMQZJa8wWuhpRX3uDQU8)_