### PR TITLE
chore(renovate): extend shared yschimke/renovate-config preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,59 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    ":dependencyDashboard",
-    ":semanticCommits"
-  ],
-  "labels": ["dependencies"],
-  "schedule": ["before 6am on monday"],
-  "timezone": "Europe/London",
-  "prConcurrentLimit": 5,
-  "prHourlyLimit": 0,
-  "rangeStrategy": "pin",
+  "extends": ["github>yschimke/renovate-config"],
   "packageRules": [
     {
-      "matchPackageNames": ["/^io\\.ktor:/"],
-      "groupName": "ktor"
-    },
-    {
-      "matchPackageNames": ["/^org\\.jetbrains\\.kotlinx:/"],
-      "groupName": "kotlinx"
-    },
-    {
+      "description": "Remote Compose renderer coords are pinned in lockstep with the compose-ai-tools renderer; keep them in their own group so a bump is a deliberate review, separate from the androidx-compose / androidx-wear trains.",
+      "groupName": "remote-compose",
       "matchPackageNames": [
-        "/^androidx\\.compose($|\\.)/",
-        "/^androidx\\.activity:activity-compose/"
-      ],
-      "groupName": "androidx-compose"
+        "/^androidx\\.compose\\.remote($|[.:])/",
+        "/^androidx\\.wear\\.compose\\.remote($|[.:])/"
+      ]
     },
     {
-      "matchPackageNames": ["/^androidx\\.wear($|\\.)/", "/^androidx\\.tv\\./"],
-      "groupName": "androidx-wear-tv"
-    },
-    {
-      "matchPackageNames": ["/^com\\.google\\.android\\.horologist:/"],
-      "groupName": "horologist"
-    },
-    {
-      "matchPackageNames": [
-        "/^androidx\\.compose\\.remote:/",
-        "/^androidx\\.wear\\.compose\\.remote:/"
-      ],
-      "groupName": "remote-compose"
-    },
-    {
-      "matchManagers": ["github-actions"],
-      "groupName": "github-actions"
-    },
-    {
-      "matchPackageNames": ["org.jetbrains.kotlinx:kotlinx-datetime"],
-      "description": "Avoid the -0.6.x-compat binaries; track mainline versions only.",
-      "allowedVersions": "!/-compat$/"
-    },
-    {
-      "matchPackageNames": ["junit:junit"],
       "description": "Stay on JUnit 4; don't auto-bump to 5.x/6.x (Jupiter is a different API).",
+      "matchPackageNames": ["junit:junit"],
       "allowedVersions": "/^4\\./",
       "enabled": false
     }


### PR DESCRIPTION
## Summary

Replaces the hand-maintained `renovate.json` groupings with an `extends` of the new shared preset [`yschimke/renovate-config`](https://github.com/yschimke/renovate-config), keeping only the two rules specific to this repo.

The preset clusters updates **by release train** rather than namespace (kotlin+KSP, compose-multiplatform, androidx-compose, androidx-wear+horologist, androidx-room, grpc, kotlinx, ktor, an `androidx` catch-all for independently-versioned small libs, plus AGP and github-actions). See the preset's README for the full rationale on why "all of AndroidX in one group" is the wrong size.

Kept repo-local:

- **remote-compose** — the Remote Compose renderer coords are pinned in lockstep with the compose-ai-tools renderer, so they stay in their own group (separate review) rather than folding into the androidx-compose / androidx-wear trains.
- **junit:junit** stay-on-4 pin (Jupiter 5.x/6.x is a different API).

## Test plan

- `renovate.json` validated as JSON.
- Preset resolves to `github>yschimke/renovate-config` (published on `main`).
- Renovate's own validation runs on the next scheduled pass (Mondays, 06:00 Europe/London); the dependency dashboard will reflect the regrouped PRs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QUvbNL2qcqRutHD9WKnAgw)_