### PR TITLE
test: cover entity state-color, domain-state parsers, ClientProfile, CardKey

### DIFF
--- a/ha-model/src/commonTest/kotlin/ee/schimke/ha/model/CardKeyTest.kt
+++ b/ha-model/src/commonTest/kotlin/ee/schimke/ha/model/CardKeyTest.kt
@@ -1,0 +1,48 @@
+package ee.schimke.ha.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class CardKeyTest {
+
+  @Test
+  fun nullPathsFallBackToDefaultMarker() {
+    val key = CardKey(dashboardUrlPath = null, viewPath = null, cardIndex = 0, type = "tile")
+    assertEquals("_default/_default/0#tile", key.toCacheKey())
+  }
+
+  @Test
+  fun fullPathWithoutSectionOmitsSectionSegment() {
+    val key =
+      CardKey(dashboardUrlPath = "lovelace", viewPath = "home", cardIndex = 2, type = "entities")
+    assertEquals("lovelace/home/2#entities", key.toCacheKey())
+  }
+
+  @Test
+  fun sectionIndexAddsPrefixedSegment() {
+    val key =
+      CardKey(
+        dashboardUrlPath = "lovelace",
+        viewPath = "home",
+        sectionIndex = 1,
+        cardIndex = 3,
+        type = "button",
+      )
+    assertEquals("lovelace/home/s1/3#button", key.toCacheKey())
+  }
+
+  @Test
+  fun reorderingCardsChangesTheKey() {
+    val base = CardKey("lovelace", "home", sectionIndex = 0, cardIndex = 0, type = "tile")
+    val moved = base.copy(cardIndex = 1)
+    assertNotEquals(base.toCacheKey(), moved.toCacheKey())
+  }
+
+  @Test
+  fun sectionZeroIsDistinctFromNoSection() {
+    val noSection = CardKey("lovelace", "home", sectionIndex = null, cardIndex = 0, type = "tile")
+    val sectionZero = CardKey("lovelace", "home", sectionIndex = 0, cardIndex = 0, type = "tile")
+    assertNotEquals(noSection.toCacheKey(), sectionZero.toCacheKey())
+  }
+}

--- a/ha-model/src/commonTest/kotlin/ee/schimke/ha/model/ClientProfileTest.kt
+++ b/ha-model/src/commonTest/kotlin/ee/schimke/ha/model/ClientProfileTest.kt
@@ -1,0 +1,35 @@
+package ee.schimke.ha.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ClientProfileTest {
+
+  @Test
+  fun wireFormIsLowercaseName() {
+    assertEquals("phone", ClientProfile.Phone.wire)
+    assertEquals("wear", ClientProfile.Wear.wire)
+    assertEquals("mono", ClientProfile.Mono.wire)
+  }
+
+  @Test
+  fun everyProfileRoundTripsThroughItsWireForm() {
+    ClientProfile.entries.forEach { profile ->
+      assertEquals(profile, ClientProfile.parse(profile.wire), "round-trip for $profile")
+    }
+  }
+
+  @Test
+  fun parseIsCaseInsensitive() {
+    assertEquals(ClientProfile.Tv, ClientProfile.parse("TV"))
+    assertEquals(ClientProfile.Glance, ClientProfile.parse("Glance"))
+  }
+
+  @Test
+  fun parseReturnsNullForNullOrUnknown() {
+    assertNull(ClientProfile.parse(null))
+    assertNull(ClientProfile.parse(""))
+    assertNull(ClientProfile.parse("desktop"))
+  }
+}

