### PR TITLE
feat: publish Terrazzo / HA-RemoteCompose design system report

### DIFF
--- a/.github/workflows/design-artifacts.yml
+++ b/.github/workflows/design-artifacts.yml
@@ -1,0 +1,114 @@
+name: Design Artifacts
+
+# Render the Terrazzo / HA-RemoteCompose design catalog (:previews @Preview
+# sticker sheet) and publish its importable bundle (catalog.json + DTCG tokens +
+# Figma variables + PNGs) to a clean `design-artifacts/homeassistant-remotecompose`
+# branch. The public preview server (preview.coo.ee) fetches that branch and
+# serves it at /homeassistant-remotecompose/.
+#
+# Pipeline mirrors compose-ai-tools' own design-artifacts job:
+#   compose-preview bundle pack  →  @design-parity/catalog-export driver
+#   (from a compose-ai-tools checkout)  →  force-push out/ to the branch.
+
+on:
+  # Weekly, so the published sticker sheet tracks the catalog as it evolves.
+  schedule:
+    - cron: '0 6 * * 1' # Mondays 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      allow_incomplete:
+        description: 'Publish even if some catalog previews fail to render or lack semantics (use for the first run while tuning the spec).'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: design-artifacts-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  generate:
+    name: homeassistant-remotecompose
+    # Don't run on forks — the publish step pushes a branch into this repo.
+    if: ${{ github.repository == 'yschimke/homeassistant-remotecompose' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      # Widened here (workflow default is read-only) for the branch force-push.
+      contents: write
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      # JDK 21 + Gradle. The Android SDK is preinstalled on ubuntu-latest, which
+      # is what the :previews Robolectric render needs (same as compose-preview.yml).
+      - uses: ./.github/actions/setup
+        with:
+          cache-read-only: 'true'
+
+      # Install the compose-preview CLI. `:previews` has the plugin AUTO-injected
+      # (via --init-script), so the CLI carries its own matching plugin and a
+      # newer CLI is safe — we install `latest` because the applied
+      # compose-preview-plugin (0.14.0) predates `bundle pack --with-semantics`.
+      - uses: yschimke/compose-ai-tools/.github/actions/install@v0.14.0
+        with:
+          version: latest
+
+      # The export driver + its render helpers live in compose-ai-tools; check it
+      # out (public repo) so we can run scripts/design-artifacts/. Pin CAT_REF to a
+      # release tag for full reproducibility once the path-URL changes have shipped.
+      - uses: actions/checkout@v6.0.2
+        with:
+          repository: yschimke/compose-ai-tools
+          ref: main
+          path: compose-ai-tools
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6.4.0
+        with:
+          node-version: 22
+      - name: Install export engine (pinned npm packages)
+        working-directory: compose-ai-tools/scripts/design-artifacts
+        run: npm ci
+
+      # Render the catalog module into a portable bundle with semantics (a11y
+      # greenlines + layout tree → tokens/wireframes in the exported catalog).
+      - name: Render catalog bundle
+        run: |
+          set -euo pipefail
+          compose-preview bundle pack --module :previews --with-semantics \
+            -o "$GITHUB_WORKSPACE/homeassistant-remotecompose-bundle.png"
+
+      # Join the render to catalog.spec.json and write the importable bundle.
+      - name: Generate importable catalog
+        run: |
+          set -euo pipefail
+          node compose-ai-tools/scripts/design-artifacts/generate-design-catalog.mjs \
+            --spec catalog.spec.json \
+            --renders "$GITHUB_WORKSPACE/homeassistant-remotecompose-bundle.png" \
+            --out "$GITHUB_WORKSPACE/out" \
+            --renderer "$(compose-preview --version | head -1)" \
+            --source-repo "${GITHUB_REPOSITORY}" \
+            --source-ref main \
+            --source-module :previews \
+            ${{ (github.event_name == 'workflow_dispatch' && inputs.allow_incomplete) && '--allow-incomplete' || '' }}
+
+      - name: Publish to design-artifacts/homeassistant-remotecompose
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          cd "$GITHUB_WORKSPACE/out"
+          git init -q
+          git checkout -q -b design-artifacts/homeassistant-remotecompose
+          # Generated delivery branch — attributed to the repo owner, not a bot.
+          git config user.name 'Yuri Schimke'
+          git config user.email 'yuri@schimke.ee'
+          git add -A
+          git commit -q -m "chore(design-artifacts): regenerate homeassistant-remotecompose catalog ($(date -u +%F))"
+          git push --force \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "HEAD:refs/heads/design-artifacts/homeassistant-remotecompose"

--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -1,0 +1,84 @@
+{
+  "$comment": "Design-catalog spec for the Terrazzo / Home Assistant RemoteCompose design system. Code-led: it declares which @Preview composables (by function name) make up the published sticker sheet, their grouping, and captions. Consumed by @design-parity/catalog-export (via compose-ai-tools' scripts/design-artifacts/generate-design-catalog.mjs) over a `compose-preview bundle pack --module :previews` render to produce the importable design-artifacts/homeassistant-remotecompose bundle the public preview server serves at /homeassistant-remotecompose/. Each `preview` MUST equal the exact @Preview function name in :previews (ee.schimke.ha.previews). Cards render through the RemoteContentPreview host but are annotated with the standard @Preview, so they rasterise headless via Robolectric.",
+  "system": "homeassistant-remotecompose",
+  "title": "Terrazzo · Home Assistant RemoteCompose",
+  "library": [
+    "androidx.compose.material3:material3",
+    "androidx.compose.remote:remote-player-compose (RemoteCompose)",
+    "ee.schimke.ha:rc-components (Terrazzo themes)"
+  ],
+  "module": "previews",
+  "modes": ["light", "dark"],
+  "breakpoints": [{ "size": "compact", "widthDp": 360 }],
+  "groups": [
+    {
+      "name": "Themes",
+      "components": [
+        {
+          "componentId": "Theme/Material3-Light",
+          "preview": "Theme_Material3_Light",
+          "caption": "Material 3 defaults — colours, type and the surface-elevation strip (light)."
+        },
+        { "componentId": "Theme/Material3-Dark", "preview": "Theme_Material3_Dark", "caption": "Material 3 defaults (dark)." },
+        {
+          "componentId": "Theme/Home-Light",
+          "preview": "Theme_Home_Light",
+          "caption": "Home palette — HA blue, Roboto Flex + Inter (light)."
+        },
+        { "componentId": "Theme/Home-Dark", "preview": "Theme_Home_Dark", "caption": "Home palette (dark)." },
+        {
+          "componentId": "Theme/Mushroom-Light",
+          "preview": "Theme_Mushroom_Light",
+          "caption": "Mushroom palette — warm salmon, Figtree (light)."
+        },
+        { "componentId": "Theme/Mushroom-Dark", "preview": "Theme_Mushroom_Dark", "caption": "Mushroom palette (dark)." },
+        {
+          "componentId": "Theme/Minimalist-Light",
+          "preview": "Theme_Minimalist_Light",
+          "caption": "Minimalist palette — neutral slate, IBM Plex Sans (light)."
+        },
+        { "componentId": "Theme/Minimalist-Dark", "preview": "Theme_Minimalist_Dark", "caption": "Minimalist palette (dark)." },
+        {
+          "componentId": "Theme/Kiosk-Light",
+          "preview": "Theme_Kiosk_Light",
+          "caption": "Kiosk palette — high-contrast teal, Atkinson Hyperlegible (light)."
+        },
+        { "componentId": "Theme/Kiosk-Dark", "preview": "Theme_Kiosk_Dark", "caption": "Kiosk palette (dark)." }
+      ]
+    },
+    {
+      "name": "Cards",
+      "components": [
+        { "componentId": "Card/Button-Light", "preview": "Button_Light", "caption": "Button card — action states (light)." },
+        { "componentId": "Card/Button-Dark", "preview": "Button_Dark", "caption": "Button card (dark)." },
+        { "componentId": "Card/Entity-Light", "preview": "Entity_Light", "caption": "Entity card — a single entity row (light)." },
+        { "componentId": "Card/Entity-Dark", "preview": "Entity_Dark", "caption": "Entity card (dark)." },
+        { "componentId": "Card/Entities-Light", "preview": "Entities_Light", "caption": "Entities card — a multi-entity list (light)." },
+        { "componentId": "Card/Entities-Dark", "preview": "Entities_Dark", "caption": "Entities card (dark)." },
+        { "componentId": "Card/Glance-Light", "preview": "Glance_Light", "caption": "Glance card — an icon grid (light)." },
+        { "componentId": "Card/Glance-Dark", "preview": "Glance_Dark", "caption": "Glance card (dark)." },
+        { "componentId": "Card/Tile-Light", "preview": "Tile_Light", "caption": "Tile card — the primary HA card (light)." },
+        { "componentId": "Card/Tile-Dark", "preview": "Tile_Dark", "caption": "Tile card (dark)." }
+      ]
+    },
+    {
+      "name": "Specialised cards",
+      "components": [
+        { "componentId": "Card/Shutter-Light", "preview": "Shutter_Light", "caption": "Enhanced shutter card (light)." },
+        { "componentId": "Card/Shutter-Dark", "preview": "Shutter_Dark", "caption": "Enhanced shutter card (dark)." },
+        {
+          "componentId": "Card/Garage-Animation",
+          "preview": "Garage_Animation_Light",
+          "caption": "Garage door — the open/close animation strip (0–100%)."
+        },
+        {
+          "componentId": "Card/Garage-State",
+          "preview": "Garage_State_Light",
+          "caption": "Garage door — closed / opening / open / closing / unavailable."
+        },
+        { "componentId": "Dashboard/Light", "preview": "Dashboard_Light", "caption": "A full mixed-card dashboard stack (light)." },
+        { "componentId": "Dashboard/Dark", "preview": "Dashboard_Dark", "caption": "A full mixed-card dashboard stack (dark)." }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Publish the Terrazzo / Home-Assistant-RemoteCompose design system as a rendered, importable **design catalog**, served by the public preview server (preview.coo.ee) at **`/homeassistant-remotecompose/`** — the same way `compose-m3` / `wear-m3` are published from compose-ai-tools.

- **`catalog.spec.json`** — the code-led inventory for the `:previews` `@Preview` sticker sheet: the five Terrazzo theme palettes (Material3 / Home / Mushroom / Minimalist / Kiosk, light + dark) plus a representative spread of RemoteCompose cards (button, entity, entities, glance, tile, shutter, garage, dashboard). Each `preview` is the exact `@Preview` function name; the exporter joins on it. The cards render through the `RemoteContentPreview` host but carry a standard `@Preview`, so they rasterise headless via Robolectric.
- **`.github/workflows/design-artifacts.yml`** — renders `:previews` via `compose-preview bundle pack --with-semantics`, runs the `@design-parity/catalog-export` driver from a compose-ai-tools checkout, and force-pushes the importable bundle to a clean `design-artifacts/homeassistant-remotecompose` branch. Weekly + `workflow_dispatch`.

No app/runtime code changes — this is catalog data + CI plumbing, so there's no visual surface to diff here. The rendered stickers appear on the `design-artifacts/homeassistant-remotecompose` branch after the first run.

## Test plan

The render only runs on GitHub (needs the Android SDK / Robolectric), so validate by dispatching:

1. Merge, then **Actions → Design Artifacts → Run workflow**. For the first run, set **`allow_incomplete: true`** — if any catalog preview doesn't render or lacks semantics, this publishes what did (so `/homeassistant-remotecompose/` comes up) and logs the gaps; then tighten the spec and re-run fail-closed.
2. Confirm the `design-artifacts/homeassistant-remotecompose` branch is created with `catalog.json` + `images/`.
3. Requires the companion compose-ai-tools PR (path routing + `SERVE_CATALOGS_UNLISTED`) merged + preview.coo.ee restarted for `https://preview.coo.ee/homeassistant-remotecompose/` to resolve.

## Notes

- The design-artifacts CLI is pinned to `latest`, not the applied `compose-preview-plugin` (0.14.0), because that version predates `bundle pack --with-semantics`. `:previews` auto-injects the plugin (no explicit `apply`), so a newer CLI carries its own matching plugin — no version-skew conflict. Say the word and I'll pin it to a specific release once you pick a target.
- The workflow checks out `yschimke/compose-ai-tools@main` for the export driver — pin to a release tag for full reproducibility once the path-URL deep-link change ships.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh2DezRdwpjddGGEZ3nveE)_