### PR TITLE
Configure Renovate to exclude kotlinx-datetime -compat binaries

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,6 +47,11 @@
       "groupName": "github-actions"
     },
     {
+      "matchPackageNames": ["org.jetbrains.kotlinx:kotlinx-datetime"],
+      "description": "Avoid the -0.6.x-compat binaries; track mainline versions only.",
+      "allowedVersions": "!/-compat$/"
+    },
+    {
       "matchPackageNames": ["junit:junit"],
       "description": "Stay on JUnit 4; don't auto-bump to 5.x/6.x (Jupiter is a different API).",
       "allowedVersions": "/^4\\./",


### PR DESCRIPTION
## Summary
Added a Renovate configuration rule to exclude `-compat` variant binaries of the `kotlinx-datetime` library, ensuring that only mainline versions are tracked for dependency updates.

## Changes
- Added a new Renovate package rule for `org.jetbrains.kotlinx:kotlinx-datetime` that filters out versions matching the `-compat$` suffix pattern
- This prevents automatic upgrades to compatibility variant releases while allowing updates to standard mainline versions

## Details
The configuration uses a negative regex pattern (`!/-compat$/`) in the `allowedVersions` field to explicitly exclude `-compat` suffixed versions. This is consistent with the existing pattern used for other dependencies in the configuration (e.g., JUnit version constraints).

https://claude.ai/code/session_01KrWzNDvQXmvjQcuYYeAb2S