### PR TITLE
fix(gauge): unblock and unify the arc-dial family (#353)

### DIFF
--- a/docs/architecture/adaptive-card-layouts.md
+++ b/docs/architecture/adaptive-card-layouts.md
@@ -467,17 +467,19 @@ and is reused. The families today:
 |---|---|---|---|---|
 | **Icon + state row/tile** | tinted icon | `tile`, `entity`, `sensor`, `statistic` | `RemoteHaTile`, `RemoteHaEntityRow` | tile/entity: `Full↔CompactStateChip`; sensor/statistic: none |
 | **Icon-centred button** | large tinted icon | `button` | `RemoteHaButton` / `RemoteHaToggleButton` | `Full↔CompactStateChip` |
-| **Arc-dial control** | the arc/dial | `gauge`, `thermostat`, `humidifier`, `light` | `RemoteHaGauge*`, `RemoteHaArcDial*`, `RenderArcDial` | thermostat/humidifier/gauge: Wide↔Full; `light`: **none (outlier)** |
+| **Arc-dial control** | the arc/dial | `gauge`, `thermostat`, `humidifier`, `light` | `RemoteHaGauge*`, `RemoteHaArcDial*`, `RenderArcDial` | thermostat/humidifier/light: Wide↔Full (width); gauge: Wide↔Stacked (height) — all via shared `RemoteSizeBreakpoint` |
 | **Multi-entity list/strip** | first row/cell | `entities`, `glance`, `area`, `picture-glance`, `entity-filter`, `*-stack` | `RemoteHaEntities`, `RemoteHaGlance` | entities: `list↔strip`; others: none |
 | **Hero + supporting detail** | condition/art/shield + value | `weather-forecast`, `media-control`, `alarm-panel` | `RemoteHaWeatherForecast*`, `RemoteHaMediaControl`, `RemoteHaAlarmPanel` | weather: `Full↔Wide`; others: none |
 | **Bulk / time-series** | spark/list head | `history-graph`, `statistics-graph`, `logbook`, `todo-list`, `calendar`, `markdown` | per-card | none — Wear `SmallOnly` |
 | **Picture / image** | the image | `picture`, `picture-entity`, `picture-elements` | `RemoteHaImage*` | none |
 
-The "Arc-dial control" family is the reference implementation: a single
-`RenderArcDial` width-ladder gives thermostat and humidifier a clean
-Wide-row↔Full-card transition with the dial retained at every size. The
-open work is bringing the other families up to that bar — see the
-per-family issues.
+The "Arc-dial control" family is the reference implementation. The shared
+`RenderArcDial` width-ladder gives thermostat, humidifier, and `light` a
+clean Wide-row↔Full-card transition with the dial retained at every size;
+`gauge` rides the same `RemoteSizeBreakpoint` helper on the height axis
+(Wide↔Stacked) so it inherits the `immediateSwap` overlay workaround
+rather than a hand-rolled `RemoteStateLayout`. The open work is bringing
+the other families up to that bar — see the per-family issues.
 
 ## Anti-patterns
 
@@ -549,21 +551,28 @@ The current state is the placeholder, not the philosophy:
    `contentAlignment = Center` on a wrapper `RemoteBox` — in alpha010 a
    `fillMaxWidth` (wrap-height) child is still pinned to the top of a
    centring box, so a wrapper-level alignment is a no-op (verified by
-   re-rendering tile/entity/button/entities — pixel-identical). The
-   arc-dial cards only _look_ centred because `RemoteHaArcDialWide`
-   itself `fillMaxSize`s and centres its content **internally**. So the
-   "fill the cell" work is per-tier-composable (each variant must fill
-   and self-centre, like the arc-dial Wide row), not a one-line wrapper
-   change. Tracked per layout family in the design-review issues.
-7. **`light` is outside the arc-dial family.** `thermostat` and
-   `humidifier` route through `RenderArcDial` and get the Wide↔Full
-   ladder + dial retention for free; `LightCardConverter` calls
-   `RemoteHaArcDial` directly with no `CardSizeMode` branch, so it never
-   reflows or degrades. It should join the shared `RenderArcDial` path.
-8. **Gauge matrix shows the #309 overlay artifact.** The Wear L /
-   widget cells render both `RemoteHaGaugeWide` and
-   `RemoteHaGaugeStacked` on top of each other (double value + double
-   arc). This is the alpha010 `RemoteStateLayout` overlay bug (#309),
-   not a layout-design fault, but it makes the gauge family un-reviewable
-   in the matrix until the visibility-modifier workaround there is
-   re-confirmed against the current alpha.
+   re-rendering tile/entity/button/entities — pixel-identical). This bites
+   the arc-dial Wide row too: on a tall cell (e.g. `3×3`)
+   `RemoteHaArcDialWide` sits high with dead space below, and it can't be
+   retrofitted to self-centre — a `RemoteRow`/`RemoteColumn` doesn't
+   propagate fill-height through the breakpoint, and a `fillMaxSize`
+   `RemoteBox` wrapper with `contentAlignment = Center` is the same
+   no-op (all three confirmed by re-render in #353). A `RemoteBox` that
+   fills *and self-positions its own drawing* (e.g. `RemoteHaGaugeStacked`,
+   which paints an arc backdrop and bottom-aligns its overlay) is the only
+   shape that fills today. So the "fill the cell" work is
+   per-tier-composable and currently blocked on an upstream
+   `RemoteStateLayout`/fill fix. Tracked per layout family in the
+   design-review issues.
+7. ~~**`light` is outside the arc-dial family.**~~ **Resolved.** `light`
+   routes through the shared `RenderArcDial` ladder (Wide↔Full) with the
+   bulb-ring dial retained at every size, and the on/off mode chip is a
+   `Static` chip (a `Toggle` chip's nested `RemoteStateLayout` collapses
+   to its captured branch inside the Fixed-mode breakpoint — #224 — which
+   painted "Off" over the bulb on the full tier).
+8. ~~**Gauge matrix shows the #309 overlay artifact.**~~ **Resolved.**
+   `GaugeCardConverter` no longer hand-rolls a `RemoteStateLayout`; it
+   routes through the shared `RemoteSizeBreakpoint` (height axis), so it
+   inherits the `immediateSwap` workaround and the Wear L / widget cells
+   render a single tier instead of double-painting `RemoteHaGaugeWide`
+   over `RemoteHaGaugeStacked`.

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaArcDial.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaArcDial.kt
@@ -122,6 +122,14 @@ fun RemoteHaArcDialWide(
     val theme = haTheme()
     val click =
         data.tapAction.toRemoteAction()?.let { RemoteModifier.clickable(it) } ?: RemoteModifier
+    // NB: on tall cells (e.g. 3×3) this row sits high with dead space
+    // below — it can't self-centre. A `RemoteRow`/`RemoteColumn` doesn't
+    // propagate fill-height through the Fixed-mode size breakpoint, and a
+    // `fillMaxSize` `RemoteBox` wrapper with `contentAlignment = Center`
+    // is a no-op for a `fillMaxWidth` child in this alpha (the same
+    // RemoteStateLayout/fill limitation tracked as known-gap #6 in
+    // docs/architecture/adaptive-card-layouts.md). Left as-is until the
+    // upstream fix lands.
     RemoteRow(
         modifier =
             modifier
@@ -246,6 +254,11 @@ private fun ModeChip(chip: HaModeChip?, accent: Color) {
         is HaModeChip.Static ->
             ChipText(LiveValues.attribute(chip.entityId, chip.attribute, chip.initial), accent)
         is HaModeChip.Toggle -> {
+            // NB: a `RemoteStateLayout` here collapses to its captured
+            // branch when nested inside a Fixed-mode size breakpoint
+            // (#224), so callers that render through `RenderArcDial`
+            // should prefer [HaModeChip.Static]. This live-boolean form
+            // is correct only for the un-nested (Wrap) full card.
             val isOn = LiveValues.isOn(chip.entityId, chip.initiallyOn)
             if (isOn != null) {
                 RemoteStateLayout(isOn) { on ->

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteStateLayoutSwap.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteStateLayoutSwap.kt
@@ -1,0 +1,47 @@
+@file:Suppress("RestrictedApi")
+
+package ee.schimke.ha.rc.components
+
+import androidx.compose.remote.core.operations.layout.animation.AnimationSpec
+import androidx.compose.remote.creation.compose.modifier.RemoteModifier
+import androidx.compose.remote.creation.compose.modifier.animationSpec
+
+/**
+ * Pin a `RemoteStateLayout` branch's enter/exit animation to zero
+ * duration so the swap between branches is immediate.
+ *
+ * The default `RemoteStateLayout` transition is a 300 ms
+ * FADE_IN/FADE_OUT cross-fade. Two failure modes ride on that window
+ * (the alpha #309 overlay bug):
+ *
+ *   * the in-process preview player captures a frame mid-fade, leaving
+ *     the outgoing branch half-visible behind the incoming one (the
+ *     "ghosting"); and
+ *   * for branches whose root layout-manager has a non-null
+ *     `mAnimateMeasure`, `checkEndOfTransition()` never clears
+ *     `inTransition`, so the overlay paints on every frame and the
+ *     previous branch's contents bleed through permanently.
+ *
+ * Zeroing both the motion and visibility durations removes the
+ * cross-fade window and the branch-root measure animation, so only the
+ * selected branch is ever drawn. Apply it to the immediate child of
+ * each `RemoteStateLayout` branch.
+ *
+ * NB: we deliberately do *not* gate the branch with `alpha(select(…))`
+ * — the derived float doesn't reliably materialise in the current alpha
+ * (#224), which blanks the *selected* branch too.
+ *
+ * Shared by [androidx.compose.remote] Fixed-mode size breakpoints
+ * (`RemoteSizeBreakpoint`) and the arc-dial mode chip's on/off toggle.
+ */
+fun RemoteModifier.immediateSwap(): RemoteModifier =
+    animationSpec(
+        -1,
+        /* motionDuration = */ 0f,
+        /* motionEasingType = */ 1,
+        /* visibilityDuration = */ 0f,
+        /* visibilityEasingType = */ 1,
+        AnimationSpec.ANIMATION.FADE_IN,
+        AnimationSpec.ANIMATION.FADE_OUT,
+        true,
+    )

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/RemoteSizeBreakpoint.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/RemoteSizeBreakpoint.kt
@@ -2,12 +2,10 @@
 
 package ee.schimke.ha.rc
 
-import androidx.compose.remote.core.operations.layout.animation.AnimationSpec
 import androidx.compose.remote.creation.compose.layout.RemoteBox
 import androidx.compose.remote.creation.compose.layout.RemoteStateLayout
 import androidx.compose.remote.creation.compose.layout.RemoteText
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
-import androidx.compose.remote.creation.compose.modifier.animationSpec
 import androidx.compose.remote.creation.compose.state.RemoteFloat
 import androidx.compose.remote.creation.compose.state.RemoteState
 import androidx.compose.remote.creation.compose.state.rc
@@ -15,6 +13,7 @@ import androidx.compose.remote.creation.compose.state.rdp
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
+import ee.schimke.ha.rc.components.immediateSwap
 import java.text.DecimalFormat
 
 /**
@@ -194,29 +193,5 @@ private fun BreakpointTier(
         }
     }
 }
-
-/**
- * Pin a state-layout branch's enter/exit animation to zero duration so
- * the swap is immediate. The default `RemoteStateLayout` transition is
- * a 300 ms FADE_IN/FADE_OUT cross-fade; the in-process preview player
- * captures a frame mid-fade, leaving the outgoing branch half-visible
- * behind the incoming one (the "ghosting"). Zero duration removes the
- * cross-fade window so only the selected branch is ever drawn.
- *
- * NB: we deliberately do *not* gate the branch with `alpha(select(…))`
- * — the derived float doesn't reliably materialise in alpha010 (#224),
- * which blanks the *selected* branch too.
- */
-private fun RemoteModifier.immediateSwap(): RemoteModifier =
-    animationSpec(
-        -1,
-        /* motionDuration = */ 0f,
-        /* motionEasingType = */ 1,
-        /* visibilityDuration = */ 0f,
-        /* visibilityEasingType = */ 1,
-        AnimationSpec.ANIMATION.FADE_IN,
-        AnimationSpec.ANIMATION.FADE_OUT,
-        true,
-    )
 
 private const val BreakpointExpressionPrefix = "__terrazzo_breakpoint_"

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/GaugeCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/GaugeCardConverter.kt
@@ -2,26 +2,17 @@
 
 package ee.schimke.ha.rc.cards
 
-import androidx.compose.remote.creation.compose.layout.RemoteBox
-import androidx.compose.remote.creation.compose.layout.RemoteStateLayout
-import androidx.compose.remote.creation.compose.layout.RemoteText
 import androidx.compose.remote.creation.compose.modifier.RemoteModifier
 import androidx.compose.remote.creation.compose.modifier.fillMaxSize
-import androidx.compose.remote.creation.compose.modifier.fillMaxWidth
-import androidx.compose.remote.creation.compose.state.RemoteFloat
-import androidx.compose.remote.creation.compose.state.RemoteState
-import androidx.compose.remote.creation.compose.state.rc
-import androidx.compose.remote.creation.compose.state.rdp
-import androidx.compose.remote.creation.compose.state.rf
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.ui.graphics.Color
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.CardTypes
 import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.BreakpointAxis
 import ee.schimke.ha.rc.CardConverter
 import ee.schimke.ha.rc.CardSizeMode
 import ee.schimke.ha.rc.LocalCardSizeMode
+import ee.schimke.ha.rc.RemoteSizeBreakpoint
 import ee.schimke.ha.rc.components.HaGaugeData
 import ee.schimke.ha.rc.components.HaGaugeSeverity
 import ee.schimke.ha.rc.components.LiveValues
@@ -31,8 +22,6 @@ import ee.schimke.ha.rc.components.RemoteHaGaugeWide
 import ee.schimke.ha.rc.defaultTapActionFor
 import ee.schimke.ha.rc.formatState
 import ee.schimke.ha.rc.parseHaAction
-import java.text.DecimalFormat
-import java.util.UUID
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -58,16 +47,14 @@ import kotlinx.serialization.json.jsonPrimitive
  *     chip up to a 3×2 dashboard tile and Wear L. The secondary
  *     text lines ellipsise on cells that can't fit them.
  *
- * Tier selection uses `componentWidth()` and `componentHeight()` and
- * lowers to nested `RemoteStateLayout(RemoteBoolean)` (the only
- * state-layout overload that respects live state in alpha010 — see
- * [ee.schimke.ha.rc.RemoteSizeBreakpoint]). Both float expressions
- * are materialised via transparent text so the runtime resolves them
- * correctly (#224).
- *
- * 2-D gates are encoded as `min(w, h · minW/minH).ge(minW)` because
- * `RemoteBoolean.and()` doesn't materialise its operands in alpha010
- * and `.and()`-composed predicates collapse to `false` at playback.
+ * Tier selection runs through the shared
+ * [ee.schimke.ha.rc.RemoteSizeBreakpoint] on the **height** axis (the
+ * discriminating cell — the 200×60 Wear S slot — pins height). Going
+ * through the shared helper rather than a hand-rolled `RemoteStateLayout`
+ * is what gives the gauge the `immediateSwap` workaround for the #309
+ * overlay artifact; without it both tiers paint on top of each other
+ * (double arc + double value). A single threshold keeps it off the
+ * nested-state-layout collapse path (#224).
  */
 class GaugeCardConverter : CardConverter {
     override val cardType: String = CardTypes.GAUGE
@@ -84,45 +71,27 @@ class GaugeCardConverter : CardConverter {
 
     @Composable
     private fun AdaptiveGauge(card: CardConfig, snapshot: HaSnapshot, modifier: RemoteModifier) {
-        val widthName = remember { "__gauge_w_${UUID.randomUUID()}" }
-        val heightName = remember { "__gauge_h_${UUID.randomUUID()}" }
-        val widthExpr =
-            RemoteFloat.createNamedRemoteFloatExpression(widthName, RemoteState.Domain.User) {
-                componentWidth()
-            }
-        val heightExpr =
-            RemoteFloat.createNamedRemoteFloatExpression(heightName, RemoteState.Domain.User) {
-                componentHeight()
-            }
-        // Single height-only outer gate — short cells (Wear S) get
-        // the side-by-side Row, everything else gets the Stacked Box
-        // overlay. Nested inner state-layouts on width or a 2-D
-        // gate don't materialise reliably in alpha010 (#224); they
-        // collapse to false at playback, so a 1-D outer toggle is
-        // all we get for now.
-        val hasRoomForStacked = heightExpr.ge(MinStackedHeightDp.rdp.toPx())
-
-        RemoteBox(modifier = modifier.fillMaxSize()) {
-            // Materialise both named expressions in the document. The
-            // state-layouts below read them via derived booleans; the
-            // alpha010 quirk (#224) means the floats won't reach the
-            // captured doc unless something visible references them.
-            RemoteText(
-                text = widthExpr.toRemoteString(IntFormat),
-                color = Color.Transparent.rc,
-            )
-            RemoteText(
-                text = heightExpr.toRemoteString(IntFormat),
-                color = Color.Transparent.rc,
-            )
-
-            val data = gaugeData(card, snapshot)
-            RemoteStateLayout(hasRoomForStacked) { tall ->
-                if (tall) {
-                    RemoteHaGaugeStacked(data, RemoteModifier.fillMaxSize())
-                } else {
-                    RemoteHaGaugeWide(data, RemoteModifier.fillMaxSize())
-                }
+        val data = gaugeData(card, snapshot)
+        // Single height gate — short cells (Wear S) get the side-by-side
+        // Wide row, everything else gets the Stacked Box overlay. Routed
+        // through the shared [RemoteSizeBreakpoint] so the gauge inherits
+        // the arc-dial family's `immediateSwap` workaround for the #309
+        // overlay artifact (without it the raw `RemoteStateLayout` paints
+        // both the Wide and Stacked tiers on top of each other — double
+        // arc + double value — making the family un-reviewable).
+        //
+        // Height is the right axis here: the discriminating cell is the
+        // 200×60 Wear S slot, which pins height, unlike the width-pinned
+        // launcher reflows. A single threshold avoids the nested
+        // state-layout collapse (#224).
+        RemoteSizeBreakpoint(
+            thresholdsDp = intArrayOf(MinStackedHeightDp),
+            axis = BreakpointAxis.Height,
+            modifier = modifier.fillMaxSize(),
+        ) { tier ->
+            when (tier) {
+                0 -> RemoteHaGaugeWide(data, RemoteModifier.fillMaxSize())
+                else -> RemoteHaGaugeStacked(data, RemoteModifier.fillMaxSize())
             }
         }
     }
@@ -169,8 +138,6 @@ private fun gaugeData(card: CardConfig, snapshot: HaSnapshot): HaGaugeData {
         tapAction = tapAction,
     )
 }
-
-private val IntFormat = DecimalFormat("0")
 
 /**
  * HA's severity config is a map of `green` / `yellow` / `red` to numeric

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/LightCardConverter.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/cards/LightCardConverter.kt
@@ -49,20 +49,18 @@ class LightCardConverter : CardConverter {
         val fraction = if (isOn) (brightness ?: 255f) / 255f else 0f
         val accent = if (isOn) Color(0xFFFFBE3E) else Color(0xFFB0B0B0)
         val centerLabel = if (isOn) "${(fraction * 100f).toInt()}%" else "Off"
+        // Static chip (not Toggle): a `RemoteStateLayout`-backed Toggle
+        // chip nested inside the Fixed-mode `RenderArcDial` breakpoint
+        // collapses to its captured branch (#224), painting "Off" over
+        // the bulb on the full tier. Thermostat / humidifier use a Static
+        // chip for the same reason; the on/off label is baked at capture
+        // and refreshed on re-encode like every other arc-dial label.
         val modeChip =
-            if (entityId != null)
-                HaModeChip.Toggle(
-                    entityId = entityId,
-                    initiallyOn = isOn,
-                    onLabel = "On",
-                    offLabel = "Off",
-                )
-            else
-                HaModeChip.Static(
-                    entityId = null,
-                    attribute = "is_on_label",
-                    initial = if (isOn) "On" else "Off",
-                )
+            HaModeChip.Static(
+                entityId = entityId,
+                attribute = "is_on_label",
+                initial = if (isOn) "On" else "Off",
+            )
 
         val tap = entityId?.let { HaAction.Toggle(it) } ?: HaAction.None
         val (inc, dec) = brightnessSteppers(entityId, isOn, brightness)


### PR DESCRIPTION
Closes #353.

## Summary

Brings the **arc-dial control family** (`gauge`, `thermostat`, `humidifier`, `light`) to the reference bar and unblocks gauge sign-off.

- **Gauge #309 overlay — fixed (the blocker).** `GaugeCardConverter` hand-rolled a raw `RemoteStateLayout`, so it lacked the `immediateSwap` workaround and painted both `RemoteHaGaugeWide` *and* `RemoteHaGaugeStacked` on top of each other (double arc + double value at Wear L / Widget 2×1 / 3×2). It now routes through the shared `RemoteSizeBreakpoint` (height axis); every gauge cell renders a single clean tier.
- **Gauge unified into the shared ladder.** It rides the same `RemoteSizeBreakpoint` helper as thermostat/humidifier/light (same retention + overlay guarantees) instead of its own height gate. The 180° dial identity and severity bands are kept (folding gauge into the 270° `RenderArcDial` was the optional path and would lose those).
- **Light toggle chip — fixed.** At 4×4 the `Toggle` chip painted "Off" over the bulb: a nested `RemoteStateLayout` collapses to its captured branch inside the Fixed-mode breakpoint (#224). Light now uses a `Static` chip like thermostat/humidifier — the host only pushes `state`/`is_on`, so label strings are baked anyway.
- **`immediateSwap` extracted** into `rc-components` so the breakpoint and the arc-dial chip path can share it.
- **Docs** (`adaptive-card-layouts.md`): light marked in-family; the gauge-overlay and light-outlier known-gaps marked resolved; gap #6 corrected.

### Not fixed (documented)

The thermostat/humidifier/light **Wide row still sits high on tall cells (3×3)**. Three approaches were tried and re-rendered — breakpoint branch-box fill, state-layout fill, and a centring `RemoteBox` wrapper — none center a `fillMaxWidth` row in this alpha (the same `RemoteStateLayout`/fill limitation already tracked as known-gap #6). The ineffective attempts were reverted; the limitation is documented in code and `adaptive-card-layouts.md`, left for the upstream fix.

## Test plan

- `./gradlew :rc-converter:testDebugUnitTest :rc-components:testDebugUnitTest` — green.
- Re-rendered all 9 `CardPreviewMatrix_*` previews (compose-preview):
  - **Gauge**: no overlay at any size (App / Wear S / Wear L / 1×1 / 2×1 / 3×2).
  - **Light**: 4×4 shows "On" (no "Off" ghost); all Wide tiers clean.
  - **Tile / Entity / Button / Entities / Weather / Thermostat / Humidifier**: unchanged (no regression from the shared `RemoteSizeBreakpoint` refactor).


---
_Generated by [Claude Code](https://claude.ai/code/session_01EY9Cpi44c3ixHQirYrQkpk)_