### PR TITLE
Fix widget blank/resize bug by rebuilding player on size changes

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/CardHistoryScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/CardHistoryScreen.kt
@@ -5,7 +5,6 @@ package ee.schimke.terrazzo.dashboard
 import android.content.Intent
 import android.graphics.Paint
 import android.net.Uri
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -329,12 +328,13 @@ internal fun LauncherGrid(
 
   val gridWidthDp = (bounds.maxCellsW * LAUNCHER_CELL_WIDTH_DP).dp
   val gridHeightDp = (bounds.maxCellsH * LAUNCHER_CELL_HEIGHT_DP).dp
-  // Glide the slot (card, outline and handle) between cell steps rather
-  // than hard-snapping. The embedded player reuses its View across sizes,
-  // so each animated frame is a cheap re-measure — no re-encode.
-  val currentWidthDp by animateDpAsState((cellsW * LAUNCHER_CELL_WIDTH_DP).dp, label = "slotWidth")
-  val currentHeightDp by
-    animateDpAsState((cellsH * LAUNCHER_CELL_HEIGHT_DP).dp, label = "slotHeight")
+  // Snap the slot (card, outline and handle) to whole cells, the way the
+  // launcher does. The embedded player is rebuilt at each slot size (a
+  // re-used RemoteComposePlayer paints blank / doesn't fill when
+  // re-measured at a new size — see WrapAdaptiveRemoteDocumentPlayer), so
+  // we step per cell rather than tweening through intermediate sizes.
+  val currentWidthDp = (cellsW * LAUNCHER_CELL_WIDTH_DP).dp
+  val currentHeightDp = (cellsH * LAUNCHER_CELL_HEIGHT_DP).dp
 
   Box(modifier = Modifier.size(gridWidthDp, gridHeightDp)) {
     // Backdrop: cell grid + smallest/largest size outlines.

--- a/app/src/main/kotlin/ee/schimke/terrazzo/widget/TerrazzoWidgetProvider.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/widget/TerrazzoWidgetProvider.kt
@@ -70,6 +70,25 @@ open class TerrazzoWidgetProvider : AppWidgetProvider() {
   }
 
   /**
+   * The launcher calls this when the user resizes the widget (the cell span changed). Re-capture
+   * the card at the new slot size and republish: the `.rc` document bakes its canvas size at
+   * capture time, so without a fresh capture the launcher keeps painting the old document — which,
+   * replayed into the new (larger or smaller) cell, leaves the surface short of the slot edges or,
+   * on a re-used player, blank. Re-rendering authors the document at the new size so the surface
+   * fills the cell and the card's size-breakpoints reflow to it.
+   */
+  override fun onAppWidgetOptionsChanged(
+    context: Context,
+    appWidgetManager: AppWidgetManager,
+    appWidgetId: Int,
+    newOptions: android.os.Bundle,
+  ) {
+    super.onAppWidgetOptionsChanged(context, appWidgetManager, appWidgetId, newOptions)
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) return
+    renderAndPublish(context, appWidgetManager, appWidgetId)
+  }
+
+  /**
    * The launcher tells us these widget ids were removed from the home screen. Drop their persisted
    * rows so the install cap frees the slots back up — a stale row would otherwise keep burning one
    * of the five even though nothing renders for it anymore.

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WidgetProfile.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WidgetProfile.kt
@@ -3,6 +3,8 @@
 package ee.schimke.ha.rc
 
 import androidx.compose.remote.core.RcProfiles
+import androidx.compose.remote.core.operations.Header
+import androidx.compose.remote.creation.RemoteComposeWriter
 import androidx.compose.remote.creation.RemoteComposeWriterAndroid
 import androidx.compose.remote.creation.platform.AndroidxRcPlatformServices
 import androidx.compose.remote.creation.profile.Profile
@@ -17,12 +19,38 @@ import androidx.compose.remote.creation.profile.Profile
  * Shape mirrors `RcPlatformProfiles.WIDGETS_V7` (document API level 7,
  * `RcProfiles.PROFILE_WIDGETS`) but ORs in `PROFILE_EXPERIMENTAL` so experimental widget ops are
  * admitted at capture time.
+ *
+ * **`FEATURE_PAINT_MEASURE = 0` (no paint-measure for widgets).** The alpha default is `1`
+ * ("measure during paint instead of wrap behaviour"), which makes
+ * [androidx.compose.remote.player.view.platform.RemoteComposeView.onMeasure] skip the document's
+ * measure pass and only re-measures content lazily during `dispatchDraw`. A widget's slot size is
+ * *externally forced* by the launcher (the cell grid), and the host re-uses one player view across
+ * resizes — the embedded long-press preview's `WrapAdaptiveRemoteDocumentPlayer`, and the
+ * launcher's own `RemoteViews.DrawInstructions` view. With paint-measure on, that re-used view
+ * paints blank the moment it's re-measured at a new size (its layout was cached at the first draw
+ * and never rebuilt), which is the "widget goes blank once resized" bug. With the feature off the
+ * player runs a real measure pass against the (EXACTLY) slot on every size change, so `fillMaxSize`
+ * re-fills and content reflows to the new cell — exactly what we want when the size is dictated
+ * from outside.
+ *
+ * Baking the bit requires the writer's `HTag` varargs constructor (the flag lands in the same
+ * single `HEADER` op that carries DOC_WIDTH / DOC_HEIGHT / DOC_PROFILES), which means dropping the
+ * `writerCallback` — same tradeoff [androidXExperimentalWrap] already takes: it only tracks
+ * PendingIntent-style side effects baked by the writer, and these cards issue none (widget taps go
+ * through named actions dispatched at playback, not writer-baked intents).
  */
 val widgetsProfile: Profile =
   Profile(
     7,
     RcProfiles.PROFILE_WIDGETS or RcProfiles.PROFILE_EXPERIMENTAL,
     AndroidxRcPlatformServices(),
-  ) { creationDisplayInfo, profile, callback ->
-    RemoteComposeWriterAndroid(creationDisplayInfo, null, profile, callback)
+  ) { creationDisplayInfo, profile, _ ->
+    RemoteComposeWriterAndroid(
+      profile,
+      RemoteComposeWriter.hTag(Header.DOC_WIDTH, creationDisplayInfo.width),
+      RemoteComposeWriter.hTag(Header.DOC_HEIGHT, creationDisplayInfo.height),
+      RemoteComposeWriter.hTag(Header.DOC_CONTENT_DESCRIPTION, ""),
+      RemoteComposeWriter.hTag(Header.DOC_PROFILES, profile.operationsProfiles),
+      RemoteComposeWriter.hTag(Header.FEATURE_PAINT_MEASURE, 0),
+    )
   }

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WrapAdaptiveRemoteDocumentPlayer.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/WrapAdaptiveRemoteDocumentPlayer.kt
@@ -15,6 +15,7 @@ import androidx.compose.remote.player.core.RemoteDocument
 import androidx.compose.remote.player.core.platform.BitmapLoader
 import androidx.compose.remote.player.view.RemoteComposePlayer
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -57,9 +58,11 @@ import kotlin.math.min
  * surface, [ee.schimke.ha.rc.components.RemoteHaWidgetSurface]) has *no* intrinsic size, so steps
  * 2–4 would collapse the slot to ~1px and render blank. Instead we play the document at the
  * parent's EXACT size — exactly as the launcher widget does — so it fills the slot and its runtime
