### PR TITLE
chore: allow trigger, send_later, and Figma MCP tools in agent sessions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,5 +18,22 @@
         ]
       }
     ]
+  },
+  "permissions": {
+    "allow": [
+      "mcp__Claude_Code_Remote__send_later",
+      "mcp__Claude_Code_Remote__create_trigger",
+      "mcp__Claude_Code_Remote__update_trigger",
+      "mcp__Claude_Code_Remote__delete_trigger",
+      "mcp__Claude_Code_Remote__list_triggers",
+      "mcp__Claude_Code_Remote__fire_trigger",
+      "mcp__claude-code-remote__send_later",
+      "mcp__claude-code-remote__create_trigger",
+      "mcp__claude-code-remote__update_trigger",
+      "mcp__claude-code-remote__delete_trigger",
+      "mcp__claude-code-remote__list_triggers",
+      "mcp__claude-code-remote__fire_trigger",
+      "mcp__Figma"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Pre-approve the Claude Code Remote scheduling tools (`send_later` + trigger create/update/delete/list/fire) in checked-in project settings so cloud agent sessions can self-schedule PR check-ins without permission prompts. Both CCR server-name spellings are listed; unmatched names are inert.
- Pre-approve the Figma MCP server (`mcp__Figma`) — this repo publishes its design system through the design-parity pipeline (`catalog.spec.json`, `design-artifacts.yml`).
- Existing SessionStart hooks are untouched; only a `permissions.allow` block is added.

## Test plan
- Non-visual settings change: JSON validated locally (parse + schema shape).
- Behavior check happens on the next cloud session: the listed tools should no longer prompt.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SThVExRiUTasR9ehW9gFSv)_