### PR TITLE
fix: use semantics-capturing previews in the HA design catalog

### DIFF
--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -49,8 +49,6 @@
     {
       "name": "Cards",
       "components": [
-        { "componentId": "Card/Button-Light", "preview": "Button_Light", "caption": "Button card — action states (light)." },
-        { "componentId": "Card/Button-Dark", "preview": "Button_Dark", "caption": "Button card (dark)." },
         { "componentId": "Card/Entity-Light", "preview": "Entity_Light", "caption": "Entity card — a single entity row (light)." },
         { "componentId": "Card/Entity-Dark", "preview": "Entity_Dark", "caption": "Entity card (dark)." },
         { "componentId": "Card/Entities-Light", "preview": "Entities_Light", "caption": "Entities card — a multi-entity list (light)." },
@@ -66,16 +64,8 @@
       "components": [
         { "componentId": "Card/Shutter-Light", "preview": "Shutter_Light", "caption": "Enhanced shutter card (light)." },
         { "componentId": "Card/Shutter-Dark", "preview": "Shutter_Dark", "caption": "Enhanced shutter card (dark)." },
-        {
-          "componentId": "Card/Garage-Animation",
-          "preview": "Garage_Animation_Light",
-          "caption": "Garage door — the open/close animation strip (0–100%)."
-        },
-        {
-          "componentId": "Card/Garage-State",
-          "preview": "Garage_State_Light",
-          "caption": "Garage door — closed / opening / open / closing / unavailable."
-        },
+        { "componentId": "Card/Garage-Light", "preview": "Garage_TwoEntities_Light", "caption": "Garage door card — cover + light (light)." },
+        { "componentId": "Card/Garage-Dark", "preview": "Garage_TwoEntities_Dark", "caption": "Garage door card — cover + light (dark)." },
         { "componentId": "Dashboard/Light", "preview": "Dashboard_Light", "caption": "A full mixed-card dashboard stack (light)." },
         { "componentId": "Dashboard/Dark", "preview": "Dashboard_Dark", "caption": "A full mixed-card dashboard stack (dark)." }
       ]


### PR DESCRIPTION
## Summary

The first fail-closed **Design Artifacts** run ([run 28497159043](https://github.com/yschimke/homeassistant-remotecompose/actions/runs/28497159043)) rendered fine (185 previews) but refused to publish:

```
[homeassistant-remotecompose] no semantics for: Card/Button-Light, Card/Button-Dark, Card/Garage-Animation, Card/Garage-State
[homeassistant-remotecompose] incomplete render — refusing to publish.
```

Those four entries are all `@PreviewParameter` multi-variant previews (`Button_Light/Dark` → `KitchenLightStatesProvider`; `Garage_Animation/State` → position/state providers). `bundle pack --with-semantics` renders them to PNG but doesn't emit a `compose-semantics.json` for parameterized previews (172/185 captured; the 13 misses are the parameterized ones), so the generator correctly reports them missing.

This keeps the catalog **fail-closed** (no `--allow-incomplete`) by pointing every entry at a preview that captures semantics:

- **Drop the Button card** — its only previews are `@PreviewParameter`, and there's no non-parameterized button preview in `:previews` to point at.
- **Swap Garage** `Garage_Animation_Light` / `Garage_State_Light` → the static `Garage_TwoEntities_Light` / `_Dark` pair (`() =`, no param), which captures semantics.

All 24 remaining entries are non-parameterized — verified against source — so the next run publishes cleanly.

## Test plan

Data-only change (catalog spec), no runtime/UI surface. After merge, re-dispatch **Design Artifacts** (fail-closed); it should publish `design-artifacts/homeassistant-remotecompose`. I'll re-dispatch and verify.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh2DezRdwpjddGGEZ3nveE)_