- * size-breakpoints (see `RemoteSizeBreakpoint`) read the real canvas. The View is then reused
- * across size changes (it just re-measures), so an animated slot resizes smoothly without
- * re-decoding or re-priming each frame.
+ * size-breakpoints (see `RemoteSizeBreakpoint`) read the real canvas. The View is rebuilt (and
+ * re-primed) whenever that size changes: a `RemoteComposePlayer` re-measured at a new size after
+ * its first draw paints blank or only fills up to its first size, so re-using one View across a
+ * resize is exactly the "widget goes blank once resized" bug. Decoded bytes are cached by the
+ * caller, so a resize only rebuilds the View + prime, not the document.
  */
 @Composable
 fun WrapAdaptiveRemoteDocumentPlayer(
@@ -76,12 +79,23 @@ fun WrapAdaptiveRemoteDocumentPlayer(
     val maxHPx = constraints.maxHeight
 
     if (constraints.hasFixedWidth && constraints.hasFixedHeight) {
-      // The parent pins the slot. Play at EXACTLY that size and reuse
-      // the View across resizes — the BoxWithConstraints is already
-      // sized by the parent, so a `fillMaxSize` document fills it and
-      // animating the slot just re-measures the (single) View.
+      // The parent pins the slot (EXACTLY on both axes) — the launcher
+      // widget and the long-press resize preview, whose size is forced
+      // from outside. Build the player for this exact size and rebuild
+      // it whenever the size changes (key on width/height too).
+      //
+      // We deliberately do NOT re-use one primed View across resizes: a
+      // `RemoteComposePlayer` that has been measured + drawn once paints
+      // blank — or only fills up to its first size — when it is later
+      // re-measured at a different size (its layout is cached at the
+      // first draw and never rebuilt; with `FEATURE_PAINT_MEASURE = 1`
+      // it doesn't even re-run the document measure). That is the
+      // "widget goes blank / doesn't fill once resized" bug. Re-keying
+      // on the size gives each slot a freshly primed View that fills it
+      // and reflows its size-breakpoints; the caller caches the decoded
+      // bytes, so only the View + prime is rebuilt per (discrete) size.
       val view =
-        remember(documentBytes) {
+        remember(documentBytes, maxWPx, maxHPx) {
           RemoteComposePlayer(context).apply {
             setBitmapLoader(bitmapLoader)
             setDocument(RemoteDocument(decode(documentBytes)))
@@ -93,7 +107,8 @@ fun WrapAdaptiveRemoteDocumentPlayer(
             addIdActionListener { id, value -> onNamedAction(id.toString(), value) }
           }
         }
-      AndroidView(factory = { view }, modifier = Modifier.fillMaxSize())
+      // Swap the embedded View when a resize produces a new instance.
+      key(view) { AndroidView(factory = { view }, modifier = Modifier.fillMaxSize()) }
     } else {
       val view =
         remember(documentBytes, maxWPx, maxHPx) {


### PR DESCRIPTION
## Summary
Fixes the "widget goes blank once resized" bug by rebuilding the `RemoteComposePlayer` view whenever the widget slot size changes, rather than attempting to reuse a single view across resizes. This includes disabling paint-measure mode in the widget profile and updating the preview UI to snap to cell boundaries instead of animating through intermediate sizes.

## Key Changes

- **WrapAdaptiveRemoteDocumentPlayer.kt**: 
  - Added `key` import and wrapped `AndroidView` in a `key(view)` block to force recreation when the view instance changes
  - Modified `remember` to include `maxWPx` and `maxHPx` as dependencies, ensuring a fresh player is created on each size change
  - Updated extensive documentation explaining why view reuse across resizes causes blank rendering and why rebuilding is necessary

- **WidgetProfile.kt**:
  - Disabled `FEATURE_PAINT_MEASURE` (set to 0) in the widget profile to ensure the player runs a full measure pass on every size change rather than caching layout from the first draw
  - Refactored the profile builder to use `RemoteComposeWriter.hTag()` varargs constructor, baking all header flags directly instead of using a callback
  - Added comprehensive documentation explaining the paint-measure issue and why it must be disabled for externally-sized widget slots

- **TerrazzoWidgetProvider.kt**:
  - Implemented `onAppWidgetOptionsChanged()` override to re-capture and republish the widget when the launcher resizes it (cell span changes)
  - Added documentation explaining that the `.rc` document bakes its canvas size at capture time, requiring a fresh capture on resize

- **CardHistoryScreen.kt**:
  - Removed `animateDpAsState` animation for slot resizing
  - Changed from tweening intermediate sizes to snapping to whole cell boundaries, matching launcher behavior
  - Updated comments explaining that the embedded player is rebuilt at each size, so intermediate animation frames would be wasteful

## Implementation Details

The root cause is that `RemoteComposePlayer` caches its layout after the first measure+draw pass. When re-measured at a different size with paint-measure enabled, it skips the document's measure pass and only re-measures lazily during `dispatchDraw`, causing blank rendering or incomplete fills. 

The fix operates at three levels:
1. **Player level**: Rebuild the view on size changes via `remember` dependencies and `key()` composition
2. **Profile level**: Disable paint-measure so the player always runs a full measure pass on size changes
3. **Widget level**: Re-capture the document at the new size when the launcher resizes the widget slot
4. **Preview level**: Snap to cell boundaries instead of animating, since each size change triggers a rebuild anyway

https://claude.ai/code/session_01R6P3b1KKKvNyq1x8UkcKw2