### PR TITLE
fix(widget): grow multi-entity strip into a grid that fills the cell

### DIFF
--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviewMatrix.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviewMatrix.kt
@@ -48,6 +48,7 @@ import ee.schimke.ha.rc.androidXExperimentalWrap
 import ee.schimke.ha.rc.cards.defaultRegistry
 import ee.schimke.ha.rc.components.HaTheme
 import ee.schimke.ha.rc.components.ProvideCardChrome
+import ee.schimke.ha.rc.components.ProvideFlowLayoutSupport
 import ee.schimke.ha.rc.components.ProvideHaTheme
 import ee.schimke.ha.rc.components.RemoteHaWidgetSurface
 import ee.schimke.ha.rc.enableRemoteComposeWrapContent
@@ -373,12 +374,21 @@ private fun WatchFaceCell(
                             ProvideHaTheme(HaTheme.Dark) {
                                 ProvideCardSizeMode(CardSizeMode.Fixed) {
                                     ProvideCardChrome(enabled = false) {
-                                        RemoteHaWidgetSurface {
-                                            RenderChild(
-                                                card,
-                                                snapshot,
-                                                RemoteModifier.rcFillMaxWidth(),
-                                            )
+                                        // Mirror the real Glance Wear slot
+                                        // surface, which disables FlowLayout
+                                        // (its capture profile rejects op
+                                        // 240); cards then take their
+                                        // non-wrapping compact path here too,
+                                        // so the matrix wear cells show what
+                                        // the watch actually draws.
+                                        ProvideFlowLayoutSupport(enabled = false) {
+                                            RemoteHaWidgetSurface {
+                                                RenderChild(
+                                                    card,
+                                                    snapshot,
+                                                    RemoteModifier.rcFillMaxWidth(),
+                                                )
+                                            }
                                         }
                                     }
                                 }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaGlance.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaGlance.kt
@@ -12,6 +12,8 @@ import androidx.compose.remote.creation.compose.layout.RemoteRow
 import androidx.compose.remote.creation.compose.layout.RemoteText
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.clickable
+import androidx.compose.remote.creation.compose.modifier.fillMaxHeight
+import androidx.compose.remote.creation.compose.modifier.fillMaxSize
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
 import androidx.compose.remote.creation.compose.modifier.padding
 import androidx.compose.remote.creation.compose.modifier.size
@@ -27,20 +29,46 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.wear.compose.remote.material3.RemoteIcon
 
 /**
+ * Maximum number of cells the non-wrapping fallback row keeps. On
+ * surfaces whose capture profile rejects `FlowLayout` (Glance Wear) the
+ * cells can't wrap, so packing every entity into one row overflows the
+ * narrow watch slot — names collide and the last cell spills off the
+ * edge. Cap to the first few that fit cleanly; the watch slot's job is
+ * a deliberate compact glance, not the whole list.
+ */
+private const val CompactRowMaxCells = 3
+
+/**
  * HA `glance` card — title header over a flow-row of compact entity
  * cells. Matches `hui-glance-card.ts` visually.
+ *
+ * When [fillHeight] is set (Fixed-mode widget / Wear slot, where the
+ * host pins a canvas taller than one row of cells) the card fills the
+ * whole cell and distributes the cell grid down it — a single row
+ * centres, extra rows space out to fill — instead of gluing one row to
+ * the top over a blank half-cell (Principle 8, "no dead space"). The
+ * title is retained in this tier (cheap P2) rather than dropped.
  */
 @Composable
 @RemoteComposable
-fun RemoteHaGlance(data: HaGlanceData, modifier: RemoteModifier = RemoteModifier) {
+fun RemoteHaGlance(
+    data: HaGlanceData,
+    modifier: RemoteModifier = RemoteModifier,
+    fillHeight: Boolean = false,
+) {
     val theme = haTheme()
+    val supportsFlow = LocalSupportsFlowLayout.current
+    val cells = if (supportsFlow) data.cells else data.cells.take(CompactRowMaxCells)
     RemoteBox(
         modifier = modifier
             .fillMaxWidth()
+            .then(if (fillHeight) RemoteModifier.fillMaxHeight() else RemoteModifier)
             .then(cardChrome(theme.cardBackground, theme.divider))
             .padding(horizontal = 12.rdp, vertical = 10.rdp),
     ) {
-        RemoteColumn {
+        RemoteColumn(
+            modifier = if (fillHeight) RemoteModifier.fillMaxSize() else RemoteModifier,
+        ) {
             if (data.title != null) {
                 RemoteText(
                     text = data.title.rs,
@@ -53,30 +81,57 @@ fun RemoteHaGlance(data: HaGlanceData, modifier: RemoteModifier = RemoteModifier
                 )
                 RemoteBox(modifier = RemoteModifier.padding(top = 6.rdp))
             }
-            // HA's glance spaces cells evenly across the card width.
-            // FlowRow handles wrapping when more cells arrive than fit
-            // the row; within each row, distribute the cells using
-            // SpaceEvenly instead of packing them to the start. On
-            // surfaces whose capture profile rejects FlowLayout
-            // (Glance Wear), fall back to a non-wrapping RemoteRow —
-            // cells overflow visually on a narrow watch slot, but the
-            // composition captures instead of throwing.
-            if (LocalSupportsFlowLayout.current) {
-                RemoteFlowRow(
-                    modifier = RemoteModifier.fillMaxWidth(),
-                    horizontalArrangement = RemoteArrangement.SpaceEvenly,
-                    verticalArrangement = RemoteArrangement.spacedBy(6.rdp),
+            // The cell grid occupies the rest of the cell. When the host
+            // pins extra height (fillHeight) wrap the grid in a weighted
+            // column that claims the leftover space and centres its
+            // content — so a short grid sits in the middle of the cell
+            // rather than glued under the title (Principle 8). Centring
+            // has to live inside this weighted filler that arranges its
+            // own child; a wrapper alignment is a no-op for a wrap-height
+            // child in alpha010 (#224, Known gap 6 — same reason the
+            // arc-dial Wide row fills and self-centres internally).
+            if (fillHeight) {
+                RemoteColumn(
+                    modifier = RemoteModifier.fillMaxWidth().weight(1f),
+                    verticalArrangement = RemoteArrangement.Center,
                 ) {
-                    data.cells.forEach { cell -> RemoteHaGlanceCell(cell) }
+                    CellGrid(supportsFlow, cells)
                 }
             } else {
-                RemoteRow(
-                    modifier = RemoteModifier.fillMaxWidth(),
-                    horizontalArrangement = RemoteArrangement.SpaceEvenly,
-                ) {
-                    data.cells.forEach { cell -> RemoteHaGlanceCell(cell) }
-                }
+                CellGrid(supportsFlow, cells)
             }
+        }
+    }
+}
+
+/**
+ * The row/grid of glance cells. HA's glance spaces cells evenly across
+ * the card width. [RemoteFlowRow] handles wrapping when more cells
+ * arrive than fit the row; within each row, cells are distributed
+ * [SpaceEvenly][RemoteArrangement.SpaceEvenly] rather than packed to the
+ * start. On surfaces whose capture profile rejects FlowLayout (Glance
+ * Wear), fall back to a non-wrapping [RemoteRow] — the caller has
+ * already capped the cell count there so it reads as a tidy compact
+ * strip instead of overflowing the slot.
+ */
+@Composable
+@RemoteComposable
+private fun CellGrid(supportsFlow: Boolean, cells: List<HaGlanceCellData>) {
+    if (supportsFlow) {
+        RemoteFlowRow(
+            modifier = RemoteModifier.fillMaxWidth(),
+            horizontalArrangement = RemoteArrangement.SpaceEvenly,
+            verticalArrangement = RemoteArrangement.spacedBy(6.rdp),
+        ) {
+            cells.forEach { cell -> RemoteHaGlanceCell(cell) }
+        }
+    } else {
+        RemoteRow(
+            modifier = RemoteModifier.fillMaxWidth(),
+            horizontalArrangement = RemoteArrangement.SpaceEvenly,
+            verticalAlignment = RemoteAlignment.CenterVertically,
+        ) {
+            cells.forEach { cell -> RemoteHaGlanceCell(cell) }
         }
     }
 }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/EntitiesCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/EntitiesCardConverter.kt
@@ -1,6 +1,7 @@
 package ee.schimke.ha.rc.cards
 
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.fillMaxSize
 import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
 import androidx.compose.remote.creation.compose.state.rc
 import androidx.compose.runtime.Composable
@@ -20,6 +21,7 @@ import ee.schimke.ha.rc.components.HaGlanceCellData
 import ee.schimke.ha.rc.components.HaGlanceData
 import ee.schimke.ha.rc.components.HaToggleAccent
 import ee.schimke.ha.rc.components.LiveValues
+import ee.schimke.ha.rc.components.LocalSupportsFlowLayout
 import ee.schimke.ha.rc.components.RemoteHaEntities
 import ee.schimke.ha.rc.components.RemoteHaGlance
 import ee.schimke.ha.rc.defaultTapActionFor
@@ -51,53 +53,71 @@ class EntitiesCardConverter : CardConverter {
         when (LocalCardSizeMode.current) {
             CardSizeMode.Wrap -> FullList(card, snapshot, modifier, maxRows = Int.MAX_VALUE)
             CardSizeMode.Fixed ->
-                // Width-axis reflow: as the widget is dragged wider, the
-                // vertical column of rows repacks into a horizontal strip
-                // of icon cells ("column of N rows -> row of N icons").
-                //
-                // Width, not height, for two reasons: (1) it's the axis
-                // every Fixed-mode surface pins (the matrix preview and
-                // the launcher both fix width and let height follow), so
-                // the gate fires consistently and is reviewable in the
-                // matrix; a height gate reads an unstable wrap-height
-                // there. (2) SINGLE threshold — a multi-rung ladder lowers
-                // to nested RemoteStateLayouts, which alpha010 collapses
-                // to tier 0 at playback (#224, see GaugeCardConverter).
-                RemoteSizeBreakpoint(
-                    thresholdsDp = intArrayOf(260),
-                    modifier = modifier,
-                    axis = BreakpointAxis.Width,
-                ) { tier ->
-                    when (tier) {
-                        // Tier 0 (w < 260): the natural vertical list, same
-                        // as Wrap — narrow cells stack rows.
-                        0 ->
-                            FullList(
-                                card,
-                                snapshot,
-                                RemoteModifier.fillMaxWidth(),
-                                maxRows = Int.MAX_VALUE,
-                                forceTitle = true,
-                            )
-                        // Tier 1 (w >= 260): wide enough to lay the
-                        // entities out side by side — reflow into a strip
-                        // of icon | name | state cells. Each cell keeps its
-                        // identity, so nothing is dropped, just repacked.
-                        else -> IconStrip(card, snapshot, RemoteModifier.fillMaxWidth())
+                // Glance Wear slots are short-and-wide and reject
+                // FlowLayout: a vertical list of rows overflows the slot
+                // (rows collide off the bottom edge). Reflow straight to
+                // the capped icon strip — the watch's "single row of the
+                // first N icons" compact tier — without a live
+                // breakpoint. The launcher, which supports flow, keeps
+                // the width gate below.
+                if (!LocalSupportsFlowLayout.current) {
+                    IconStrip(card, snapshot, modifier.fillMaxSize())
+                } else {
+                    // Width-axis reflow: as the widget is dragged wider,
+                    // the vertical column of rows repacks into a grid of
+                    // icon cells ("column of N rows -> grid of N icons").
+                    //
+                    // Width, not height, for two reasons: (1) it's the
+                    // axis every Fixed-mode surface pins (the matrix
+                    // preview and the launcher both fix width and let
+                    // height follow), so the gate fires consistently and
+                    // is reviewable in the matrix; a height gate reads an
+                    // unstable wrap-height there. (2) SINGLE threshold — a
+                    // multi-rung ladder lowers to nested
+                    // RemoteStateLayouts, which alpha010 collapses to tier
+                    // 0 at playback (#224, see GaugeCardConverter). The
+                    // grid self-fills the large end (it grows rows to fill
+                    // the cell height), so no second gate is needed.
+                    RemoteSizeBreakpoint(
+                        thresholdsDp = intArrayOf(260),
+                        modifier = modifier,
+                        axis = BreakpointAxis.Width,
+                    ) { tier ->
+                        when (tier) {
+                            // Tier 0 (w < 260): the natural vertical list,
+                            // same as Wrap — narrow cells stack rows.
+                            0 ->
+                                FullList(
+                                    card,
+                                    snapshot,
+                                    RemoteModifier.fillMaxWidth(),
+                                    maxRows = Int.MAX_VALUE,
+                                    forceTitle = true,
+                                )
+                            // Tier 1 (w >= 260): wide enough to lay the
+                            // entities out side by side — reflow into a
+                            // grid of icon | name | state cells that fills
+                            // the cell height. Each cell keeps its
+                            // identity, so nothing is dropped, just
+                            // repacked.
+                            else -> IconStrip(card, snapshot, RemoteModifier.fillMaxSize())
+                        }
                     }
                 }
         }
     }
 
     /**
-     * Wide-thin reflow: the same entities, repacked as a horizontal
-     * strip of [RemoteHaGlance] icon cells instead of a vertical list.
-     * Reuses the glance component so the cells match the `glance` card
-     * exactly. Title chrome is dropped — at this height the strip is
-     * all that fits.
+     * Reflow tier: the same entities, repacked as a [RemoteHaGlance] grid
+     * of icon cells instead of a vertical list. Reuses the glance
+     * component so the cells match the `glance` card exactly and the
+     * whole multi-entity family shares one reflow. The title is retained
+     * (cheap P2) and the grid fills the cell height rather than gluing a
+     * single row to the top over a blank half-cell (Principle 8).
      */
     @Composable
     private fun IconStrip(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
+        val title = card.raw["title"]?.jsonPrimitive?.content
         val entries: List<JsonElement> = card.raw["entities"]?.jsonArray ?: emptyList()
         val cells =
             entries.mapNotNull { el ->
@@ -127,7 +147,11 @@ class EntitiesCardConverter : CardConverter {
                     tapAction = tapAction,
                 )
             }
-        RemoteHaGlance(HaGlanceData(title = null, cells = cells), modifier = modifier)
+        RemoteHaGlance(
+            HaGlanceData(title = title, cells = cells),
+            modifier = modifier,
+            fillHeight = true,
+        )
     }
 
     @Composable

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/GlanceCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/GlanceCardConverter.kt
@@ -8,7 +8,9 @@ import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
 import ee.schimke.ha.model.toTyped
 import ee.schimke.ha.rc.CardConverter
+import ee.schimke.ha.rc.CardSizeMode
 import ee.schimke.ha.rc.HaStateColor
+import ee.schimke.ha.rc.LocalCardSizeMode
 import ee.schimke.ha.rc.components.HaGlanceCellData
 import ee.schimke.ha.rc.components.HaGlanceData
 import ee.schimke.ha.rc.components.HaToggleAccent
@@ -70,7 +72,17 @@ class GlanceCardConverter : CardConverter {
                     tapAction = tapAction,
                 )
             }
-        RemoteHaGlance(HaGlanceData(title = title, cells = cells), modifier = modifier)
+        // In Fixed mode (launcher widget / Wear slot) the host pins a
+        // canvas taller than one row of cells; fill it (grid grows / row
+        // centres) instead of gluing the cells to the top over a blank
+        // half-cell. In Wrap mode (dashboard) the card flows to its
+        // content height, matching the HA reference.
+        val fillHeight = LocalCardSizeMode.current == CardSizeMode.Fixed
+        RemoteHaGlance(
+            HaGlanceData(title = title, cells = cells),
+            modifier = modifier,
+            fillHeight = fillHeight,
+        )
     }
 
     private fun normalize(el: JsonElement): Pair<String?, JsonObject?> = when (el) {


### PR DESCRIPTION
The Fixed-mode `entities` strip and the `glance` card rendered a single
row of cells glued to the top of the widget cell, leaving ~70% of a
4×3 / 5×4 cell blank, and dropped the card title in the strip tier. On
the short Glance Wear slot the vertical list / non-wrapping row
overflowed — rows collided off the bottom edge and a stray icon showed.

- `RemoteHaGlance` gains a `fillHeight` mode: it fills the cell and
  centres the cell grid in the space below the title (via a weighted
  inner column that arranges its own child — a wrapper alignment is a
  no-op for a wrap-height child in alpha010). The title is retained.
  The non-wrapping Wear fallback now caps to the first few cells that
  fit, so the watch slot reads as a deliberate compact strip.
- `EntitiesCardConverter` keeps the title in the reflow tier and routes
  the FlowLayout-less Wear slot straight to the capped icon strip
  instead of a clipped vertical list. The launcher keeps its single
  width@260 list↔grid breakpoint; the grid self-fills the large end.
- `GlanceCardConverter` fills the cell in Fixed mode.
- The preview matrix's Wear cells now disable FlowLayout to mirror the
  real Glance Wear surface, so the matrix shows what the watch draws.

Closes #354