### PR TITLE
feat(dashboard): make history-screen preview resizable to launcher sizes

### DIFF
--- a/app/src/debug/kotlin/ee/schimke/terrazzo/previews/CardDebugPreviews.kt
+++ b/app/src/debug/kotlin/ee/schimke/terrazzo/previews/CardDebugPreviews.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Lightbulb
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -39,6 +40,13 @@ import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.model.View
 import ee.schimke.terrazzo.dashboard.CardChangeFlash
 import ee.schimke.terrazzo.dashboard.DataGridOverlay
+import ee.schimke.terrazzo.core.prefs.DarkModePref
+import ee.schimke.terrazzo.dashboard.LauncherGrid
+import ee.schimke.terrazzo.dashboard.ResizeLegend
+import ee.schimke.terrazzo.ui.TerrazzoTheme
+import ee.schimke.terrazzo.widget.LauncherGridBounds
+import ee.schimke.terrazzo.widget.WidgetSizeClass
+import ee.schimke.ha.rc.components.ThemeStyle
 import kotlin.time.Instant
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -179,6 +187,116 @@ private fun FauxDashboardBackdrop() {
                     .height(72.dp)
                     .background(Color(0xFFD9D9E3), RoundedCornerShape(16.dp))
             )
+        }
+    }
+}
+
+/**
+ * Animated walk-through of the card-history screen's resizable launcher
+ * preview ([LauncherGrid] / [ResizeLegend]). An infinite transition
+ * steps the slot diagonally out to the largest size and back — the same
+ * cell-snapped path a finger drag on the corner handle produces — so the
+ * handle, current-slot outline, and legend animate across the size
+ * class's range against the static smallest/largest guides.
+ * `@AnimatedPreview` captures it as a GIF.
+ */
+@Preview(name = "Resize widget preview", widthDp = 360, heightDp = 460, showBackground = true)
+@AnimatedPreview(durationMs = 4500, frameIntervalMs = 150, showCurves = false)
+@Composable
+private fun ResizeWidgetPreview() {
+    TerrazzoTheme(style = ThemeStyle.TerrazzoHome, darkMode = DarkModePref.Light) {
+        val bounds = WidgetSizeClass.Standard.gridBounds
+        val steps = remember { dragSteps(bounds) }
+        val transition = rememberInfiniteTransition(label = "resize-demo")
+        val t by
+            transition.animateFloat(
+                initialValue = 0f,
+                targetValue = steps.size.toFloat(),
+                animationSpec =
+                    infiniteRepeatable(
+                        animation = tween(durationMillis = 4500, easing = LinearEasing),
+                        repeatMode = RepeatMode.Restart,
+                    ),
+                label = "step",
+            )
+        val (w, h) = steps[t.toInt().coerceIn(0, steps.lastIndex)]
+
+        val gridColor = MaterialTheme.colorScheme.outlineVariant
+        val smallestColor = MaterialTheme.colorScheme.tertiary
+        val largestColor = MaterialTheme.colorScheme.secondary
+        val currentColor = MaterialTheme.colorScheme.primary
+
+        Box(
+            modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text(
+                    "Resizing widget on the launcher grid",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                )
+                LauncherGrid(
+                    bounds = bounds,
+                    cellsW = w,
+                    cellsH = h,
+                    onResize = { _, _ -> },
+                    gridColor = gridColor,
+                    smallestColor = smallestColor,
+                    largestColor = largestColor,
+                    currentColor = currentColor,
+                ) {
+                    FauxWidgetCard()
+                }
+                ResizeLegend(
+                    bounds = bounds,
+                    cellsW = w,
+                    cellsH = h,
+                    smallestColor = smallestColor,
+                    largestColor = largestColor,
+                    currentColor = currentColor,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * The cell sizes a there-and-back diagonal drag of the corner handle
+ * passes through: grow width to max, then height to max, then shrink
+ * back to the smallest slot. One entry per cell-snapped step.
+ */
+private fun dragSteps(b: LauncherGridBounds): List<Pair<Int, Int>> {
+    val out = mutableListOf<Pair<Int, Int>>()
+    var w = b.minCellsW
+    var h = b.minCellsH
+    out.add(w to h)
+    while (w < b.maxCellsW) { w++; out.add(w to h) }
+    while (h < b.maxCellsH) { h++; out.add(w to h) }
+    while (h > b.minCellsH) { h--; out.add(w to h) }
+    while (w > b.minCellsW) { w--; out.add(w to h) }
+    return out
+}
+
+/** A themed tile-shaped stand-in that fills the current launcher slot. */
+@Composable
+private fun FauxWidgetCard() {
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        shape = RoundedCornerShape(12.dp),
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Icon(Icons.Filled.Lightbulb, contentDescription = null, modifier = Modifier.size(24.dp))
+            Text("Living room", fontSize = 13.sp, fontWeight = FontWeight.Medium)
+            Text("On", fontSize = 12.sp)
         }
     }
 }

--- a/app/src/debug/kotlin/ee/schimke/terrazzo/previews/CardDebugPreviews.kt
+++ b/app/src/debug/kotlin/ee/schimke/terrazzo/previews/CardDebugPreviews.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -205,8 +206,9 @@ private fun FauxDashboardBackdrop() {
 @Composable
 private fun ResizeWidgetPreview() {
     TerrazzoTheme(style = ThemeStyle.TerrazzoHome, darkMode = DarkModePref.Light) {
-        val bounds = WidgetSizeClass.Standard.gridBounds
-        val steps = remember { dragSteps(bounds) }
+        val context = LocalContext.current
+        val bounds = remember(context) { WidgetSizeClass.Standard.gridBounds(context) }
+        val steps = remember(bounds) { dragSteps(bounds) }
         val transition = rememberInfiniteTransition(label = "resize-demo")
         val t by
             transition.animateFloat(

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/CardHistoryScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/CardHistoryScreen.kt
@@ -222,11 +222,12 @@ private fun ResizableLauncherPreview(session: HaSession, card: CardConfig, snaps
     }
 
     // Quantise the card's continuous size hint onto the launcher size
-    // class, then read its resize range in whole cells.
+    // class, then read its resize range in whole cells from the same
+    // appwidget-provider metadata the launcher uses.
     val sizeClass = remember(card, snapshot) {
         WidgetSizeClass.forConstraints(registry.cardSizeConstraints(card, snapshot))
     }
-    val bounds = sizeClass.gridBounds
+    val bounds = remember(sizeClass, context) { sizeClass.gridBounds(context) }
 
     // Current slot, in cells. Starts at the comfortable default the
     // widget pins at; resized by dragging the corner handle.

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/CardHistoryScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/CardHistoryScreen.kt
@@ -5,20 +5,28 @@ package ee.schimke.terrazzo.dashboard
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AddToHomeScreen
 import androidx.compose.material.icons.filled.Link
+import androidx.compose.material.icons.filled.OpenInFull
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
@@ -34,16 +42,23 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
@@ -53,12 +68,17 @@ import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.model.HistoryPoint
 import ee.schimke.ha.rc.CachedCardPreview
+import ee.schimke.ha.rc.CardSizeMode
 import ee.schimke.ha.rc.ProvideCardRegistry
+import ee.schimke.ha.rc.ProvideCardSizeMode
 import ee.schimke.ha.rc.RenderChild
 import ee.schimke.ha.rc.androidXExperimentalWrap
+import ee.schimke.ha.rc.cardSizeConstraints
 import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.cards.shutter.withEnhancedShutter
+import ee.schimke.ha.rc.components.ProvideCardChrome
 import ee.schimke.ha.rc.components.ProvideHaTheme
+import ee.schimke.ha.rc.components.RemoteHaWidgetSurface
 import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.ha.rc.components.haThemeFor
 import ee.schimke.ha.rc.image.CoilBitmapLoader
@@ -67,6 +87,10 @@ import ee.schimke.terrazzo.core.session.DemoData
 import ee.schimke.terrazzo.core.session.HaSession
 import ee.schimke.terrazzo.ui.LocalIsDarkTheme
 import ee.schimke.terrazzo.ui.LocalThemeStyle
+import ee.schimke.terrazzo.widget.LAUNCHER_CELL_HEIGHT_DP
+import ee.schimke.terrazzo.widget.LAUNCHER_CELL_WIDTH_DP
+import ee.schimke.terrazzo.widget.LauncherGridBounds
+import ee.schimke.terrazzo.widget.WidgetSizeClass
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
@@ -156,9 +180,34 @@ fun CardHistoryScreen(
     }
 }
 
-/** Top region: the card rendered exactly as it appears on the dashboard. */
+/**
+ * Top region: the card previewed as a launcher widget on a resizable
+ * slot.
+ *
+ * The card's [WidgetSizeClass] — the same one [ee.schimke.terrazzo.widget.WidgetInstaller]
+ * pins when you tap "Add to Home Screen" — defines a resize range in
+ * whole launcher cells, with a smallest and largest slot. We draw that
+ * grid behind the card, dash-outline the smallest and largest sizes,
+ * and let the user drag the corner handle to resize the widget across
+ * the range a cell at a time. The card re-renders in launcher mode
+ * (fixed size, full-bleed surface, no in-app chrome) at each slot, so
+ * it's a faithful preview of how the widget reflows before committing
+ * to a home-screen position.
+ */
 @Composable
 private fun CardPreviewCard(session: HaSession, card: CardConfig, snapshot: HaSnapshot) {
+    OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+        Box(
+            modifier = Modifier.fillMaxWidth().padding(12.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            ResizableLauncherPreview(session = session, card = card, snapshot = snapshot)
+        }
+    }
+}
+
+@Composable
+private fun ResizableLauncherPreview(session: HaSession, card: CardConfig, snapshot: HaSnapshot) {
     val context = LocalContext.current
     val registry = remember { defaultRegistry().withEnhancedShutter() }
     val style = LocalThemeStyle.current
@@ -172,33 +221,237 @@ private fun CardPreviewCard(session: HaSession, card: CardConfig, snapshot: HaSn
         CoilBitmapLoader(context.applicationContext, imageLoader = imageLoader, baseUrl = session.baseUrl)
     }
 
-    OutlinedCard(modifier = Modifier.fillMaxWidth()) {
-        Box(
-            modifier = Modifier.fillMaxWidth().padding(12.dp),
-            contentAlignment = Alignment.Center,
+    // Quantise the card's continuous size hint onto the launcher size
+    // class, then read its resize range in whole cells.
+    val sizeClass = remember(card, snapshot) {
+        WidgetSizeClass.forConstraints(registry.cardSizeConstraints(card, snapshot))
+    }
+    val bounds = sizeClass.gridBounds
+
+    // Current slot, in cells. Starts at the comfortable default the
+    // widget pins at; resized by dragging the corner handle.
+    var cellsW by remember(sizeClass) { mutableIntStateOf(bounds.defaultCellsW) }
+    var cellsH by remember(sizeClass) { mutableIntStateOf(bounds.defaultCellsH) }
+
+    val gridColor = MaterialTheme.colorScheme.outlineVariant
+    val smallestColor = MaterialTheme.colorScheme.tertiary
+    val largestColor = MaterialTheme.colorScheme.secondary
+    val currentColor = MaterialTheme.colorScheme.primary
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        LauncherGrid(
+            bounds = bounds,
+            cellsW = cellsW,
+            cellsH = cellsH,
+            onResize = { w, h -> cellsW = w; cellsH = h },
+            gridColor = gridColor,
+            smallestColor = smallestColor,
+            largestColor = largestColor,
+            currentColor = currentColor,
         ) {
             CachedCardPreview(
-                cacheKey = HistoryPreviewCacheKey(card, style, dark),
+                cacheKey = LauncherPreviewKey(card, style, dark, cellsW, cellsH),
                 profile = androidXExperimentalWrap,
                 card = card,
                 snapshot = snapshot,
                 bitmapLoader = bitmapLoader,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxSize(),
             ) {
                 ProvideCardRegistry(registry) {
                     ProvideHaTheme(haTheme) {
-                        RenderChild(card, snapshot, RemoteModifier.rcFillMaxWidth())
+                        // The same fixed-size, full-bleed surface the
+                        // launcher widget wraps the card in (no in-app
+                        // card chrome), so the preview matches the slot.
+                        ProvideCardSizeMode(CardSizeMode.Fixed) {
+                            ProvideCardChrome(enabled = false) {
+                                RemoteHaWidgetSurface {
+                                    RenderChild(card, snapshot, RemoteModifier.rcFillMaxWidth())
+                                }
+                            }
+                        }
                     }
                 }
             }
         }
+
+        ResizeLegend(
+            bounds = bounds,
+            cellsW = cellsW,
+            cellsH = cellsH,
+            smallestColor = smallestColor,
+            largestColor = largestColor,
+            currentColor = currentColor,
+        )
     }
 }
 
-private data class HistoryPreviewCacheKey(
+/**
+ * Draws the launcher grid (one cell = [LAUNCHER_CELL_WIDTH_DP] ×
+ * [LAUNCHER_CELL_HEIGHT_DP] dp) spanning the largest slot, dash-outlines
+ * the smallest and largest sizes, and overlays [content] (the card)
+ * sized to the current slot with a draggable resize handle at its
+ * bottom-right corner.
+ */
+@Composable
+private fun LauncherGrid(
+    bounds: LauncherGridBounds,
+    cellsW: Int,
+    cellsH: Int,
+    onResize: (Int, Int) -> Unit,
+    gridColor: Color,
+    smallestColor: Color,
+    largestColor: Color,
+    currentColor: Color,
+    content: @Composable () -> Unit,
+) {
+    val density = LocalDensity.current
+    val cellWpx = with(density) { LAUNCHER_CELL_WIDTH_DP.dp.toPx() }
+    val cellHpx = with(density) { LAUNCHER_CELL_HEIGHT_DP.dp.toPx() }
+    // Drag distance not yet spent on a cell step, in px. Reset between
+    // gestures so a fresh drag starts from the current slot edge.
+    var dragX by remember { mutableFloatStateOf(0f) }
+    var dragY by remember { mutableFloatStateOf(0f) }
+
+    val gridWidthDp = (bounds.maxCellsW * LAUNCHER_CELL_WIDTH_DP).dp
+    val gridHeightDp = (bounds.maxCellsH * LAUNCHER_CELL_HEIGHT_DP).dp
+    val currentWidthDp = (cellsW * LAUNCHER_CELL_WIDTH_DP).dp
+    val currentHeightDp = (cellsH * LAUNCHER_CELL_HEIGHT_DP).dp
+
+    Box(modifier = Modifier.size(gridWidthDp, gridHeightDp)) {
+        // Backdrop: cell grid + smallest/largest size outlines.
+        Canvas(modifier = Modifier.matchParentSize()) {
+            val dash = PathEffect.dashPathEffect(floatArrayOf(10f, 8f))
+            for (i in 0..bounds.maxCellsW) {
+                val x = (i * cellWpx).coerceAtMost(size.width)
+                drawLine(gridColor, Offset(x, 0f), Offset(x, size.height), 1.dp.toPx())
+            }
+            for (j in 0..bounds.maxCellsH) {
+                val y = (j * cellHpx).coerceAtMost(size.height)
+                drawLine(gridColor, Offset(0f, y), Offset(size.width, y), 1.dp.toPx())
+            }
+            // Largest size = the whole grid; smallest = top-left block.
+            drawRect(
+                color = largestColor,
+                topLeft = Offset.Zero,
+                size = Size(size.width, size.height),
+                style = Stroke(width = 2.dp.toPx(), pathEffect = dash),
+            )
+            drawRect(
+                color = smallestColor,
+                topLeft = Offset.Zero,
+                size = Size(bounds.minCellsW * cellWpx, bounds.minCellsH * cellHpx),
+                style = Stroke(width = 2.dp.toPx(), pathEffect = dash),
+            )
+        }
+
+        // The card at its current slot, anchored top-left so it grows
+        // toward the handle.
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .size(currentWidthDp, currentHeightDp)
+                .border(2.dp, currentColor),
+        ) {
+            content()
+        }
+
+        // Resize handle at the current slot's bottom-right corner. A
+        // drag of one cell's width / height steps the slot by one cell,
+        // clamped to the size class's min/max range.
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .offset(
+                    x = currentWidthDp - HANDLE_SIZE_DP.dp / 2,
+                    y = currentHeightDp - HANDLE_SIZE_DP.dp / 2,
+                )
+                .size(HANDLE_SIZE_DP.dp)
+                .clip(CircleShape)
+                .background(currentColor)
+                .pointerInput(bounds) {
+                    detectDragGestures(
+                        onDragEnd = { dragX = 0f; dragY = 0f },
+                        onDragCancel = { dragX = 0f; dragY = 0f },
+                    ) { change, drag ->
+                        change.consume()
+                        dragX += drag.x
+                        dragY += drag.y
+                        var w = cellsW
+                        var h = cellsH
+                        while (dragX >= cellWpx && w < bounds.maxCellsW) { w++; dragX -= cellWpx }
+                        while (dragX <= -cellWpx && w > bounds.minCellsW) { w--; dragX += cellWpx }
+                        while (dragY >= cellHpx && h < bounds.maxCellsH) { h++; dragY -= cellHpx }
+                        while (dragY <= -cellHpx && h > bounds.minCellsH) { h--; dragY += cellHpx }
+                        // Don't bank drag past the clamp, or the user
+                        // has to "unwind" it before the slot moves back.
+                        if (w == bounds.maxCellsW) dragX = dragX.coerceAtMost(0f)
+                        if (w == bounds.minCellsW) dragX = dragX.coerceAtLeast(0f)
+                        if (h == bounds.maxCellsH) dragY = dragY.coerceAtMost(0f)
+                        if (h == bounds.minCellsH) dragY = dragY.coerceAtLeast(0f)
+                        if (w != cellsW || h != cellsH) onResize(w, h)
+                    }
+                },
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                Icons.Filled.OpenInFull,
+                contentDescription = "Resize widget preview",
+                tint = MaterialTheme.colorScheme.onPrimary,
+                modifier = Modifier.size(16.dp),
+            )
+        }
+    }
+}
+
+/** Colour-keyed caption: current / smallest / largest slot, in cells. */
+@Composable
+private fun ResizeLegend(
+    bounds: LauncherGridBounds,
+    cellsW: Int,
+    cellsH: Int,
+    smallestColor: Color,
+    largestColor: Color,
+    currentColor: Color,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+            LegendSwatch(currentColor, "Now $cellsW×$cellsH")
+            LegendSwatch(smallestColor, "Min ${bounds.minCellsW}×${bounds.minCellsH}")
+            LegendSwatch(largestColor, "Max ${bounds.maxCellsW}×${bounds.maxCellsH}")
+        }
+        Text(
+            "Drag the handle to resize the widget",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun LegendSwatch(color: Color, label: String) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(modifier = Modifier.size(10.dp).clip(CircleShape).background(color))
+        Text(label, style = MaterialTheme.typography.labelSmall)
+    }
+}
+
+private const val HANDLE_SIZE_DP = 28
+
+private data class LauncherPreviewKey(
     val card: CardConfig,
     val style: ThemeStyle,
     val dark: Boolean,
+    val cellsW: Int,
+    val cellsH: Int,
 )
 
 /** Middle region: range chips + one chart block per entity. */

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/CardHistoryScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/CardHistoryScreen.kt
@@ -296,7 +296,7 @@ private fun ResizableLauncherPreview(session: HaSession, card: CardConfig, snaps
  * bottom-right corner.
  */
 @Composable
-private fun LauncherGrid(
+internal fun LauncherGrid(
     bounds: LauncherGridBounds,
     cellsW: Int,
     cellsH: Int,
@@ -408,7 +408,7 @@ private fun LauncherGrid(
 
 /** Colour-keyed caption: current / smallest / largest slot, in cells. */
 @Composable
-private fun ResizeLegend(
+internal fun ResizeLegend(
     bounds: LauncherGridBounds,
     cellsW: Int,
     cellsH: Int,

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/CardHistoryScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/CardHistoryScreen.kt
@@ -72,7 +72,6 @@ import ee.schimke.ha.rc.CardSizeMode
 import ee.schimke.ha.rc.ProvideCardRegistry
 import ee.schimke.ha.rc.ProvideCardSizeMode
 import ee.schimke.ha.rc.RenderChild
-import ee.schimke.ha.rc.androidXExperimentalWrap
 import ee.schimke.ha.rc.cardSizeConstraints
 import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.cards.shutter.withEnhancedShutter
@@ -81,6 +80,7 @@ import ee.schimke.ha.rc.components.ProvideHaTheme
 import ee.schimke.ha.rc.components.RemoteHaWidgetSurface
 import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.ha.rc.components.haThemeFor
+import ee.schimke.ha.rc.widgetsProfile
 import ee.schimke.ha.rc.image.CoilBitmapLoader
 import ee.schimke.terrazzo.LocalHaImageStack
 import ee.schimke.terrazzo.core.session.DemoData
@@ -255,7 +255,12 @@ private fun ResizableLauncherPreview(session: HaSession, card: CardConfig, snaps
         ) {
             CachedCardPreview(
                 cacheKey = LauncherPreviewKey(card, style, dark, cellsW, cellsH),
-                profile = androidXExperimentalWrap,
+                // Capture with the launcher's constrained op vocabulary —
+                // the same widgetsProfile TerrazzoWidgetProvider and the
+                // install sheet use — so a card that the launcher runtime
+                // would reject or render empty looks the same here as on
+                // the home screen, not artificially richer.
+                profile = widgetsProfile,
                 card = card,
                 snapshot = snapshot,
                 bitmapLoader = bitmapLoader,

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetSizeClass.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetSizeClass.kt
@@ -55,6 +55,23 @@ internal enum class WidgetSizeClass(val providerClass: Class<out TerrazzoWidgetP
     fun componentName(context: Context): ComponentName =
         ComponentName(context, providerClass)
 
+    /**
+     * The launcher resize range for this size class, in whole grid
+     * cells — the smallest and largest home-screen slots the widget
+     * will occupy, plus the comfortable default it pins at. Quantises
+     * the `min/maxResize*` and `targetCell*` values in the matching
+     * `@xml/terrazzo_widget_info*` provider metadata onto the
+     * [LAUNCHER_CELL_WIDTH_DP] × [LAUNCHER_CELL_HEIGHT_DP] grid, and
+     * matches the `~AxB .. CxD` ranges in each constant's KDoc above.
+     * The card-history screen draws this range as a resizable preview.
+     */
+    val gridBounds: LauncherGridBounds
+        get() = when (this) {
+            Small -> LauncherGridBounds(minCellsW = 1, minCellsH = 1, defaultCellsW = 2, defaultCellsH = 1, maxCellsW = 2, maxCellsH = 2)
+            Standard -> LauncherGridBounds(minCellsW = 2, minCellsH = 1, defaultCellsW = 4, defaultCellsH = 2, maxCellsW = 4, maxCellsH = 3)
+            Tall -> LauncherGridBounds(minCellsW = 2, minCellsH = 2, defaultCellsW = 4, defaultCellsH = 3, maxCellsW = 4, maxCellsH = 4)
+        }
+
     companion object {
         /** Default height (dp) at or above which a Full-width card pins Tall. */
         private const val TALL_DEFAULT_HEIGHT_DP = 200
@@ -72,3 +89,29 @@ internal enum class WidgetSizeClass(val providerClass: Class<out TerrazzoWidgetP
         }
     }
 }
+
+/**
+ * Approximate size of one launcher home-screen cell on a typical phone,
+ * in dp. Widget slots are an integer number of these cells; the
+ * card-history resize preview tiles its grid on this unit. Mirrors the
+ * `LauncherCellWidthDp` / `LauncherCellHeightDp` constants the
+ * `CardPreviewMatrix` @Preview renders against, so the in-app preview
+ * and the tooling matrix quantise to the same grid.
+ */
+internal const val LAUNCHER_CELL_WIDTH_DP = 72
+internal const val LAUNCHER_CELL_HEIGHT_DP = 84
+
+/**
+ * A [WidgetSizeClass]'s resize range expressed in whole launcher cells:
+ * the smallest and largest slots the launcher will let the widget
+ * occupy, plus the comfortable default it pins at. See
+ * [WidgetSizeClass.gridBounds].
+ */
+internal data class LauncherGridBounds(
+    val minCellsW: Int,
+    val minCellsH: Int,
+    val defaultCellsW: Int,
+    val defaultCellsH: Int,
+    val maxCellsW: Int,
+    val maxCellsH: Int,
+)

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetSizeClass.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetSizeClass.kt
@@ -2,7 +2,11 @@ package ee.schimke.terrazzo.widget
 
 import android.content.ComponentName
 import android.content.Context
+import android.util.Xml
 import ee.schimke.ha.rc.WidgetSizeConstraints
+import ee.schimke.terrazzo.R
+import kotlin.math.roundToInt
+import org.xmlpull.v1.XmlPullParser
 
 /**
  * Quantises a card's continuous [WidgetSizeConstraints] band onto the
@@ -55,22 +59,29 @@ internal enum class WidgetSizeClass(val providerClass: Class<out TerrazzoWidgetP
     fun componentName(context: Context): ComponentName =
         ComponentName(context, providerClass)
 
+    /** The `@xml/terrazzo_widget_info*` resource backing this class. */
+    private val providerInfoXmlRes: Int
+        get() = when (this) {
+            Small -> R.xml.terrazzo_widget_info_small
+            Standard -> R.xml.terrazzo_widget_info
+            Tall -> R.xml.terrazzo_widget_info_tall
+        }
+
     /**
      * The launcher resize range for this size class, in whole grid
      * cells — the smallest and largest home-screen slots the widget
-     * will occupy, plus the comfortable default it pins at. Quantises
-     * the `min/maxResize*` and `targetCell*` values in the matching
-     * `@xml/terrazzo_widget_info*` provider metadata onto the
-     * [LAUNCHER_CELL_WIDTH_DP] × [LAUNCHER_CELL_HEIGHT_DP] grid, and
-     * matches the `~AxB .. CxD` ranges in each constant's KDoc above.
-     * The card-history screen draws this range as a resizable preview.
+     * will occupy, plus the comfortable default it pins at.
+     *
+     * Read straight from the matching `@xml/terrazzo_widget_info*`
+     * provider metadata — the same `appwidget-provider` element the
+     * launcher itself reads — so the card-history resize preview and
+     * the real launcher constraints can't drift apart. The `targetCell*`
+     * default is already in cells; the `min/maxResize*` dimensions are
+     * quantised onto the [LAUNCHER_CELL_WIDTH_DP] ×
+     * [LAUNCHER_CELL_HEIGHT_DP] grid (nearest whole cell, floor of one).
      */
-    val gridBounds: LauncherGridBounds
-        get() = when (this) {
-            Small -> LauncherGridBounds(minCellsW = 1, minCellsH = 1, defaultCellsW = 2, defaultCellsH = 1, maxCellsW = 2, maxCellsH = 2)
-            Standard -> LauncherGridBounds(minCellsW = 2, minCellsH = 1, defaultCellsW = 4, defaultCellsH = 2, maxCellsW = 4, maxCellsH = 3)
-            Tall -> LauncherGridBounds(minCellsW = 2, minCellsH = 2, defaultCellsW = 4, defaultCellsH = 3, maxCellsW = 4, maxCellsH = 4)
-        }
+    fun gridBounds(context: Context): LauncherGridBounds =
+        readProviderGridBounds(context, providerInfoXmlRes)
 
     companion object {
         /** Default height (dp) at or above which a Full-width card pins Tall. */
@@ -115,3 +126,64 @@ internal data class LauncherGridBounds(
     val maxCellsW: Int,
     val maxCellsH: Int,
 )
+
+/**
+ * Read the `appwidget-provider` resize range out of [xmlRes] and
+ * quantise it onto the launcher cell grid. `targetCell*` is already in
+ * cells; `min/maxResize*` are dimensions resolved against the device
+ * density, then rounded to the nearest whole cell (floor of one). The
+ * default is clamped into `[min, max]` so the range is always valid even
+ * if the metadata's target falls outside the resize bounds.
+ */
+private fun readProviderGridBounds(context: Context, xmlRes: Int): LauncherGridBounds {
+    val parser = context.resources.getXml(xmlRes)
+    // Advance to the single <appwidget-provider> element.
+    var event = parser.eventType
+    while (event != XmlPullParser.START_TAG && event != XmlPullParser.END_DOCUMENT) {
+        event = parser.next()
+    }
+    val attrs = Xml.asAttributeSet(parser)
+    val density = context.resources.displayMetrics.density
+
+    // One styled-attribute lookup per attr: a single-element array is
+    // trivially sorted, so we don't have to order android.R.attr ids.
+    fun dimPx(attr: Int): Int {
+        val a = context.obtainStyledAttributes(attrs, intArrayOf(attr))
+        return try {
+            a.getDimensionPixelSize(0, 0)
+        } finally {
+            a.recycle()
+        }
+    }
+    fun intVal(attr: Int): Int {
+        val a = context.obtainStyledAttributes(attrs, intArrayOf(attr))
+        return try {
+            a.getInt(0, 0)
+        } finally {
+            a.recycle()
+        }
+    }
+
+    fun cellsW(px: Int) = ((px / density) / LAUNCHER_CELL_WIDTH_DP).roundToInt().coerceAtLeast(1)
+    fun cellsH(px: Int) = ((px / density) / LAUNCHER_CELL_HEIGHT_DP).roundToInt().coerceAtLeast(1)
+
+    // Read every attribute while the parser is still positioned on the
+    // start tag (the AttributeSet reads through the live parser), then
+    // close it.
+    val minW = cellsW(dimPx(android.R.attr.minResizeWidth))
+    val minH = cellsH(dimPx(android.R.attr.minResizeHeight))
+    val maxW = cellsW(dimPx(android.R.attr.maxResizeWidth)).coerceAtLeast(minW)
+    val maxH = cellsH(dimPx(android.R.attr.maxResizeHeight)).coerceAtLeast(minH)
+    val defW = intVal(android.R.attr.targetCellWidth).coerceIn(minW, maxW)
+    val defH = intVal(android.R.attr.targetCellHeight).coerceIn(minH, maxH)
+    parser.close()
+
+    return LauncherGridBounds(
+        minCellsW = minW,
+        minCellsH = minH,
+        defaultCellsW = defW,
+        defaultCellsH = defH,
+        maxCellsW = maxW,
+        maxCellsH = maxH,
+    )
+}


### PR DESCRIPTION
The card-history "more info" preview now shows the card as a launcher
widget on a resizable slot instead of a static dashboard-width render.

- Add WidgetSizeClass.gridBounds + LauncherGridBounds: each size class's
  resize range in whole launcher cells (min/default/max), quantised from
  the appwidget-provider XML onto a 72×84dp cell grid.
- ResizableLauncherPreview draws that grid behind the card, dash-outlines
  the smallest and largest sizes, and renders the card in launcher mode
  (fixed size, full-bleed RemoteHaWidgetSurface, no in-app chrome) at the
  current slot.
- A corner drag handle steps the slot a cell at a time, clamped to the
  size class's range; a colour-keyed legend reports now/min/max in cells.