### PR TITLE
fix(dashboard): render and smoothly resize the widget preview

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/CardHistoryScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/CardHistoryScreen.kt
@@ -4,6 +4,7 @@ package ee.schimke.terrazzo.dashboard
 
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -245,7 +246,11 @@ private fun ResizableLauncherPreview(session: HaSession, card: CardConfig, snaps
       currentColor = currentColor,
     ) {
       CachedCardPreview(
-        cacheKey = LauncherPreviewKey(card, style, dark, cellsW, cellsH),
+        // Size-independent: the captured document reflows to the slot
+        // at playback via its runtime size-breakpoints, so the same
+        // bytes serve every cell size — keying on cellsW/cellsH would
+        // only force a redundant (blocking) re-encode on every drag step.
+        cacheKey = LauncherPreviewKey(card, style, dark),
         // Capture with the launcher's constrained op vocabulary —
         // the same widgetsProfile TerrazzoWidgetProvider and the
         // install sheet use — so a card that the launcher runtime
@@ -312,8 +317,12 @@ internal fun LauncherGrid(
 
   val gridWidthDp = (bounds.maxCellsW * LAUNCHER_CELL_WIDTH_DP).dp
   val gridHeightDp = (bounds.maxCellsH * LAUNCHER_CELL_HEIGHT_DP).dp
-  val currentWidthDp = (cellsW * LAUNCHER_CELL_WIDTH_DP).dp
-  val currentHeightDp = (cellsH * LAUNCHER_CELL_HEIGHT_DP).dp
+  // Glide the slot (card, outline and handle) between cell steps rather
+  // than hard-snapping. The embedded player reuses its View across sizes,
+  // so each animated frame is a cheap re-measure — no re-encode.
+  val currentWidthDp by animateDpAsState((cellsW * LAUNCHER_CELL_WIDTH_DP).dp, label = "slotWidth")
+  val currentHeightDp by
+    animateDpAsState((cellsH * LAUNCHER_CELL_HEIGHT_DP).dp, label = "slotHeight")
 
   Box(modifier = Modifier.size(gridWidthDp, gridHeightDp)) {
     // Backdrop: cell grid + smallest/largest size outlines.
@@ -463,8 +472,6 @@ private data class LauncherPreviewKey(
   val card: CardConfig,
   val style: ThemeStyle,
   val dark: Boolean,
-  val cellsW: Int,
-  val cellsH: Int,
 )
 
 /** Middle region: range chips + one chart block per entity. */

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WrapAdaptiveRemoteDocumentPlayer.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WrapAdaptiveRemoteDocumentPlayer.kt
@@ -50,6 +50,16 @@ import kotlin.math.min
  *
  * Single-View, no throwaway measurer — the same view we warm up is the one Compose displays.
  * Re-warms only when [documentBytes] or the parent's constraints change.
+ *
+ * **Pinned (EXACTLY) slots.** When the parent fixes *both* axes (`Modifier.size(...)`, or a
+ * `fillMaxSize()` inside an already-sized box — the card-history resize preview), the intrinsic
+ * measurement above is the wrong model: a full-bleed `fillMaxSize()` document (the launcher widget
+ * surface, [ee.schimke.ha.rc.components.RemoteHaWidgetSurface]) has *no* intrinsic size, so steps
+ * 2–4 would collapse the slot to ~1px and render blank. Instead we play the document at the
+ * parent's EXACT size — exactly as the launcher widget does — so it fills the slot and its runtime
+ * size-breakpoints (see `RemoteSizeBreakpoint`) read the real canvas. The View is then reused
+ * across size changes (it just re-measures), so an animated slot resizes smoothly without
+ * re-decoding or re-priming each frame.
  */
 @Composable
 fun WrapAdaptiveRemoteDocumentPlayer(
@@ -64,25 +74,47 @@ fun WrapAdaptiveRemoteDocumentPlayer(
     val density = LocalDensity.current
     val maxWPx = constraints.maxWidth
     val maxHPx = constraints.maxHeight
-    val view =
-      remember(documentBytes, maxWPx, maxHPx) {
-        RemoteComposePlayer(context).apply {
-          setBitmapLoader(bitmapLoader)
-          setDocument(RemoteDocument(decode(documentBytes)))
-          primeAndMeasure(this, maxWPx, maxHPx)
-          init(this)
-          // The View only exposes id-keyed action callbacks.
-          // The dashboard's `decodeHaAction` is keyed on the
-          // payload value (it doesn't care about the name),
-          // so we surface the id as the synthetic name and
-          // pass the value through.
-          addIdActionListener { id, value -> onNamedAction(id.toString(), value) }
+
+    if (constraints.hasFixedWidth && constraints.hasFixedHeight) {
+      // The parent pins the slot. Play at EXACTLY that size and reuse
+      // the View across resizes — the BoxWithConstraints is already
+      // sized by the parent, so a `fillMaxSize` document fills it and
+      // animating the slot just re-measures the (single) View.
+      val view =
+        remember(documentBytes) {
+          RemoteComposePlayer(context).apply {
+            setBitmapLoader(bitmapLoader)
+            setDocument(RemoteDocument(decode(documentBytes)))
+            // One off-screen draw warms the paint context so the first
+            // on-screen frame isn't blank; EXACTLY constraints size the
+            // View directly, so no intrinsic re-measure is needed.
+            primeFixed(this, maxWPx, maxHPx)
+            init(this)
+            addIdActionListener { id, value -> onNamedAction(id.toString(), value) }
+          }
         }
-      }
-    val widthDp = with(density) { clampWarmupDimension(view.measuredWidth, maxWPx).toDp() }
-    val heightDp = with(density) { clampWarmupDimension(view.measuredHeight, maxHPx).toDp() }
-    Box(modifier = Modifier.size(widthDp, heightDp)) {
       AndroidView(factory = { view }, modifier = Modifier.fillMaxSize())
+    } else {
+      val view =
+        remember(documentBytes, maxWPx, maxHPx) {
+          RemoteComposePlayer(context).apply {
+            setBitmapLoader(bitmapLoader)
+            setDocument(RemoteDocument(decode(documentBytes)))
+            primeAndMeasure(this, maxWPx, maxHPx)
+            init(this)
+            // The View only exposes id-keyed action callbacks.
+            // The dashboard's `decodeHaAction` is keyed on the
+            // payload value (it doesn't care about the name),
+            // so we surface the id as the synthetic name and
+            // pass the value through.
+            addIdActionListener { id, value -> onNamedAction(id.toString(), value) }
+          }
+        }
+      val widthDp = with(density) { clampWarmupDimension(view.measuredWidth, maxWPx).toDp() }
+      val heightDp = with(density) { clampWarmupDimension(view.measuredHeight, maxHPx).toDp() }
+      Box(modifier = Modifier.size(widthDp, heightDp)) {
+        AndroidView(factory = { view }, modifier = Modifier.fillMaxSize())
+      }
     }
   }
 }
@@ -119,6 +151,24 @@ private fun primeAndMeasure(view: RemoteComposePlayer, maxWPx: Int, maxHPx: Int)
   warmupBmp.recycle()
   view.forceLayout()
   view.measure(widthSpec, heightSpec)
+}
+
+/**
+ * Single off-screen `measure → layout → draw` at an EXACTLY-sized slot, purely to populate the
+ * `AndroidPaintContext` (the first on-screen frame would otherwise be blank). Unlike
+ * [primeAndMeasure] there's no intrinsic re-measure: an EXACTLY constraint sizes the View directly,
+ * and subsequent (e.g. animated) sizes are handled by the View re-measuring in place.
+ */
+private fun primeFixed(view: RemoteComposePlayer, wPx: Int, hPx: Int) {
+  val w = wPx.coerceIn(1, MAX_WARMUP_DIMENSION_PX)
+  val h = hPx.coerceIn(1, MAX_WARMUP_DIMENSION_PX)
+  val widthSpec = View.MeasureSpec.makeMeasureSpec(w, View.MeasureSpec.EXACTLY)
+  val heightSpec = View.MeasureSpec.makeMeasureSpec(h, View.MeasureSpec.EXACTLY)
+  view.measure(widthSpec, heightSpec)
+  view.layout(0, 0, w, h)
+  val warmupBmp = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+  view.draw(Canvas(warmupBmp))
+  warmupBmp.recycle()
 }
 
 private fun clampWarmupDimension(measuredPx: Int, constraintMaxPx: Int): Int {


### PR DESCRIPTION
The card-history resize preview rendered blank because the launcher
widget surface wraps the card in a remote-side fillMaxSize(), but
WrapAdaptiveRemoteDocumentPlayer measured the document at AT_MOST to
find its intrinsic size and pinned the slot to that — a fillMaxSize
document has zero intrinsic size, so the slot collapsed to ~1px.

When the parent fixes both axes (Modifier.size / fillMaxSize in a
sized box), play the document at the parent's EXACT size, exactly as
the launcher widget does, so a full-bleed surface fills the slot and
its runtime size-breakpoints read the real canvas.

Resizing is now smooth: the preview cache key no longer includes the
cell size (the captured document is size-independent and reflows at
playback), so dragging no longer triggers a blocking re-encode per
step; the fixed-slot player reuses its View across sizes; and the
slot glides between cell steps via animateDpAsState.