### PR TITLE
fix(release): add -dontwarn rules for androidx.window OEM extensions

### DIFF
--- a/app/crashlytics-rules.pro
+++ b/app/crashlytics-rules.pro
@@ -9,3 +9,28 @@
 -keep class ee.schimke.terrazzo.crash.FirebaseCrashReporter {
     <init>();
 }
+
+# Crashlytics pulls in firebase-sessions, which adds androidx.window:window
+# as a *direct* dependency. That makes androidx.window.layout.adapter.* live,
+# and R8 then sees its references to the OEM window-extension classes
+# (androidx.window.extensions.** / androidx.window.sidecar.**) that are
+# provided by the system at runtime and never bundled — a hard "Missing
+# classes" R8 error. These rules only matter in the Crashlytics-enabled
+# release build (the non-Crashlytics build never resolves window directly),
+# which is why they live here rather than in an always-applied proguard file.
+-dontwarn androidx.window.extensions.WindowExtensions
+-dontwarn androidx.window.extensions.WindowExtensionsProvider
+-dontwarn androidx.window.extensions.area.ExtensionWindowAreaPresentation
+-dontwarn androidx.window.extensions.core.util.function.Consumer
+-dontwarn androidx.window.extensions.core.util.function.Function
+-dontwarn androidx.window.extensions.core.util.function.Predicate
+-dontwarn androidx.window.extensions.layout.DisplayFeature
+-dontwarn androidx.window.extensions.layout.FoldingFeature
+-dontwarn androidx.window.extensions.layout.WindowLayoutComponent
+-dontwarn androidx.window.extensions.layout.WindowLayoutInfo
+-dontwarn androidx.window.sidecar.SidecarDeviceState
+-dontwarn androidx.window.sidecar.SidecarDisplayFeature
+-dontwarn androidx.window.sidecar.SidecarInterface$SidecarCallback
+-dontwarn androidx.window.sidecar.SidecarInterface
+-dontwarn androidx.window.sidecar.SidecarProvider
+-dontwarn androidx.window.sidecar.SidecarWindowLayoutInfo


### PR DESCRIPTION
The release job's "Assemble release APK" step fails under R8 with a hard
"Missing classes" error for androidx.window.extensions.** and
androidx.window.sidecar.**. These OEM window-extension classes are supplied
by the system at runtime and never bundled.

The failure only surfaces in the Crashlytics-enabled build that CI runs when
GOOGLE_SERVICES_JSON is configured: firebase-sessions (pulled in by
Crashlytics) adds androidx.window:window as a direct dependency, making
androidx.window.layout.adapter.* live so R8 checks its references to the
absent extension classes. PR/local builds skip Crashlytics, so this never
showed up before release.

Add the AGP-recommended -dontwarn rules to crashlytics-rules.pro, the
proguard file applied only on that build path.