### PR TITLE
fix(build): resolve google-services.json by rootDir, not CWD-relative path

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,10 +8,15 @@ buildscript {
   // Gradle plugins on the buildscript classpath when an
   // `app/google-services.json` is present — without it nothing here
   // resolves, so the default build is byte-for-byte unaffected and pulls
-  // in no Firebase tooling. The path is resolved relative to the root
-  // project dir (Gradle's working directory). Versions are only fetched
-  // by developers who have configured a key; bump as needed.
-  if (java.io.File("app/google-services.json").exists()) {
+  // in no Firebase tooling. Resolve against `rootDir` (not a CWD-relative
+  // `java.io.File`) so the check matches the app module's Gradle `file(…)`
+  // lookup regardless of the launcher's working directory — e.g. the VS
+  // Code / Android Studio Compose preview daemon starts Gradle from a
+  // different CWD, which made this classpath silently drop out while the
+  // app still applied the plugin, failing with "Plugin … not found".
+  // Versions are only fetched by developers who have configured a key;
+  // bump as needed.
+  if (rootDir.resolve("app/google-services.json").exists()) {
     repositories {
       google()
       mavenCentral()


### PR DESCRIPTION
The root buildscript gated the Google Services / Crashlytics plugin
classpath on java.io.File("app/google-services.json"), which resolves
against the JVM working directory. The app module gates applying the
plugin on Gradle's file("google-services.json"), which resolves against
the project dir. When a launcher starts Gradle from a different CWD —
e.g. the VS Code / Android Studio Compose preview daemon
(composePreviewDaemonStart) — the two checks disagree: the classpath is
dropped while the app still applies the plugin, failing with
"Plugin with id 'com.google.gms.google-services' not found".

Resolve the root check against rootDir so both lookups always agree
regardless of the launcher's working directory.