### PR TITLE
feat(rc-converter): icon+state Fixed-mode ladder for tile/entity/sensor/statistic

### DIFF
--- a/docs/architecture/adaptive-card-layouts.md
+++ b/docs/architecture/adaptive-card-layouts.md
@@ -465,7 +465,7 @@ and is reused. The families today:
 
 | Family | Key element | Cards | Shared composable(s) | Ladder state |
 |---|---|---|---|---|
-| **Icon + state row/tile** | tinted icon | `tile`, `entity`, `sensor`, `statistic` | `RemoteHaTile`, `RemoteHaEntityRow` | tile/entity: `Full↔CompactStateChip`; sensor/statistic: none |
+| **Icon + state row/tile** | tinted icon | `tile`, `entity`, `sensor`, `statistic` | `RemoteHaTile` (+`RemoteHaIconChip`), `RemoteHaEntityRow` | all four: `Full↔IconChip` (Full self-centred via `CenteredCell`) |
 | **Icon-centred button** | large tinted icon | `button` | `RemoteHaButton` / `RemoteHaToggleButton` | `Full↔CompactStateChip` |
 | **Arc-dial control** | the arc/dial | `gauge`, `thermostat`, `humidifier`, `light` | `RemoteHaGauge*`, `RemoteHaArcDial*`, `RenderArcDial` | thermostat/humidifier/gauge: Wide↔Full; `light`: **none (outlier)** |
 | **Multi-entity list/strip** | first row/cell | `entities`, `glance`, `area`, `picture-glance`, `entity-filter`, `*-stack` | `RemoteHaEntities`, `RemoteHaGlance` | entities: `list↔strip`; others: none |
@@ -513,10 +513,16 @@ The current state is the placeholder, not the philosophy:
    `entities` reflows on a single width threshold; per-card ladders
    should pick the one pinned axis that best discriminates their
    variants — see `GaugeCardConverter`.
