### PR TITLE
fix(rc): don't crash the host screen when a constrained capture profile rejects a card

### DIFF
--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CachedCardPreview.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/CachedCardPreview.kt
@@ -88,17 +88,31 @@ fun CachedCardPreview(
     remember(effectiveCacheKey) {
       cache.get(effectiveCacheKey)
         ?: runBlocking {
+            val captureContent: @RemoteComposable @Composable () -> Unit =
+              if (debugBorders) {
+                { DebugRcBorderWrapper { content() } }
+              } else {
+                content
+              }
+            // A constrained capture [profile] (e.g. `widgetsProfile`,
+            // the launcher's stricter op set) can reject a card whose
+            // ops fall outside its vocabulary by throwing mid-capture.
+            // This capture runs synchronously inside composition via
+            // `runBlocking`, so an uncaught throw would take down the
+            // whole host screen (the card-history preview captures every
+            // card with the widgets profile — see CardHistoryScreen).
+            // Degrade to an empty document instead: the card renders
+            // blank, matching how the launcher shows a widget it can't
+            // paint, rather than crashing the screen hosting the preview.
             val captured =
-              captureSingleRemoteDocument(
-                context = context,
-                profile = profile,
-                content =
-                  if (debugBorders) {
-                    { DebugRcBorderWrapper { content() } }
-                  } else {
-                    content
-                  },
-              )
+              runCatching {
+                  captureSingleRemoteDocument(
+                    context = context,
+                    profile = profile,
+                    content = captureContent,
+                  )
+                }
+                .getOrElse { captureSingleRemoteDocument(context = context, profile = profile) {} }
             CardDocument(bytes = captured.bytes, widthPx = 0, heightPx = 0)
           }
           .also { cache.put(effectiveCacheKey, it) }


### PR DESCRIPTION
CachedCardPreview captures the card's .rc document synchronously inside
composition via runBlocking. When the caller passes a constrained profile
(widgetsProfile, the launcher's stricter op set — used by the card-history
"more info" preview since #364), capturing a card whose ops fall outside
that vocabulary throws mid-capture. Because the capture runs on the main
thread during composition, the uncaught throw tore down the whole
CardHistoryScreen: the long-press opened the history screen, its preview
crashed while composing, and "Other actions" never surfaced — which the
LongPressHistoryTest instrumentation test reported (misleadingly) as the
long-press being swallowed. The test has failed on every CI run since #364.

Degrade gracefully instead: catch the capture failure and fall back to an
empty document, so a rejected card renders blank — matching how the
launcher shows a widget it can't paint — rather than crashing the screen
hosting the preview. The dashboard path uses the full AndroidX profile,
which never rejects, so its behaviour is unchanged.