### PR TITLE
Remove AD_ID permission from merged manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <!--
+      firebase-analytics (pulled in alongside Crashlytics when a
+      google-services.json key is configured) transitively adds the
+      com.google.android.gms.permission.AD_ID permission via its
+      play-services-measurement dependency. We don't use the advertising
+      ID, and the Play Console declaration says so — strip the permission
+      here so the merged manifest matches that declaration. Crashlytics
+      (and Analytics, minus ad-id collection) keeps working. Harmless when
+      Firebase isn't applied: there's no such permission to remove.
+    -->
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove" />
     <!-- mDNS discovery for _home-assistant._tcp instances on the LAN. -->
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />


### PR DESCRIPTION
## Summary
This change removes the `com.google.android.gms.permission.AD_ID` permission from the merged Android manifest to align with the app's Play Console declaration that advertising ID collection is not used.

## Changes
- Added `xmlns:tools` namespace declaration to the manifest root element
- Added a `uses-permission` entry with `tools:node="remove"` directive to strip the `AD_ID` permission that is transitively pulled in by Firebase Analytics (via Crashlytics and play-services-measurement)
- Included detailed comments explaining why this permission is being removed and that it doesn't affect Crashlytics or Analytics functionality

## Details
Firebase Analytics transitively adds the `com.google.android.gms.permission.AD_ID` permission through its play-services-measurement dependency. Since the app doesn't use the advertising ID, this change explicitly removes that permission from the merged manifest to match the Play Console declaration. The removal is harmless when Firebase isn't applied, and Crashlytics and Analytics continue to function normally without ad-id collection.

https://claude.ai/code/session_01CL4SPh8XatUJ8TUbHMu9MV