### PR TITLE
chore: set up compose-preview for cloud sessions and bump compose-ai-tools to 0.14.0

### DIFF
--- a/.claude/hooks/compose-preview-setup.sh
+++ b/.claude/hooks/compose-preview-setup.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Cloud session bootstrap for Compose @Preview rendering.
+#
+# Provisions the toolchain + the compose-preview skill via coo.ee (devenv
+# backend), then bootstraps the compose-preview CLI and warms preview
+# discovery once. The warm-up resolves the auto-injected Gradle plugin's
+# artifacts so the first interactive `compose-preview list` works WITHOUT
+# `ee.schimke.composeai.preview` being applied in any build file.
+#
+# No-op on developer machines (gated on CLAUDE_CODE_REMOTE), matching the
+# sibling session-start.sh hook.
+set -euo pipefail
+
+[ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || exit 0
+
+cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
+
+# 1. Toolchain (JDK adopted; Android SDK + devenv via Nix) + the
+#    compose-preview skill bundle. Idempotent: re-runs short-circuit.
+curl -fsSL 'https://env.coo.ee/compose?devenv=1' | bash
+
+# 2. Activate the env coo.ee just persisted into this and future shells.
+[ -f "$HOME/.config/coo-ee/env.sh" ] && . "$HOME/.config/coo-ee/env.sh" || true
+export PATH="$HOME/.local/bin:$PATH"
+
+# 3. Bootstrap the compose-preview CLI (the skill ships a self-installing
+#    stub) and warm discovery once from the project root. Best-effort: a
+#    network/build hiccup here must not fail session start.
+cli=""
+if command -v compose-preview >/dev/null 2>&1; then
+  cli=compose-preview
+elif [ -x "$HOME/.claude/skills/compose-preview/scripts/compose-preview" ]; then
+  cli="$HOME/.claude/skills/compose-preview/scripts/compose-preview"
+fi
+[ -n "$cli" ] && { "$cli" list >/dev/null 2>&1 || true; }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,14 @@
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/compose-preview-setup.sh"
+          }
+        ]
       }
     ]
   }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       # render before `./gradlew test`. (The `compose-preview` workflow
       # still publishes baselines / PR comments separately; this step is
       # local to the test job and doesn't push anything.)
-      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.12.5
+      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.14.0
         with:
           version: catalog
           catalog-key: compose-preview-plugin

--- a/.github/workflows/compose-preview.yml
+++ b/.github/workflows/compose-preview.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
-      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.12.5
+      - uses: yschimke/compose-ai-tools/.github/actions/apply@v0.14.0
         with:
           cli-version: catalog
           catalog-key: compose-preview-plugin

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -148,7 +148,7 @@ dependencies {
   debugImplementation(libs.compose.ui.tooling)
   // Debug-only: @AnimatedPreview drives the compose-preview GIF capture
   // of the card-flash debug feature. Kept out of the release APK.
-  debugImplementation("ee.schimke.composeai:preview-annotations:0.12.5")
+  debugImplementation("ee.schimke.composeai:preview-annotations:0.14.0")
   implementation(libs.activity.compose)
   implementation(libs.materialkolor)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ indriya = "2.2.4"
 # of the plugin marker. The preview-baselines / preview-comment GitHub
 # Actions read this key (`catalog-key: compose-preview-plugin`) to pin
 # the CLI release they install on the runner.
-compose-preview-plugin = "0.12.5"
+compose-preview-plugin = "0.14.0"
 tapmoc = "0.4.2"
 
 # Image loading (BitmapLoader / RemoteCompose named-bitmap resolution)


### PR DESCRIPTION
## What

- **Add compose-preview `SessionStart` hook** for Claude Code on the web / cloud sandboxes. It provisions the dev environment via coo.ee (`?devenv=1`) and does a one-time `compose-preview list` warm-up, so the first cold render works without the plugin being applied in any build file.
- **Bump compose-ai-tools to 0.14.0**:
  - `ci.yml`: `install@v0.12.5` → `@v0.14.0`
  - `compose-preview.yml`: `apply@v0.12.5` → `@v0.14.0`
  - `app/build.gradle.kts`: `preview-annotations:0.12.5` → `0.14.0`
  - `libs.versions.toml`: `compose-preview-plugin` `0.12.5` → `0.14.0`

## Notes

- v0.14.0 is the current latest release of `yschimke/compose-ai-tools`.
- The `[plugins]` alias uses `version.ref`, so it picks up the catalog bump automatically.

https://claude.ai/code/session_01WXNu4Y4xjWWNB5PaYjBesz

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXNu4Y4xjWWNB5PaYjBesz)_