### PR TITLE
ci: add @claude mention-triggered agent sessions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,78 @@
+name: Claude
+
+# Mention-triggered agent sessions: comment `@claude <request>` on any issue,
+# PR, or review thread and a Claude Code session runs on this runner with the
+# full thread as context. Follow-up `@claude` replies re-read the whole
+# conversation plus the branch already pushed, so a thread behaves like one
+# resumable session. Only users with write access can trigger it.
+#
+# One-time setup: install the Claude GitHub App (https://github.com/apps/claude)
+# and add a CLAUDE_CODE_OAUTH_TOKEN secret (from `claude setup-token`; runs
+# bill the Claude subscription's included usage — swap the input to
+# `anthropic_api_key` for metered API billing). Design notes live in the
+# canonical copy:
+# https://github.com/yschimke/compose-ai-tools/blob/main/docs/AGENT_INVOCATION.md
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    name: Claude agent session
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    # Queue (don't cancel) concurrent mentions on the same thread so two runs
+    # never race pushes to the same working branch.
+    concurrency:
+      group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      # Exchanged by the action for a short-lived Claude GitHub App token.
+      id-token: write
+      # Lets Claude read CI results on the PR it is working on.
+      actions: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history so Claude can diff against main and render
+          # before/after evidence.
+          fetch-depth: 0
+      - uses: ./.github/actions/setup
+        with:
+          cache-read-only: 'true'
+      - uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
+        with:
+          # Bills the Claude subscription's included usage (shared with
+          # interactive Claude Code sessions) rather than per-token API spend.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Request the CI-read scope on the Claude App token the action
+          # mints for itself — the job-level `actions: read` grant above only
+          # covers the workflow token.
+          additional_permissions: |
+            actions: read
+          # House style: agent branches use the agent/ prefix, never claude/.
+          branch_prefix: agent/
+          # Never let the CLI append an agent Co-authored-by trailer.
+          settings: |
+            {
+              "includeCoAuthoredBy": false,
+              "attribution": { "coAuthoredBy": false }
+            }
+          claude_args: >-
+            --max-turns 100
+            --allowedTools "Bash(./gradlew:*),Bash(git:*)"
+            --append-system-prompt "Follow the repo conventions in AGENTS.md. Visual evidence is mandatory for any UI-affecting request: render the affected @Preview composables before and after your change with the compose-preview pipeline (./gradlew :previews:composePreviewRenderAll or the specific module render task), commit the PNGs you cite to your working branch, push, and only then embed them inline in your comment and PR text as markdown images whose URLs are commit-SHA-pinned raw.githubusercontent.com links to those pushed files. Describing an image is not evidence; the reviewer must see pixels inline. When reviewing an existing PR, reuse renders already published on the compose-preview/pr and compose-preview/main branches where possible. Use conventional commit subjects (feat:, fix:, ci:, docs:, test:). Never add Co-authored-by trailers or any agent attribution to commits, PR titles, or PR bodies."


### PR DESCRIPTION
## Summary

Adds the `@claude` mention-triggered agent workflow (same pattern as yschimke/compose-ai-tools#2194 + #2205): commenting `@claude <request>` on any issue, PR, or review thread runs a Claude Code session on the Actions runner with the full thread as context, gated to users with write access.

- Auth via `CLAUDE_CODE_OAUTH_TOKEN` (Claude subscription usage; `anthropic_api_key` remains the documented swap-back for metered billing).
- Toolchain via the repo's own setup action (Temurin 21 + Gradle, `cache-read-only`), with `./gradlew` and `git` Bash-allowlisted so the agent can build and render.
- Visual-evidence contract in the appended system prompt: before/after `@Preview` renders (e.g. `:previews:composePreviewRenderAll`) committed to the working branch and embedded as commit-SHA-pinned `raw.githubusercontent.com` images; reuse `compose-preview/pr` / `compose-preview/main` renders when reviewing.
- `branch_prefix: agent/`, `includeCoAuthoredBy: false` — no agent attribution in history.
- Action SHA-pinned to `v1.0.163`.

Full design and adoption notes: [compose-ai-tools docs/AGENT_INVOCATION.md](https://github.com/yschimke/compose-ai-tools/blob/main/docs/AGENT_INVOCATION.md).

## Test plan

- YAML parsed and `settings` JSON validated locally; structure mirrors the vendor's canonical `examples/claude.yml` and the already-merged compose-ai-tools copy.
- Non-visual change (CI wiring only), so text-only evidence is correct.
- After merge: add the `CLAUDE_CODE_OAUTH_TOKEN` secret and confirm the Claude GitHub App is installed on this repo, then re-comment `@claude` on PR #443 (the existing mention won't replay — only new comments trigger).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SThVExRiUTasR9ehW9gFSv)_