-2. Tile / entity / button / gauge ship two-tier ladders
-   (`Full → CompactStateChip`). That's the value-fallback path,
-   skipping every reflow / identity tier above it. Each card needs
-   the worked-example ladder above.
+2. `button` still ships the `Full → CompactStateChip` text-only
+   ladder (the value-fallback path, skipping the identity tier above
+   it) and needs the worked-example ladder. The icon-+-state family
+   (`tile`, `entity`, `sensor`, `statistic`) now lands on
+   `Full ↔ RemoteHaIconChip`: the smallest cell keeps the tinted icon
+   (identity tier) instead of dropping to a text chip, and the `Full`
+   tier self-centres (`CenteredCell`) so tall cells fill rather than
+   top-glue. Still a single live breakpoint per card (#224) — the
+   reflow / expanded rungs between identity and full are the design
+   target, not encodable yet.
 3. Runtime tier selection **does** fire — the matrix preview shows tile
    switching chip↔full and entities switching list↔strip per size. Two
    gotchas were shaped around: the `componentWidth()` named expression

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviewMatrix.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviewMatrix.kt
@@ -499,11 +499,53 @@ fun CardPreviewMatrix_Tile() {
 @Composable
 fun CardPreviewMatrix_Entity() {
     val card = card("""{"type":"entity","entity":"lock.front_door","name":"Front door"}""")
+    // Base launcher shape is 2×1 — the row's natural pinned-card shape.
+    // The old 3×1 base left the matrix +1 neighbour (4×2) ~70 % empty
+    // (adaptive-card-layouts.md Q5 / §"Icon + state row/tile").
     CardPreviewMatrix(
         card = card,
         snapshot = Fixtures.mixed,
-        baseGridSize = WidgetGridSize(cellsW = 3, cellsH = 1),
+        baseGridSize = WidgetGridSize(cellsW = 2, cellsH = 1),
         label = "entity · lock.front_door",
+    )
+}
+
+@Preview(
+    name = "matrix — sensor",
+    showBackground = false,
+    widthDp = MATRIX_CANVAS_WIDTH_DP,
+    heightDp = 400,
+)
+@Composable
+fun CardPreviewMatrix_Sensor() {
+    val card = card("""{"type":"sensor","entity":"sensor.outside_temp","name":"Outside"}""")
+    // sensor's P5 is the history sparkline: dropped on the icon-chip tier
+    // (1×1), promoted back on the full tier (2×1 / 3×2). Uses the
+    // temperature-history fixture so the full tier has real samples to
+    // draw. See adaptive-card-layouts.md §"Icon + state row/tile".
+    CardPreviewMatrix(
+        card = card,
+        snapshot = Fixtures.temperatureHistory,
+        baseGridSize = WidgetGridSize(cellsW = 2, cellsH = 1),
+        label = "sensor · sensor.outside_temp",
+    )
+}
+
+@Preview(
+    name = "matrix — statistic",
+    showBackground = false,
+    widthDp = MATRIX_CANVAS_WIDTH_DP,
+    heightDp = 400,
+)
+@Composable
+fun CardPreviewMatrix_Statistic() {
+    val card =
+        card("""{"type":"statistic","entity":"sensor.living_room","name":"Living Room","period":"day","stat_type":"mean"}""")
+    CardPreviewMatrix(
+        card = card,
+        snapshot = Fixtures.mixed,
+        baseGridSize = WidgetGridSize(cellsW = 2, cellsH = 1),
+        label = "statistic · sensor.living_room",
     )
 }
 

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaTile.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaTile.kt
@@ -3,6 +3,7 @@
 package ee.schimke.ha.rc.components
 
 import androidx.compose.remote.creation.compose.layout.RemoteAlignment
+import androidx.compose.remote.creation.compose.layout.RemoteArrangement
 import androidx.compose.remote.creation.compose.layout.RemoteBox
 import androidx.compose.remote.creation.compose.layout.RemoteColumn
 import androidx.compose.remote.creation.compose.layout.RemoteComposable
@@ -12,6 +13,7 @@ import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.background
 import androidx.compose.remote.creation.compose.modifier.clickable
 import androidx.compose.remote.creation.compose.modifier.clip
+import androidx.compose.remote.creation.compose.modifier.fillMaxSize
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
 import androidx.compose.remote.creation.compose.modifier.padding
 import androidx.compose.remote.creation.compose.modifier.size
@@ -105,6 +107,81 @@ fun RemoteHaTile(data: HaTileData, modifier: RemoteModifier = RemoteModifier) {
                     overflow = TextOverflow.Ellipsis,
                 )
             }
+        }
+    }
+}
+
+/**
+ * Icon-only identity tier for the icon-+-state family (`tile`, `entity`,
+ * `sensor`, `statistic`). Centres the tinted state icon in the cell with
+ * a single state line beneath it — the "minimum viable identity" rung
+ * (P1: icon + value; P2 name dropped) that Fixed-mode converters fall to
+ * on the smallest launcher cells.
+ *
+ * This is the compact tier the family was missing: the previous
+ * `Full → CompactStateChip` ladder hid the icon first and rendered a
+ * bare text chip (`21.4 °C`) on a `1×1` cell — a direct violation of
+ * Principle 1 (_identity before density_) and the "hiding the icon
+ * first" anti-pattern. The chip keeps the icon at every size; the text
+ * chip is demoted to the genuine last resort (only reached when even a
+ * ~40 dp icon can't fit). It [fillMaxSize]s and self-centres so the cell
+ * is never half-empty (Principle 8), the way [RemoteHaArcDialWide] does
+ * — a wrapper `contentAlignment` is a no-op for `fillMaxWidth` children
+ * in alpha010.
+ *
+ * Reuses [HaTileData] so every member of the family can feed the same
+ * tier; the icon is tinted by the entity's state colour.
+ *
+ * Two deliberate alpha010 concessions vs the full tile's icon treatment,
+ * both because this composable is a **state-layout sibling** of the full
+ * tier and a hidden branch can corrupt the visible one:
+ *
+ *   * **Static accent, no live `isOn` `select`.** The full tier already
+ *     registers `<entity>.is_on`; re-registering that named
+ *     `RemoteBoolean` here collides and blanks the other branch (a
+ *     duplicate named `RemoteString` like `state` is fine — a duplicate
+ *     `RemoteBoolean` is not). The accent is resolved from the
+ *     encode-time state instead.
+ *   * **No clipped circle backing.** A `.clip(RemoteCircleShape)` +
+ *     `background` box in this branch likewise blanks the sibling full
+ *     tier at playback. The tinted glyph alone carries the identity —
+ *     the circle halo is the cosmetic part, and dropping it costs
+ *     nothing semantically.
+ *
+ * Both are cosmetic — the icon, not its tint animation or halo, is what
+ * says what kind of card this is. Revisit the circle / live colour once
+ * the alpha010 state-layout bugs (#224) lift.
+ */
+@Composable
+@RemoteComposable
+fun RemoteHaIconChip(data: HaTileData, modifier: RemoteModifier = RemoteModifier) {
+    val theme = haTheme()
+    val clickable =
+        data.tapAction.toRemoteAction()?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
+    val accent: RemoteColor =
+        if (data.accent.toggleable && !data.accent.initiallyOn) data.accent.inactiveAccent
+        else data.accent.activeAccent
+
+    RemoteColumn(
+        modifier = modifier.then(clickable).fillMaxSize().padding(4.rdp),
+        verticalArrangement = RemoteArrangement.Center,
+        horizontalAlignment = RemoteAlignment.CenterHorizontally,
+    ) {
+        RemoteIcon(
+            imageVector = data.icon,
+            contentDescription = data.name.rs,
+            modifier = RemoteModifier.size(32.rdp),
+            tint = accent,
+        )
+        RemoteBox(modifier = RemoteModifier.padding(top = 6.rdp)) {
+            RemoteText(
+                text = data.state,
+                color = theme.secondaryText.rc,
+                fontSize = 11.rsp,
+                style = RemoteTextStyle.Default,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
         }
     }
 }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/EntityCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/EntityCardConverter.kt
@@ -1,6 +1,7 @@
 package ee.schimke.ha.rc.cards
 
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.fillMaxSize
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
 import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.runtime.Composable
@@ -16,9 +17,11 @@ import ee.schimke.ha.rc.HaStateColor
 import ee.schimke.ha.rc.LocalCardSizeMode
 import ee.schimke.ha.rc.RemoteSizeBreakpoint
 import ee.schimke.ha.rc.components.HaEntityRowData
+import ee.schimke.ha.rc.components.HaTileData
 import ee.schimke.ha.rc.components.HaToggleAccent
 import ee.schimke.ha.rc.components.LiveValues
 import ee.schimke.ha.rc.components.RemoteHaEntityRow
+import ee.schimke.ha.rc.components.RemoteHaIconChip
 import ee.schimke.ha.rc.defaultTapActionFor
 import ee.schimke.ha.rc.formatState
 import ee.schimke.ha.rc.icons.HaIconMap
@@ -26,7 +29,19 @@ import ee.schimke.ha.rc.parseHaAction
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
-/** HA `entity` card — single-entity compact row. */
+/**
+ * HA `entity` card — single-entity compact row.
+ *
+ * In [CardSizeMode.Fixed] the converter runs the shared icon-+-state
+ * ladder (adaptive-card-layouts.md §"Icon + state row/tile"): a narrow
+ * cell (`w < 96 dp`) drops to the [RemoteHaIconChip] identity tier
+ * (tinted icon + state, no name), and the [RemoteHaEntityRow] full tier
+ * is wrapped in [CenteredCell] so a tall cell centres the row instead of
+ * leaving a blank lower half.
+ *
+ * Base launcher shape is `2×1` (see [CardPreviewMatrix_Entity]) — the
+ * old `3×1` left the matrix `+1` neighbour ~70 % empty (Q5).
+ */
 class EntityCardConverter : CardConverter {
     override val cardType: String = CardTypes.ENTITY
 
@@ -41,12 +56,18 @@ class EntityCardConverter : CardConverter {
             CardSizeMode.Wrap -> FullRow(card, snapshot, modifier)
             CardSizeMode.Fixed ->
                 RemoteSizeBreakpoint(
-                    thresholdsDp = intArrayOf(120),
-                    modifier = modifier,
+                    thresholdsDp = intArrayOf(96),
+                    modifier = modifier.fillMaxSize(),
                 ) { tier ->
                     when (tier) {
-                        0 -> CompactStateChip(card, snapshot)
-                        else -> FullRow(card, snapshot, RemoteModifier.fillMaxWidth())
+                        0 -> RemoteHaIconChip(iconChipData(card, snapshot), RemoteModifier.fillMaxSize())
+                        // The row fills the cell and self-centres via its
+                        // own `CenterVertically` (like RemoteHaGaugeWide),
+                        // so a tall cell isn't top-glued (Principle 8). A
+                        // `fillMaxWidth` wrap-height row collapses to zero
+                        // height under a filled-height parent in alpha010,
+                        // so `fillMaxSize`, not `CenteredCell`.
+                        else -> FullRow(card, snapshot, RemoteModifier.fillMaxSize())
                     }
                 }
         }
@@ -76,6 +97,32 @@ class EntityCardConverter : CardConverter {
                 tapAction = tapAction,
             ),
             modifier = modifier,
+        )
+    }
+
+    /** Identity-tier payload — same fields as the full row, shaped as
+     *  [HaTileData] so the shared [RemoteHaIconChip] can render it. */
+    @Composable
+    private fun iconChipData(card: CardConfig, snapshot: HaSnapshot): HaTileData {
+        val entityId = card.raw["entity"]?.jsonPrimitive?.content
+        val entity = entityId?.let { snapshot.states[it] }
+        val tapCfg = card.raw["tap_action"]?.jsonObject
+        val tapAction =
+            if (tapCfg != null) parseHaAction(tapCfg, entityId) else defaultTapActionFor(entityId)
+        val isActive = entity?.toTyped()?.isActive
+        return HaTileData(
+            entityId = entityId,
+            name = nameFor(card, entity, entityId),
+            state = LiveValues.state(entityId, formatState(entity)),
+            icon = HaIconMap.resolve(card.raw["icon"]?.jsonPrimitive?.content, entity),
+            accent =
+                HaToggleAccent(
+                    activeAccent = HaStateColor.activeFor(entity).rc,
+                    inactiveAccent = HaStateColor.inactiveFor(entity).rc,
+                    initiallyOn = isActive ?: false,
+                    toggleable = isActive != null,
+                ),
+            tapAction = tapAction,
         )
     }
 

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/FixedTier.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/FixedTier.kt
@@ -1,0 +1,43 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.cards
+
+import androidx.compose.remote.creation.compose.layout.RemoteBox
+import androidx.compose.remote.creation.compose.layout.RemoteColumn
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.fillMaxSize
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.runtime.Composable
+
+/**
+ * Self-centre a **box/column-rooted** Fixed-mode `Full` tier (the tile,
+ * statistic and sensor cards) inside the cell it's handed.
+ *
+ * These full composables are `fillMaxWidth` + wrap-height, so on a cell
+ * taller than their natural shape (e.g. a `tile` rendered into a `3×2`
+ * widget) they glue to the top edge and leave the lower half blank — the
+ * Principle 8 "no dead space" / "earn the canvas" failure called out in
+ * `docs/architecture/adaptive-card-layouts.md`. Centring is the cheapest
+ * correct version of "earn the canvas" (Principle 7); a card promotes a
+ * real Expanded tier once the single-breakpoint limit (#224) lifts.
+ *
+ * Centring is done with weighted spacers in a **default-arrangement**
+ * [RemoteColumn], not a wrapper `contentAlignment = Center` — the latter
+ * is a no-op for the `fillMaxWidth` children these tiers use in alpha010.
+ *
+ * Row-rooted full tiers (`RemoteHaEntityRow`) do **not** go through this
+ * helper: a `fillMaxWidth` wrap-height row measures to zero height under
+ * the filled-height constraint a centring column hands down and vanishes
+ * (a box root survives, which is why this helper is box-only). Those
+ * tiers instead take `fillMaxSize` and self-centre via their own
+ * `verticalAlignment = CenterVertically`, the way `RemoteHaGaugeWide`
+ * does.
+ */
+@Composable
+internal fun CenteredCell(content: @Composable () -> Unit) {
+    RemoteColumn(modifier = RemoteModifier.fillMaxSize()) {
+        RemoteBox(modifier = RemoteModifier.fillMaxWidth().weight(1f))
+        content()
+        RemoteBox(modifier = RemoteModifier.fillMaxWidth().weight(1f))
+    }
+}

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/SensorCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/SensorCardConverter.kt
@@ -1,21 +1,42 @@
+@file:Suppress("RestrictedApi")
+
 package ee.schimke.ha.rc.cards
 
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.fillMaxSize
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.runtime.Composable
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.CardSizeMode
 import ee.schimke.ha.rc.HaStateColor