--- a/ha-model/src/commonTest/kotlin/ee/schimke/ha/model/HaDomainStateTest.kt
+++ b/ha-model/src/commonTest/kotlin/ee/schimke/ha/model/HaDomainStateTest.kt
@@ -1,0 +1,104 @@
+package ee.schimke.ha.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HaDomainStateTest {
+
+  @Test
+  fun knownValuesParseToSymbolicStates() {
+    assertEquals(OnOffState.On, OnOffState.parse("on"))
+    assertEquals(OnOffState.Off, OnOffState.parse("off"))
+    assertEquals(CoverState.Opening, CoverState.parse("opening"))
+    assertEquals(LockState.Jammed, LockState.parse("jammed"))
+    assertEquals(MediaPlayerState.Buffering, MediaPlayerState.parse("buffering"))
+    assertEquals(ClimateMode.HeatCool, ClimateMode.parse("heat_cool"))
+    assertEquals(AlarmState.ArmedCustomBypass, AlarmState.parse("armed_custom_bypass"))
+    assertEquals(VacuumState.Returning, VacuumState.parse("returning"))
+    assertEquals(PersonState.NotHome, PersonState.parse("not_home"))
+  }
+
+  @Test
+  fun everyDomainMapsUnavailable() {
+    assertEquals(OnOffState.Unavailable, OnOffState.parse("unavailable"))
+    assertEquals(CoverState.Unavailable, CoverState.parse("unavailable"))
+    assertEquals(LockState.Unavailable, LockState.parse("unavailable"))
+    assertEquals(MediaPlayerState.Unavailable, MediaPlayerState.parse("unavailable"))
+    assertEquals(ClimateMode.Unavailable, ClimateMode.parse("unavailable"))
+    assertEquals(AlarmState.Unavailable, AlarmState.parse("unavailable"))
+    assertEquals(VacuumState.Unavailable, VacuumState.parse("unavailable"))
+    assertEquals(PersonState.Unavailable, PersonState.parse("unavailable"))
+  }
+
+  @Test
+  fun unrecognisedValuesCarryRawThroughUnknown() {
+    // The stability promise: a new HA release / custom integration state
+    // flows through as Unknown(raw) instead of crashing the converter.
+    assertEquals(OnOffState.Unknown("flickering"), OnOffState.parse("flickering"))
+    assertEquals(ClimateMode.Unknown("eco_boost"), ClimateMode.parse("eco_boost"))
+    assertEquals(AlarmState.Unknown("armed_pets"), AlarmState.parse("armed_pets"))
+    assertEquals("eco_boost", (ClimateMode.parse("eco_boost") as ClimateMode.Unknown).raw)
+  }
+
+  @Test
+  fun parseIsCaseSensitiveByContract() {
+    // HA state strings are canonical lower-case; an upper-case value is an
+    // unknown, not a silent match.
+    assertEquals(OnOffState.Unknown("ON"), OnOffState.parse("ON"))
+  }
+
+  @Test
+  fun alarmIsArmedOnlyForArmedVariants() {
+    listOf(
+        AlarmState.ArmedHome,
+        AlarmState.ArmedAway,
+        AlarmState.ArmedNight,
+        AlarmState.ArmedVacation,
+        AlarmState.ArmedCustomBypass,
+      )
+      .forEach { assertTrue(it.isArmed, "$it should be armed") }
+    listOf(
+        AlarmState.Disarmed,
+        AlarmState.Triggered,
+        AlarmState.Pending,
+        AlarmState.Arming,
+        AlarmState.Disarming,
+        AlarmState.Unavailable,
+        AlarmState.Unknown("x"),
+      )
+      .forEach { assertFalse(it.isArmed, "$it should not be armed") }
+  }
+
+  @Test
+  fun alarmIntKeysAreStableDistinctAndDeclarationOrdered() {
+    // These keys are a host <-> .rc wire contract: stable, distinct, and in
+    // the same order as AlarmStateInt.All.
+    val expected =
+      listOf(
+        AlarmState.Disarmed to 0,
+        AlarmState.ArmedHome to 1,
+        AlarmState.ArmedAway to 2,
+        AlarmState.ArmedNight to 3,
+        AlarmState.ArmedVacation to 4,
+        AlarmState.ArmedCustomBypass to 5,
+        AlarmState.Triggered to 6,
+        AlarmState.Pending to 7,
+        AlarmState.Arming to 8,
+        AlarmState.Disarming to 9,
+        AlarmState.Unavailable to 10,
+        AlarmState.Unknown("whatever") to 11,
+      )
+    expected.forEach { (state, key) -> assertEquals(key, state.intKey(), "$state") }
+
+    assertEquals(expected.map { it.second }, AlarmStateInt.All.toList())
+    assertEquals(AlarmStateInt.All.size, AlarmStateInt.All.toSet().size, "keys must be distinct")
+  }
+
+  @Test
+  fun alarmStateIntFromRawComposesParseAndIntKey() {
+    assertEquals(AlarmStateInt.ArmedAway, alarmStateIntFromRaw("armed_away"))
+    assertEquals(AlarmStateInt.Unknown, alarmStateIntFromRaw("armed_pets"))
+  }
+}

