### PR TITLE
chore(hooks): install Build Brief on session start (non-fatal)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -8,3 +8,13 @@ cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
 
 git config core.hooksPath .githooks
 echo "Configured git core.hooksPath -> .githooks"
+
+# Install Build Brief. Best-effort — the network may be unavailable under the
+# session's network policy, so a failure here must not abort session start.
+echo "installing Build Brief"
+# Linux/macOS — downloads the matching release tarball from GitHub.
+if curl -fsSL https://bb.staticvar.dev/install.sh | bash; then
+  echo "Build Brief installed"
+else
+  echo "Build Brief install failed (non-fatal); continuing" >&2
+fi


### PR DESCRIPTION
The SessionStart hook runs under 'set -euo pipefail', so the Build Brief
install is wrapped in an if-block to ensure a failure (e.g. no network
under the session's policy) logs a warning instead of aborting session
start.