### PR TITLE
test(app): add screen previews for settings, logs, pinned, wear & sync

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -69,6 +70,7 @@ import ee.schimke.terrazzo.dashboard.rememberDashboardListState
 import ee.schimke.terrazzo.dashboard.rememberSelectedDashboardListState
 import ee.schimke.terrazzo.discovery.DiscoveryScreen
 import ee.schimke.terrazzo.notifications.NotificationBell
+import ee.schimke.terrazzo.ui.statusColors
 import ee.schimke.terrazzo.wearsync.WearWidgetsScreen
 import ee.schimke.terrazzo.widget.WidgetInstallSheet
 import ee.schimke.terrazzo.widget.WidgetRefreshScheduler
@@ -631,15 +633,16 @@ private fun DashboardsRoot(
               },
               onClearAll = { scope.launch { runCatching { session.dismissAllNotifications() } } },
             )
+            val statusColor = connectionStatus.statusColor()
             Surface(
               onClick = onRetryConnection,
-              color = connectionStatus.color.copy(alpha = 0.16f),
+              color = statusColor.copy(alpha = 0.16f),
               shape = MaterialTheme.shapes.small,
               modifier = Modifier.padding(end = 8.dp),
             ) {
               Text(
                 text = connectionStatus.label,
-                color = connectionStatus.color,
+                color = statusColor,
                 style = MaterialTheme.typography.labelSmall,
                 modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp),
               )