+import ee.schimke.ha.rc.LocalCardSizeMode
+import ee.schimke.ha.rc.RemoteSizeBreakpoint
 import ee.schimke.ha.rc.components.HaSensorCardData
+import ee.schimke.ha.rc.components.HaTileData
+import ee.schimke.ha.rc.components.HaToggleAccent
+import ee.schimke.ha.rc.components.LiveValues
+import ee.schimke.ha.rc.components.RemoteHaIconChip
 import ee.schimke.ha.rc.components.RemoteHaSensorCard
 import ee.schimke.ha.rc.formatState
+import ee.schimke.ha.rc.icons.HaIconMap
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
  * `sensor` card — entity name + big value + a small inline sparkline
  * of recent values. Pulls history from `HaSnapshot.history[entityId]`
  * and reuses the history-graph row visual as a hero tile.
+ *
+ * In [CardSizeMode.Fixed] the converter runs the shared icon-+-state
+ * ladder (adaptive-card-layouts.md §"Icon + state row/tile"): a narrow
+ * cell drops to the [RemoteHaIconChip] identity tier (tinted icon +
+ * value, sparkline + name dropped — the sparkline is the card's P5, so
+ * it's the first thing to go), while the full [RemoteHaSensorCard]
+ * promotes the sparkline back on cells with the width to host it, and is
+ * [CenteredCell]-wrapped so a tall cell fills rather than top-glues.
  */
 class SensorCardConverter : CardConverter {
     override val cardType: String = CardTypes.SENSOR
@@ -24,12 +45,25 @@ class SensorCardConverter : CardConverter {
 
     @Composable
     override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        when (LocalCardSizeMode.current) {
+            CardSizeMode.Wrap -> FullSensor(card, snapshot, modifier)
+            CardSizeMode.Fixed ->
+                RemoteSizeBreakpoint(
+                    thresholdsDp = intArrayOf(120),
+                    modifier = modifier.fillMaxSize(),
+                ) { tier ->
+                    when (tier) {
+                        0 -> RemoteHaIconChip(iconChipData(card, snapshot), RemoteModifier.fillMaxSize())
+                        else -> CenteredCell { FullSensor(card, snapshot, RemoteModifier.fillMaxWidth()) }
+                    }
+                }
+        }
+    }
+
+    @Composable
+    private fun FullSensor(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
         val entityId = card.raw["entity"]?.jsonPrimitive?.content
         val entity = entityId?.let { snapshot.states[it] }
-        val name = card.raw["name"]?.jsonPrimitive?.content
-            ?: entity?.attributes?.get("friendly_name")?.jsonPrimitive?.content
-            ?: entityId
-            ?: "Sensor"
         val hours = card.raw["hours_to_show"]?.jsonPrimitive?.content?.toIntOrNull() ?: 24
         val history = entityId?.let { snapshot.history[it].orEmpty() } ?: emptyList()
         val numeric = history.mapNotNull { it.state.toFloatOrNull() }
@@ -37,7 +71,7 @@ class SensorCardConverter : CardConverter {
         RemoteHaSensorCard(
             HaSensorCardData(
                 entityId = entityId,
-                name = name,
+                name = nameFor(card, snapshot),
                 valueLabel = formatState(entity),
                 accent = HaStateColor.activeFor(entity),
                 points = numeric,
@@ -45,5 +79,35 @@ class SensorCardConverter : CardConverter {
             ),
             modifier = modifier,
         )
+    }
+
+    /** Identity-tier payload shaped as [HaTileData] so the shared
+     *  [RemoteHaIconChip] can render the icon + live value. */
+    @Composable
+    private fun iconChipData(card: CardConfig, snapshot: HaSnapshot): HaTileData {
+        val entityId = card.raw["entity"]?.jsonPrimitive?.content
+        val entity = entityId?.let { snapshot.states[it] }
+        val accent = HaStateColor.activeFor(entity).rc
+        return HaTileData(
+            entityId = entityId,
+            name = nameFor(card, snapshot),
+            state = LiveValues.state(entityId, formatState(entity)),
+            icon = HaIconMap.resolve(card.raw["icon"]?.jsonPrimitive?.content, entity),
+            accent =
+                HaToggleAccent(
+                    activeAccent = accent,
+                    inactiveAccent = accent,
+                    toggleable = false,
+                ),
+        )
+    }
+
+    private fun nameFor(card: CardConfig, snapshot: HaSnapshot): String {
+        val entityId = card.raw["entity"]?.jsonPrimitive?.content
+        val entity = entityId?.let { snapshot.states[it] }
+        return card.raw["name"]?.jsonPrimitive?.content
+            ?: entity?.attributes?.get("friendly_name")?.jsonPrimitive?.content
+            ?: entityId
+            ?: "Sensor"
     }
 }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/StatisticCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/StatisticCardConverter.kt
@@ -1,15 +1,27 @@
+@file:Suppress("RestrictedApi")
+
 package ee.schimke.ha.rc.cards
 
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.fillMaxSize
+import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
+import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.runtime.Composable
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.CardSizeMode
 import ee.schimke.ha.rc.HaStateColor
+import ee.schimke.ha.rc.LocalCardSizeMode
+import ee.schimke.ha.rc.RemoteSizeBreakpoint
 import ee.schimke.ha.rc.components.HaStatisticCardData
+import ee.schimke.ha.rc.components.HaTileData
+import ee.schimke.ha.rc.components.HaToggleAccent
 import ee.schimke.ha.rc.components.LiveValues
+import ee.schimke.ha.rc.components.RemoteHaIconChip
 import ee.schimke.ha.rc.components.RemoteHaStatisticCard
+import ee.schimke.ha.rc.icons.HaIconMap
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
@@ -18,6 +30,13 @@ import kotlinx.serialization.json.jsonPrimitive
  * aggregates the configured `stat_type` over the snapshot's window.
  * Falls back to the entity's current state when there's no statistic
  * data — keeps the card useful even before recorder backfill.
+ *
+ * In [CardSizeMode.Fixed] the converter runs the shared icon-+-state
+ * ladder (adaptive-card-layouts.md §"Icon + state row/tile"): a narrow
+ * cell drops to the [RemoteHaIconChip] identity tier (tinted icon +
+ * value, name + period dropped), while the full [RemoteHaStatisticCard]
+ * keeps the trend + period and is [CenteredCell]-wrapped so a tall cell
+ * fills rather than top-glues.
  */
 class StatisticCardConverter : CardConverter {
     override val cardType: String = CardTypes.STATISTIC
@@ -26,18 +45,81 @@ class StatisticCardConverter : CardConverter {
 
     @Composable
     override fun Render(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        when (LocalCardSizeMode.current) {
+            CardSizeMode.Wrap -> FullStatistic(card, snapshot, modifier)
+            CardSizeMode.Fixed ->
+                RemoteSizeBreakpoint(
+                    thresholdsDp = intArrayOf(96),
+                    modifier = modifier.fillMaxSize(),
+                ) { tier ->
+                    when (tier) {
+                        0 -> RemoteHaIconChip(iconChipData(card, snapshot), RemoteModifier.fillMaxSize())
+                        else ->
+                            CenteredCell { FullStatistic(card, snapshot, RemoteModifier.fillMaxWidth()) }
+                    }
+                }
+        }
+    }
+
+    @Composable
+    private fun FullStatistic(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
         val entityId = card.raw["entity"]?.jsonPrimitive?.content
         val entity = entityId?.let { snapshot.states[it] }
-        val name = card.raw["name"]?.jsonPrimitive?.content
-            ?: entity?.attributes?.get("friendly_name")?.jsonPrimitive?.content
-            ?: entityId
-            ?: "Statistic"
         val unit = entity?.attributes?.get("unit_of_measurement")?.jsonPrimitive?.content
         val statType = card.raw["stat_type"]?.jsonPrimitive?.content ?: "mean"
         val period = card.raw["period"]?.jsonPrimitive?.content?.let { p ->
             "${p.replaceFirstChar { it.uppercaseChar() }} • ${statType.replaceFirstChar { it.uppercaseChar() }}"
         }
 
+        RemoteHaStatisticCard(
+            HaStatisticCardData(
+                entityId = entityId,
+                name = nameFor(card, snapshot),
+                valueLabel = LiveValues.state(entityId, valueLabel(card, snapshot)),
+                unit = unit,
+                periodLabel = period,
+                accent = HaStateColor.activeFor(entity),
+            ),
+            modifier = modifier,
+        )
+    }
+
+    /** Identity-tier payload shaped as [HaTileData] so the shared
+     *  [RemoteHaIconChip] can render the icon + statistic value. */
+    @Composable
+    private fun iconChipData(card: CardConfig, snapshot: HaSnapshot): HaTileData {
+        val entityId = card.raw["entity"]?.jsonPrimitive?.content
+        val entity = entityId?.let { snapshot.states[it] }
+        val accent = HaStateColor.activeFor(entity).rc
+        return HaTileData(
+            entityId = entityId,
+            name = nameFor(card, snapshot),
+            state = LiveValues.state(entityId, valueLabel(card, snapshot)),
+            icon = HaIconMap.resolve(card.raw["icon"]?.jsonPrimitive?.content, entity),
+            accent =
+                HaToggleAccent(
+                    activeAccent = accent,
+                    inactiveAccent = accent,
+                    toggleable = false,
+                ),
+        )
+    }
+
+    private fun nameFor(card: CardConfig, snapshot: HaSnapshot): String {
+        val entityId = card.raw["entity"]?.jsonPrimitive?.content
+        val entity = entityId?.let { snapshot.states[it] }
+        return card.raw["name"]?.jsonPrimitive?.content
+            ?: entity?.attributes?.get("friendly_name")?.jsonPrimitive?.content
+            ?: entityId
+            ?: "Statistic"
+    }
+
+    /** Aggregate the configured `stat_type` over the snapshot window,
+     *  falling back to the entity's current state. */
+    private fun valueLabel(card: CardConfig, snapshot: HaSnapshot): String {
+        val entityId = card.raw["entity"]?.jsonPrimitive?.content
+        val entity = entityId?.let { snapshot.states[it] }
+        val statType = card.raw["stat_type"]?.jsonPrimitive?.content ?: "mean"
         val statistics = entityId?.let { snapshot.statistics[it].orEmpty() } ?: emptyList()
         val numericValue = if (statistics.isNotEmpty()) {
             val values = statistics.mapNotNull {
@@ -56,21 +138,9 @@ class StatisticCardConverter : CardConverter {
                 else -> values.average().takeIf { values.isNotEmpty() }
             }
         } else null
-        val valueLabel = numericValue?.let { formatValue(it) }
+        return numericValue?.let { formatValue(it) }
             ?: entity?.state?.takeUnless { it == "unknown" || it == "unavailable" }
             ?: "—"
-
-        RemoteHaStatisticCard(
-            HaStatisticCardData(
-                entityId = entityId,
-                name = name,
-                valueLabel = LiveValues.state(entityId, valueLabel),
-                unit = unit,
-                periodLabel = period,
-                accent = HaStateColor.activeFor(entity),
-            ),
-            modifier = modifier,
-        )
     }
 }
 

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/TileCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/TileCardConverter.kt
@@ -3,6 +3,7 @@
 package ee.schimke.ha.rc.cards
 
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.fillMaxSize
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
 import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.runtime.Composable
@@ -19,6 +20,7 @@ import ee.schimke.ha.rc.RemoteSizeBreakpoint
 import ee.schimke.ha.rc.components.HaTileData
 import ee.schimke.ha.rc.components.HaToggleAccent
 import ee.schimke.ha.rc.components.LiveValues
+import ee.schimke.ha.rc.components.RemoteHaIconChip
 import ee.schimke.ha.rc.components.RemoteHaTile
 import ee.schimke.ha.rc.defaultTapActionFor
 import ee.schimke.ha.rc.formatState
@@ -32,9 +34,16 @@ import kotlinx.serialization.json.jsonPrimitive
  *
  * In [CardSizeMode.Wrap] the card always renders the full HA-style tile.
  * In [CardSizeMode.Fixed] (launcher / wear widgets) the converter wraps
- * its output in a [RemoteSizeBreakpoint] so the runtime swaps to a
- * compact "state-only" chip on narrow surfaces (< 120 dp); above that
- * the widget shows the same tile as wrap mode.
+ * its output in a [RemoteSizeBreakpoint] icon-+-state ladder
+ * (adaptive-card-layouts.md §"Icon + state row/tile"):
+ *
+ *   * **Narrow** (`w < 96 dp`, e.g. a `1×1` launcher cell) →
+ *     [RemoteHaIconChip], the tinted state icon centred over a single
+ *     state line. Keeps the icon identity at the smallest size instead
+ *     of dropping to a bare text chip (Principle 1).
+ *   * **Full** (otherwise) → the HA-reference [RemoteHaTile], wrapped in
+ *     [CenteredCell] so a tall cell (`3×2`) centres the row rather than
+ *     gluing it to the top over a blank half (Principles 7–8).
  */
 class TileCardConverter : CardConverter {
     override val cardType: String = CardTypes.TILE
@@ -50,12 +59,12 @@ class TileCardConverter : CardConverter {
             CardSizeMode.Wrap -> FullTile(card, snapshot, modifier)
             CardSizeMode.Fixed ->
                 RemoteSizeBreakpoint(
-                    thresholdsDp = intArrayOf(120),
-                    modifier = modifier,
+                    thresholdsDp = intArrayOf(96),
+                    modifier = modifier.fillMaxSize(),
                 ) { tier ->
                     when (tier) {
-                        0 -> CompactStateChip(card, snapshot)
-                        else -> FullTile(card, snapshot, RemoteModifier.fillMaxWidth())
+                        0 -> RemoteHaIconChip(tileData(card, snapshot), RemoteModifier.fillMaxSize())
+                        else -> CenteredCell { FullTile(card, snapshot, RemoteModifier.fillMaxWidth()) }
                     }
                 }
         }
@@ -63,6 +72,11 @@ class TileCardConverter : CardConverter {
 
     @Composable
     private fun FullTile(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        RemoteHaTile(tileData(card, snapshot), modifier = modifier)
+    }
+
+    @Composable
+    private fun tileData(card: CardConfig, snapshot: HaSnapshot): HaTileData {
         val entityId = card.raw["entity"]?.jsonPrimitive?.content
         val entity = entityId?.let { snapshot.states[it] }
         val name =
@@ -75,22 +89,19 @@ class TileCardConverter : CardConverter {
             if (tapCfg != null) parseHaAction(tapCfg, entityId) else defaultTapActionFor(entityId)
         val isActive = entity?.toTyped()?.isActive
 
-        RemoteHaTile(
-            HaTileData(
-                entityId = entityId,
-                name = name,
-                state = LiveValues.state(entityId, formatState(entity)),
-                icon = HaIconMap.resolve(card.raw["icon"]?.jsonPrimitive?.content, entity),
-                accent =
-                    HaToggleAccent(
-                        activeAccent = HaStateColor.activeFor(entity).rc,
-                        inactiveAccent = HaStateColor.inactiveFor(entity).rc,
-                        initiallyOn = isActive ?: false,
-                        toggleable = isActive != null,
-                    ),
-                tapAction = tapAction,
-            ),
-            modifier = modifier,
+        return HaTileData(
+            entityId = entityId,
+            name = name,
+            state = LiveValues.state(entityId, formatState(entity)),
+            icon = HaIconMap.resolve(card.raw["icon"]?.jsonPrimitive?.content, entity),
+            accent =
+                HaToggleAccent(
+                    activeAccent = HaStateColor.activeFor(entity).rc,
+                    inactiveAccent = HaStateColor.inactiveFor(entity).rc,
+                    initiallyOn = isActive ?: false,
+                    toggleable = isActive != null,
+                ),
+            tapAction = tapAction,
         )
     }
 }


### PR DESCRIPTION
Replace the Full↔CompactStateChip text fallback with a shared
RemoteHaIconChip identity tier so the smallest launcher cell keeps the
tinted state icon instead of a bare value (Principle 1, "identity before
density"). Self-centre the Full tier so tall cells fill rather than
top-glue (Principles 7–8): box-rooted tiles/statistic/sensor via a
CenteredCell weighted-spacer column, the entity row via fillMaxSize +
its own CenterVertically. sensor and statistic adopt the ladder
(icon chip ↔ full sparkline / value); entity base drops 3×1 → 2×1 so the
matrix +1 neighbour isn't mostly empty.

Adds CardPreviewMatrix_Sensor / _Statistic and documents the alpha010
state-layout constraints that shaped the chip (static accent + no
clipped circle, since a duplicate named RemoteBoolean or a clipped
background box in a sibling branch blanks the visible tier) and the
row-vs-box centring split.

Closes #351