--- a/rc-converter/src/test/kotlin/ee/schimke/ha/rc/HaStateColorTest.kt
+++ b/rc-converter/src/test/kotlin/ee/schimke/ha/rc/HaStateColorTest.kt
@@ -1,0 +1,95 @@
+package ee.schimke.ha.rc
+
+import androidx.compose.ui.graphics.Color
+import ee.schimke.ha.model.EntityState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class HaStateColorTest {
+
+  private val grayOff = Color(0xFFB0B0B0)
+  private val grayInactive = Color(0xFF757575)
+
+  private fun state(entityId: String, state: String, deviceClass: String? = null) =
+    EntityState(
+      entityId = entityId,
+      state = state,
+      attributes = buildJsonObject { if (deviceClass != null) put("device_class", deviceClass) },
+    )
+
+  // --- resolve -------------------------------------------------------------
+
+  @Test
+  fun resolveNullEntityIsInactiveGray() {
+    assertEquals(grayInactive, HaStateColor.resolve(null))
+  }
+
+  @Test
+  fun resolveSensorUsesDeviceClassColor() {
+    assertEquals(Color(0xFF2196F3), HaStateColor.resolve(state("sensor.t", "21.0", "temperature")))
+    assertEquals(Color(0xFFFFA000), HaStateColor.resolve(state("sensor.p", "120", "power")))
+  }
+
+  @Test
+  fun resolveSensorWithoutKnownDeviceClassFallsBack() {
+    assertEquals(Color(0xFF546E7A), HaStateColor.resolve(state("sensor.x", "5")))
+    assertEquals(Color(0xFF546E7A), HaStateColor.resolve(state("sensor.x", "5", "nonsense")))
+  }
+
+  @Test
+  fun resolveBinarySensorOnUsesDeviceClassButOffIsGray() {
+    assertEquals(Color(0xFFE65100), HaStateColor.resolve(state("binary_sensor.m", "on", "motion")))
+    assertEquals(grayOff, HaStateColor.resolve(state("binary_sensor.m", "off", "motion")))
+  }
+
+  @Test
+  fun resolveTrackerIsGreenWhenHomeGrayWhenAway() {
+    assertEquals(Color(0xFF4CAF50), HaStateColor.resolve(state("person.a", "home")))
+    assertEquals(grayOff, HaStateColor.resolve(state("device_tracker.a", "not_home")))
+  }
+
+  @Test
+  fun resolveToggleableUsesActiveColorOnlyWhenOn() {
+    // Light on → its active accent; off → gray, regardless of accent.
+    assertEquals(Color(0xFFFFBE3E), HaStateColor.resolve(state("light.k", "on")))
+    assertEquals(grayOff, HaStateColor.resolve(state("light.k", "off")))
+  }
+
+  // --- activeFor (state-independent) --------------------------------------
+
+  @Test
+  fun activeForPerDomainAccents() {
+    assertEquals(Color(0xFFFFBE3E), HaStateColor.activeFor(state("light.k", "off")))
+    assertEquals(Color(0xFF2196F3), HaStateColor.activeFor(state("switch.k", "off")))
+    assertEquals(Color(0xFF43A047), HaStateColor.activeFor(state("lock.door", "unlocked")))
+    assertEquals(Color(0xFF673AB7), HaStateColor.activeFor(state("media_player.tv", "idle")))
+  }
+
+  @Test
+  fun activeForClimateDependsOnMode() {
+    assertEquals(Color(0xFFE65100), HaStateColor.activeFor(state("climate.h", "heat")))
+    assertEquals(Color(0xFF2196F3), HaStateColor.activeFor(state("climate.h", "cool")))
+    assertEquals(grayOff, HaStateColor.activeFor(state("climate.h", "off")))
+  }
+
+  @Test
+  fun activeForUnmodeledDomainIsInactiveGray() {
+    assertEquals(grayInactive, HaStateColor.activeFor(state("scene.movie", "on")))
+  }
+
+  // --- inactiveFor ---------------------------------------------------------
+
+  @Test
+  fun inactiveForLockIsAlertRed() {
+    // A lock's "inactive" (unlocked) state is an alert colour, not gray.
+    assertEquals(Color(0xFFE53935), HaStateColor.inactiveFor(state("lock.door", "locked")))
+  }
+
+  @Test
+  fun inactiveForSensorKeepsDeviceClassColorOthersAreGray() {
+    assertEquals(Color(0xFF43A047), HaStateColor.inactiveFor(state("sensor.b", "80", "battery")))
+    assertEquals(grayOff, HaStateColor.inactiveFor(state("light.k", "on")))
+  }
+}


### PR DESCRIPTION
Adds pure-JVM unit tests for previously-untested deterministic logic surfaced by the code-quality review. All logic here is testable without a Compose runtime, Android context, or network, so the tests are fast and stable.

## What's covered

- **`HaStateColorTest`** (rc-converter) — `resolve` / `activeFor` / `inactiveFor` across sensor device classes, binary-sensor on/off, trackers, toggleable accents, climate modes, and the lock alert-colour special case.
- **`HaDomainStateTest`** (ha-model) — the eight sealed state parsers (known values, `unavailable`, and the `Unknown(raw)` stability fallback), plus the `AlarmState` wire contract: `isArmed`, `intKey()`, the declaration-ordered & distinct `AlarmStateInt.All`, and `alarmStateIntFromRaw`. The ordering test guards a host↔`.rc` wire contract the source comments warn must never be reordered.
- **`ClientProfileTest`** (ha-model) — wire round-trip for every profile, case-insensitive parse, null/unknown handling.
- **`CardKeyTest`** (ha-model) — cache-key shape, `_default` fallbacks, the section segment, and that reordering / section-zero-vs-none produce distinct keys.

## Test plan

- `./gradlew :ha-model:jvmTest` ✅
- `./gradlew :rc-converter:testDebugUnitTest --tests "ee.schimke.ha.rc.HaStateColorTest"` ✅
- `./gradlew ktfmtCheck` ✅

Purely additive — no production code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_012tTMCR2fTa9kYrCzG7ftBW)_