### PR TITLE
feat(previews): non-parameterized button preview for the design catalog

### DIFF
--- a/catalog.spec.json
+++ b/catalog.spec.json
@@ -49,6 +49,8 @@
     {
       "name": "Cards",
       "components": [
+        { "componentId": "Card/Button-Light", "preview": "Button_On_Light", "caption": "Button card — a light entity, on (light)." },
+        { "componentId": "Card/Button-Dark", "preview": "Button_On_Dark", "caption": "Button card — a light entity, on (dark)." },
         { "componentId": "Card/Entity-Light", "preview": "Entity_Light", "caption": "Entity card — a single entity row (light)." },
         { "componentId": "Card/Entity-Dark", "preview": "Entity_Dark", "caption": "Entity card (dark)." },
         { "componentId": "Card/Entities-Light", "preview": "Entities_Light", "caption": "Entities card — a multi-entity list (light)." },

--- a/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
+++ b/previews/src/main/kotlin/ee/schimke/ha/previews/CardPreviews.kt
@@ -113,6 +113,28 @@ fun Button_Dark(
 private fun buttonCard() =
   card("""{"type":"button","entity":"light.kitchen","name":"Kitchen","show_name":true}""")
 
+// Non-parameterized button previews for the PUBLISHED design catalog. Button_Light/Dark above fan
+// out over on/off/unavailable via @PreviewParameter, which renders one PNG per state but emits NO
+// compose-semantics.json — and the fail-closed catalog exporter drops any component without a
+// captured semantics tree. These render a single fixed "on" state (the provider's first value) so
+// the daemon captures semantics, keeping the button card in the sticker sheet. See
+// homeassistant-remotecompose#418.
+private val KitchenLightOn: HaSnapshot = KitchenLightStatesProvider().values.first().second
+
+@Preview(name = "button on (light)", showBackground = false, widthDp = 187, heightDp = 91)
+@Composable
+fun Button_On_Light() =
+  CardHost(HaTheme.Light) {
+    RenderChild(buttonCard(), KitchenLightOn, RemoteModifier.fillMaxWidth())
+  }
+
+@Preview(name = "button on (dark)", showBackground = false, widthDp = 187, heightDp = 91)
+@Composable
+fun Button_On_Dark() =
+  CardHost(HaTheme.Dark) {
+    RenderChild(buttonCard(), KitchenLightOn, RemoteModifier.fillMaxWidth())
+  }
+
 // ——— entity ———
 
 // Our converter emits a simple row that's visibly smaller than HA's


### PR DESCRIPTION
## Summary

Restores the **Button card** to the published design catalog (`/homeassistant-remotecompose/`), which #417 had to drop.

The button's only previews — `Button_Light` / `Button_Dark` — fan out over on/off/unavailable via `@PreviewParameter`. `bundle pack --with-semantics` renders those to PNG but emits **no** `compose-semantics.json` for parameterized previews, and the fail-closed catalog exporter drops any component without a captured semantics tree (that's exactly why #417 removed it).

Fix: add `Button_On_Light` / `Button_On_Dark` — plain `@Preview` wrappers that render `buttonCard()` with a single **fixed "on" snapshot** (reusing `KitchenLightStatesProvider`'s first value), so the daemon captures a semantics tree like every other non-parameterized preview. The catalog spec's `Card/Button-*` entries now point at them. The parameterized `Button_Light/Dark` stay for the compose-preview state-diff coverage.

Fixes #418.

## Test plan

Verified locally against the installed Android SDK:
- `./gradlew :previews:ktfmtFormat` — no change (already format-clean)
- `./gradlew :previews:compileReleaseKotlin` — `BUILD SUCCESSFUL`

Full end-to-end validation (the daemon actually capturing semantics for the new wrappers) is the **fail-closed Design Artifacts run** — I'm kicking it on this branch; if it publishes `design-artifacts/homeassistant-remotecompose` with the button present, the fix is confirmed. Data/preview-only change; no app runtime surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vh2DezRdwpjddGGEZ3nveE)_