### PR TITLE
fix(previews): stop flaky card-history and animated-card screenshots

### DIFF
--- a/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/CardHistoryScreen.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/dashboard/CardHistoryScreen.kt
@@ -129,6 +129,11 @@ fun CardHistoryScreen(
   onBack: () -> Unit,
   onAddToHomeScreen: () -> Unit,
   contentPadding: PaddingValues = PaddingValues(0.dp),
+  // Pre-fetched history to seed the first composition. Production leaves this null and the section
+  // fetches asynchronously (showing a spinner meanwhile); deterministic screenshot previews pass a
+  // synchronously-computed series so the render shows the settled chart on the first frame rather
+  // than racing the async fetch and capturing the spinner (the #409 flaky-render investigation).
+  initialHistory: Map<String, List<HistoryPoint>>? = null,
 ) {
   val entityIds = remember(card) { card.historyEntityIds() }
   var hours by remember { mutableIntStateOf(24) }
@@ -171,6 +176,7 @@ fun CardHistoryScreen(
           snapshot = snapshot,
           hours = hours,
           onHoursChange = { hours = it },
+          initialHistory = initialHistory,
         )
       }
 
@@ -494,6 +500,7 @@ private fun HistorySection(
   snapshot: HaSnapshot,
   hours: Int,
   onHoursChange: (Int) -> Unit,
+  initialHistory: Map<String, List<HistoryPoint>>? = null,
 ) {
   Text("History", style = MaterialTheme.typography.titleMedium)
 
@@ -508,9 +515,16 @@ private fun HistorySection(
   }
 
   // produceState keyed by (entityIds, hours) re-runs the fetch whenever
-  // the user picks a new range; null means "still loading".
+  // the user picks a new range; null means "still loading". Seeded with
+  // [initialHistory] so a preview renders the settled chart on the first
+  // frame rather than racing the async fetch and capturing the spinner.
   val history by
-    produceState<Map<String, List<HistoryPoint>>?>(initialValue = null, session, entityIds, hours) {
+    produceState<Map<String, List<HistoryPoint>>?>(
+      initialValue = initialHistory,
+      session,
+      entityIds,
+      hours,
+    ) {
       value = null
       value = runCatching { session.fetchHistory(entityIds, hours) }.getOrDefault(emptyMap())
     }

--- a/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import ee.schimke.ha.client.DashboardSummary
 import ee.schimke.ha.model.CardConfig
+import ee.schimke.ha.model.HistoryPoint
 import ee.schimke.ha.rc.components.ThemeStyle
 import ee.schimke.terrazzo.LocalTerrazzoGraph
 import ee.schimke.terrazzo.SettingsScreen
@@ -52,6 +53,7 @@ import ee.schimke.terrazzo.dashboard.DashboardSelectionScreen
 import ee.schimke.terrazzo.dashboard.DashboardViewScreen
 import ee.schimke.terrazzo.dashboard.ManagePinnedContent
 import ee.schimke.terrazzo.dashboard.PinRowItem
+import ee.schimke.terrazzo.dashboard.historyEntityIds
 import ee.schimke.terrazzo.discovery.DiscoveryScreen
 import ee.schimke.terrazzo.logs.LogsContent
 import ee.schimke.terrazzo.ui.TerrazzoTheme
@@ -336,6 +338,16 @@ private val HISTORY_SAMPLE_CARD =
       },
   )
 
+/**
+ * History series for [HISTORY_SAMPLE_CARD], computed synchronously off the same frozen
+ * [DEMO_CLOCK_MS] the preview session reads, for the default 24-hour range. Seeding
+ * [CardHistoryScreen] with this makes the first composition render the settled chart instead of the
+ * async loading spinner, so the screenshot can't capture the spinner mid-fetch (the #409
+ * flaky-render investigation).
+ */
+private val HISTORY_SAMPLE_SERIES: Map<String, List<HistoryPoint>> =
+  DemoData.history(HISTORY_SAMPLE_CARD.historyEntityIds(), hours = 24, nowMs = DEMO_CLOCK_MS)
+
 @Preview(
   name = "card history",
   showBackground = false,
@@ -350,6 +362,7 @@ fun Screen_CardHistory() = PhoneHost {
     snapshot = DemoData.snapshot(),
     onBack = {},
     onAddToHomeScreen = {},
+    initialHistory = HISTORY_SAMPLE_SERIES,
   )
 }
 
