### PR TITLE
ci: add weekly issue triage and claude label kickoff

### DIFF
--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -1,0 +1,65 @@
+name: Claude Triage
+
+# Weekly issue triage in automation mode: labels new issues, closes ones
+# already fixed by merged PRs (with evidence), and maintains a "Weekly
+# triage" summary issue with a shortlist of items ready for an agent. To
+# start work on an issue, apply the `claude` label or comment
+# `@claude <task>` (see claude.yml). Manual run: Actions -> Claude Triage.
+
+on:
+  schedule:
+    # Mondays 08:00 UTC
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: claude-triage
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    name: Triage open issues
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+      # Exchanged by the action for a short-lived Claude GitHub App token.
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history so recent commits can be matched against issues.
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
+        with:
+          # Bills the Claude subscription's included usage.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: >-
+            --max-turns 100
+            --allowedTools "Bash(git log:*),Bash(git diff:*),Bash(git show:*)"
+          prompt: |
+            Run the weekly issue triage for this repository. Work through ALL
+            open issues (skip pull requests):
+
+            1. Label new or unlabeled issues: bug, enhancement, question, or
+               needs-info, plus priority-high only when clearly urgent.
+               Create any missing labels.
+            2. For each open issue, check whether it has already been
+               resolved: search merged PRs and recent commits on main that
+               reference or plausibly fix it. If confident it is fixed,
+               comment with the evidence (PR/commit links) and close it as
+               completed. If plausible but unconfirmed, comment asking the
+               maintainer to confirm and apply needs-info; do not close.
+            3. Maintain a single open summary issue titled "Weekly triage"
+               (create it if missing, otherwise update the existing one by
+               editing its body): a table of open issues with labels, a
+               one-line status, and what is blocking each. End with a
+               "Ready for an agent" shortlist of issues that are specified
+               well enough to implement, each with a suggested kickoff:
+               apply the `claude` label, or comment `@claude <one-line task>`.
+
+            Rules: do not modify code or open PRs in this run. Be
+            conservative about closing - only close with concrete evidence.
+            Keep all comments brief and factual.

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -8,8 +8,8 @@ name: Claude Triage
 
 on:
   schedule:
-    # Mondays 08:00 UTC
-    - cron: '0 8 * * 1'
+    # Friday evenings 17:00 UTC — shortlist ready for the weekend
+    - cron: '0 17 * * 5'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -38,14 +38,15 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: >-
             --max-turns 100
-            --allowedTools "Bash(git log:*),Bash(git diff:*),Bash(git show:*)"
+            --allowedTools "mcp__github__list_issues,mcp__github__search_issues,mcp__github__get_issue,mcp__github__issue_read,mcp__github__create_issue,mcp__github__update_issue,mcp__github__issue_write,mcp__github__add_issue_comment,mcp__github__get_issue_comments,mcp__github__get_label,mcp__github__list_pull_requests,mcp__github__search_pull_requests,mcp__github__get_pull_request,mcp__github__pull_request_read,mcp__github__list_commits,mcp__github__search_code,Bash(git log:*),Bash(git diff:*),Bash(git show:*)"
           prompt: |
             Run the weekly issue triage for this repository. Work through ALL
             open issues (skip pull requests):
 
             1. Label new or unlabeled issues: bug, enhancement, question, or
                needs-info, plus priority-high only when clearly urgent.
-               Create any missing labels.
+               If a needed label does not exist and cannot be created
+               with the available tools, note that in the summary instead.
             2. For each open issue, check whether it has already been
                resolved: search merged PRs and recent commits on main that
                reference or plausibly fix it. If confident it is fixed,

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -78,5 +78,5 @@ jobs:
             }
           claude_args: >-
             --max-turns 100
-            --allowedTools "Bash(./gradlew:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*)"
+            --allowedTools "Bash(./gradlew:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(javap:*)"
             --append-system-prompt "Follow the repo conventions in AGENTS.md. Visual evidence is mandatory for any UI-affecting request: render the affected @Preview composables before and after your change with the compose-preview pipeline (./gradlew :previews:composePreviewRenderAll or the specific module render task), commit the PNGs you cite to your working branch, push, and only then embed them inline in your comment and PR text as markdown images whose URLs are commit-SHA-pinned raw.githubusercontent.com links to those pushed files. Describing an image is not evidence; the reviewer must see pixels inline. When reviewing an existing PR, reuse renders already published on the compose-preview/pr and compose-preview/main branches where possible. Use conventional commit subjects (feat:, fix:, ci:, docs:, test:). Never add Co-authored-by trailers or any agent attribution to commits, PR titles, or PR bodies."

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,7 +21,7 @@ on:
   pull_request_review:
     types: [submitted]
   issues:
-    types: [opened, assigned]
+    types: [opened, assigned, labeled]
 
 jobs:
   claude:
@@ -30,7 +30,8 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
+      (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label.name == 'claude')
     runs-on: ubuntu-latest
     timeout-minutes: 90
     # Queue (don't cancel) concurrent mentions on the same thread so two runs
@@ -59,6 +60,9 @@ jobs:
           # Bills the Claude subscription's included usage (shared with
           # interactive Claude Code sessions) rather than per-token API spend.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Applying the `claude` label to an issue starts a work session on it
+          # (the weekly triage shortlist suggests candidates).
+          label_trigger: claude
           # Request the CI-read scope on the Claude App token the action
           # mints for itself — the job-level `actions: read` grant above only
           # covers the workflow token.


### PR DESCRIPTION
## Summary

Adds the issue-flow layer on top of the `@claude` agent setup:

- **`claude-triage.yml`** — Friday evenings 17:00 UTC (and via workflow_dispatch), an automation-mode agent run labels new issues, closes issues already fixed by merged PRs (commenting the evidence, conservative by rule), and maintains a **"Weekly triage"** summary issue ending with a *Ready for an agent* shortlist. No code changes in triage runs; read-only git allowlist only.
- **`claude.yml`** — adds the `issues: labeled` event + `label_trigger: claude`: applying the `claude` label to an issue starts an agent work session on it (branch → implementation with visual evidence → PR → merge gates). Also allowlists `javap` — the agent run on #443 had to write ad-hoc Gradle tasks (`javapClass`, `dumpClass`) to inspect the new OkHttp `Interceptor.Chain` surface because only `./gradlew` was permitted; javap is read-only with no network/write surface.

## Test plan

- Both workflows YAML-parsed; `label_trigger` and automation-mode `prompt` are documented action inputs; job `if:` gate extended to accept only the `claude` label on `labeled` events.
- Triage permissions are minimal: `contents: read`, `issues: write`, `pull-requests: read`.
- After merge: run Actions → Claude Triage manually once to seed the "Weekly triage" issue, then label one shortlist item `claude` to verify the kickoff.


---
_Generated by [Claude Code](https://claude.ai/code)_