### PR TITLE
chore(deps): update compose-ai-tools to 0.12.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       # render before `./gradlew test`. (The `compose-preview` workflow
       # still publishes baselines / PR comments separately; this step is
       # local to the test job and doesn't push anything.)
-      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.12.2
+      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.12.4
         with:
           version: catalog
           catalog-key: compose-preview-plugin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       # render before `./gradlew test`. (The `compose-preview` workflow
       # still publishes baselines / PR comments separately; this step is
       # local to the test job and doesn't push anything.)
-      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.12.1
+      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.12.2
         with:
           version: catalog
           catalog-key: compose-preview-plugin

--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.12.1
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.12.2
         with:
           cli-version: catalog
           catalog-key: compose-preview-plugin

--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.12.2
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.12.4
         with:
           cli-version: catalog
           catalog-key: compose-preview-plugin

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -147,7 +147,7 @@ dependencies {
   debugImplementation(libs.compose.ui.tooling)
   // Debug-only: @AnimatedPreview drives the compose-preview GIF capture
   // of the card-flash debug feature. Kept out of the release APK.
-  debugImplementation("ee.schimke.composeai:preview-annotations:0.12.2")
+  debugImplementation("ee.schimke.composeai:preview-annotations:0.12.4")
   implementation(libs.activity.compose)
   implementation(libs.materialkolor)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -147,7 +147,7 @@ dependencies {
   debugImplementation(libs.compose.ui.tooling)
   // Debug-only: @AnimatedPreview drives the compose-preview GIF capture
   // of the card-flash debug feature. Kept out of the release APK.
-  debugImplementation("ee.schimke.composeai:preview-annotations:0.12.1")
+  debugImplementation("ee.schimke.composeai:preview-annotations:0.12.2")
   implementation(libs.activity.compose)
   implementation(libs.materialkolor)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ indriya = "2.2.4"
 # of the plugin marker. The preview-baselines / preview-comment GitHub
 # Actions read this key (`catalog-key: compose-preview-plugin`) to pin
 # the CLI release they install on the runner.
-compose-preview-plugin = "0.12.1"
+compose-preview-plugin = "0.12.2"
 tapmoc = "0.4.2"
 
 # Image loading (BitmapLoader / RemoteCompose named-bitmap resolution)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ indriya = "2.2.4"
 # of the plugin marker. The preview-baselines / preview-comment GitHub
 # Actions read this key (`catalog-key: compose-preview-plugin`) to pin
 # the CLI release they install on the runner.
-compose-preview-plugin = "0.12.2"
+compose-preview-plugin = "0.12.4"
 tapmoc = "0.4.2"
 
 # Image loading (BitmapLoader / RemoteCompose named-bitmap resolution)


### PR DESCRIPTION
Bump the pinned compose-ai-tools release from 0.12.1 to 0.12.2 across
all four version pins:

- gradle/libs.versions.toml: compose-preview-plugin catalog version
- app/build.gradle.kts: preview-annotations debug dependency
- .github/workflows/ci.yml: install action ref
- .github/workflows/compose-preview.yml: apply action ref