@@ -650,7 +653,7 @@ private fun DashboardsRoot(
             ) {
               Text(
                 text = if (readOnly) "Read" else "Write",
-                color = if (readOnly) READ_ONLY_COLOR else WRITE_COLOR,
+                color = if (readOnly) statusColors.readOnly else statusColors.warning,
                 style = MaterialTheme.typography.labelSmall,
                 modifier = Modifier.padding(end = 4.dp),
               )
@@ -739,15 +742,23 @@ private const val DASHBOARD_UNSET = "__none__"
  */
 private const val RECONNECT_BACKOFF_MS = 5_000L
 
-enum class ConnectionStatus(val label: String, val color: Color) {
-  Failed("Failed", Color(0xFFD32F2F)),
-  Connecting("Connecting", Color(0xFF2E7D32)),
-  Connected("Connected", Color(0xFF1976D2)),
-  Disconnected("Paused", Color(0xFF757575)),
+enum class ConnectionStatus(val label: String) {
+  Failed("Failed"),
+  Connecting("Connecting"),
+  Connected("Connected"),
+  Disconnected("Paused"),
 }
 
-private val READ_ONLY_COLOR = Color(0xFF455A64)
-private val WRITE_COLOR = Color(0xFFE65100)
+/** Theme-aware chrome colour for the top-bar connection chip. */
+@Composable
+@ReadOnlyComposable
+private fun ConnectionStatus.statusColor(): Color =
+  when (this) {
+    ConnectionStatus.Failed -> statusColors.error
+    ConnectionStatus.Connecting -> statusColors.success
+    ConnectionStatus.Connected -> statusColors.info
+    ConnectionStatus.Disconnected -> statusColors.neutral
+  }
 
 private fun SessionConnectionStatus.toUiConnectionStatus(): ConnectionStatus =
   when (this) {

--- a/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/TerrazzoApp.kt
@@ -787,7 +787,7 @@ private fun initialDashboardToOpened(stored: String?): String? =
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun SettingsScreen(
+internal fun SettingsScreen(
   session: HaSession,
   onToggleDemo: (Boolean) -> Unit,
   onSignOut: () -> Unit,

--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/ManagePinnedScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/ManagePinnedScreen.kt
@@ -44,7 +44,6 @@ import kotlinx.coroutines.launch
  * Cards and sections share a single ordered list — the position here is the position the watch's
  * top-level nav will render. New pins land at the tail; the user reshuffles from this screen.
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ManagePinnedScreen(onBack: () -> Unit) {
   val pinStore = LocalTerrazzoGraph.current.pinStore
@@ -61,6 +60,29 @@ fun ManagePinnedScreen(onBack: () -> Unit) {
         .sortedBy { it.orderIndex }
     }
 
+  ManagePinnedContent(
+    items = items,
+    onReorder = { newOrder -> scope.launch { pinStore.reorder(newOrder) } },
+    onUnpin = { item ->
+      scope.launch {
+        when (item) {
+          is PinRowItem.Card -> pinStore.unpinCard(item.key)
+          is PinRowItem.Section -> pinStore.unpinSection(item.key)
+        }
+      }
+    },
+    onBack = onBack,
+  )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ManagePinnedContent(
+  items: List<PinRowItem>,
+  onReorder: (List<String>) -> Unit,
+  onUnpin: (PinRowItem) -> Unit,
+  onBack: () -> Unit,
+) {
   Scaffold(
     topBar = {
       TopAppBar(
@@ -101,27 +123,16 @@ fun ManagePinnedScreen(onBack: () -> Unit) {
           canMoveUp = index > 0,
           canMoveDown = index >= 0 && index < items.lastIndex,
           onMoveUp = {
-            scope.launch {
-              val reordered =
-                items.toMutableList().apply { add(index - 1, removeAt(index)) }.map { it.key }
-              pinStore.reorder(reordered)
-            }
+            val reordered =
+              items.toMutableList().apply { add(index - 1, removeAt(index)) }.map { it.key }
+            onReorder(reordered)
           },
           onMoveDown = {
-            scope.launch {
-              val reordered =
-                items.toMutableList().apply { add(index + 1, removeAt(index)) }.map { it.key }
-              pinStore.reorder(reordered)
-            }
+            val reordered =
+              items.toMutableList().apply { add(index + 1, removeAt(index)) }.map { it.key }
+            onReorder(reordered)
           },
-          onUnpin = {
-            scope.launch {
-              when (item) {
-                is PinRowItem.Card -> pinStore.unpinCard(item.key)
-                is PinRowItem.Section -> pinStore.unpinSection(item.key)
-              }
-            }
-          },
+          onUnpin = { onUnpin(item) },
         )
       }
     }
@@ -158,7 +169,7 @@ private fun PinRow(
   }
 }
 
-private sealed interface PinRowItem {
+internal sealed interface PinRowItem {
   val key: String
   val orderIndex: Int
   val title: String

--- a/app/src/main/kotlin/ee/schimke/terrazzo/logs/LogsScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/logs/LogsScreen.kt
@@ -32,12 +32,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import ee.schimke.terrazzo.LocalTerrazzoGraph
 import ee.schimke.terrazzo.core.logs.LogConnectionStatus
 import ee.schimke.terrazzo.core.logs.LogEntry
+import ee.schimke.terrazzo.ui.statusColors
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -191,7 +191,7 @@ private fun CrashRow(entry: LogEntry.Crash) {
       )
       CrashChip(fatal = entry.fatal)
       Column(modifier = Modifier.weight(1f)) {
-        Text(entry.summary, style = MaterialTheme.typography.bodyMedium, color = Color(0xFFD32F2F))
+        Text(entry.summary, style = MaterialTheme.typography.bodyMedium, color = statusColors.error)
         Text(
           "thread: ${entry.threadName}",
           style = MaterialTheme.typography.bodySmall,
@@ -213,7 +213,7 @@ private fun CrashRow(entry: LogEntry.Crash) {
 
 @Composable
 private fun CrashChip(fatal: Boolean) {
-  val color = if (fatal) Color(0xFFD32F2F) else Color(0xFFF57C00)
+  val color = if (fatal) statusColors.error else statusColors.warning
   AssistChip(
     onClick = {},
     enabled = false,
@@ -282,10 +282,10 @@ private fun LogRow(
 private fun StatusChip(status: LogConnectionStatus) {
   val color =
     when (status) {
-      LogConnectionStatus.Connected -> Color(0xFF1976D2)
-      LogConnectionStatus.Connecting -> Color(0xFF2E7D32)
-      LogConnectionStatus.Disconnected -> Color(0xFF757575)
-      LogConnectionStatus.Error -> Color(0xFFD32F2F)
+      LogConnectionStatus.Connected -> statusColors.info
+      LogConnectionStatus.Connecting -> statusColors.success
+      LogConnectionStatus.Disconnected -> statusColors.neutral
+      LogConnectionStatus.Error -> statusColors.error
     }
   AssistChip(
     onClick = {},

--- a/app/src/main/kotlin/ee/schimke/terrazzo/logs/LogsScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/logs/LogsScreen.kt
@@ -59,7 +59,6 @@ import java.util.Locale
  * Hidden behind `PreferencesStore.logsViewEnabled` — the overflow menu doesn't show the entry until
  * the user flips the toggle in Settings.
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LogsScreen(onBack: () -> Unit) {
   val store = LocalTerrazzoGraph.current.logStore
@@ -72,6 +71,26 @@ fun LogsScreen(onBack: () -> Unit) {
     entries.filterIsInstance<LogEntry.Connection>().sortedByDescending { it.timestamp }
   val actions = entries.filterIsInstance<LogEntry.LocalAction>().sortedByDescending { it.timestamp }
 
+  LogsContent(
+    crashes = crashes,
+    connections = connections,
+    actions = actions,
+    dataUpdates = dataUpdates,
+    onClear = { store.clear() },
+    onBack = onBack,
+  )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun LogsContent(
+  crashes: List<LogEntry.Crash>,
+  connections: List<LogEntry.Connection>,
+  actions: List<LogEntry.LocalAction>,
+  dataUpdates: List<LogEntry.DataUpdate>,
+  onClear: () -> Unit,
+  onBack: () -> Unit,
+) {
   Scaffold(
     topBar = {
       TopAppBar(
@@ -81,7 +100,7 @@ fun LogsScreen(onBack: () -> Unit) {
             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
           }
         },
-        actions = { TextButton(onClick = { store.clear() }) { Text("Clear") } },
+        actions = { TextButton(onClick = onClear) { Text("Clear") } },
       )
     },
     contentWindowInsets = WindowInsets.safeDrawing,

--- a/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
@@ -549,6 +549,30 @@ fun Screen_Logs() = PhoneHost {
   )
 }
 
+/**
+ * Dark variant — guards that the semantic status colours ([ee.schimke.terrazzo.ui.statusColors])
+ * stay legible on a dark surface (the severity chips and crash text used to be baked light-only hex
+ * literals).
+ */
+@Preview(
+  name = "logs · dark",
+  showBackground = false,
+  widthDp = PHONE_WIDTH_DP,
+  heightDp = PHONE_HEIGHT_DP,
+)
+@Composable
+fun Screen_Logs_Dark() =
+  PhoneHost(darkMode = DarkModePref.Dark) {
+    LogsContent(
+      crashes = SAMPLE_CRASHES,
+      connections = SAMPLE_CONNECTIONS,
+      actions = SAMPLE_ACTIONS,
+      dataUpdates = SAMPLE_DATA_UPDATES,
+      onClear = {},
+      onBack = {},
+    )
+  }
+
 @Preview(
   name = "logs · empty",
   showBackground = false,

--- a/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
@@ -2,6 +2,7 @@ package ee.schimke.terrazzo.previews
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
@@ -14,19 +15,28 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
 import ee.schimke.ha.client.DashboardSummary
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.terrazzo.LocalTerrazzoGraph
+import ee.schimke.terrazzo.SettingsScreen
 import ee.schimke.terrazzo.core.auth.HaAuthService
 import ee.schimke.terrazzo.core.auth.TokenVault
 import ee.schimke.terrazzo.core.cache.OfflineCache
 import ee.schimke.terrazzo.core.di.HaSessionFactory
 import ee.schimke.terrazzo.core.di.TerrazzoGraph
+import ee.schimke.terrazzo.core.logs.LogConnectionStatus
+import ee.schimke.terrazzo.core.logs.LogEntry
 import ee.schimke.terrazzo.core.mobileapp.MobileAppRegistrar
 import ee.schimke.terrazzo.core.mobileapp.MobileAppStore
 import ee.schimke.terrazzo.core.monitor.CardMonitor
+import ee.schimke.terrazzo.core.pin.MobilePinnedCard
+import ee.schimke.terrazzo.core.pin.MobilePinnedSection
 import ee.schimke.terrazzo.core.pin.PinStore
+import ee.schimke.terrazzo.core.pin.PinnedCardData
+import ee.schimke.terrazzo.core.pin.SlotSize
+import ee.schimke.terrazzo.core.pin.WearWidgetSlot
 import ee.schimke.terrazzo.core.pin.WearWidgetSlotsStore
 import ee.schimke.terrazzo.core.prefs.DarkModePref
 import ee.schimke.terrazzo.core.prefs.PreferencesStore
@@ -40,8 +50,14 @@ import ee.schimke.terrazzo.dashboard.DashboardListState
 import ee.schimke.terrazzo.dashboard.DashboardPickerScreen
 import ee.schimke.terrazzo.dashboard.DashboardSelectionScreen
 import ee.schimke.terrazzo.dashboard.DashboardViewScreen
+import ee.schimke.terrazzo.dashboard.ManagePinnedContent
+import ee.schimke.terrazzo.dashboard.PinRowItem
 import ee.schimke.terrazzo.discovery.DiscoveryScreen
+import ee.schimke.terrazzo.logs.LogsContent
 import ee.schimke.terrazzo.ui.TerrazzoTheme
+import ee.schimke.terrazzo.wearsync.SyncDiagnosticsContent
+import ee.schimke.terrazzo.wearsync.WearWidgetsContent
+import ee.schimke.terrazzo.wearsync.proto.SyncStats
 import ee.schimke.terrazzo.widget.WidgetsScreen
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -226,6 +242,11 @@ fun Screen_DashboardPicker() = PhoneHost {
           )
       ),
     onDashboardPicked = {},
+    // The real screen hosts the picker inside a Scaffold and hands
+    // it the top-bar inset as contentPadding; mirror that here so
+    // the first card isn't clipped flush against the preview's top
+    // edge.
+    contentPadding = PaddingValues(vertical = 12.dp),
   )
 }
 
@@ -251,6 +272,11 @@ fun Screen_DashboardPicker_ThemeStyle(
             )
         ),
       onDashboardPicked = {},
+      // The real screen hosts the picker inside a Scaffold and hands
+      // it the top-bar inset as contentPadding; mirror that here so
+      // the first card isn't clipped flush against the preview's top
+      // edge.
+      contentPadding = PaddingValues(vertical = 12.dp),
     )
   }
 
@@ -409,6 +435,259 @@ fun Screen_DashboardSelection_ThemeStyle(
     )
   }
 
+/**
+ * Settings screen in demo mode. Reads theme / dark-mode / experimental toggles from the preview
+ * graph's real (empty) [PreferencesStore], so every row renders at its default value — this is the
+ * home of the theme picker (style guide §6.1), so a preview here guards the picker layout and the
+ * five palette rows against regressions.
+ */
+@Preview(
+  name = "settings",
+  showBackground = false,
+  widthDp = PHONE_WIDTH_DP,
+  heightDp = PHONE_HEIGHT_DP,
+)
+@Composable
+fun Screen_Settings() = PhoneHost {
+  SettingsScreen(
+    session = demoSession(),
+    onToggleDemo = {},
+    onSignOut = {},
+    onBack = {},
+    onOpenSyncDiagnostics = {},
+    onManageDashboards = {},
+  )
+}
+
+@Preview(
+  name = "settings · theme",
+  showBackground = false,
+  widthDp = PHONE_WIDTH_DP,
+  heightDp = PHONE_HEIGHT_DP,
+)
+@Composable
+fun Screen_Settings_ThemeStyle(@PreviewParameter(ThemeStyleProvider::class) style: ThemeStyle) =
+  PhoneHost(style = style) {
+    SettingsScreen(
+      session = demoSession(),
+      onToggleDemo = {},
+      onSignOut = {},
+      onBack = {},
+      onOpenSyncDiagnostics = {},
+      onManageDashboards = {},
+    )
+  }
+
+// --- Secondary / power-user screens -------------------------------------
+//
+// These read their data from runtime stores in production; each has a
+// stateless `*Content` layer (extracted for previewability) that takes
+// hand-rolled fixtures so the populated layout — not just the empty
+// state the preview graph's empty stores would produce — is exercised.
+
+// Fixed wall-clock anchor so the log timestamps render identically every
+// run (the rows format `HH:mm:ss` from these values).
+private const val LOG_ANCHOR_MS = 1_700_000_000_000L
+
+private val SAMPLE_CRASHES =
+  listOf(
+    LogEntry.Crash(
+      timestamp = LOG_ANCHOR_MS,
+      threadName = "main",
+      summary = "IllegalStateException: no card renderer for type 'custom:mini-graph'",
+      stackTrace =
+        "java.lang.IllegalStateException: no card renderer…\n  at ee.schimke.ha.rc.RenderChild(RenderChild.kt:48)",
+      fatal = true,
+    ),
+    LogEntry.Crash(
+      timestamp = LOG_ANCHOR_MS - 90_000,
+      threadName = "DefaultDispatcher-worker-3",
+      summary = "JobCancellationException: snapshot flow cancelled",
+      stackTrace = "kotlinx.coroutines.JobCancellationException…",
+      fatal = false,
+    ),
+  )
+
+private val SAMPLE_CONNECTIONS =
+  listOf(
+    LogEntry.Connection(LOG_ANCHOR_MS, LogConnectionStatus.Connected, "homeassistant.local:8123"),
+    LogEntry.Connection(LOG_ANCHOR_MS - 20_000, LogConnectionStatus.Connecting, null),
+    LogEntry.Connection(
+      LOG_ANCHOR_MS - 35_000,
+      LogConnectionStatus.Error,
+      "handshake timed out after 10s",
+    ),
+  )
+
+private val SAMPLE_ACTIONS =
+  listOf(
+    LogEntry.LocalAction(LOG_ANCHOR_MS, "homeassistant.toggle", "light.kitchen"),
+    LogEntry.LocalAction(LOG_ANCHOR_MS - 4_000, "cover.open_cover", "cover.garage_door"),
+  )
+
+private val SAMPLE_DATA_UPDATES =
+  listOf(
+    LogEntry.DataUpdate(LOG_ANCHOR_MS, "sensor.living_room_temperature", "21.3", "21.4"),
+    LogEntry.DataUpdate(LOG_ANCHOR_MS - 3_000, "binary_sensor.front_door", "off", "on"),
+  )
+
+@Preview(
+  name = "logs",
+  showBackground = false,
+  widthDp = PHONE_WIDTH_DP,
+  heightDp = PHONE_HEIGHT_DP,
+)
+@Composable
+fun Screen_Logs() = PhoneHost {
+  LogsContent(
+    crashes = SAMPLE_CRASHES,
+    connections = SAMPLE_CONNECTIONS,
+    actions = SAMPLE_ACTIONS,
+    dataUpdates = SAMPLE_DATA_UPDATES,
+    onClear = {},
+    onBack = {},
+  )
+}
+
+@Preview(
+  name = "logs · empty",
+  showBackground = false,
+  widthDp = PHONE_WIDTH_DP,
+  heightDp = PHONE_HEIGHT_DP,
+)
+@Composable
+fun Screen_Logs_Empty() = PhoneHost {
+  LogsContent(
+    crashes = emptyList(),
+    connections = emptyList(),
+    actions = emptyList(),
+    dataUpdates = emptyList(),
+    onClear = {},
+    onBack = {},
+  )
+}
+
+private const val SAMPLE_BASE_URL = "http://homeassistant.local:8123"
+
+private val SAMPLE_PIN_ITEMS: List<PinRowItem> =
+  listOf(
+    PinRowItem.Card(
+      MobilePinnedCard(
+        key = "card-living",
+        baseUrl = SAMPLE_BASE_URL,
+        dashboardUrlPath = "lovelace-mobile",
+        card = PinnedCardData(type = "tile", title = "Living Room"),
+        orderIndex = 0,
+      )
+    ),
+    PinRowItem.Section(
+      MobilePinnedSection(
+        key = "section-cameras",
+        baseUrl = SAMPLE_BASE_URL,
+        dashboardUrlPath = "lovelace-garage",
+        viewPath = "0",
+        sectionIndex = 1,
+        title = "Outdoor cameras",
+        cards = listOf(PinnedCardData(), PinnedCardData()),
+        orderIndex = 1,
+      )
+    ),
+    PinRowItem.Card(
+      MobilePinnedCard(
+        key = "card-thermostat",
+        baseUrl = SAMPLE_BASE_URL,
+        dashboardUrlPath = "",
+        card = PinnedCardData(type = "thermostat", title = ""),
+        orderIndex = 2,
+      )
+    ),
+  )
+
+@Preview(
+  name = "manage pinned",
+  showBackground = false,
+  widthDp = PHONE_WIDTH_DP,
+  heightDp = PHONE_HEIGHT_DP,
+)
+@Composable
+fun Screen_ManagePinned() = PhoneHost {
+  ManagePinnedContent(items = SAMPLE_PIN_ITEMS, onReorder = {}, onUnpin = {}, onBack = {})
+}
+
+@Preview(
+  name = "manage pinned · empty",
+  showBackground = false,
+  widthDp = PHONE_WIDTH_DP,
+  heightDp = PHONE_HEIGHT_DP,
+)
+@Composable
+fun Screen_ManagePinned_Empty() = PhoneHost {
+  ManagePinnedContent(items = emptyList(), onReorder = {}, onUnpin = {}, onBack = {})
+}
+
+private val SAMPLE_WEAR_CARDS =
+  listOf(
+    MobilePinnedCard(
+      "card-living",
+      SAMPLE_BASE_URL,
+      "lovelace-mobile",
+      PinnedCardData(type = "tile", title = "Living Room"),
+      0,
+    ),
+    MobilePinnedCard(
+      "card-garage",
+      SAMPLE_BASE_URL,
+      "lovelace-garage",
+      PinnedCardData(type = "cover", title = "Garage Door"),
+      1,
+    ),
+  )
+
+private val SAMPLE_WEAR_SLOTS =
+  listOf(
+    WearWidgetSlot(slotIndex = 0, cardKey = "card-living", size = SlotSize.Both),
+    WearWidgetSlot(slotIndex = 1, cardKey = "card-garage", size = SlotSize.SmallOnly),
+    WearWidgetSlot(slotIndex = 2, cardKey = ""),
+    WearWidgetSlot(slotIndex = 3, cardKey = ""),
+    WearWidgetSlot(slotIndex = 4, cardKey = ""),
+  )
+
+@Preview(
+  name = "wear widgets",
+  showBackground = false,
+  widthDp = PHONE_WIDTH_DP,
+  heightDp = PHONE_HEIGHT_DP,
+)
+@Composable
+fun Screen_WearWidgets() = PhoneHost {
+  WearWidgetsContent(
+    slots = SAMPLE_WEAR_SLOTS,
+    pinnedCards = SAMPLE_WEAR_CARDS,
+    onAssign = { _, _ -> },
+    onClear = {},
+    onSizeChange = { _, _ -> },
+    onBack = {},
+  )
+}
+
+private val SAMPLE_SYNC_STATS =
+  SyncStats(
+    datastoreWrites = 128,
+    messageSends = 342,
+    recentSendMs = listOf(0L, 1_500L, 2_800L, 4_100L, 5_600L, 7_000L, 8_300L, 9_900L),
+  )
+
+@Preview(
+  name = "sync diagnostics",
+  showBackground = false,
+  widthDp = PHONE_WIDTH_DP,
+  heightDp = PHONE_HEIGHT_DP,
+)
+@Composable
+fun Screen_SyncDiagnostics() = PhoneHost {
+  SyncDiagnosticsContent(stats = SAMPLE_SYNC_STATS, streamActive = true, onReset = {}, onBack = {})
+}
+
 class ThemeStyleProvider : PreviewParameterProvider<ThemeStyle> {
   override val values: Sequence<ThemeStyle> = ThemeStyle.entries.asSequence()
 }
@@ -461,6 +740,11 @@ fun Play_Phone_04_Picker() =
             )
         ),
       onDashboardPicked = {},
+      // The real screen hosts the picker inside a Scaffold and hands
+      // it the top-bar inset as contentPadding; mirror that here so
+      // the first card isn't clipped flush against the preview's top
+      // edge.
+      contentPadding = PaddingValues(vertical = 12.dp),
     )
   }
 

--- a/app/src/main/kotlin/ee/schimke/terrazzo/ui/StatusColors.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/ui/StatusColors.kt
@@ -1,0 +1,66 @@
+package ee.schimke.terrazzo.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Semantic status colours for app chrome — connection state, log severity, and the read/write
+ * indicator.
+ *
+ * These are deliberately **fixed across the Terrazzo palettes** (the same rationale as
+ * [HaStateColor][ee.schimke.ha.rc.HaStateColor]: a "failed" red reads as red whatever palette the
+ * user picked — the palette describes the chrome, not the status). But unlike a baked
+ * `Color(0xFF…)` literal, they **adapt to light / dark** so a label or chip stays legible on either
+ * surface. The light tones are Material 700-level; the dark tones are the 200/300-level
+ * brightenings that hold contrast on a dark background.
+ *
+ * This is the single home for what used to be duplicated hex literals scattered across
+ * `TerrazzoApp` and `LogsScreen` — per the style guide, screens never hardcode `Color(0xFF…)`; a
+ * missing role is added here.
+ */
+@Immutable
+data class StatusColorSet(
+  /** Failure / error / fatal crash. */
+  val error: Color,
+  /** Caught (non-fatal) problem, or the write-enabled indicator. */
+  val warning: Color,
+  /** In-progress / connecting. */
+  val success: Color,
+  /** Healthy / connected. */
+  val info: Color,
+  /** Paused / disconnected / inert. */
+  val neutral: Color,
+  /** Read-only indicator (muted blue-grey). */
+  val readOnly: Color,
+)
+
+private val LightStatusColors =
+  StatusColorSet(
+    error = Color(0xFFD32F2F),
+    warning = Color(0xFFE65100),
+    success = Color(0xFF2E7D32),
+    info = Color(0xFF1976D2),
+    neutral = Color(0xFF757575),
+    readOnly = Color(0xFF455A64),
+  )
+
+private val DarkStatusColors =
+  StatusColorSet(
+    error = Color(0xFFF2B8B5),
+    warning = Color(0xFFFFB74D),
+    success = Color(0xFFA5D6A7),
+    info = Color(0xFF90CAF9),
+    neutral = Color(0xFFBDBDBD),
+    readOnly = Color(0xFFB0BEC5),
+  )
+
+/**
+ * The active [StatusColorSet], resolved against [LocalIsDarkTheme] so it tracks the user's
+ * dark-mode choice the same way the rest of the app chrome does.
+ */
+val statusColors: StatusColorSet
+  @Composable
+  @ReadOnlyComposable
+  get() = if (LocalIsDarkTheme.current) DarkStatusColors else LightStatusColors

--- a/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/SyncDiagnosticsScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/SyncDiagnosticsScreen.kt
@@ -43,7 +43,6 @@ import kotlinx.coroutines.launch
  *   batching)
  * - rolling-window send frequency from [SyncStats.recentSendMs]
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SyncDiagnosticsScreen(
   statsStore: MobileSyncStatsStore,
@@ -52,7 +51,22 @@ fun SyncDiagnosticsScreen(
 ) {
   val stats by statsStore.flow.collectAsState(initial = SyncStats())
   val scope = rememberCoroutineScope()
+  SyncDiagnosticsContent(
+    stats = stats,
+    streamActive = streamActive,
+    onReset = { scope.launch { statsStore.reset() } },
+    onBack = onBack,
+  )
+}
 
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun SyncDiagnosticsContent(
+  stats: SyncStats,
+  streamActive: Boolean,
+  onReset: () -> Unit,
+  onBack: () -> Unit,
+) {
   Scaffold(
     topBar = {
       TopAppBar(
@@ -126,7 +140,7 @@ fun SyncDiagnosticsScreen(
 
       HorizontalDivider()
 
-      OutlinedButton(onClick = { scope.launch { statsStore.reset() } }) { Text("Reset counters") }
+      OutlinedButton(onClick = onReset) { Text("Reset counters") }
     }
   }
 }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/WearWidgetsScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/wearsync/WearWidgetsScreen.kt
@@ -50,7 +50,6 @@ import kotlinx.coroutines.launch
  * [WearCapabilityProbe] reports that a paired Wear node advertises widget support. The menu entry
  * is hidden otherwise, so this screen always has a meaningful effect when the user gets to it.
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WearWidgetsScreen(onBack: () -> Unit) {
   val pinStore = LocalTerrazzoGraph.current.pinStore
@@ -60,6 +59,26 @@ fun WearWidgetsScreen(onBack: () -> Unit) {
   val slots by slotsStore.slots.collectAsState(initial = emptyList())
   val pinnedCards by pinStore.cards.collectAsState(initial = emptyList())
 
+  WearWidgetsContent(
+    slots = slots,
+    pinnedCards = pinnedCards,
+    onAssign = { slotIndex, card -> scope.launch { slotsStore.setSlot(slotIndex, card.key) } },
+    onClear = { slotIndex -> scope.launch { slotsStore.clearSlot(slotIndex) } },
+    onSizeChange = { slotIndex, size -> scope.launch { slotsStore.setSize(slotIndex, size) } },
+    onBack = onBack,
+  )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun WearWidgetsContent(
+  slots: List<WearWidgetSlot>,
+  pinnedCards: List<MobilePinnedCard>,
+  onAssign: (slotIndex: Int, card: MobilePinnedCard) -> Unit,
+  onClear: (slotIndex: Int) -> Unit,
+  onSizeChange: (slotIndex: Int, size: SlotSize) -> Unit,
+  onBack: () -> Unit,
+) {
   Scaffold(
     topBar = {
       TopAppBar(
@@ -99,9 +118,9 @@ fun WearWidgetsScreen(onBack: () -> Unit) {
           SlotRow(
             slot = slot,
             pinnedCards = pinnedCards,
-            onAssign = { card -> scope.launch { slotsStore.setSlot(slot.slotIndex, card.key) } },
-            onClear = { scope.launch { slotsStore.clearSlot(slot.slotIndex) } },
-            onSizeChange = { size -> scope.launch { slotsStore.setSize(slot.slotIndex, size) } },
+            onAssign = { card -> onAssign(slot.slotIndex, card) },
+            onClear = { onClear(slot.slotIndex) },
+            onSizeChange = { size -> onSizeChange(slot.slotIndex, size) },
           )
         }
       }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetsScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/WidgetsScreen.kt
@@ -1,14 +1,15 @@
 package ee.schimke.terrazzo.widget
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Widgets
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -17,7 +18,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
 /**
@@ -43,13 +46,32 @@ fun WidgetsScreen(onBack: () -> Unit) {
     },
     contentWindowInsets = WindowInsets.safeDrawing,
   ) { padding ->
+    // Always-empty for now (the install list lands in a later pass),
+    // so this is a proper centred empty state rather than a stray
+    // line of text pinned to the top-left.
     Column(
-      modifier =
-        Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(padding).padding(24.dp)
+      modifier = Modifier.fillMaxSize().padding(padding).padding(horizontal = 32.dp),
+      verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterVertically),
+      horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+      Icon(
+        imageVector = Icons.Outlined.Widgets,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.size(56.dp),
+      )
       Text(
-        "Long-press a card on a dashboard to install it here. Up to 5.",
+        text = "No widgets yet",
+        style = MaterialTheme.typography.titleMedium,
+        textAlign = TextAlign.Center,
+      )
+      Text(
+        text =
+          "Long-press a card on a dashboard to add it to your home " +
+            "screen. You can pin up to 5.",
         style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center,
       )
     }
   }


### PR DESCRIPTION
Several top-level screens had no @Preview coverage. Extract a stateless
*Content layer for LogsScreen, ManagePinnedScreen, WearWidgetsScreen and
SyncDiagnosticsScreen (behaviour-preserving — the stateful wrapper still
wires the runtime stores) and make SettingsScreen internal, so each can
be rendered from :app's ScreenPreviews with hand-rolled fixtures.

Adds populated + empty previews for the four secondary screens and a
settings preview (plus a per-palette theme fan-out) that exercises the
theme picker. Also fixes the dashboard-picker previews clipping their
first card by passing the same top-bar contentPadding the real screen
receives from its Scaffold.