### PR TITLE
fix(release): unblock R8 minify and Play publish in the release job

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -93,6 +93,15 @@ android {
       applicationIdSuffix = ".experimental"
     }
   }
+  // `experimental` is a local side-by-side install (`.experimental`
+  // applicationId suffix); it is never shipped to Play — the internal track
+  // hosts ee.schimke.harc. Disable Play publishing for it so the umbrella
+  // `:app:publishBundle` task the release job runs doesn't drag in
+  // `bundleExperimental`. That assembly would otherwise fail at
+  // `processExperimentalGoogleServices` (Crashlytics' google-services.json has
+  // no client for the suffixed package) and, even past that, Play would reject
+  // a bundle whose package isn't the listing's.
+  playConfigs { register("experimental") { enabled.set(false) } }
   buildFeatures {
     compose = true
     buildConfig = true

--- a/app/crashlytics-rules.pro
+++ b/app/crashlytics-rules.pro
@@ -9,3 +9,28 @@
 -keep class ee.schimke.terrazzo.crash.FirebaseCrashReporter {
     <init>();
 }
+
+# Crashlytics pulls in firebase-sessions, which adds androidx.window:window
+# as a *direct* dependency. That makes androidx.window.layout.adapter.* live,
+# and R8 then sees its references to the OEM window-extension classes
+# (androidx.window.extensions.** / androidx.window.sidecar.**) that are
+# provided by the system at runtime and never bundled — a hard "Missing
+# classes" R8 error. These rules only matter in the Crashlytics-enabled
+# release build (the non-Crashlytics build never resolves window directly),
+# which is why they live here rather than in an always-applied proguard file.
+-dontwarn androidx.window.extensions.WindowExtensions
+-dontwarn androidx.window.extensions.WindowExtensionsProvider
+-dontwarn androidx.window.extensions.area.ExtensionWindowAreaPresentation
+-dontwarn androidx.window.extensions.core.util.function.Consumer
+-dontwarn androidx.window.extensions.core.util.function.Function
+-dontwarn androidx.window.extensions.core.util.function.Predicate
+-dontwarn androidx.window.extensions.layout.DisplayFeature
+-dontwarn androidx.window.extensions.layout.FoldingFeature
+-dontwarn androidx.window.extensions.layout.WindowLayoutComponent
+-dontwarn androidx.window.extensions.layout.WindowLayoutInfo
+-dontwarn androidx.window.sidecar.SidecarDeviceState
+-dontwarn androidx.window.sidecar.SidecarDisplayFeature
+-dontwarn androidx.window.sidecar.SidecarInterface$SidecarCallback
+-dontwarn androidx.window.sidecar.SidecarInterface
+-dontwarn androidx.window.sidecar.SidecarProvider
+-dontwarn androidx.window.sidecar.SidecarWindowLayoutInfo


### PR DESCRIPTION
## Problem

The release job (`release-build.yml`) was failing. These bugs only surface on the **release/publish path with secrets present** (`GOOGLE_SERVICES_JSON` + `PLAY_SERVICE_ACCOUNT_JSON`), so PR/local builds never caught them. Reproduced locally by enabling the Crashlytics path with a stub `google-services.json`.

## Two failures, fixed in order

### 1. `Assemble release APK` — R8 missing-class error
```
Missing class androidx.window.extensions.WindowExtensions … (16 classes)
```
Crashlytics pulls in `firebase-sessions`, which adds `androidx.window:window` as a **direct** dependency. That makes `androidx.window.layout.adapter.*` reachable, so R8 inspects its references to the OEM window-extension classes (`androidx.window.extensions.**` / `androidx.window.sidecar.**`) — provided by the system at runtime, never bundled — and fails hard. The plain (non-Crashlytics) build never resolves `window` directly, so it passes.

**Fix:** add the AGP-recommended `-dontwarn` rules to `crashlytics-rules.pro`, the proguard file applied only on that build path.

### 2. `Publish to Play` — `processExperimentalGoogleServices` failure
```
No matching client found for package name 'ee.schimke.harc.experimental' in google-services.json
```
`:app:publishBundle` is the umbrella task that builds/uploads *every* publishable variant, which dragged in the `experimental` build type (`.experimental` applicationId suffix). That suffixed package has no client in `google-services.json`. The experimental variant is a local side-by-side install — never shipped to Play (the internal track hosts `ee.schimke.harc`, and Play would reject a different package anyway).

**Fix:** disable Play publishing for `experimental` via `playConfigs`, so `publishBundle` only handles the release variant.

## Verification

- Installed `platforms;android-37.0` locally and reproduced **both** failures with a stub `google-services.json`.
- After fix #1: `:app:assembleRelease` (Crashlytics enabled) → `minifyReleaseWithR8` **passes**, full build **succeeds**.
- After fix #2: `:app:publishBundle --dry-run` graph contains only `processReleaseGoogleServices` / `publishReleaseBundle` — **no experimental tasks**.
- `ktfmtCheck` passes (pre-commit hook).

https://claude.ai/code/session_01WVWGPpwgy9ysK6JugPjfWo

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVWGPpwgy9ysK6JugPjfWo)_