@@ -368,6 +381,7 @@ fun Screen_CardHistory_ThemeStyle(@PreviewParameter(ThemeStyleProvider::class) s
       snapshot = DemoData.snapshot(),
       onBack = {},
       onAddToHomeScreen = {},
+      initialHistory = HISTORY_SAMPLE_SERIES,
     )
   }
 

--- a/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
+++ b/app/src/main/kotlin/ee/schimke/terrazzo/previews/ScreenPreviews.kt
@@ -359,7 +359,7 @@ fun Screen_CardHistory() = PhoneHost {
   CardHistoryScreen(
     session = demoSession(),
     card = HISTORY_SAMPLE_CARD,
-    snapshot = DemoData.snapshot(),
+    snapshot = DemoData.snapshot(DEMO_CLOCK_MS),
     onBack = {},
     onAddToHomeScreen = {},
     initialHistory = HISTORY_SAMPLE_SERIES,
@@ -378,7 +378,7 @@ fun Screen_CardHistory_ThemeStyle(@PreviewParameter(ThemeStyleProvider::class) s
     CardHistoryScreen(
       session = demoSession(),
       card = HISTORY_SAMPLE_CARD,
-      snapshot = DemoData.snapshot(),
+      snapshot = DemoData.snapshot(DEMO_CLOCK_MS),
       onBack = {},
       onAddToHomeScreen = {},
       initialHistory = HISTORY_SAMPLE_SERIES,

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviewMatrix.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviewMatrix.kt
@@ -244,6 +244,22 @@ private fun WithImageStrategy(strategy: PictureImageStrategy?, content: @Composa
   }
 }
 
+/**
+ * Locals every matrix cell installs **inside** its `CachedCardPreview` capture composition. Outer
+ * CompositionLocals don't cross the `captureSingleRemoteDocument` boundary, so the matrix-level
+ * [FixedHaClock] (provided above `CardPreviewMatrix`'s content) never reaches the captured cards.
+ * Re-providing it here freezes time-based content and — through [ProvideCardRegistry]'s `isFrozen`
+ * bridge — drops the cards' startup value tweens, which otherwise leave the per-cell capture
+ * landing mid-animation so the PNG drifts between runs (the #409 / #412 flaky-render
+ * investigation).
+ */
+@Composable
+private fun MatrixCaptureLocals(content: @Composable () -> Unit) {
+  CompositionLocalProvider(LocalHaClock provides FixedHaClock(PreviewNow)) {
+    ProvideCardRegistry(defaultRegistry()) { ProvideHaTheme(HaTheme.Dark, content = content) }
+  }
+}
+
 @Composable
 private fun WrapModeCell(
   card: CardConfig,
@@ -264,12 +280,10 @@ private fun WrapModeCell(
         card = card,
         snapshot = snapshot,
       ) {
-        ProvideCardRegistry(defaultRegistry()) {
-          ProvideHaTheme(HaTheme.Dark) {
-            ProvideCardSizeMode(CardSizeMode.Wrap) {
-              WithImageStrategy(imageStrategy) {
-                RenderChild(card, snapshot, RemoteModifier.rcFillMaxWidth())
-              }
+        MatrixCaptureLocals {
+          ProvideCardSizeMode(CardSizeMode.Wrap) {
+            WithImageStrategy(imageStrategy) {
+              RenderChild(card, snapshot, RemoteModifier.rcFillMaxWidth())
             }
           }
         }
@@ -308,18 +322,16 @@ private fun FixedModeCell(
           card = card,
           snapshot = snapshot,
         ) {
-          ProvideCardRegistry(defaultRegistry()) {
-            ProvideHaTheme(HaTheme.Dark) {
-              ProvideCardSizeMode(CardSizeMode.Fixed) {
-                // Same full-canvas surface the launcher
-                // widget wraps the card in, so the preview
-                // fills the cell instead of leaving blank
-                // space below short content.
-                ProvideCardChrome(enabled = false) {
-                  RemoteHaWidgetSurface {
-                    WithImageStrategy(imageStrategy) {
-                      RenderChild(card, snapshot, RemoteModifier.rcFillMaxWidth())
-                    }
+          MatrixCaptureLocals {
+            ProvideCardSizeMode(CardSizeMode.Fixed) {
+              // Same full-canvas surface the launcher
+              // widget wraps the card in, so the preview
+              // fills the cell instead of leaving blank
+              // space below short content.
+              ProvideCardChrome(enabled = false) {
+                RemoteHaWidgetSurface {
+                  WithImageStrategy(imageStrategy) {
+                    RenderChild(card, snapshot, RemoteModifier.rcFillMaxWidth())
                   }
                 }
               }
@@ -370,22 +382,20 @@ private fun WatchFaceCell(
             card = card,
             snapshot = snapshot,
           ) {
-            ProvideCardRegistry(defaultRegistry()) {
-              ProvideHaTheme(HaTheme.Dark) {
-                ProvideCardSizeMode(CardSizeMode.Fixed) {
-                  ProvideCardChrome(enabled = false) {
-                    // Mirror the real Glance Wear slot
-                    // surface, which disables FlowLayout
-                    // (its capture profile rejects op
-                    // 240); cards then take their
-                    // non-wrapping compact path here too,
-                    // so the matrix wear cells show what
-                    // the watch actually draws.
-                    ProvideFlowLayoutSupport(enabled = false) {
-                      RemoteHaWidgetSurface {
-                        WithImageStrategy(imageStrategy) {
-                          RenderChild(card, snapshot, RemoteModifier.rcFillMaxWidth())
-                        }
+            MatrixCaptureLocals {
+              ProvideCardSizeMode(CardSizeMode.Fixed) {
+                ProvideCardChrome(enabled = false) {
+                  // Mirror the real Glance Wear slot
+                  // surface, which disables FlowLayout
+                  // (its capture profile rejects op
+                  // 240); cards then take their
+                  // non-wrapping compact path here too,
+                  // so the matrix wear cells show what
+                  // the watch actually draws.
+                  ProvideFlowLayoutSupport(enabled = false) {
+                    RemoteHaWidgetSurface {
+                      WithImageStrategy(imageStrategy) {
+                        RenderChild(card, snapshot, RemoteModifier.rcFillMaxWidth())
                       }
                     }
                   }

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Animations.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/Animations.kt
@@ -13,6 +13,8 @@ import androidx.compose.remote.creation.compose.state.CUBIC_STANDARD
 import androidx.compose.remote.creation.compose.state.EASE_OUT_BOUNCE
 import androidx.compose.remote.creation.compose.state.EASE_OUT_ELASTIC
 import androidx.compose.remote.creation.compose.state.RemoteFloat
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
 
 /**
  * Easing curve identifiers (mirrored from RemoteCompose's `RemoteFloat.kt`). The encoded `.rc`
@@ -30,6 +32,20 @@ object RcEasing {
 }
 
 /**
+ * Whether encoded value tweens ([animateRemoteFloat]) are emitted into the document.
+ *
+ * Production leaves this `true`: a card animates host writebacks (a toggle flip, a fresh gauge
+ * value) so the player crossfades between successive values instead of snapping. Deterministic
+ * screenshot renders flip it to `false` — bridged from `LocalHaClock.isFrozen` by the converter
+ * host `ProvideCardRegistry` — so the encoded document carries the settled value with **no**
+ * animation. A document otherwise kicks off its ~0.20 s startup tween (default → bound target) on
+ * load, and the preview capture lands at a nondeterministic point in that tween, so the rendered
+ * PNG drifts between runs (see the homeassistant-remotecompose #409 / #412 flaky-render
+ * investigation). Same rationale as the clock card's frozen static-label path.
+ */
+val LocalRemoteAnimationsEnabled = staticCompositionLocalOf { true }
+
+/**
  * Wrap [input] in an [AnimatedRemoteFloat] so the player tweens between successive values whenever
  * the document state behind [input] changes (typically via `RemoteBoolean.select(1f.rf, 0f.rf)` or
  * a `MutableRemoteFloat` write).
@@ -37,15 +53,21 @@ object RcEasing {
  * The encoded animation spec is a 5-tuple `(duration, easingType, customCurve, wrap, offset)` — we
  * only ever need the first two, so the rest stay at their defaults.
  *
+ * When [LocalRemoteAnimationsEnabled] is `false` (a frozen preview / test render) the tween is
+ * omitted entirely: [input] is returned as-is so the document encodes the settled value with no
+ * startup animation for the capture to catch mid-flight.
+ *
  * @param durationSeconds tween duration in seconds (player real time).
  * @param easing easing curve id from [RcEasing].
  */
+@Composable
 fun animateRemoteFloat(
   input: RemoteFloat,
   durationSeconds: Float = 0.20f,
   easing: Int = RcEasing.Standard,
-): RemoteFloat =
-  AnimatedRemoteFloat(
+): RemoteFloat {
+  if (!LocalRemoteAnimationsEnabled.current) return input
+  return AnimatedRemoteFloat(
     input,
     // Pack only the duration + easing; pass NaN for wrap / offset so
     // the packed array omits those slots (`packToFloatArray` skips NaN
@@ -53,3 +75,4 @@ fun animateRemoteFloat(
     // try to apply as a wrap-around / phase offset).
     FloatAnimation.packToFloatArray(durationSeconds, easing, null, Float.NaN, Float.NaN),
   )
+}

--- a/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaArcDial.kt
+++ b/rc-components/src/main/kotlin/ee/schimke/ha/rc/components/RemoteHaArcDial.kt
@@ -291,9 +291,9 @@ private fun ArcCanvas(
     if (target != null) {
       LiveValues.namedFloat(data.entityId, "target_fraction", target.coerceIn(0f, 1f))
     } else null
-  val animatedTargetFraction = rawTargetFraction?.let {
-    animateRemoteFloat(it, DialAnimationSeconds)
-  }
+  val animatedTargetFraction =
+    if (rawTargetFraction != null) animateRemoteFloat(rawTargetFraction, DialAnimationSeconds)
+    else null
   val animatedMarkerAngle = animatedTargetFraction?.let { 135f.rf + it * 270f.rf }
 
   RemoteCanvas(modifier = RemoteModifier.fillMaxSize()) {

--- a/rc-converter/src/main/kotlin/ee/schimke/ha/rc/LocalCardRegistry.kt
+++ b/rc-converter/src/main/kotlin/ee/schimke/ha/rc/LocalCardRegistry.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.staticCompositionLocalOf
 import ee.schimke.ha.model.CardConfig
 import ee.schimke.ha.model.HaSnapshot
+import ee.schimke.ha.rc.components.LocalRemoteAnimationsEnabled
 
 /**
  * Composition local that lets stack / grid / conditional cards recurse into the registry for their
@@ -20,7 +21,16 @@ val LocalCardRegistry =
 
 @Composable
 fun ProvideCardRegistry(registry: CardRegistry, content: @Composable () -> Unit) {
-  CompositionLocalProvider(LocalCardRegistry provides registry, content = content)
+  // A frozen clock (previews / tests provide a [FixedHaClock]) also freezes value tweens: the
+  // encoded document carries the settled value with no startup animation, so a screenshot capture
+  // can't land mid-tween and drift the PNG between runs. Production's [SystemHaClock] leaves
+  // `isFrozen == false`, so live host writebacks keep animating. Same contract the clock card uses
+  // for its static-label path — see [LocalRemoteAnimationsEnabled].
+  CompositionLocalProvider(
+    LocalCardRegistry provides registry,
+    LocalRemoteAnimationsEnabled provides !LocalHaClock.current.isFrozen,
+    content = content,
+  )
 }
 
 /**


### PR DESCRIPTION
## Summary

Investigating the flaky screenshots reported on #409 and #412: both are Renovate dependency bumps that **cannot affect Android Compose rendering** (`navigation3-runtime`; `logback-classic`, a server-side logging dep), yet the preview-diff bot flagged UI previews as "changed" — and *different* previews each run:

| PR | Dependency | Previews flagged "changed" |
|----|-----------|----------------------------|
| #409 | `navigation3-runtime` | `Screen_CardHistory`, `Screen_CardHistory_ThemeStyle` |
| #412 | `logback-classic` | `CardPreviewMatrix_Button`, `CardPreviewMatrix_Entities` |

`Screen_CardHistory` is in the *unchanged* list on #412, confirming this is general render **nondeterminism** — the capture lands before the frame settles — not one bug on one screen. Two concrete, capture-before-settle causes, both fixed here:

**1. App-screen previews (`Screen_CardHistory`) — async-load race.**
`HistorySection` loads history via `produceState(initialValue = null, …)` and shows an animating `CircularProgressIndicator` until `fetchHistory()` resolves. The Robolectric-based render harness leaves `LocalInspectionMode` off (per `TvKioskPreview.kt`), so the snapshot sometimes catches the spinner, sometimes the chart. `CardHistoryScreen` now takes an optional `initialHistory` seed; the preview passes a synchronously-computed series so the first composition renders the settled chart. Production still fetches asynchronously (`initialHistory` defaults to `null`).

**2. Card-matrix previews (`CardPreviewMatrix_*`) — animation-phase race.**
Cards render as RemoteCompose documents; an active state (e.g. `CardPreviewMatrix_Button` binds `light.kitchen`, which is `"on"`) kicks off a ~0.20 s `animateRemoteFloat` value tween on document load, and the per-cell capture lands mid-tween (already noted verbatim in the `CardPreviewMatrix_Entities` comment). Fix:
- New `LocalRemoteAnimationsEnabled` (rc-components) gates `animateRemoteFloat`: when off, the tween is omitted and the document encodes the settled value.
- `ProvideCardRegistry` bridges it from `LocalHaClock.isFrozen` — frozen preview/test renders → no tween; production `SystemHaClock` (`isFrozen == false`) → live host writebacks still animate. Same contract the clock card already uses for its static-label path.
- The matrix provided its `FixedHaClock` *outside* the per-cell `captureSingleRemoteDocument` boundary, where it never reached the cards; a `MatrixCaptureLocals` helper now provides it *inside* the capture, so time-based content is byte-stable and the animation bridge engages.

The `*_Animated_*` / `*_Strip_*` animation showcases in `AnimationPreviews.kt` are unaffected — they render components directly (not through the frozen `ProvideCardRegistry`), so they keep their documents' tweens on purpose.

## Test plan

- `./gradlew ktfmtCheck` ✅
- `./gradlew :rc-components:compileReleaseKotlin :rc-converter:compileReleaseKotlin :previews:compileReleaseKotlin :app:compileDebugKotlin` ✅
- `./gradlew :rc-components:testReleaseUnitTest :rc-converter:testReleaseUnitTest` ✅
- No existing test references `animateRemoteFloat` / `ProvideCardRegistry` / `FixedHaClock`, so no golden-byte assertions change.

## Visual evidence

The "before" state here is *inherently* non-deterministic (a loading spinner or a mid-tween frame) — that flakiness is the bug — so a stable before/after pair can't be captured by hand. The canonical visual check for this repo is the **compose-preview CI diff bot**, which renders base vs head on this PR — the same mechanism that surfaced the flakiness on #409/#412. After this change the affected previews (`Screen_CardHistory*`, `CardPreviewMatrix_Button`, `CardPreviewMatrix_Entities`, plus any active-toggle / time-based matrix card) should render the settled frame deterministically and stop reappearing as spurious "changed" entries on unrelated dependency bumps.

---
_Generated by [Claude Code](https://claude.ai/code/session_016USbq3daSYhunGripHP4Ud)_